### PR TITLE
Invalid hbase-common test-jar dependency scope

### DIFF
--- a/hbase-client/pom.xml
+++ b/hbase-client/pom.xml
@@ -124,6 +124,7 @@
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-common</artifactId>
       <type>test-jar</type>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>


### PR DESCRIPTION
hbase-client has hbase-common test-jar as dependency in compile scope, while it should be test scope instead.
This patch fixes the bug.