### PR TITLE
HBASE-19547: HBase fails building on AArch64 due to asciidoctor-maven…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1234,6 +1234,11 @@
             <artifactId>asciidoctorj-pdf</artifactId>
             <version>${asciidoctorj.pdf.version}</version>
           </dependency>
+          <dependency>
+            <groupId>org.jruby</groupId>
+            <artifactId>jruby-complete</artifactId>
+            <version>${jruby.version}</version>
+          </dependency>
         </dependencies>
         <configuration>
           <outputDirectory>${project.reporting.outputDirectory}/</outputDirectory>


### PR DESCRIPTION
This error took place because asciidoctor-maven-plugin used an old version
of Jruby (1.7.26) which didn’t work with AArch64 (due to the fact that
Jffi 1.2.12 which Jruby 1.7.26 depends on has no native AArch64 libraries).
This patch resolves the issue by upgradeing Jruby to version 9.1.10.0 that supports AArch64.

Change-Id: I17c2372434cc536f9436aa9e101ecf27571a5623
Signed-off-by: Yuqi Gu <yuqi.gu@arm.com>