### PR TITLE
HBASE-21011 Provide CLI option to run oldwals and hfiles cleaner separately when cleaner chore is disabled

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hbase.replication.ReplicationException;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
 import org.apache.hadoop.hbase.replication.ReplicationPeerDescription;
 import org.apache.hadoop.hbase.replication.SyncReplicationState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.CleanerType;
 import org.apache.hadoop.hbase.snapshot.HBaseSnapshotException;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotException;
 import org.apache.hadoop.hbase.snapshot.SnapshotCreationException;
@@ -1266,10 +1267,12 @@ public interface Admin extends Abortable, Closeable {
   /**
    * Ask for cleaner chore to run.
    *
+   * @param cleanerType HFILES, OLDWALS, or DEFAULT that first execute HFILES cleaner then OLDWALS
+   *                    cleaner chore
    * @return <code>true</code> if cleaner chore ran, <code>false</code> otherwise
    * @throws IOException
    */
-  boolean runCleanerChore() throws IOException;
+  boolean runCleanerChore(final CleanerType cleanerType) throws IOException;
 
   /**
    * Query on the cleaner chore state (Enabled/Disabled?).

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hbase.quotas.QuotaSettings;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
 import org.apache.hadoop.hbase.replication.ReplicationPeerDescription;
 import org.apache.hadoop.hbase.replication.SyncReplicationState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.CleanerType;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -1169,7 +1170,7 @@ public interface AsyncAdmin {
    * @return true if cleaner chore ran, false otherwise. The return value will be wrapped by a
    *         {@link CompletableFuture}
    */
-  CompletableFuture<Boolean> runCleanerChore();
+  CompletableFuture<Boolean> runCleanerChore(CleanerType cleanerType);
 
   /**
    * Turn the catalog janitor on/off.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hbase.quotas.QuotaSettings;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
 import org.apache.hadoop.hbase.replication.ReplicationPeerDescription;
 import org.apache.hadoop.hbase.replication.SyncReplicationState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.CleanerType;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -708,8 +709,8 @@ class AsyncHBaseAdmin implements AsyncAdmin {
   }
 
   @Override
-  public CompletableFuture<Boolean> runCleanerChore() {
-    return wrap(rawAdmin.runCleanerChore());
+  public CompletableFuture<Boolean> runCleanerChore(CleanerType cleanerType) {
+    return wrap(rawAdmin.runCleanerChore(cleanerType));
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
@@ -30,6 +30,7 @@ import java.util.HashMap;
 import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.Callable;
@@ -127,6 +128,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos.CoprocessorServiceRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos.CoprocessorServiceResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.CleanerType;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.ProcedureDescription;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.RegionSpecifier.RegionSpecifierType;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.TableSchema;
@@ -1662,12 +1664,16 @@ public class HBaseAdmin implements Admin {
     });
   }
 
+  public boolean runCleanerChore(final String cleanerType) throws IOException {
+    return runCleanerChore(CleanerType.valueOf(cleanerType.toUpperCase(Locale.ROOT)));
+  }
+
   @Override
-  public boolean runCleanerChore() throws IOException {
+  public boolean runCleanerChore(final CleanerType cleanerType) throws IOException {
     return executeCallable(new MasterCallable<Boolean>(getConnection(), getRpcControllerFactory()) {
       @Override public Boolean rpcCall() throws Exception {
         return master.runCleanerChore(getRpcController(),
-            RequestConverter.buildRunCleanerChoreRequest()).getCleanerChoreRan();
+            RequestConverter.buildRunCleanerChoreRequest(cleanerType)).getCleanerChoreRan();
       }
     });
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -122,6 +122,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.StopServerR
 import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.StopServerResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.UpdateConfigurationRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.UpdateConfigurationResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.CleanerType;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.ProcedureDescription;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.RegionSpecifier.RegionSpecifierType;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.TableSchema;
@@ -3174,13 +3175,13 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
   }
 
   @Override
-  public CompletableFuture<Boolean> runCleanerChore() {
+  public CompletableFuture<Boolean> runCleanerChore(CleanerType cleanerType) {
     return this
         .<Boolean> newMasterCaller()
         .action(
           (controller, stub) -> this
               .<RunCleanerChoreRequest, RunCleanerChoreResponse, Boolean> call(controller, stub,
-                RequestConverter.buildRunCleanerChoreRequest(),
+                RequestConverter.buildRunCleanerChoreRequest(cleanerType),
                 (s, c, req, done) -> s.runCleanerChore(c, req, done),
                 (resp) -> resp.getCleanerChoreRan())).call();
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
@@ -91,6 +91,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos.MutationPr
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos.RegionAction;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos.ScanRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.CleanerType;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.CompareType;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.RegionSpecifier;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.RegionSpecifier.RegionSpecifierType;
@@ -1560,17 +1561,11 @@ public final class RequestConverter {
   }
 
   /**
-   * @see #buildRunCleanerChoreRequest()
-   */
-  private static final RunCleanerChoreRequest CLEANER_CHORE_REQUEST =
-    RunCleanerChoreRequest.newBuilder().build();
-
-  /**
    * Creates a request for running cleaner chore
    * @return A {@link RunCleanerChoreRequest}
    */
-  public static RunCleanerChoreRequest buildRunCleanerChoreRequest() {
-    return CLEANER_CHORE_REQUEST;
+  public static RunCleanerChoreRequest buildRunCleanerChoreRequest(CleanerType cleanerType) {
+    return RunCleanerChoreRequest.newBuilder().setType(cleanerType).build();
   }
 
   /**

--- a/hbase-protocol-shaded/src/main/protobuf/HBase.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/HBase.proto
@@ -274,3 +274,10 @@ message RegionLocation {
   optional ServerName server_name = 2;
   required int64 seq_num = 3;
 }
+
+/* cleaner chore type */
+enum CleanerType {
+  DEFAULT = 0;
+  HFILES = 1;
+  OLDWALS = 2;
+}

--- a/hbase-protocol-shaded/src/main/protobuf/Master.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/Master.proto
@@ -373,6 +373,7 @@ message IsCatalogJanitorEnabledResponse {
 }
 
 message RunCleanerChoreRequest {
+  required CleanerType type = 1;
 }
 
 message RunCleanerChoreResponse {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestRpcAccessChecks.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestRpcAccessChecks.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hbase.ipc.protobuf.generated.TestProtos;
 import org.apache.hadoop.hbase.ipc.protobuf.generated.TestRpcServiceProtos;
 import org.apache.hadoop.hbase.security.AccessDeniedException;
 import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.CleanerType;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.SecurityTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -223,7 +224,7 @@ public class TestRpcAccessChecks {
 
   @Test
   public void testRunCleanerChore() throws Exception {
-    verifyAdminCheckForAction((admin) -> admin.runCleanerChore());
+    verifyAdminCheckForAction((admin) -> admin.runCleanerChore(CleanerType.DEFAULT));
   }
 
   @Test

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -272,8 +272,9 @@ module Hbase
 
     #----------------------------------------------------------------------------------------------
     # Request cleaner chore to run (for garbage collection of HFiles and WAL files)
-    def cleaner_chore_run
-      @admin.runCleanerChore
+    def cleaner_chore_run(type = "default")
+      raise(ArgumentError, "Cleaner type name must be of type String") unless type.kind_of?(String)
+      @admin.runCleanerChore(type)
     end
 
     #----------------------------------------------------------------------------------------------

--- a/hbase-shell/src/main/ruby/shell/commands/cleaner_chore_run.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/cleaner_chore_run.rb
@@ -24,12 +24,18 @@ module Shell
 Cleaner chore command for garbage collection of HFiles and WAL files.
 
   hbase> cleaner_chore_run
-
+  hbase> cleaner_chore_run 'hfiles'
+  hbase> cleaner_chore_run 'oldwals'
 EOF
       end
 
-      def command
-        admin.cleaner_chore_run
+      def command(type = "default")
+        ret = admin.cleaner_chore_run(type)
+        if ret
+          puts 'Ran the cleaner(s) and succeeded.'
+        else
+          puts "Couldn't run the cleaner(s) if cleaner chore is enabled or ran but failed."
+        end
       end
     end
   end


### PR DESCRIPTION
There is a corner case when cleaner chore for HFiles and oldwals is disabled, admin/user needs to manually execute admin command `cleaner_chore_run` to clean the old HFiles and oldwals. Existing logic of `cleaner_chore_run` is to firstly trigger the HFiles cleaner and then oldwals cleaner, and only return succeed if both completes. 

but when running this `cleaner_chore_run` command, there is a potential use case that admin would like trigger the cleaner for only oldwals or hfiles but still keep the automatic cleaner chore disabled. So, this change aims to provide support for this corner case, and provide flexibility for those user with cleaner chore disabled by default to execute admin CLI to run oldwals and HFiles cleaning procedure individually.

NOTE that `cleaner_chore_run` was introduced in HBASE-17280, this patch added options 'hfiles' and 'oldwals' to it. Also changed default behavior of `cleaner_chore_run` will be only ran when cleaner chore is set to disabled.

JIRA https://issues.apache.org/jira/browse/HBASE-21011