### PR TITLE
HBASE-18470: Fix a bug in `RetriesExhaustedWithDetailsException#getDesc` describe

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RetriesExhaustedWithDetailsException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RetriesExhaustedWithDetailsException.java
@@ -114,7 +114,7 @@ extends RetriesExhaustedException {
     for (String addr : uniqAddr) {
       addrs.append(addr).append(", ");
     }
-    return uniqAddr.size() > 0 ? addrs.substring(0, addrs.length() - 2) : addrs.toString();
+    return uniqAddr.isEmpty() ? addrs.toString() : addrs.substring(0, addrs.length() - 2);
   }
 
   public String getExhaustiveDescription() {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RetriesExhaustedWithDetailsException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RetriesExhaustedWithDetailsException.java
@@ -111,10 +111,10 @@ extends RetriesExhaustedException {
     Set<String> uniqAddr = new HashSet<>();
     uniqAddr.addAll(hostnamePort);
 
-    for(String addr : uniqAddr) {
+    for (String addr : uniqAddr) {
       addrs.append(addr).append(", ");
     }
-    return addrs.toString();
+    return uniqAddr.size() > 0 ? addrs.substring(0, addrs.length() - 2) : addrs.toString();
   }
 
   public String getExhaustiveDescription() {


### PR DESCRIPTION
The describe from `RetriesExhaustedWithDetailsException#getDesc` is `
org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException: Failed 3 actions: FailedServerException: 3 times, `, there is a not need ', ' in the tail.