### PR TITLE
[HBASE-22592] : HMaster Construction failure stacktrace to be availab…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMasterCommandLine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMasterCommandLine.java
@@ -244,6 +244,7 @@ public class HMasterCommandLine extends ServerCommandLine {
           throw new RuntimeException("HMaster Aborted");
       }
     } catch (Throwable t) {
+      t.printStackTrace();
       LOG.error("Master exiting", t);
       return 1;
     }


### PR DESCRIPTION
…le in .out file - Useful if Logger class is not loaded yet (branch-2)
This is cherry-pick from master branch PR: #311 

An example of Exception(NoSuchMethodError) which is not present in .log/.out files:

![image-2019-06-16-15-06-40-109](https://user-images.githubusercontent.com/34790606/59564089-0cf2a700-9060-11e9-9eb7-8f80f4eba8eb.png)
