### PR TITLE
HBASE-22174 Remove error prone from our precommit javac check

### DIFF
--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -153,6 +153,7 @@ pipeline {
                         YETUS_ARGS+=("--whitespace-tabs-ignore-list=.*/generated/.*")
                         YETUS_ARGS+=("--personality=${SOURCEDIR}/dev-support/hbase-personality.sh")
                         YETUS_ARGS+=("--quick-hadoopcheck")
+                        YETUS_ARGS+=("--skip-errorprone")
                         # effectively treat dev-support as a custom maven module
                         YETUS_ARGS+=("--skip-dir=dev-support")
                         # help keep the ASF boxes clean

--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -94,6 +94,9 @@ function personality_parse_args
       --hadoop-profile=*)
         HADOOP_PROFILE=${i#*=}
       ;;
+      --skip-errorprone)
+        SKIP_ERRORPRONE=true
+      ;;
     esac
   done
 }
@@ -166,7 +169,7 @@ function personality_modules
     return
   fi
 
-  if [[ ${testtype} == compile ]]; then
+  if [[ ${testtype} == compile ]] && [[ "${SKIP_ERRORPRONE}" != "true" ]]; then
     extra="${extra} -PerrorProne"
   fi
 


### PR DESCRIPTION
The output of the error prone check is not stable, sometimes we miss several warnings, and sometimes the order of the warnings are changed. Remove it for now. Can add back later after we fix all these problems. Or another solution is to add it back as a separated check in pre commit and add it to the filter list, so it will only generate a -0 instead of -1.