### PR TITLE
HBASE-20766. Typo "remove cluster" error

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/replication/VerifyReplication.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/replication/VerifyReplication.java
@@ -352,7 +352,7 @@ public class VerifyReplication extends Configured implements Tool {
       return Pair.newPair(peerConfig,
         ReplicationUtils.getPeerClusterConfiguration(peerConfig, conf));
     } catch (ReplicationException e) {
-      throw new IOException("An error occurred while trying to connect to the remove peer cluster",
+      throw new IOException("An error occurred while trying to connect to the remote peer cluster",
           e);
     } finally {
       if (localZKW != null) {


### PR DESCRIPTION
It was a trivial typo error on line 355 "remove cluster" instead of "remote cluster.

Fix it.