### PR TITLE
HBASE-22188 Make TestSplitMerge more stable

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestSplitMerge.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestSplitMerge.java
@@ -79,6 +79,7 @@ public class TestSplitMerge {
         return "Split has not finished yet";
       }
     });
+    UTIL.waitUntilNoRegionsInTransition();
     RegionInfo regionA = null;
     RegionInfo regionB = null;
     for (RegionInfo region : UTIL.getAdmin().getRegions(tableName)) {


### PR DESCRIPTION
Add a `UTIL.waitUntilNoRegionsInTransition();`  before merging to make sure that the split regions are all online.