### PR TITLE
HBASE-22519 New Hadoop 2.8 dependencies fail shaded invariants check

### DIFF
--- a/hbase-rsgroup/pom.xml
+++ b/hbase-rsgroup/pom.xml
@@ -203,44 +203,8 @@
           <artifactId>hadoop-common</artifactId>
           <exclusions>
             <exclusion>
-              <groupId>com.github.stephenc.findbugs</groupId>
-              <artifactId>findbugs-annotations</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>net.java.dev.jets3t</groupId>
-              <artifactId>jets3t</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>javax.servlet.jsp</groupId>
-              <artifactId>jsp-api</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>org.mortbay.jetty</groupId>
-              <artifactId>jetty</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>com.sun.jersey</groupId>
-              <artifactId>jersey-server</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>com.sun.jersey</groupId>
-              <artifactId>jersey-core</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>com.sun.jersey</groupId>
-              <artifactId>jersey-json</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>javax.servlet</groupId>
-              <artifactId>servlet-api</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>tomcat</groupId>
-              <artifactId>jasper-compiler</artifactId>
-            </exclusion>
-            <exclusion>
-              <groupId>tomcat</groupId>
-              <artifactId>jasper-runtime</artifactId>
+              <groupId>org.apache.htrace</groupId>
+              <artifactId>htrace-core</artifactId>
             </exclusion>
           </exclusions>
         </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -2283,6 +2283,10 @@
                 <groupId>net.minidev</groupId>
                 <artifactId>json-smart</artifactId>
               </exclusion>
+              <exclusion>
+                <groupId>com.nimbusds</groupId>
+                <artifactId>nimbus-jose-jwt</artifactId>
+              </exclusion>
             </exclusions>
           </dependency>
           <dependency>
@@ -2316,6 +2320,12 @@
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop-two.version}</version>
+            <exclusions>
+              <exclusion>
+                <groupId>com.squareup.okhttp</groupId>
+                <artifactId>okhttp</artifactId>
+              </exclusion>
+            </exclusions>
           </dependency>
           <!-- This was marked as test dep in earlier pom, but was scoped compile.
             Where do we actually need it? -->


### PR DESCRIPTION
These dependencies are not required for HBase communicating with Hadoop.

nimbusds is used in JWTRedirectAuthenticationHandler which was added by HADOOP-11717. It's server side functionality, although if we ever wanted to incorporate this functionality into our infoserver stack we'd want to un-exclude.

The okhttp dependency comes from HDFS-8155, support for OAuth2 credentials with WebHDFS. When bundled with HBase no WebHDFS options or access methods are utilized. 

Also remove duplicate exclusions from _hbase-rsgroups_ module. The exclusions in the parent _hbase_ module already apply. I do see htrace exclusions even in leaf modules so put that one there. No compelling reason to do so other than sake of consistency with other leaf POMs. Future followup could include tidying the POMs. Not in scope here (IMHO)