### PR TITLE
HBASE-22613: Bump Apache Avro to 1.9.0

### DIFF
--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -318,10 +318,6 @@
 
                                     <!-- org.apache relocations not in org.apache.hadoop or org.apache.commons -->
                                     <relocation>
-                                        <pattern>org.apache.avro</pattern>
-                                        <shadedPattern>${shaded.prefix}.org.apache.avro</shadedPattern>
-                                    </relocation>
-                                    <relocation>
                                         <pattern>org.apache.curator</pattern>
                                         <shadedPattern>${shaded.prefix}.org.apache.curator</shadedPattern>
                                     </relocation>

--- a/pom.xml
+++ b/pom.xml
@@ -1439,7 +1439,6 @@
     <netty.hadoop.version>3.6.2.Final</netty.hadoop.version>
     <!-- end HBASE-15925 default hadoop compatibility values -->
     <audience-annotations.version>0.5.0</audience-annotations.version>
-    <avro.version>1.9.0</avro.version>
     <caffeine.version>2.6.2</caffeine.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-validator.version>1.6</commons-validator.version>
@@ -1839,12 +1838,6 @@
         <groupId>log4j</groupId>
         <artifactId>log4j</artifactId>
         <version>${log4j.version}</version>
-      </dependency>
-      <!-- Avro dependencies we mostly get transitively, manual version coallescing -->
-      <dependency>
-        <groupId>org.apache.avro</groupId>
-        <artifactId>avro</artifactId>
-        <version>${avro.version}</version>
       </dependency>
       <!--This is not used by hbase directly.  Used by thrift,
           dropwizard and zk.-->

--- a/pom.xml
+++ b/pom.xml
@@ -1439,7 +1439,7 @@
     <netty.hadoop.version>3.6.2.Final</netty.hadoop.version>
     <!-- end HBASE-15925 default hadoop compatibility values -->
     <audience-annotations.version>0.5.0</audience-annotations.version>
-    <avro.version>1.7.7</avro.version>
+    <avro.version>1.9.0</avro.version>
     <caffeine.version>2.6.2</caffeine.version>
     <commons-codec.version>1.10</commons-codec.version>
     <commons-validator.version>1.6</commons-validator.version>


### PR DESCRIPTION
I've compiled it locally and expected some breaking changes since we're upgrading from 1.7.7. But I did not find anything.

Apache Avro 1.9.0 brings a lot of new features:

- Deprecate Joda-Time in favor of Java8 JSR310 and setting it as default
- Remove support for Hadoop 1.x
- Move from Jackson 1.x to 2.9
- Add ZStandard Codec
- Lots of updates on the dependencies to fix CVE's
- Remove Jackson classes from public API
- Apache Avro is built by default with Java 8
- Apache Avro is compiled and tested with Java 11 to guarantee compatibility
- Apache Avro MapReduce is compiled and tested with Hadoop 3
- Apache Avro is now leaner, multiple dependencies were removed: guava, paranamer, commons-codec, and commons-logging
- and many, many more!