### PR TITLE
HBASE-22299 Documentation has incorrect default number of versions

### DIFF
--- a/src/main/asciidoc/_chapters/architecture.adoc
+++ b/src/main/asciidoc/_chapters/architecture.adoc
@@ -1816,8 +1816,8 @@ Instead, the expired data is filtered out and is not written back to the compact
 
 [[compaction.and.versions]]
 .Compaction and Versions
-When you create a Column Family, you can specify the maximum number of versions to keep, by specifying `HColumnDescriptor.setMaxVersions(int versions)`.
-The default value is `3`.
+When you create a Column Family, you can specify the maximum number of versions to keep, by specifying `ColumnFamilyDescriptorBuilder.setMaxVersions(int versions)`.
+The default value is `1`.
 If more versions than the specified maximum exist, the excess versions are filtered out and not written back to the compacted StoreFile.
 
 .Major Compactions Can Impact Query Results


### PR DESCRIPTION
Corrected the default value as 1. Also updated the deprecated HColumnDescriptor class and added ColumnFamilyDescriptorBuilder in the documentation.

Fixes: [HBASE-22299](https://issues.apache.org/jira/browse/HBASE-22299)