### PR TITLE
HBASE-12108 | Setting classloader so that HBase resources resolve even when HBaseConfiguration is loaded from a different class loader

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HBaseConfiguration.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HBaseConfiguration.java
@@ -91,6 +91,10 @@ public class HBaseConfiguration extends Configuration {
    */
   public static Configuration create() {
     Configuration conf = new Configuration();
+    // In case HBaseConfiguration is loaded from a different classloader than
+    // Configuration, conf needs to be set with appropriate class loader to resolve
+    // HBase resources.
+    conf.setClassLoader(HBaseConfiguration.class.getClassLoader());
     return addHbaseResources(conf);
   }
 


### PR DESCRIPTION
This should fix the case when HBaseConfiguration is loaded by a child classloader to Hadoop's Configuration's classloader.