### PR TITLE
Update findbugs-maven-plugin version [1.3 branch]

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -571,7 +571,7 @@
         <plugin>
           <groupId>org.codehaus.mojo</groupId>
           <artifactId>findbugs-maven-plugin</artifactId>
-          <version>3.0.0</version>
+          <version>3.0.5</version>
           <!--NOTE: Findbugs 3.0.0 requires jdk7-->
           <configuration>
             <excludeFilterFile>${project.basedir}/../dev-support/findbugs-exclude.xml</excludeFilterFile>

--- a/pom.xml
+++ b/pom.xml
@@ -1907,7 +1907,7 @@
             <plugin>
               <groupId>org.codehaus.mojo</groupId>
               <artifactId>findbugs-maven-plugin</artifactId>
-              <version>3.0.0</version>
+              <version>3.0.5</version>
               <!--NOTE: Findbugs 3.0.0 requires jdk7-->
               <configuration>
                 <excludeFilterFile>${project.basedir}/../dev-support/findbugs-exclude.xml</excludeFilterFile>


### PR DESCRIPTION
 Makes build compatible with Maven 3.6.0