### PR TITLE
HBASE-22616 responseTooXXX logging for Multi should characterize the component ops

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
@@ -517,6 +517,28 @@ public abstract class RpcServer implements RpcServerInterface,
         }
       }
     }
+    if (param instanceof ClientProtos.MultiRequest) {
+      int numGets = 0;
+      int numMutations = 0;
+      int numServiceCalls = 0;
+      ClientProtos.MultiRequest multi = (ClientProtos.MultiRequest)param;
+      for (ClientProtos.RegionAction regionAction : multi.getRegionActionList()) {
+        for (ClientProtos.Action action: regionAction.getActionList()) {
+          if (action.hasMutation()) {
+            numMutations++;
+          }
+          if (action.hasGet()) {
+            numGets++;
+          }
+          if (action.hasServiceCall()) {
+            numServiceCalls++;
+          }
+        }
+      }
+      responseInfo.put("multi.gets", numGets);
+      responseInfo.put("multi.mutations", numMutations);
+      responseInfo.put("multi.servicecalls", numServiceCalls);
+    }
     LOG.warn("(response" + tag + "): " + GSON.toJson(responseInfo));
   }
 


### PR DESCRIPTION
Multi RPC can be a mix of gets and mutations. The responseTooXXX logging for Multi ops should characterize the operations within the request so we have some clue about whether read or write dispatch was involved.