### PR TITLE
HBASE-22294 Removed deprecated method from WALKeyImpl

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALKeyImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALKeyImpl.java
@@ -349,14 +349,6 @@ public class WALKeyImpl implements WALKey {
     return tablename;
   }
 
-  /** @return log sequence number
-   * @deprecated Use {@link #getSequenceId()}
-   */
-  @Deprecated
-  public long getLogSeqNum() {
-    return getSequenceId();
-  }
-
   /**
    * Used to set original sequenceId for WALKeyImpl during WAL replay
    */


### PR DESCRIPTION
Removed deprecated methods in ReplicationLoadSink.
Fixes: [HBASE-22294](https://issues.apache.org/jira/browse/HBASE-22294)