### PR TITLE
Fix typo, add missing space between two words.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServerCommandLine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServerCommandLine.java
@@ -88,7 +88,7 @@ public class HRegionServerCommandLine extends ServerCommandLine {
     } else if ("stop".equals(cmd)) {
       System.err.println(
         "To shutdown the regionserver run " +
-        "bin/hbase-daemon.sh stop regionserver or send a kill signal to" +
+        "bin/hbase-daemon.sh stop regionserver or send a kill signal to " +
         "the regionserver pid");
       return 1;
     } else {


### PR DESCRIPTION
Fix typo, add missing space between two words.