### PR TITLE
HBASE-22246 Removed deprecated field from MetricsReplicationSourceSource

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/replication/regionserver/MetricsReplicationSourceSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/replication/regionserver/MetricsReplicationSourceSource.java
@@ -28,11 +28,6 @@ public interface MetricsReplicationSourceSource extends BaseSource {
   public static final String SOURCE_AGE_OF_LAST_SHIPPED_OP = "source.ageOfLastShippedOp";
   public static final String SOURCE_SHIPPED_BATCHES = "source.shippedBatches";
 
-  /**
-   * @deprecated Use {@link #SOURCE_SHIPPED_BYTES} instead
-   */
-  @Deprecated
-  public static final String SOURCE_SHIPPED_KBS = "source.shippedKBs";
   public static final String SOURCE_SHIPPED_BYTES = "source.shippedBytes";
   public static final String SOURCE_SHIPPED_OPS = "source.shippedOps";
 

--- a/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/replication/regionserver/MetricsReplicationGlobalSourceSource.java
+++ b/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/replication/regionserver/MetricsReplicationGlobalSourceSource.java
@@ -36,12 +36,6 @@ public class MetricsReplicationGlobalSourceSource implements MetricsReplicationS
   private final MutableFastCounter shippedBatchesCounter;
   private final MutableFastCounter shippedOpsCounter;
   private final MutableFastCounter shippedBytesCounter;
-
-  /**
-   * @deprecated since 1.3.0. Use {@link #shippedBytesCounter} instead.
-   */
-  @Deprecated
-  private final MutableFastCounter shippedKBsCounter;
   private final MutableFastCounter logReadInBytesCounter;
   private final MutableFastCounter shippedHFilesCounter;
   private final MutableGaugeLong sizeOfHFileRefsQueueGauge;
@@ -64,8 +58,6 @@ public class MetricsReplicationGlobalSourceSource implements MetricsReplicationS
     shippedBatchesCounter = rms.getMetricsRegistry().getCounter(SOURCE_SHIPPED_BATCHES, 0L);
 
     shippedOpsCounter = rms.getMetricsRegistry().getCounter(SOURCE_SHIPPED_OPS, 0L);
-
-    shippedKBsCounter = rms.getMetricsRegistry().getCounter(SOURCE_SHIPPED_KBS, 0L);
 
     shippedBytesCounter = rms.getMetricsRegistry().getCounter(SOURCE_SHIPPED_BYTES, 0L);
 
@@ -124,23 +116,6 @@ public class MetricsReplicationGlobalSourceSource implements MetricsReplicationS
 
   @Override public void incrShippedBytes(long size) {
     shippedBytesCounter.incr(size);
-    // obtained value maybe smaller than 1024. We should make sure that KB count
-    // eventually picks up even from multiple smaller updates.
-    incrementKBsCounter(shippedBytesCounter, shippedKBsCounter);
-  }
-
-  static void incrementKBsCounter(MutableFastCounter bytesCounter, MutableFastCounter kbsCounter) {
-    // Following code should be thread-safe.
-    long delta = 0;
-    while(true) {
-      long bytes = bytesCounter.value();
-      delta = (bytes / 1024) - kbsCounter.value();
-      if (delta > 0) {
-        kbsCounter.incr(delta);
-      } else {
-        break;
-      }
-    }
   }
 
   @Override public void incrLogReadInBytes(long size) {

--- a/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/replication/regionserver/MetricsReplicationSourceSourceImpl.java
+++ b/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/replication/regionserver/MetricsReplicationSourceSourceImpl.java
@@ -35,11 +35,6 @@ public class MetricsReplicationSourceSourceImpl implements MetricsReplicationSou
   private final String shippedOpsKey;
   private String keyPrefix;
 
-  /**
-   * @deprecated since 1.3.0. Use {@link #shippedBytesKey} instead.
-   */
-  @Deprecated
-  private final String shippedKBsKey;
   private final String shippedBytesKey;
   private final String logReadInBytesKey;
   private final String shippedHFilesKey;
@@ -51,7 +46,6 @@ public class MetricsReplicationSourceSourceImpl implements MetricsReplicationSou
   private final MutableFastCounter walEditsFilteredCounter;
   private final MutableFastCounter shippedBatchesCounter;
   private final MutableFastCounter shippedOpsCounter;
-  private final MutableFastCounter shippedKBsCounter;
   private final MutableFastCounter shippedBytesCounter;
   private final MutableFastCounter logReadInBytesCounter;
   private final MutableFastCounter shippedHFilesCounter;
@@ -88,9 +82,6 @@ public class MetricsReplicationSourceSourceImpl implements MetricsReplicationSou
 
     shippedOpsKey = this.keyPrefix + "shippedOps";
     shippedOpsCounter = rms.getMetricsRegistry().getCounter(shippedOpsKey, 0L);
-
-    shippedKBsKey = this.keyPrefix + "shippedKBs";
-    shippedKBsCounter = rms.getMetricsRegistry().getCounter(shippedKBsKey, 0L);
 
     shippedBytesKey = this.keyPrefix + "shippedBytes";
     shippedBytesCounter = rms.getMetricsRegistry().getCounter(shippedBytesKey, 0L);
@@ -162,8 +153,6 @@ public class MetricsReplicationSourceSourceImpl implements MetricsReplicationSou
 
   @Override public void incrShippedBytes(long size) {
     shippedBytesCounter.incr(size);
-    MetricsReplicationGlobalSourceSource
-      .incrementKBsCounter(shippedBytesCounter, shippedKBsCounter);
   }
 
   @Override public void incrLogReadInBytes(long size) {
@@ -177,7 +166,6 @@ public class MetricsReplicationSourceSourceImpl implements MetricsReplicationSou
 
     rms.removeMetric(shippedBatchesKey);
     rms.removeMetric(shippedOpsKey);
-    rms.removeMetric(shippedKBsKey);
     rms.removeMetric(shippedBytesKey);
 
     rms.removeMetric(logReadInBytesKey);


### PR DESCRIPTION
Removed the deprecated field- SOURCE_SHIPPED_KBS from MetricsReplicationSourceSource class and the required dependencies.

Fixes: [HBASE-22246](https://issues.apache.org/jira/browse/HBASE-22246)