### PR TITLE
HBASE-20684: Documentation fix (class Scan)

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Scan.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Scan.java
@@ -483,7 +483,7 @@ public class Scan extends Query {
    * @return this
    * @throws IllegalArgumentException if stopRow does not meet criteria for a row key (when length
    *           exceeds {@link HConstants#MAX_ROW_LENGTH})
-   * @deprecated use {@link #withStartRow(byte[])} instead. This method may change the inclusive of
+   * @deprecated use {@link #withStopRow(byte[])} instead. This method may change the inclusive of
    *             the stop row to keep compatible with the old behavior.
    */
   @Deprecated


### PR DESCRIPTION
Fix incorrect method reference in documentation. setStopRow method is deprecated and withStopRow should be used instead (was a matcher to withStartRow)