### PR TITLE
HBASE-22513 Admin#getQuota does not work correctly if exceedThrottleQuota is set

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaRetriever.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaRetriever.java
@@ -26,6 +26,7 @@ import java.util.Objects;
 import java.util.Queue;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -102,6 +103,11 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
   public QuotaSettings next() throws IOException {
     if (cache.isEmpty()) {
       Result result = scanner.next();
+      // Skip exceedThrottleQuota row key because this is not a QuotaSettings
+      if (result != null
+          && Bytes.equals(result.getRow(), QuotaTableUtil.getExceedThrottleQuotaRowKey())) {
+        result = scanner.next();
+      }
       if (result == null) {
         return null;
       }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaAdmin.java
@@ -636,6 +636,7 @@ public class TestQuotaAdmin {
     assertTrue(admin.exceedThrottleQuotaSwitch(true));
     assertTrue(admin.exceedThrottleQuotaSwitch(false));
     assertFalse(admin.exceedThrottleQuotaSwitch(false));
+    assertEquals(2, admin.getQuota(new QuotaFilter()).size());
     admin.setQuota(QuotaSettingsFactory.unthrottleRegionServer(regionServer));
   }
 


### PR DESCRIPTION
Admin#getQuota get nothing if exceedThrottleQuota is set, because exceedThrottleQuota is a special row key in quota table and can not be parsed to a QuotaSettings.