### PR TITLE
HBASE-22459 Expose store reader reference count

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/RegionLoad.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/RegionLoad.java
@@ -364,6 +364,13 @@ public class RegionLoad implements RegionMetrics {
   }
 
   /**
+   * @return the reference count for the stores of this region
+   */
+  public int getStoreRefCount() {
+    return metrics.getStoreRefCount();
+  }
+
+  /**
    * @see java.lang.Object#toString()
    */
   @Override
@@ -371,6 +378,7 @@ public class RegionLoad implements RegionMetrics {
     StringBuilder sb = Strings.appendKeyValue(new StringBuilder(), "numberOfStores",
         this.getStores());
     Strings.appendKeyValue(sb, "numberOfStorefiles", this.getStorefiles());
+    Strings.appendKeyValue(sb, "storeRefCount", this.getStoreRefCount());
     Strings.appendKeyValue(sb, "storefileUncompressedSizeMB",
         this.getStoreUncompressedSizeMB());
     Strings.appendKeyValue(sb, "lastMajorCompactionTimestamp",

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/RegionMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/RegionMetrics.java
@@ -150,4 +150,8 @@ public interface RegionMetrics {
    */
   long getLastMajorCompactionTimestamp();
 
+  /**
+   * @return the reference count for the stores of this region
+   */
+  int getStoreRefCount();
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/RegionMetricsBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/RegionMetricsBuilder.java
@@ -65,6 +65,7 @@ public final class RegionMetricsBuilder {
           Size.Unit.KILOBYTE))
         .setStoreCount(regionLoadPB.getStores())
         .setStoreFileCount(regionLoadPB.getStorefiles())
+        .setStoreRefCount(regionLoadPB.getStoreRefCount())
         .setStoreFileSize(new Size(regionLoadPB.getStorefileSizeMB(), Size.Unit.MEGABYTE))
         .setStoreSequenceIds(regionLoadPB.getStoreCompleteSequenceIdList().stream()
           .collect(Collectors.toMap(
@@ -111,6 +112,7 @@ public final class RegionMetricsBuilder {
           .get(Size.Unit.KILOBYTE))
         .setStores(regionMetrics.getStoreCount())
         .setStorefiles(regionMetrics.getStoreCount())
+        .setStoreRefCount(regionMetrics.getStoreRefCount())
         .setStorefileSizeMB((int) regionMetrics.getStoreFileSize().get(Size.Unit.MEGABYTE))
         .addAllStoreCompleteSequenceId(toStoreSequenceId(regionMetrics.getStoreSequenceId()))
         .setStoreUncompressedSizeMB(
@@ -125,6 +127,7 @@ public final class RegionMetricsBuilder {
   private final byte[] name;
   private int storeCount;
   private int storeFileCount;
+  private int storeRefCount;
   private long compactingCellCount;
   private long compactedCellCount;
   private Size storeFileSize = Size.ZERO;
@@ -152,6 +155,10 @@ public final class RegionMetricsBuilder {
   }
   public RegionMetricsBuilder setStoreFileCount(int value) {
     this.storeFileCount = value;
+    return this;
+  }
+  public RegionMetricsBuilder setStoreRefCount(int value) {
+    this.storeRefCount = value;
     return this;
   }
   public RegionMetricsBuilder setCompactingCellCount(long value) {
@@ -227,6 +234,7 @@ public final class RegionMetricsBuilder {
     return new RegionMetricsImpl(name,
         storeCount,
         storeFileCount,
+        storeRefCount,
         compactingCellCount,
         compactedCellCount,
         storeFileSize,
@@ -250,6 +258,7 @@ public final class RegionMetricsBuilder {
     private final byte[] name;
     private final int storeCount;
     private final int storeFileCount;
+    private final int storeRefCount;
     private final long compactingCellCount;
     private final long compactedCellCount;
     private final Size storeFileSize;
@@ -270,6 +279,7 @@ public final class RegionMetricsBuilder {
     RegionMetricsImpl(byte[] name,
         int storeCount,
         int storeFileCount,
+        int storeRefCount,
         final long compactingCellCount,
         long compactedCellCount,
         Size storeFileSize,
@@ -290,6 +300,7 @@ public final class RegionMetricsBuilder {
       this.name = Preconditions.checkNotNull(name);
       this.storeCount = storeCount;
       this.storeFileCount = storeFileCount;
+      this.storeRefCount = storeRefCount;
       this.compactingCellCount = compactingCellCount;
       this.compactedCellCount = compactedCellCount;
       this.storeFileSize = Preconditions.checkNotNull(storeFileSize);
@@ -322,6 +333,11 @@ public final class RegionMetricsBuilder {
     @Override
     public int getStoreFileCount() {
       return storeFileCount;
+    }
+
+    @Override
+    public int getStoreRefCount() {
+      return storeRefCount;
     }
 
     @Override
@@ -415,6 +431,8 @@ public final class RegionMetricsBuilder {
           this.getStoreCount());
       Strings.appendKeyValue(sb, "storeFileCount",
           this.getStoreFileCount());
+      Strings.appendKeyValue(sb, "storeRefCount",
+        this.getStoreRefCount());
       Strings.appendKeyValue(sb, "uncompressedStoreFileSize",
           this.getUncompressedStoreFileSize());
       Strings.appendKeyValue(sb, "lastMajorCompactionTimestamp",

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSource.java
@@ -231,6 +231,8 @@ public interface MetricsRegionServerSource extends BaseSource, JvmPauseMonitorSo
   String WALFILE_SIZE_DESC = "Size of all WAL Files";
   String STOREFILE_COUNT = "storeFileCount";
   String STOREFILE_COUNT_DESC = "Number of Store Files";
+  String STORE_REF_COUNT = "storeRefCount";
+  String STORE_REF_COUNT_DESC = "Store reference count";
   String MEMSTORE_SIZE = "memStoreSize";
   String MEMSTORE_SIZE_DESC = "Size of the memstore";
   String STOREFILE_SIZE = "storeFileSize";

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionWrapper.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionWrapper.java
@@ -159,4 +159,9 @@ public interface MetricsRegionWrapper {
    * Get the replica id of this region.
    */
   int getReplicaId();
+
+  /**
+   * @return the number of references active on the store
+   */
+  long getStoreRefCount();
 }

--- a/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionSourceImpl.java
+++ b/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionSourceImpl.java
@@ -214,6 +214,10 @@ public class MetricsRegionSourceImpl implements MetricsRegionSource {
               MetricsRegionServerSource.STOREFILE_COUNT_DESC),
           this.regionWrapper.getNumStoreFiles());
       mrb.addGauge(Interns.info(
+              regionNamePrefix + MetricsRegionServerSource.STORE_REF_COUNT,
+              MetricsRegionServerSource.STORE_REF_COUNT),
+          this.regionWrapper.getStoreRefCount());
+      mrb.addGauge(Interns.info(
               regionNamePrefix + MetricsRegionServerSource.MEMSTORE_SIZE,
               MetricsRegionServerSource.MEMSTORE_SIZE_DESC),
           this.regionWrapper.getMemStoreSize());

--- a/hbase-hadoop2-compat/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsRegionSourceImpl.java
+++ b/hbase-hadoop2-compat/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsRegionSourceImpl.java
@@ -95,6 +95,11 @@ public class TestMetricsRegionSourceImpl {
     }
 
     @Override
+    public long getStoreRefCount() {
+      return 0;
+    }
+
+    @Override
     public long getMemStoreSize() {
       return 0;
     }

--- a/hbase-protocol-shaded/src/main/protobuf/ClusterStatus.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/ClusterStatus.proto
@@ -146,6 +146,9 @@ message RegionLoad {
 
   /** the current total coprocessor requests made to region */
   optional uint64 cp_requests_count = 20;
+
+  /** the number of references active on the store */
+  optional int32 store_ref_count = 21 [default = 0];
 }
 
 /* Server-level protobufs */

--- a/hbase-protocol/src/main/protobuf/ClusterStatus.proto
+++ b/hbase-protocol/src/main/protobuf/ClusterStatus.proto
@@ -142,6 +142,9 @@ message RegionLoad {
 
   /** the current total coprocessor requests made to region */
   optional uint64 cp_requests_count = 20;
+
+  /** the number of references active on the store */
+  optional int32 store_ref_count = 21 [default = 0];
 }
 
 /* Server-level protobufs */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -2776,4 +2776,10 @@ public class HStore implements Store, HeapSize, StoreConfigInformation, Propagat
   public int getCurrentParallelPutCount() {
     return currentParallelPutCount.get();
   }
+
+  public int getStoreRefCount() {
+    return this.storeEngine.getStoreFileManager().getStorefiles().stream()
+      .filter(sf -> sf.getReader() != null).filter(HStoreFile::isHFile)
+      .mapToInt(HStoreFile::getRefCount).sum();
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionWrapperImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionWrapperImpl.java
@@ -48,6 +48,7 @@ public class MetricsRegionWrapperImpl implements MetricsRegionWrapper, Closeable
   private ScheduledExecutorService executor;
   private Runnable runnable;
   private long numStoreFiles;
+  private long storeRefCount;
   private long memstoreSize;
   private long storeFileSize;
   private long maxStoreFileAge;
@@ -117,6 +118,11 @@ public class MetricsRegionWrapperImpl implements MetricsRegionWrapper, Closeable
   @Override
   public long getStoreFileSize() {
     return storeFileSize;
+  }
+
+  @Override
+  public long getStoreRefCount() {
+    return storeRefCount;
   }
 
   @Override
@@ -226,6 +232,7 @@ public class MetricsRegionWrapperImpl implements MetricsRegionWrapper, Closeable
     @Override
     public void run() {
       long tempNumStoreFiles = 0;
+      int tempStoreRefCount = 0;
       long tempMemstoreSize = 0;
       long tempStoreFileSize = 0;
       long tempMaxStoreFileAge = 0;
@@ -237,8 +244,9 @@ public class MetricsRegionWrapperImpl implements MetricsRegionWrapper, Closeable
       long avgAgeNumerator = 0;
       long numHFiles = 0;
       if (region.stores != null) {
-        for (Store store : region.stores.values()) {
+        for (HStore store : region.stores.values()) {
           tempNumStoreFiles += store.getStorefilesCount();
+          tempStoreRefCount += store.getStoreRefCount();
           tempMemstoreSize += store.getMemStoreSize().getDataSize();
           tempStoreFileSize += store.getStorefilesSize();
           OptionalLong storeMaxStoreFileAge = store.getMaxStoreFileAge();
@@ -265,6 +273,7 @@ public class MetricsRegionWrapperImpl implements MetricsRegionWrapper, Closeable
       }
 
       numStoreFiles = tempNumStoreFiles;
+      storeRefCount = tempStoreRefCount;
       memstoreSize = tempMemstoreSize;
       storeFileSize = tempStoreFileSize;
       maxStoreFileAge = tempMaxStoreFileAge;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/MetricsRegionWrapperStub.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/MetricsRegionWrapperStub.java
@@ -61,6 +61,11 @@ public class MetricsRegionWrapperStub implements MetricsRegionWrapper {
   }
 
   @Override
+  public long getStoreRefCount() {
+    return 0;
+  }
+
+  @Override
   public long getMemStoreSize() {
     return 103;
   }


### PR DESCRIPTION


Expose the reference count over a region's store file readers as a metric in region metrics and also as a new field in RegionLoad. This will make visible the reader reference count over all stores in the region to both metrics capture and anything that consumes ClusterStatus, like the shell's status command and the master UI.

Coprocessors that wrap scanners might leak them, which will leak readers. We log when this happens but in order to notice the increasing trend of reference counts you have to scrape log output. It would be better if this information is also available as a metric.