### PR TITLE
a bug of checking if restoreDir is subDir of rootDir

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/RestoreSnapshotHelper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/RestoreSnapshotHelper.java
@@ -827,7 +827,7 @@ public class RestoreSnapshotHelper {
       throw new IllegalArgumentException("Filesystems for restore directory and HBase root " +
           "directory should be the same");
     }
-    if (restoreDir.toUri().getPath().startsWith(rootDir.toUri().getPath())) {
+    if (restoreDir.toUri().getPath().startsWith(rootDir.toUri().getPath() + "/" )) {
       throw new IllegalArgumentException("Restore directory cannot be a sub directory of HBase " +
           "root directory. RootDir: " + rootDir + ", restoreDir: " + restoreDir);
     }


### PR DESCRIPTION
The restoreDir shouldn't be a sub directory of rootDir. The code check it with a prefix check "restoreDir.toUri().getPath().startsWith(rootDir.toUri().getPath())". But it goes error in some reasonable cases.

eg: rootDir = hdfs://user/hbase restoreDir = hdfs://user/hbase_restore. So I think it's more reasonable to chang the code to "restoreDir.toUri().getPath().startsWith(rootDir.toUri().getPath() + "/" )".

jira:https://issues.apache.org/jira/browse/HBASE-22070