### PR TITLE
Fixed JavaDoc in areSerializedFieldsEqual

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/PrefixFilter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/PrefixFilter.java
@@ -127,7 +127,7 @@ public class PrefixFilter extends FilterBase {
   }
 
   /**
-   * @param other
+   * @param o Other filter
    * @return true if and only if the fields of the filter that are serialized
    * are equal to the corresponding fields in other.  Used for testing.
    */


### PR DESCRIPTION
Minor patch. Just fixed javadoc and other purpose of this PR is to get familiar with development process. 