### PR TITLE
HBASE-20521 change getConf as first sequence instead of jobContext in…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mapreduce/TableOutputFormat.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mapreduce/TableOutputFormat.java
@@ -173,9 +173,13 @@ implements Configurable {
   @Override
   public void checkOutputSpecs(JobContext context) throws IOException,
       InterruptedException {
+    Configuration hConf = getConf();
+    if (hConf == null) {
+      hConf = context.getConfiguration();
+    }
 
-    try (Admin admin = ConnectionFactory.createConnection(getConf()).getAdmin()) {
-      TableName tableName = TableName.valueOf(this.conf.get(OUTPUT_TABLE));
+    try (Admin admin = ConnectionFactory.createConnection(hConf).getAdmin()) {
+      TableName tableName = TableName.valueOf(hConf.get(OUTPUT_TABLE));
       if (!admin.tableExists(tableName)) {
         throw new TableNotFoundException("Can't write, table does not exist:" +
             tableName.getNameAsString());


### PR DESCRIPTION
… checkoutspecs 1.4

checkoutspecs to use context configuration if it is null  to work in 1.4.x versions, it is merged in 2.x version