### PR TITLE
Fix colDescFromHbase to provide correct timeToLive

### DIFF
--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftUtilities.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftUtilities.java
@@ -94,6 +94,7 @@ public class ThriftUtilities {
     col.inMemory = in.isInMemory();
     col.blockCacheEnabled = in.isBlockCacheEnabled();
     col.bloomFilterType = in.getBloomFilterType().toString();
+    col.timeToLive = in.getTimeToLive();
     return col;
   }
 


### PR DESCRIPTION
When accessed via Thrift, all column families have `timeToLive` equal to -1. This fix solves the problem (probably).