### PR TITLE
HBASE-22283 Print row and table information when failed to get region location

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RpcRetryingCallerWithReadReplicas.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RpcRetryingCallerWithReadReplicas.java
@@ -322,8 +322,6 @@ public class RpcRetryingCallerWithReadReplicas {
       throws RetriesExhaustedException, DoNotRetryIOException, InterruptedIOException {
 
     RegionLocations rl;
-    String errorMsg = "Cannot get the location for replica" + replicaId + " of region for "
-        + Bytes.toStringBinary(row) + " in " + tableName;
     try {
       if (useCache) {
         rl = cConnection.locateRegion(tableName, row, true, true, replicaId);
@@ -333,10 +331,12 @@ public class RpcRetryingCallerWithReadReplicas {
     } catch (DoNotRetryIOException | InterruptedIOException | RetriesExhaustedException e) {
       throw e;
     } catch (IOException e) {
-      throw new RetriesExhaustedException(errorMsg, e);
+      throw new RetriesExhaustedException("Cannot get the location for replica" + replicaId
+          + " of region for " + Bytes.toStringBinary(row) + " in " + tableName, e);
     }
     if (rl == null) {
-      throw new RetriesExhaustedException(errorMsg);
+      throw new RetriesExhaustedException("Cannot get the location for replica" + replicaId
+          + " of region for " + Bytes.toStringBinary(row) + " in " + tableName);
     }
 
     return rl;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RpcRetryingCallerWithReadReplicas.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RpcRetryingCallerWithReadReplicas.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hbase.client;
 
 
+import static org.apache.hadoop.hbase.HConstants.PRIORITY_UNSET;
+
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.Collections;
@@ -34,18 +36,17 @@ import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.ipc.HBaseRpcController;
+import org.apache.hadoop.hbase.ipc.RpcControllerFactory;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.hbase.ipc.HBaseRpcController;
-import org.apache.hadoop.hbase.ipc.RpcControllerFactory;
+
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.RequestConverter;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
-import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
-
-import static org.apache.hadoop.hbase.HConstants.PRIORITY_UNSET;
 
 /**
  * Caller that goes to replica if the primary region does no answer within a configurable

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RpcRetryingCallerWithReadReplicas.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RpcRetryingCallerWithReadReplicas.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hbase.ipc.RpcControllerFactory;
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.RequestConverter;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 
 import static org.apache.hadoop.hbase.HConstants.PRIORITY_UNSET;
@@ -320,6 +321,8 @@ public class RpcRetryingCallerWithReadReplicas {
       throws RetriesExhaustedException, DoNotRetryIOException, InterruptedIOException {
 
     RegionLocations rl;
+    String errorMsg = "Cannot get the location for replica" + replicaId + " of region for "
+        + Bytes.toStringBinary(row) + " in " + tableName;
     try {
       if (useCache) {
         rl = cConnection.locateRegion(tableName, row, true, true, replicaId);
@@ -329,10 +332,10 @@ public class RpcRetryingCallerWithReadReplicas {
     } catch (DoNotRetryIOException | InterruptedIOException | RetriesExhaustedException e) {
       throw e;
     } catch (IOException e) {
-      throw new RetriesExhaustedException("Can't get the location for replica " + replicaId, e);
+      throw new RetriesExhaustedException(errorMsg, e);
     }
     if (rl == null) {
-      throw new RetriesExhaustedException("Can't get the location for replica " + replicaId);
+      throw new RetriesExhaustedException(errorMsg);
     }
 
     return rl;


### PR DESCRIPTION
## What is the purpose of the change

This PR refines the client logging message on `RpcRetryingCallerWithReadReplicas.getRegionLocations` for easier debugging.

## Brief change log

* Add row and table name into the logging message of `RpcRetryingCallerWithReadReplicas.getRegionLocations` when failed to get region location or the location got is null.


## Verifying this change

This change could be verified by existing tests.

## Does this pull request potentially affect one of the following parts:

  - Dependencies (does it add or upgrade a dependency): (no)
  - The public API, i.e., is any changed class annotated with `@Public(Evolving)`: (no)
  - The runtime code path (performance sensitive): (no)
  - Anything that affects deployment or recovery: AssignmentManager, WAL system, ZooKeeper: (no)
  - File system relative (HDFS/S3): (no)

## Documentation

  - Does this pull request introduce a new feature? (no)
  - If yes, how is the feature documented? (not applicable)
