### PR TITLE
HBASE-20070 refactor website generation

### DIFF
--- a/dev-support/jenkins-scripts/generate-hbase-website.sh
+++ b/dev-support/jenkins-scripts/generate-hbase-website.sh
@@ -23,74 +23,176 @@
 #
 # It needs to be built on a Jenkins server with the label git-websites
 #
-# It expects to have the hbase repo cloned to the directory hbase
+# Allows specifying options for working directory, maven repo, and publishing to git
+# run with --help for usage.
 #
 # If there is a build error, the Jenkins job is configured to send an email
 
-LOCAL_REPO=${WORKSPACE}/.m2/repo
-# Nuke the local maven repo each time, to start with a known environment
-rm -Rf "${LOCAL_REPO}"
-mkdir -p "${LOCAL_REPO}"
+declare CURRENT_HBASE_COMMIT
+declare PUSHED
+declare FILE
+declare WEBSITE_COMMIT_MSG
+declare -a FILES_TO_REMOVE
 
-# Clean any leftover files in case we are reusing the workspace
-rm -Rf -- *.patch *.patch.zip hbase/target target *.txt hbase-site
+set -e
+function usage {
+  echo "Usage: ${0} [options] /path/to/hbase/checkout"
+  echo ""
+  echo "    --working-dir /path/to/use  Path for writing logs and a local checkout of hbase-site repo."
+  echo "                                if given must exist."
+  echo "                                defaults to making a directory in /tmp."
+  echo "    --local-repo /path/for/maven/.m2  Path for putting local maven repo."
+  echo "                                if given must exist."
+  echo "                                defaults to making a clean directory in --working-dir."
+  echo "    --publish                   if given, will attempt to push results back to the hbase-site repo."
+  echo "    --help                      show this usage message."
+  exit 1
+}
+# if no args specified, show usage
+if [ $# -lt 1 ]; then
+  usage
+fi
+
+# Get arguments
+declare component_dir
+declare working_dir
+declare local_repo
+declare publish
+while [ $# -gt 0 ]
+do
+  case "$1" in
+    --working-dir) shift; working_dir=$1; shift;;
+    --local-repo) shift; local_repo=$1; shift;;
+    --publish) shift; publish="true";;
+    --) shift; break;;
+    -*) usage ;;
+    *)  break;;  # terminate while loop
+  esac
+done
+
+# should still have where component checkout is.
+if [ $# -lt 1 ]; then
+  usage
+fi
+component_dir="$(cd "$(dirname "$1")"; pwd)/$(basename "$1")"
+
+if [ -z "${working_dir}" ]; then
+  echo "[DEBUG] defaulting to creating a directory in /tmp"
+  working_dir=/tmp
+  while [[ -e ${working_dir} ]]; do
+    working_dir=/tmp/hbase-generate-website-${RANDOM}.${RANDOM}
+  done
+  mkdir "${working_dir}"
+else
+  # absolutes please
+  working_dir="$(cd "$(dirname "${working_dir}")"; pwd)/$(basename "${working_dir}")"
+  if [ ! -d "${working_dir}" ]; then
+    echo "passed working directory '${working_dir}' must already exist."
+    exit 1
+  fi
+fi
+
+echo "You'll find logs and temp files in ${working_dir}"
+
+if [ -z "${local_repo}" ]; then
+  echo "[DEBUG] defaulting to creating a local repo within '${working_dir}'"
+  local_repo="${working_dir}/.m2/repo"
+  # Nuke the local maven repo each time, to start with a known environment
+  rm -Rf "${local_repo}"
+  mkdir -p "${local_repo}"
+else
+  # absolutes please
+  local_repo="$(cd "$(dirname "${local_repo}")"; pwd)/$(basename "${local_repo}")"
+  if [ ! -d "${local_repo}" ]; then
+    echo "passed directory for storing the maven repo '${local_repo}' must already exist."
+    exit 1
+  fi
+fi
 
 # Set up the environment
-export JAVA_HOME=$JDK_1_8_LATEST__HOME
-export PATH=$JAVA_HOME/bin:$MAVEN_3_3_3_HOME/bin:$PATH
-export MAVEN_OPTS="-XX:MaxPermSize=256m -Dmaven.repo.local=${LOCAL_REPO}"
+if [ -z "${JAVA_HOME}" ]; then
+  JAVA_HOME="${JDK_1_8_LATEST__HOME}"
+  export JAVA_HOME
+  export PATH="${JAVA_HOME}/bin:${PATH}"
+fi
+if [ -z "${MAVEN_HOME}" ]; then
+  MAVEN_HOME="${MAVEN_3_3_3_HOME}"
+  export MAVEN_HOME
+  export PATH="${MAVEN_HOME}/bin:${PATH}"
+fi
+export MAVEN_OPTS="${MAVEN_OPTS} -Dmaven.repo.local=${local_repo}"
 
 # Verify the Maven version
 mvn -version
+# Verify the git version
+git --version
+
+cd "${working_dir}"
+
+# Clean any leftover files in case we are reusing the workspace
+rm -Rf -- *.patch *.patch.zip target *.txt hbase-site
 
 # Save and print the SHA we are building
-CURRENT_HBASE_COMMIT="$(git log --pretty=format:%H -n1)"
+CURRENT_HBASE_COMMIT="$(cd "${component_dir}" && git show-ref --hash --dereference --verify refs/remotes/origin/HEAD)"
+# Fail if it's empty
+if [ -z "${CURRENT_HBASE_COMMIT}" ]; then
+  echo "Got back a blank answer for the current HEAD on the remote hbase repository. failing."
+  exit 1
+fi
 echo "Current HBase commit: $CURRENT_HBASE_COMMIT"
 
 # Clone the hbase-site repo manually so it doesn't trigger spurious
 # commits in Jenkins.
 git clone --depth 1 --branch asf-site https://git-wip-us.apache.org/repos/asf/hbase-site.git
 
-# Figure out the last commit we built the site from, and bail if the build
-# still represents the SHA of HBase master
-cd "${WORKSPACE}/hbase-site" || exit -1
-git log --pretty=%s | grep ${CURRENT_HBASE_COMMIT}
-PUSHED=$?
-echo "PUSHED is $PUSHED"
+# Figure out if the commit of the hbase repo has already been built and bail if so.
+declare -i PUSHED
+PUSHED=$(cd hbase-site && git rev-list --grep "${CURRENT_HBASE_COMMIT}" --fixed-strings --count HEAD)
+echo "[DEBUG] hash was found in $PUSHED commits for hbase-site repository."
 
-if [ $PUSHED -eq 0 ]; then
+if [ "${PUSHED}" -ne 0 ]; then
   echo "$CURRENT_HBASE_COMMIT is already mentioned in the hbase-site commit log. Not building."
   exit 0
 else
-  echo "$CURRENT_HBASE_COMMIT is not yet mentioned in the hbase-site commit log. Assuming we don't have it yet. $PUSHED"
+  echo "$CURRENT_HBASE_COMMIT is not yet mentioned in the hbase-site commit log. Assuming we don't have it yet."
 fi
 
 # Go to the hbase directory so we can build the site
-cd "${WORKSPACE}/hbase" || exit -1
+cd "${component_dir}"
 
 # This will only be set for builds that are triggered by SCM change, not manual builds
-if [ "$CHANGE_ID" ]; then
+if [ -n "$CHANGE_ID" ]; then
   echo -n " ($CHANGE_ID - $CHANGE_TITLE)"
 fi
 
 # Build and install HBase, then build the site
 echo "Building HBase"
-mvn \
-  -DskipTests \
-  -Dmaven.javadoc.skip=true \
-  --batch-mode \
-  -Dcheckstyle.skip=true \
-  -Dfindbugs.skip=true \
-  --log-file="${WORKSPACE}/hbase-build-log-${CURRENT_HBASE_COMMIT}.txt" \
-  clean install \
-&& mvn clean site \
-  --batch-mode \
-  -DskipTests \
-  --log-file="${WORKSPACE}/hbase-install-log-${CURRENT_HBASE_COMMIT}.txt"
-
-status=$?
-if [ $status -ne 0 ]; then
-  echo "Failure: mvn clean site"
+# TODO we have to do a local install first because for whatever reason, the maven-javadoc-plugin's
+# forked compile phase requires that test-scoped dependencies be available, which
+# doesn't work since we will not have done a test-compile phase (MJAVADOC-490). the first place this
+# breaks for me is hbase-server trying to find hbase-http:test and hbase-zookeeper:test.
+# But! some sunshine: because we're doing a full install before running site, we can skip all the
+# compiling in the forked executions. We have to do it awkwardly because MJAVADOC-444.
+if mvn \
+    -DskipTests \
+    -Dmaven.javadoc.skip=true \
+    --batch-mode \
+    -Denforcer.skip=true \
+    -Dcheckstyle.skip=true \
+    -Dfindbugs.skip=true \
+    --log-file="${working_dir}/hbase-install-log-${CURRENT_HBASE_COMMIT}.txt" \
+    clean install \
+  && mvn site \
+    --batch-mode \
+    -Denforcer.skip=true \
+    -Dmaven.main.skip=true \
+    -Dmaven.test.skip=true \
+    -DskipTests \
+    --log-file="${working_dir}/hbase-site-log-${CURRENT_HBASE_COMMIT}.txt"; then
+  echo "Successfully built site."
+else
+  status=$?
+  echo "Maven commands to build the site failed. check logs for details ${working_dir}/hbase-*-log-*.txt"
   exit $status
 fi
 
@@ -98,7 +200,7 @@ fi
 echo "Staging HBase site"
 mvn \
   --batch-mode \
-  --log-file="${WORKSPACE}/hbase-stage-log-${CURRENT_HBASE_COMMIT}.txt" \
+  --log-file="${working_dir}/hbase-stage-log-${CURRENT_HBASE_COMMIT}.txt" \
   site:stage
 status=$?
 if [ $status -ne 0 ] || [ ! -d target/staging ]; then
@@ -107,7 +209,7 @@ if [ $status -ne 0 ] || [ ! -d target/staging ]; then
 fi
 
 # Get ready to update the hbase-site repo with the new artifacts
-cd "${WORKSPACE}/hbase-site" || exit -1
+cd "${working_dir}/hbase-site"
 
 #Remove previously-generated files
 FILES_TO_REMOVE=("hbase-*"
@@ -125,46 +227,59 @@ FILES_TO_REMOVE=("hbase-*"
                  "images")
 
 for FILE in "${FILES_TO_REMOVE[@]}"; do
-  echo "Removing ${WORKSPACE}/hbase-site/$FILE"
-  rm -Rf "${FILE}"
+  if [ -e "${FILE}" ]; then
+    echo "Removing hbase-site/$FILE"
+    rm -Rf "${FILE}"
+  fi
 done
 
 # Copy in the newly-built artifacts
-cp -au "${WORKSPACE}"/hbase/target/staging/* .
+# TODO what do we do when the site build wants to remove something? Can't rsync because e.g. release-specific docs.
+cp -pPR "${component_dir}"/target/staging/* .
 
 # If the index.html is missing, bail because this is serious
 if [ ! -f index.html ]; then
   echo "The index.html is missing. Aborting."
   exit 1
-else
-  # Add all the changes
-  echo "Adding all the files we know about"
-  git add .
-  # Create the commit message and commit the changes
-  WEBSITE_COMMIT_MSG="Published site at $CURRENT_HBASE_COMMIT."
-  echo "WEBSITE_COMMIT_MSG: $WEBSITE_COMMIT_MSG"
-  git commit -m "${WEBSITE_COMMIT_MSG}" -a
-  # Dump a little report
-  echo "This commit changed these files (excluding Modified files):"
-  git diff --name-status --diff-filter=ADCRTXUB origin/asf-site
-  # Create a patch, which Jenkins can save as an artifact and can be examined for debugging
-  git format-patch --stdout origin/asf-site > "${WORKSPACE}/${CURRENT_HBASE_COMMIT}.patch"
-  echo "Change set saved to patch ${WORKSPACE}/${CURRENT_HBASE_COMMIT}.patch"
-  # Push the real commit
-  git push origin asf-site || (echo "Failed to push to asf-site. Website not updated." && exit -1)
-  # Create an empty commit to work around INFRA-10751
-  git commit --allow-empty -m "INFRA-10751 Empty commit"
-  # Push the empty commit
-  git push origin asf-site || (echo "Failed to push the empty commit to asf-site. Website may not update. Manually push an empty commit to fix this. (See INFRA-10751)" && exit -1)
-  echo "Pushed the changes to branch asf-site. Refresh http://hbase.apache.org/ to see the changes within a few minutes."
-  git fetch origin
-  git reset --hard origin/asf-site
-
-  # Zip up the patch so Jenkins can save it
-  cd "${WORKSPACE}" || exit -1
-  zip website.patch.zip "${CURRENT_HBASE_COMMIT}.patch"
 fi
 
-#echo "Dumping current environment:"
-#env
+echo "Adding all the files we know about"
+git add .
+# Create the commit message and commit the changes
+WEBSITE_COMMIT_MSG="Published site at $CURRENT_HBASE_COMMIT."
+echo "WEBSITE_COMMIT_MSG: $WEBSITE_COMMIT_MSG"
+git commit -m "${WEBSITE_COMMIT_MSG}" -a
+# Dump a little report
+echo "This commit changed these files (excluding Modified files):"
+git diff --name-status --diff-filter=ADCRTXUB origin/asf-site | tee "${working_dir}/hbase-file-diff-summary-${CURRENT_HBASE_COMMIT}.txt"
+# Create a patch, which Jenkins can save as an artifact and can be examined for debugging
+git format-patch --stdout origin/asf-site > "${working_dir}/${CURRENT_HBASE_COMMIT}.patch"
+if [ ! -s "${working_dir}/${CURRENT_HBASE_COMMIT}.patch" ]; then
+  echo "Something went wrong when creating the patch of our updated site."
+  exit 1
+fi
+echo "Change set saved to patch ${working_dir}/${CURRENT_HBASE_COMMIT}.patch"
 
+if [ -n "${publish}" ]; then
+  echo "Publishing changes to remote repo..."
+  if git push origin asf-site; then
+    "changes pushed."
+  else
+    echo "Failed to push to asf-site. Website not updated."
+    exit 1
+  fi
+  echo "Sending empty commit to work around INFRA-10751."
+  git commit --allow-empty -m "INFRA-10751 Empty commit"
+  # Push the empty commit
+  if git push origin asf-site; then
+    echo "empty commit pushed."
+  else
+    echo "Failed to push the empty commit to asf-site. Website may not update. Manually push an empty commit to fix this. (See INFRA-10751)"
+    exit 1
+  fi
+  echo "Pushed the changes to branch asf-site. Refresh http://hbase.apache.org/ to see the changes within a few minutes."
+fi
+
+# Zip up the patch so Jenkins can save it
+cd "${working_dir}"
+zip website.patch.zip "${CURRENT_HBASE_COMMIT}.patch"

--- a/hbase-annotations/pom.xml
+++ b/hbase-annotations/pom.xml
@@ -35,6 +35,13 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-checkstyle-plugin</artifactId>
         <configuration>
           <failOnViolation>true</failOnViolation>

--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -98,13 +98,6 @@
           </descriptors>
         </configuration>
       </plugin>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
       <plugin>
         <artifactId>maven-dependency-plugin</artifactId>
         <executions>

--- a/hbase-backup/pom.xml
+++ b/hbase-backup/pom.xml
@@ -32,13 +32,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-build-configuration/pom.xml
+++ b/hbase-build-configuration/pom.xml
@@ -35,6 +35,13 @@
   <build>
     <plugins>
       <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-client/pom.xml
+++ b/hbase-client/pom.xml
@@ -36,13 +36,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-common/pom.xml
+++ b/hbase-common/pom.xml
@@ -63,13 +63,6 @@
         <artifactId>maven-remote-resources-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-endpoint/pom.xml
+++ b/hbase-endpoint/pom.xml
@@ -35,13 +35,6 @@
   </properties>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-examples/pom.xml
+++ b/hbase-examples/pom.xml
@@ -33,13 +33,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-external-blockcache/pom.xml
+++ b/hbase-external-blockcache/pom.xml
@@ -47,13 +47,6 @@
         <artifactId>maven-remote-resources-plugin</artifactId>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-hadoop-compat/pom.xml
+++ b/hbase-hadoop-compat/pom.xml
@@ -37,13 +37,6 @@
 
     <build>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
       <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>

--- a/hbase-hadoop2-compat/pom.xml
+++ b/hbase-hadoop2-compat/pom.xml
@@ -35,13 +35,6 @@ limitations under the License.
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-http/pom.xml
+++ b/hbase-http/pom.xml
@@ -51,13 +51,6 @@
       </testResource>
     </testResources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- licensing info from our bundled works -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-it/pom.xml
+++ b/hbase-it/pom.xml
@@ -53,13 +53,6 @@
     </testResources>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
         <!-- Make a jar and put the sources in the jar -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-mapreduce/pom.xml
+++ b/hbase-mapreduce/pom.xml
@@ -39,13 +39,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-metrics-api/pom.xml
+++ b/hbase-metrics-api/pom.xml
@@ -33,13 +33,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-metrics/pom.xml
+++ b/hbase-metrics/pom.xml
@@ -33,13 +33,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-procedure/pom.xml
+++ b/hbase-procedure/pom.xml
@@ -34,13 +34,6 @@
 
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-protocol-shaded/pom.xml
+++ b/hbase-protocol-shaded/pom.xml
@@ -47,13 +47,6 @@
       </resource>
     </resources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-protocol/pom.xml
+++ b/hbase-protocol/pom.xml
@@ -34,13 +34,6 @@
   </properties>
   <build>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-replication/pom.xml
+++ b/hbase-replication/pom.xml
@@ -34,13 +34,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-resource-bundle/pom.xml
+++ b/hbase-resource-bundle/pom.xml
@@ -40,13 +40,6 @@
   <build>
     <plugins>
       <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <configuration>
-              <skip>true</skip>
-          </configuration>
-      </plugin>
-      <plugin>
           <!--Make it so assembly:single does nothing in here-->
           <artifactId>maven-assembly-plugin</artifactId>
           <configuration>

--- a/hbase-rest/pom.xml
+++ b/hbase-rest/pom.xml
@@ -51,13 +51,6 @@
     </testResources>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-rsgroup/pom.xml
+++ b/hbase-rsgroup/pom.xml
@@ -32,13 +32,6 @@
   <build>
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -65,13 +65,6 @@
       </testResource>
     </testResources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- licensing info from our bundled works -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-shaded/hbase-shaded-check-invariants/pom.xml
+++ b/hbase-shaded/hbase-shaded-check-invariants/pom.xml
@@ -71,6 +71,13 @@
     <plugins>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-site-plugin</artifactId>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
         <dependencies>
           <dependency>

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -65,13 +65,6 @@
     <build>
         <plugins>
             <plugin>
-                <groupId>org.apache.maven.plugins</groupId>
-                <artifactId>maven-site-plugin</artifactId>
-                <configuration>
-                    <skip>true</skip>
-                </configuration>
-            </plugin>
-            <plugin>
                 <!--Make it so assembly:single does nothing in here-->
                 <artifactId>maven-assembly-plugin</artifactId>
                 <configuration>

--- a/hbase-shell/pom.xml
+++ b/hbase-shell/pom.xml
@@ -50,13 +50,6 @@
       </testResource>
     </testResources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Run with -Dmaven.test.skip.exec=true to build -tests.jar without running
         tests (this is needed for upstream projects whose tests need this jar simply for
         compilation) -->

--- a/hbase-spark-it/pom.xml
+++ b/hbase-spark-it/pom.xml
@@ -46,13 +46,6 @@
   <build>
     <pluginManagement>
       <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
         <!-- Make a jar and put the sources in the jar -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-testing-util/pom.xml
+++ b/hbase-testing-util/pom.xml
@@ -29,17 +29,6 @@
     <artifactId>hbase-testing-util</artifactId>
     <name>Apache HBase - Testing Util</name>
     <description>HBase Testing Utilities.</description>
-    <build>
-      <plugins>
-        <plugin>
-          <groupId>org.apache.maven.plugins</groupId>
-          <artifactId>maven-site-plugin</artifactId>
-          <configuration>
-            <skip>true</skip>
-          </configuration>
-        </plugin>
-      </plugins>
-    </build>
     <dependencies>
         <!-- Intra-project dependencies -->
         <dependency>

--- a/hbase-thrift/pom.xml
+++ b/hbase-thrift/pom.xml
@@ -70,13 +70,6 @@
 
     <plugins>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
-      <plugin>
         <!--Make it so assembly:single does nothing in here-->
         <artifactId>maven-assembly-plugin</artifactId>
         <configuration>

--- a/hbase-zookeeper/pom.xml
+++ b/hbase-zookeeper/pom.xml
@@ -51,13 +51,6 @@
       </testResource>
     </testResources>
     <plugins>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-site-plugin</artifactId>
-        <configuration>
-          <skip>true</skip>
-        </configuration>
-      </plugin>
       <!-- Run with -Dmaven.test.skip.exec=true to build -tests.jar without running
         tests (this is needed for upstream projects whose tests need this jar simply for
         compilation) -->

--- a/pom.xml
+++ b/pom.xml
@@ -606,6 +606,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
            <artifactId>maven-javadoc-plugin</artifactId>
+           <version>${maven.javadoc.version}</version>
         </plugin>
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1474,6 +1475,7 @@
     <maven.eclipse.version>2.10</maven.eclipse.version>
     <maven.install.version>2.5.2</maven.install.version>
     <maven.jar.version>3.0.2</maven.jar.version>
+    <maven.javadoc.version>3.0.0</maven.javadoc.version>
     <maven.patch.version>1.2</maven.patch.version>
     <maven.scala.version>2.15.2</maven.scala.version>
     <maven.shade.version>3.0.0</maven.shade.version>
@@ -1544,6 +1546,9 @@
         this parameter by invoking mvn with -Dbuild.id=$BUILD_ID-->
     <build.id>${maven.build.timestamp}</build.id>
     <shell-executable>bash</shell-executable>
+    <!-- TODO HBASE-15041 clean up our javadocs so jdk8 linter can be used.
+         property as of javadoc-plugin 3.0.0 -->
+    <doclint>none</doclint>
   </properties>
   <!-- Sorted by groups of dependencies then groupId and artifactId -->
   <dependencyManagement>
@@ -2239,14 +2244,6 @@
       <build>
         <pluginManagement>
           <plugins>
-            <plugin>
-              <groupId>org.apache.maven.plugins</groupId>
-              <artifactId>maven-javadoc-plugin</artifactId>
-              <configuration>
-                <!-- TODO HBASE-15041 clean up our javadocs so jdk8 linter can be used -->
-                <additionalparam>-Xdoclint:none</additionalparam>
-              </configuration>
-            </plugin>
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>findbugs-maven-plugin</artifactId>
@@ -3486,7 +3483,7 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-javadoc-plugin</artifactId>
-        <version>3.0.0</version>
+        <version>${maven.javadoc.version}</version>
         <reportSets>
           <!-- Dev API -->
           <reportSet>


### PR DESCRIPTION
* rely on git plumbing commands when checking if we've built the site for a particular commit already
* switch to forcing '-e' for bash
* add command line switches for: path to hbase, working directory, and publishing
* only export JAVA/MAVEN HOME if they aren't already set.
* add some docs about assumptions
* Update javadoc plugin to consistently be version 3.0.0
* avoid duplicative site invocations on reactor modules
* update use of cp command so it works both on linux and mac
* manually skip enforcer plugin during build
* still doing install of all jars due to MJAVADOC-490, but then skip rebuilding during aggregate reports.
* avoid the pager on git-diff by teeing to a log file, which also helps later reviewing in the case of big changesets.