### PR TITLE
HBASE-NNNN Clarify Scan comment about caching

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Scan.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Scan.java
@@ -128,7 +128,7 @@ public class Scan extends Query {
   static public final String SCAN_ATTRIBUTES_TABLE_NAME = "scan.attributes.table.name";
 
   /*
-   * -1 means no caching
+   * -1 means caching is not overridden in Scan so use the default configuration
    */
   private int caching = -1;
   private long maxResultSize = -1;


### PR DESCRIPTION
The Scan class has an integer field, caching, that defaults to -1.
The meaning of -1 is that the option was not overriden (aka not set) and
therefore that the default configuration should be used.

This trivial patch corrects the comment of that field to reflect this
meaning rather than misleading the reader to believe that caching is
disabled.