### PR TITLE
HBASE-22481: Javadoc Warnings reference not found

### DIFF
--- a/hbase-checkstyle/src/main/resources/hbase/checkstyle-suppressions.xml
+++ b/hbase-checkstyle/src/main/resources/hbase/checkstyle-suppressions.xml
@@ -45,5 +45,4 @@
   <suppress checks="IllegalImport" message="org\.apache\.htrace\.core"/>
   <suppress checks="ImportOrder" message="Extra separation in import group before"/>
   <suppress checks="MethodLength" files="DemoClient.java"/>
-  <suppress checks="LineLength" files="[\\/]org.apache.hadoop.hbase.mapred[\\/].*\.java$"/>
 </suppressions>

--- a/hbase-checkstyle/src/main/resources/hbase/checkstyle-suppressions.xml
+++ b/hbase-checkstyle/src/main/resources/hbase/checkstyle-suppressions.xml
@@ -45,5 +45,5 @@
   <suppress checks="IllegalImport" message="org\.apache\.htrace\.core"/>
   <suppress checks="ImportOrder" message="Extra separation in import group before"/>
   <suppress checks="MethodLength" files="DemoClient.java"/>
-  <suppress checks="LineLength" files="MultiTableSnapshotInputFormat.java"/>
+  <suppress checks="LineLength" files="[\\/]org.apache.hadoop.hbase.mapred[\\/].*\.java$"/>
 </suppressions>

--- a/hbase-checkstyle/src/main/resources/hbase/checkstyle-suppressions.xml
+++ b/hbase-checkstyle/src/main/resources/hbase/checkstyle-suppressions.xml
@@ -45,4 +45,5 @@
   <suppress checks="IllegalImport" message="org\.apache\.htrace\.core"/>
   <suppress checks="ImportOrder" message="Extra separation in import group before"/>
   <suppress checks="MethodLength" files="DemoClient.java"/>
+  <suppress checks="LineLength" files="MultiTableSnapshotInputFormat.java"/>
 </suppressions>

--- a/hbase-checkstyle/src/main/resources/hbase/checkstyle.xml
+++ b/hbase-checkstyle/src/main/resources/hbase/checkstyle.xml
@@ -31,6 +31,10 @@
 
 -->
 <module name="Checker">
+  <!-- Filter out Checkstyle warnings that have been suppressed with the @SuppressWarnings
+  annotation -->
+  <module name="SuppressWarningsFilter"/>
+
   <module name="FileTabCharacter"/>
   <module name="TreeWalker">
 
@@ -130,5 +134,8 @@
     http://checkstyle.sourceforge.net/config_whitespace.html -->
     <module name="MethodParamPad"/>
     <module name="ParenPad"/>
+
+    <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
+    <module name="SuppressWarningsHolder"/>
   </module>
 </module>

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/MultiTableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/MultiTableSnapshotInputFormat.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hbase.mapred;
 
+import edu.umd.cs.findbugs.annotations.SuppressWarnings;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -107,6 +108,7 @@ public class MultiTableSnapshotInputFormat extends TableSnapshotInputFormat
     return new TableSnapshotRecordReader((TableSnapshotRegionSplit) split, job);
   }
 
+  @SuppressWarnings("checkstyle:linelength")
   /**
    * Configure conf to read from snapshotScans, with snapshots restored to a subdirectory of
    * restoreDir.

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/MultiTableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/MultiTableSnapshotInputFormat.java
@@ -44,7 +44,8 @@ import java.util.Map;
  * configured for each.
  * Internally, the input format delegates to
  * {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat}
- * and thus has the same performance advantages; see {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat}
+ * and thus has the same performance advantages; see
+ * {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat}
  * for more details.
  * Usage is similar to TableSnapshotInputFormat, with the following exception:
  * initMultiTableSnapshotMapperJob takes in a map
@@ -70,7 +71,8 @@ import java.util.Map;
  * </pre>
  * Internally, this input format restores each snapshot into a subdirectory of the given tmp
  * directory. Input splits and
- * record readers are created as described in {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat}
+ * record readers are created as described in
+ * {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat}
  * (one per region).
  * See {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat} for more notes on
  * permissioning; the
@@ -108,7 +110,8 @@ public class MultiTableSnapshotInputFormat extends TableSnapshotInputFormat
   /**
    * Configure conf to read from snapshotScans, with snapshots restored to a subdirectory of
    * restoreDir.
-   * Sets: {@link org.apache.hadoop.hbase.mapreduce.MultiTableSnapshotInputFormatImpl#RESTORE_DIRS_KEY},
+   * Sets:
+   * {@link org.apache.hadoop.hbase.mapreduce.MultiTableSnapshotInputFormatImpl#RESTORE_DIRS_KEY},
    * {@link org.apache.hadoop.hbase.mapreduce.MultiTableSnapshotInputFormatImpl#SNAPSHOT_TO_SCANS_KEY}
    *
    * @param conf

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/MultiTableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/MultiTableSnapshotInputFormat.java
@@ -38,15 +38,14 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * MultiTableSnapshotInputFormat generalizes {@link org.apache.hadoop.hbase.mapred
- * .TableSnapshotInputFormat}
+ * MultiTableSnapshotInputFormat generalizes
+ * {@link org.apache.hadoop.hbase.mapred.TableSnapshotInputFormat}
  * allowing a MapReduce job to run over one or more table snapshots, with one or more scans
  * configured for each.
- * Internally, the input format delegates to {@link org.apache.hadoop.hbase.mapreduce
- * .TableSnapshotInputFormat}
- * and thus has the same performance advantages; see {@link org.apache.hadoop.hbase.mapreduce
- * .TableSnapshotInputFormat} for
- * more details.
+ * Internally, the input format delegates to
+ * {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat}
+ * and thus has the same performance advantages; see {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat}
+ * for more details.
  * Usage is similar to TableSnapshotInputFormat, with the following exception:
  * initMultiTableSnapshotMapperJob takes in a map
  * from snapshot name to a collection of scans. For each snapshot in the map, each corresponding
@@ -71,8 +70,7 @@ import java.util.Map;
  * </pre>
  * Internally, this input format restores each snapshot into a subdirectory of the given tmp
  * directory. Input splits and
- * record readers are created as described in {@link org.apache.hadoop.hbase.mapreduce
- * .TableSnapshotInputFormat}
+ * record readers are created as described in {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat}
  * (one per region).
  * See {@link org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat} for more notes on
  * permissioning; the
@@ -110,10 +108,8 @@ public class MultiTableSnapshotInputFormat extends TableSnapshotInputFormat
   /**
    * Configure conf to read from snapshotScans, with snapshots restored to a subdirectory of
    * restoreDir.
-   * Sets: {@link org.apache.hadoop.hbase.mapreduce
-   * .MultiTableSnapshotInputFormatImpl#RESTORE_DIRS_KEY},
-   * {@link org.apache.hadoop.hbase.mapreduce
-   * .MultiTableSnapshotInputFormatImpl#SNAPSHOT_TO_SCANS_KEY}
+   * Sets: {@link org.apache.hadoop.hbase.mapreduce.MultiTableSnapshotInputFormatImpl#RESTORE_DIRS_KEY},
+   * {@link org.apache.hadoop.hbase.mapreduce.MultiTableSnapshotInputFormatImpl#SNAPSHOT_TO_SCANS_KEY}
    *
    * @param conf
    * @param snapshotScans


### PR DESCRIPTION
Fixed the warnings javadoc warnings for MultiTableSnapshotInputFormat.java file. 