### PR TITLE
fix PreemptiveFastFailInterceptor clean repeatedFailuresMap issue

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/PreemptiveFastFailInterceptor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/PreemptiveFastFailInterceptor.java
@@ -96,8 +96,11 @@ class PreemptiveFastFailInterceptor extends RetryingCallerInterceptor {
         HConstants.HBASE_CLIENT_FAST_FAIL_THREASHOLD_MS,
         HConstants.HBASE_CLIENT_FAST_FAIL_THREASHOLD_MS_DEFAULT);
     this.failureMapCleanupIntervalMilliSec = conf.getLong(
-        HConstants.HBASE_CLIENT_FAST_FAIL_CLEANUP_MS_DURATION_MS,
-        HConstants.HBASE_CLIENT_FAST_FAIL_CLEANUP_DURATION_MS_DEFAULT);
+            HConstants.HBASE_CLIENT_FAILURE_MAP_CLEANUP_INTERVAL_MS,
+            HConstants.HBASE_CLIENT_FAILURE_MAP_CLEANUP_INTERVAL_MS_DEFAULT);
+    this.fastFailClearingTimeMilliSec = conf.getLong(
+            HConstants.HBASE_CLIENT_FAST_FAIL_CLEANUP_MS_DURATION_MS,
+            HConstants.HBASE_CLIENT_FAST_FAIL_CLEANUP_DURATION_MS_DEFAULT);
     lastFailureMapCleanupTimeMilliSec = EnvironmentEdgeManager.currentTime();
   }
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1313,6 +1313,12 @@ public final class HConstants {
   public static final long HBASE_CLIENT_FAST_FAIL_THREASHOLD_MS_DEFAULT =
       60000;
 
+  public static final String HBASE_CLIENT_FAILURE_MAP_CLEANUP_INTERVAL_MS =
+          "hbase.client.failure.map.cleanup.interval";
+
+  public static final long HBASE_CLIENT_FAILURE_MAP_CLEANUP_INTERVAL_MS_DEFAULT =
+          600000;
+
   public static final String HBASE_CLIENT_FAST_FAIL_CLEANUP_MS_DURATION_MS =
       "hbase.client.fast.fail.cleanup.duration";
 


### PR DESCRIPTION
in PreemptiveFastFailInterceptor, the failureMapCleanupIntervalMilliSec and fastFailClearingTimeMilliSec are used to clean repeatedFailuresMap, but the HConstants.HBASE_CLIENT_FAST_FAIL_CLEANUP_MS_DURATION_MS seem to config fastFailClearingTimeMilliSec, and fastFailClearingTimeMilliSec has no config value. so in occasionallyCleanupFailureInformation function the else if branch will be always true.