### PR TITLE
[HBASE-22592] : HMaster Construction failure stacktrace to be availab…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMasterCommandLine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMasterCommandLine.java
@@ -242,6 +242,7 @@ public class HMasterCommandLine extends ServerCommandLine {
           throw new RuntimeException("HMaster Aborted");
       }
     } catch (Throwable t) {
+      t.printStackTrace();
       LOG.error("Master exiting", t);
       return 1;
     }


### PR DESCRIPTION
…le in .out file - Useful if Logger class is not loaded yet (branch-1)
This is cherry-pick from master branch PR: https://github.com/apache/hbase/pull/311

An example of Exception(NoSuchMethodError) which is not present in .log/.out files:

![image-2019-06-16-15-06-40-109](https://user-images.githubusercontent.com/34790606/59562475-f3933000-904a-11e9-8c31-7cdc0c8d4802.png)
