### PR TITLE
HBASE-22451 TestLoadIncrementalHFiles and TestSecureLoadIncrementalHFiles are flaky

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/TableNamespaceManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/TableNamespaceManager.java
@@ -235,14 +235,16 @@ public class TableNamespaceManager {
       return true;
     }
 
+    if (zkNamespaceManager == null) {
+      zkNamespaceManager = new ZKNamespaceManager(masterServices.getZooKeeper());
+      zkNamespaceManager.start();
+    }
+
     // Now check if the table is assigned, if not then fail fast
     if (isTableAssigned()) {
       try {
         boolean initGoodSofar = true;
         nsTable = this.masterServices.getConnection().getTable(TableName.NAMESPACE_TABLE_NAME);
-        zkNamespaceManager = new ZKNamespaceManager(masterServices.getZooKeeper());
-        zkNamespaceManager.start();
-
         if (get(nsTable, NamespaceDescriptor.DEFAULT_NAMESPACE.getName()) == null) {
           if (createNamespaceAync) {
             masterServices.getMasterProcedureExecutor().submitProcedure(


### PR DESCRIPTION
Start ZKNamespaceManager as first step in TableNamespaceManager initialization