### PR TITLE
HBASE-21400 correct spelling error of 'initilize' in comment

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
@@ -579,7 +579,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
 
   private void negotiateCryptoAes(RPCProtos.CryptoCipherMeta cryptoCipherMeta)
       throws IOException {
-    // initilize the Crypto AES with CryptoCipherMeta
+    // initialize the Crypto AES with CryptoCipherMeta
     saslRpcClient.initCryptoCipher(cryptoCipherMeta, this.rpcClient.conf);
     // reset the inputStream/outputStream for Crypto AES encryption
     this.in = new DataInputStream(new BufferedInputStream(saslRpcClient.getInputStream()));


### PR DESCRIPTION
When I learned the code of HBase-RPC,I found a spelling error in the comment. I changed the 'initilize' to 'initialize'