### PR TITLE
HBASE-22189 Removed remaining usage of StoreFile.getModificationTimeStamp

### DIFF
--- a/hbase-server/src/main/resources/hbase-webapps/regionserver/region.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/regionserver/region.jsp
@@ -69,7 +69,7 @@
          <tr>
            <td><a href="storeFile.jsp?name=<%= sf.getPath() %>"><%= sf.getPath() %></a></td>
            <td><%= (int) (rs.getFileSystem().getLength(sf.getPath()) / 1024 / 1024) %></td>
-           <td><%= new Date(sf.getModificationTimeStamp()) %></td>
+           <td><%= new Date(sf.getModificationTimestamp()) %></td>
          </tr>
          <% } %>
 


### PR DESCRIPTION
Moved the remaining usage of `StoreFile.getModificationTimeStamp` to `StoreFile.getModificationTimestamp`.