### PR TITLE
HBASE-22260 Removed deprecated method in ReplicationLoadSink

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationLoadSink.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationLoadSink.java
@@ -31,15 +31,6 @@ public class ReplicationLoadSink {
     return this.ageOfLastAppliedOp;
   }
 
-  /**
-   * @deprecated Since hbase-2.0.0. Will be removed in 3.0.0.
-   * @see #getTimestampsOfLastAppliedOp()
-   */
-  @Deprecated
-  public long getTimeStampsOfLastAppliedOp() {
-    return getTimestampsOfLastAppliedOp();
-  }
-
   public long getTimestampsOfLastAppliedOp() {
     return this.timestampsOfLastAppliedOp;
   }


### PR DESCRIPTION
Removed deprecated methods in ReplicationLoadSink.
Fixes: [HBASE-22260](https://issues.apache.org/jira/browse/HBASE-22260)