### PR TITLE
HBASE-22243 Removed deprecated method in Result

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Result.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Result.java
@@ -924,16 +924,6 @@ public class Result implements CellScannable, CellScanner {
   }
 
   /**
-   * @deprecated the word 'partial' ambiguous, use {@link #mayHaveMoreCellsInRow()} instead.
-   *             Deprecated since 1.4.0.
-   * @see #mayHaveMoreCellsInRow()
-   */
-  @Deprecated
-  public boolean isPartial() {
-    return mayHaveMoreCellsInRow;
-  }
-
-  /**
    * For scanning large rows, the RS may choose to return the cells chunk by chunk to prevent OOM
    * or timeout. This flag is used to tell you if the current Result is the last one of the current
    * row. False means this Result is the last one. True means there MAY be more cells belonging to


### PR DESCRIPTION
Removed the deprecated method - isPartial() from Result.
Fixes: [HBASE-22243](https://issues.apache.org/jira/browse/HBASE-22243)