### PR TITLE
HBASE-22554 Upgrade to surefire 2.22.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1506,6 +1506,7 @@
     <maven.warbucks.version>1.1.0</maven.warbucks.version>
     <os.maven.version>1.5.0.Final</os.maven.version>
     <spotbugs.version>3.1.11</spotbugs.version>
+    <surefire.version>2.22.2</surefire.version>
     <wagon.ssh.version>2.12</wagon.ssh.version>
     <xml.maven.version>1.0.1</xml.maven.version>
     <hbase-thirdparty.version>2.2.1</hbase-thirdparty.version>


### PR DESCRIPTION
The `surefire.version` property is inherited from ASF parent pom with version 2.22.0.
[SUREFIRE-1614](https://issues.apache.org/jira/browse/SUREFIRE-1614) is included in 2.22.2 release which fixes an issue with corrupted outputs which could help us for fixing the issue described in [HBASE-22470](https://issues.apache.org/jira/browse/HBASE-22470).