### PR TITLE
HBASE-20665: Changed log level of HBASE-8547 warning to debug

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
@@ -391,7 +391,7 @@ public class LruBlockCache implements ResizableBlockCache, HeapSize {
       } else {
         String msg = "Cached an already cached block: " + cacheKey + " cb:" + cb.getCacheKey();
         msg += ". This is harmless and can happen in rare cases (see HBASE-8547)";
-        LOG.warn(msg);
+        LOG.debug(msg);
         return;
       }
     }


### PR DESCRIPTION
As raised on the associated JIRA, the log level for a message about a block being cached twice was *warn*, when it should be *debug*.

merging to master for now, but the JIRA suggests we should also backport to multiple versions.