### PR TITLE
[HBASE-22461] A "NullPointerException" could be thrown

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
@@ -1050,6 +1050,9 @@ public class MetaTableAccessor {
    */
   @Nullable
   private static RegionInfo getRegionInfo(final Result r, byte [] qualifier) {
+    if (r == null){
+      throw new NullPointerException("Result cannot be null");
+    }
     Cell cell = r.getColumnLatestCell(getCatalogFamily(), qualifier);
     if (cell == null) return null;
     return RegionInfo.parseFromOrNull(cell.getValueArray(),


### PR DESCRIPTION
In hbase-client model the class  "org.apache.hadoop.hbase.MetaTableAccessor"'s method getRegionInfo(final Result r, byte [] qualifier),A "NullPointerException" could be thrown; "r" is nullable here.

```java
@Nullable
private static RegionInfo getRegionInfo(final Result r, byte [] qualifier) {
  Cell cell = r.getColumnLatestCell(getCatalogFamily(), qualifier);
  if (cell == null) return null;
  return RegionInfo.parseFromOrNull(cell.getValueArray(),
    cell.getValueOffset(), cell.getValueLength());
}
```