### PR TITLE
HBASE-22358 Change rubocop configuration for method length

### DIFF
--- a/hbase-shell/src/main/ruby/.rubocop.yml
+++ b/hbase-shell/src/main/ruby/.rubocop.yml
@@ -6,3 +6,6 @@ Layout/IndentHeredoc:
 
 Metrics/LineLength:
   Max: 100
+
+Metrics/MethodLength:
+  Max: 75


### PR DESCRIPTION
Changed configuration and analyzed the code and the change in configuration works. 