### PR TITLE
Related jiras that update our handling of Hadoop transitive dependencies

### DIFF
--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
@@ -978,6 +978,24 @@ Copyright 2010 FasterXML.com
   </supplement>
 
   <supplement>
+    <project> <!-- hadoop.profile=3.0 from hadoop-3.3.0 -->
+      <groupId>org.jline</groupId>
+      <artifactId>jline</artifactId>
+      <version>3.9.0</version>
+      <licenses>
+        <license>
+          <name>BSD license</name>
+          <url>https://opensource.org/licenses/BSD-3-Clause</url>
+          <distribution>repo</distribution>
+          <comments>
+            Copyright (c) 2002-2018, the original author or authors.
+          </comments>
+        </license>
+      </licenses>
+    </project>
+  </supplement>
+
+  <supplement>
     <project>
       <groupId>org.jruby.jcodings</groupId>
       <artifactId>jcodings</artifactId>

--- a/hbase-shaded/hbase-shaded-client-byo-hadoop/pom.xml
+++ b/hbase-shaded/hbase-shaded-client-byo-hadoop/pom.xml
@@ -58,4 +58,62 @@
         </dependency>
     </dependencies>
 
+    <profiles>
+      <!-- These hadoop profiles should be derived from those in the hbase-client
+           module. Essentially, you must list the same hadoop-* dependencies
+           so provided dependencies will not be transitively included.
+      -->
+      <profile>
+        <id>hadoop-2.0</id>
+        <activation>
+          <property>
+              <!--Below formatting for dev-support/generate-hadoopX-poms.sh-->
+              <!--h2--><name>!hadoop.profile</name>
+          </property>
+        </activation>
+        <dependencies>
+          <dependency>
+             <groupId>com.github.stephenc.findbugs</groupId>
+             <artifactId>findbugs-annotations</artifactId>
+             <optional>true</optional>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-auth</artifactId>
+            <scope>provided</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>provided</scope>
+          </dependency>
+        </dependencies>
+      </profile>
+
+      <!--
+        profile for building against Hadoop 3.0.x. Activate using:
+         mvn -Dhadoop.profile=3.0
+      -->
+      <profile>
+        <id>hadoop-3.0</id>
+        <activation>
+          <property>
+            <name>hadoop.profile</name>
+            <value>3.0</value>
+          </property>
+        </activation>
+        <dependencies>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-auth</artifactId>
+            <scope>provided</scope>
+          </dependency>
+          <dependency>
+            <groupId>org.apache.hadoop</groupId>
+            <artifactId>hadoop-common</artifactId>
+            <scope>provided</scope>
+          </dependency>
+        </dependencies>
+      </profile>
+    </profiles>
 </project>

--- a/hbase-shaded/hbase-shaded-mapreduce/pom.xml
+++ b/hbase-shaded/hbase-shaded-mapreduce/pom.xml
@@ -304,6 +304,17 @@
               <artifactId>hadoop-auth</artifactId>
               <scope>provided</scope>
             </dependency>
+            <dependency>
+              <groupId>org.apache.hadoop</groupId>
+              <artifactId>hadoop-mapreduce-client-core</artifactId>
+              <scope>provided</scope>
+              <exclusions>
+                <exclusion>
+                  <groupId>com.google.guava</groupId>
+                  <artifactId>guava</artifactId>
+                </exclusion>
+              </exclusions>
+            </dependency>
           </dependencies>
         </profile>
     </profiles>

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -214,6 +214,11 @@
                                         <shadedPattern>${shaded.prefix}.com.zaxxer</shadedPattern>
                                     </relocation>
 
+                                    <!-- dnsjava -->
+                                    <relocation>
+                                        <pattern>org.xbill</pattern>
+                                        <shadedPattern>${shaded.prefix}.org.xbill</shadedPattern>
+                                    </relocation>
 
                                     <!-- netty family -->
                                     <relocation>
@@ -426,6 +431,10 @@
                                         <pattern>org.apache.commons.codec</pattern>
                                         <shadedPattern>${shaded.prefix}.org.apache.commons.codec</shadedPattern>
                                     </relocation>
+                                    <relocation>
+                                        <pattern>org.apache.commons.text</pattern>
+                                        <shadedPattern>${shaded.prefix}.org.apache.commons.text</shadedPattern>
+                                    </relocation>
 
                                     <!-- top level net-->
                                     <relocation>
@@ -463,6 +472,16 @@
                                   </transformer>
                                 </transformers>
                                 <filters>
+                                    <!-- remove utility classes which are not required from dnsjava -->
+                                    <filter>
+                                        <artifact>dnsjava:dnsjava</artifact>
+                                        <excludes>
+                                            <exclude>dig*</exclude>
+                                            <exclude>jnamed*</exclude>
+                                            <exclude>lookup*</exclude>
+                                            <exclude>update*</exclude>
+                                        </excludes>
+                                    </filter>
                                   <filter>
                                     <!-- this is a signed osgi bundle -->
                                     <artifact>org.eclipse.jetty.orbit:javax.servlet.jsp.jstl</artifact>

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -233,8 +233,12 @@
 
                                     <!-- top level org -->
                                     <relocation>
-                                        <pattern>org.codehaus</pattern>
-                                        <shadedPattern>${shaded.prefix}.org.codehaus</shadedPattern>
+                                      <pattern>org.checkerframework</pattern>
+                                      <shadedPattern>${shaded.prefix}.org.checkerframework</shadedPattern>
+                                    </relocation>
+                                    <relocation>
+                                      <pattern>org.codehaus</pattern>
+                                      <shadedPattern>${shaded.prefix}.org.codehaus</shadedPattern>
                                     </relocation>
                                     <relocation>
                                         <pattern>org.eclipse</pattern>


### PR DESCRIPTION
This includes two general fixes that will be needed by all branch-2 releases

* HBASE-22312 when built against hadoop 3 our hbase-shaded-mapreduce module incorrectly includes the mapreduce client's transitive dependencies
* HBASE-22314 when built against hadoop 3 our hbase-shaded-client-byo-hadoop module incorrectly includes the hadoop client's transitive dependencies

and also two fixes that will only be needed for upcoming minor releases, since they fix problems that depend on which version(s) of Hadoop 3 end up getting released and built against. These are both modified versions of patches provided by other contributors.

* HBASE-22109 Update hbase shaded client for new transitive dependencies of guava after hadoop update
* HBASE-22087 Update LICENSE/shading for the dependencies from the latest Hadoop trunk