### PR TITLE
 Fixing a well known binary search bug, -ve bounds

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/RowIndexSeekerV1.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/RowIndexSeekerV1.java
@@ -126,10 +126,10 @@ public class RowIndexSeekerV1 extends AbstractEncodedSeeker {
   private int binarySearch(Cell seekCell, boolean seekBefore) {
     int low = 0;
     int high = rowNumber - 1;
-    int mid = (low + high) >>> 1;
+    int mid = low + (high - low) >> 1;
     int comp = 0;
     while (low <= high) {
-      mid = (low + high) >>> 1;
+      mid = mid = low + (high - low) >> 1;
       ByteBuffer row = getRow(mid);
       comp = compareRows(row, seekCell);
       if (comp < 0) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/RowIndexSeekerV1.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/RowIndexSeekerV1.java
@@ -129,7 +129,7 @@ public class RowIndexSeekerV1 extends AbstractEncodedSeeker {
     int mid = low + (high - low) >> 1;
     int comp = 0;
     while (low <= high) {
-      mid = mid = low + (high - low) >> 1;
+      mid = low + (high - low) >> 1;
       ByteBuffer row = getRow(mid);
       comp = compareRows(row, seekCell);
       if (comp < 0) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/RowIndexSeekerV1.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/RowIndexSeekerV1.java
@@ -126,10 +126,10 @@ public class RowIndexSeekerV1 extends AbstractEncodedSeeker {
   private int binarySearch(Cell seekCell, boolean seekBefore) {
     int low = 0;
     int high = rowNumber - 1;
-    int mid = low + (high - low) >> 1;
+    int mid = low + ((high - low) >> 1);
     int comp = 0;
     while (low <= high) {
-      mid = low + (high - low) >> 1;
+      mid = low + ((high - low) >> 1);
       ByteBuffer row = getRow(mid);
       comp = compareRows(row, seekCell);
       if (comp < 0) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/nio/ByteBuff.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/nio/ByteBuff.java
@@ -527,7 +527,7 @@ public abstract class ByteBuff {
     int high = toIndex - 1;
 
     while (low <= high) {
-      int mid = low + (high - low) >> 1;
+      int mid = low + ((high - low) >> 1);
       int midVal = a.get(mid) & 0xff;
 
       if (midVal < unsignedKey) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/nio/ByteBuff.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/nio/ByteBuff.java
@@ -527,7 +527,7 @@ public abstract class ByteBuff {
     int high = toIndex - 1;
 
     while (low <= high) {
-      int mid = (low + high) >>> 1;
+      int mid = low + (high - low) >> 1;
       int midVal = a.get(mid) & 0xff;
 
       if (midVal < unsignedKey) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/Bytes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/Bytes.java
@@ -2104,7 +2104,7 @@ public class Bytes implements Comparable<Bytes> {
     int low = 0;
     int high = arr.length - 1;
     while (low <= high) {
-      int mid = (low+high) >>> 1;
+      int mid = low + ((high - low) >> 1);
       // we have to compare in this order, because the comparator order
       // has special logic when the 'left side' is a special key.
       int cmp = comparator.compare(key, arr[mid]);

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/Bytes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/Bytes.java
@@ -2029,7 +2029,7 @@ public class Bytes implements Comparable<Bytes> {
     int high = arr.length - 1;
 
     while (low <= high) {
-      int mid = low + (high - low) >> 1;
+      int mid = low + ((high - low) >> 1);
       // we have to compare in this order, because the comparator order
       // has special logic when the 'left side' is a special key.
       int cmp = Bytes.BYTES_RAWCOMPARATOR
@@ -2278,7 +2278,7 @@ public class Bytes implements Comparable<Bytes> {
     int high = toIndex - 1;
 
     while (low <= high) {
-      int mid = low + (high - low) >> 1;
+      int mid = low + ((high - low) >> 1);
       int midVal = a[mid] & 0xff;
 
       if (midVal < unsignedKey) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/Bytes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/Bytes.java
@@ -2029,7 +2029,7 @@ public class Bytes implements Comparable<Bytes> {
     int high = arr.length - 1;
 
     while (low <= high) {
-      int mid = (low + high) >>> 1;
+      int mid = low + (high - low) >> 1;
       // we have to compare in this order, because the comparator order
       // has special logic when the 'left side' is a special key.
       int cmp = Bytes.BYTES_RAWCOMPARATOR
@@ -2278,7 +2278,7 @@ public class Bytes implements Comparable<Bytes> {
     int high = toIndex - 1;
 
     while (low <= high) {
-      int mid = (low + high) >>> 1;
+      int mid = low + (high - low) >> 1;
       int midVal = a[mid] & 0xff;
 
       if (midVal < unsignedKey) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
@@ -745,7 +745,7 @@ public class HFileBlockIndex {
       ByteBufferKeyOnlyKeyValue nonRootIndexkeyOnlyKV = new ByteBufferKeyOnlyKeyValue();
       ObjectIntPair<ByteBuffer> pair = new ObjectIntPair<>();
       while (low <= high) {
-        mid = (low + high) >>> 1;
+        mid = low + (high - low) >> 1;
 
         // Midkey's offset relative to the end of secondary index
         int midKeyRelOffset = nonRootIndex.getIntAfterPosition(Bytes.SIZEOF_INT * (mid + 1));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
@@ -745,7 +745,7 @@ public class HFileBlockIndex {
       ByteBufferKeyOnlyKeyValue nonRootIndexkeyOnlyKV = new ByteBufferKeyOnlyKeyValue();
       ObjectIntPair<ByteBuffer> pair = new ObjectIntPair<>();
       while (low <= high) {
-        mid = low + (high - low) >> 1;
+        mid = low + ((high - low) >> 1);
 
         // Midkey's offset relative to the end of secondary index
         int midKeyRelOffset = nonRootIndex.getIntAfterPosition(Bytes.SIZEOF_INT * (mid + 1));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CellFlatMap.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CellFlatMap.java
@@ -83,7 +83,7 @@ public abstract class CellFlatMap implements NavigableMap<Cell,Cell> {
     int end = maxCellIdx - 1;
 
     while (begin <= end) {
-      int mid = (begin + end) >>> 1;
+      int mid = begin + ((end - begin) >> 1);
       Cell midCell = getCell(mid);
       int compareRes = comparator.compare(midCell, needle);
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/BoundedPriorityBlockingQueue.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/BoundedPriorityBlockingQueue.java
@@ -119,7 +119,7 @@ public class BoundedPriorityBlockingQueue<E> extends AbstractQueue<E> implements
 
     private int upperBound(int start, int end, E key) {
       while (start < end) {
-        int mid = (start + end) >>> 1;
+        int mid = start + ((end - start) >> 1);
         E mitem = objects[mid];
         int cmp = comparator.compare(mitem, key);
         if (cmp > 0) {


### PR DESCRIPTION
  There are couple of issues in the code being fixed:
*  `>>>` operator would mess the values if `low` + `high` end up being negative.  This shouldn't happen but I don't see anything to prevent this from happening. 

* The code fails around boundary values of `low` and `high`. This is a well known binary search catch. https://ai.googleblog.com/2006/06/extra-extra-read-all-about-it-nearly.html