### PR TITLE
adds exception to the javadoc of Table.java

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Table.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Table.java
@@ -293,10 +293,11 @@ public interface Table extends Closeable {
    * @param deletes List of things to delete.  List gets modified by this
    * method (in particular it gets re-ordered, so the order in which the elements
    * are inserted in the list gives no guarantee as to the order in which the
-   * {@link Delete}s are executed).
+   * {@link Delete}s are executed), make sure that you pass a mutable list.
    * @throws IOException if a remote or network exception occurs. In that case
    * the {@code deletes} argument will contain the {@link Delete} instances
    * that have not be successfully applied.
+   * @exception java.lang.UnsupportedOperationException if the {@code deletes} argument is immutable.
    * @since 0.20.1
    */
   void delete(List<Delete> deletes) throws IOException;


### PR DESCRIPTION
The documentation for delete(List<Delete> deletes) doesn't make it clear that an UnsupportedOperationException would be thrown if the list argument is immutable, and hence I've added it to the documentation.
Thanks
