### PR TITLE
HBASE-22598 Deprecated the hbase.ipc.server.reservoir.initial.buffer.…

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
@@ -68,9 +68,32 @@ public class ByteBuffAllocator {
   // default heap allocator, it will just allocate ByteBuffers from heap but wrapped by an ByteBuff.
   public static final ByteBuffAllocator HEAP = ByteBuffAllocator.createOnHeap();
 
-  public static final String MAX_BUFFER_COUNT_KEY = "hbase.ipc.server.allocator.max.buffer.count";
+  public static final String MAX_BUFFER_COUNT_KEY = "hbase.server.allocator.max.buffer.count";
 
-  public static final String BUFFER_SIZE_KEY = "hbase.ipc.server.allocator.buffer.size";
+  public static final String BUFFER_SIZE_KEY = "hbase.server.allocator.buffer.size";
+
+  /**
+   * @deprecated use {@link ByteBuffAllocator#MAX_BUFFER_COUNT_KEY} instead.
+   */
+  @Deprecated
+  static final String DEPRECATED_MAX_BUFFER_COUNT_KEY = "hbase.ipc.server.reservoir.initial.max";
+
+  /**
+   * @deprecated use {@link ByteBuffAllocator#BUFFER_SIZE_KEY} instead.
+   */
+  @Deprecated
+  static final String DEPRECATED_BUFFER_SIZE_KEY = "hbase.ipc.server.reservoir.initial.buffer.size";
+
+  /**
+   * The hbase.ipc.server.reservoir.initial.max and hbase.ipc.server.reservoir.initial.buffer.size
+   * were introduced in HBase2.0.0, while in HBase3.0.0 the two config keys will be replaced by
+   * {@link ByteBuffAllocator#MAX_BUFFER_COUNT_KEY} and {@link ByteBuffAllocator#BUFFER_SIZE_KEY}.
+   * Keep the two old config keys here for HBase2.x compatibility.
+   */
+  static {
+    Configuration.addDeprecation(DEPRECATED_MAX_BUFFER_COUNT_KEY, MAX_BUFFER_COUNT_KEY);
+    Configuration.addDeprecation(DEPRECATED_BUFFER_SIZE_KEY, BUFFER_SIZE_KEY);
+  }
 
   /**
    * There're some reasons why better to choose 65KB(rather than 64KB) as the default buffer size:
@@ -129,6 +152,13 @@ public class ByteBuffAllocator {
    * @return ByteBuffAllocator to manage the byte buffers.
    */
   public static ByteBuffAllocator create(Configuration conf, boolean reservoirEnabled) {
+    if (conf.get(DEPRECATED_BUFFER_SIZE_KEY) != null
+        || conf.get(DEPRECATED_MAX_BUFFER_COUNT_KEY) != null) {
+      LOG.warn("The config keys {} and {} are deprecated now, instead please use {} and {}. In "
+            + "future release we will remove the two deprecated configs.",
+        DEPRECATED_BUFFER_SIZE_KEY, DEPRECATED_MAX_BUFFER_COUNT_KEY, BUFFER_SIZE_KEY,
+        MAX_BUFFER_COUNT_KEY);
+    }
     int poolBufSize = conf.getInt(BUFFER_SIZE_KEY, DEFAULT_BUFFER_SIZE);
     if (reservoirEnabled) {
       // The max number of buffers to be pooled in the ByteBufferPool. The default value been

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/TestByteBuffAllocator.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/TestByteBuffAllocator.java
@@ -25,12 +25,14 @@ import static org.junit.Assert.fail;
 
 import java.nio.ByteBuffer;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.MultiByteBuff;
 import org.apache.hadoop.hbase.nio.SingleByteBuff;
 import org.apache.hadoop.hbase.testclassification.RPCTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -337,5 +339,22 @@ public class TestByteBuffAllocator {
     } catch (Exception e) {
       // expected exception.
     }
+  }
+
+  @Test
+  public void testDeprecatedConfigs() {
+    Configuration conf = new Configuration();
+    conf.setInt(ByteBuffAllocator.DEPRECATED_MAX_BUFFER_COUNT_KEY, 10);
+    conf.setInt(ByteBuffAllocator.DEPRECATED_BUFFER_SIZE_KEY, 1024);
+    ByteBuffAllocator allocator = ByteBuffAllocator.create(conf, true);
+    Assert.assertEquals(1024, allocator.getBufferSize());
+    Assert.assertEquals(10, allocator.getTotalBufferCount());
+
+    conf = new Configuration();
+    conf.setInt(ByteBuffAllocator.MAX_BUFFER_COUNT_KEY, 11);
+    conf.setInt(ByteBuffAllocator.BUFFER_SIZE_KEY, 2048);
+    allocator = ByteBuffAllocator.create(conf, true);
+    Assert.assertEquals(2048, allocator.getBufferSize());
+    Assert.assertEquals(11, allocator.getTotalBufferCount());
   }
 }


### PR DESCRIPTION
…size & hbase.ipc.server.reservoir.initial.max for HBase2.x compatibility