### PR TITLE
HBASE-22540 [Memstore] Correct counters in MemStoreChunkPool

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreChunkPool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreChunkPool.java
@@ -77,6 +77,7 @@ public class MemStoreChunkPool {
   private static final int statThreadPeriod = 60 * 5;
   private AtomicLong createdChunkCount = new AtomicLong();
   private AtomicLong reusedChunkCount = new AtomicLong();
+  private AtomicLong gotChunkCount = new AtomicLong();
 
   MemStoreChunkPool(Configuration conf, int chunkSize, int maxCount,
       int initialCount) {
@@ -88,6 +89,7 @@ public class MemStoreChunkPool {
       chunk.init();
       reclaimedChunks.add(chunk);
     }
+    createdChunkCount.set(initialCount);
     final String n = Thread.currentThread().getName();
     scheduleThreadPool = Executors.newScheduledThreadPool(1,
         new ThreadFactoryBuilder().setNameFormat(n+"-MemStoreChunkPool Statistics")
@@ -102,6 +104,7 @@ public class MemStoreChunkPool {
    * @return a chunk
    */
   Chunk getChunk() {
+    gotChunkCount.incrementAndGet();
     Chunk chunk = reclaimedChunks.poll();
     if (chunk == null) {
       chunk = new Chunk(chunkSize);
@@ -172,15 +175,16 @@ public class MemStoreChunkPool {
   }
 
   private void logStats() {
-    if (!LOG.isDebugEnabled()) return;
-    long created = createdChunkCount.get();
+    long total = createdChunkCount.get();
     long reused = reusedChunkCount.get();
-    long total = created + reused;
-    LOG.debug("Stats: current pool size=" + reclaimedChunks.size()
-        + ",created chunk count=" + created
-        + ",reused chunk count=" + reused
-        + ",reuseRatio=" + (total == 0 ? "0" : StringUtils.formatPercent(
-            (float) reused / (float) total, 2)));
+    long available = reclaimedChunks.size();
+    long got = gotChunkCount.get();
+    LOG.info("Stats: chunk in pool=" + available
+        + ", chunk in use=" + (total - available)
+        + ", total chunk=" + total
+        + ", reused chunk count=" + reused
+        + ", reuse ratio=" + (got == 0 ? "0" : StringUtils.formatPercent(
+            (float) reused / (float) got, 2)));
   }
 
   /**


### PR DESCRIPTION
Add a new counter `gotChunkCount` for calculating reuse ratio.
Correct `createdChunkCount` initial count.
Set `logStats` INFO level, every 5 minutes which is not very chatty, and it is useful information.