### PR TITLE
HBASE-20405 Update website to meet foundation recommendations

### DIFF
--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -27,10 +27,10 @@ under the License.
 
   <body>
     <section name="Welcome to Apache HBase&#8482;">
-      <p><a href="http://www.apache.org/">Apache</a> HBase&#8482; is the <a href="http://hadoop.apache.org/">Hadoop</a> database, a distributed, scalable, big data store.</p>
+      <p><a href="https://www.apache.org/">Apache</a> HBase&#8482; is the <a href="https://hadoop.apache.org/">Hadoop</a> database, a distributed, scalable, big data store.</p>
       <p>Use Apache HBase&#8482; when you need random, realtime read/write access to your Big Data.
         This project's goal is the hosting of very large tables -- billions of rows X millions of columns -- atop clusters of commodity hardware.
-        Apache HBase is an open-source, distributed, versioned, non-relational database modeled after Google's <a href="http://research.google.com/archive/bigtable.html">Bigtable: A Distributed Storage System for Structured Data</a> by Chang et al.
+        Apache HBase is an open-source, distributed, versioned, non-relational database modeled after Google's <a href="https://research.google.com/archive/bigtable.html">Bigtable: A Distributed Storage System for Structured Data</a> by Chang et al.
         Just as Bigtable leverages the distributed data storage provided by the Google File System, Apache HBase provides Bigtable-like capabilities on top of Hadoop and HDFS.
       </p>
     </section>
@@ -60,15 +60,15 @@ under the License.
         <dt>Export Control</dt>
         <dd><p>The HBase distribution includes cryptographic software. See the export control notice <a href="export_control.html">here</a></p></dd>
         <dt>Code Of Conduct</dt>
-        <dd><p>We expect participants in discussions on the HBase project mailing lists, Slack and IRC channels, and JIRA issues to abide by the Apache Software Foundation's <a href="http://apache.org/foundation/policies/conduct.html">Code of Conduct</a>. More information can be found <a href="coc.html">here</a>.</p></dd>
+        <dd><p>We expect participants in discussions on the HBase project mailing lists, Slack and IRC channels, and JIRA issues to abide by the Apache Software Foundation's <a href="https://apache.org/foundation/policies/conduct.html">Code of Conduct</a>. More information can be found <a href="coc.html">here</a>.</p></dd>
         <dt>License</dt>
-        <dd><p>Apache HBase is licensed under the <a href="licenses.html">Apache License, Version 2.0</a></p></dd>
+        <dd><p>Apache HBase is licensed under the <a href="https://www.apache.org/licenses/LICENSE-2.0">Apache License, Version 2.0</a></p></dd>
         <dt>Trademarks</dt>
-        <dd><p>Apache HBase, HBase, Apache, the Apache feather logo, and the Apache HBase project logo are either <a href="http://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a> of The Apache Software Foundation in the United States and other countries.</p></dd>
+        <dd><p>Apache HBase, HBase, Apache, the Apache feather logo, and the Apache HBase project logo are either <a href="https://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a> of The Apache Software Foundation in the United States and other countries.</p></dd>
         <dt>Thanks</dt>
-        <dd><p>Thanks for all the sponsors, who are <a href="http://www.apache.org/foundation/thanks.html">supporting Apache</a> or <a href="sponsors.html">supporting the HBase project</a>!</p></dd>
+        <dd><p>Thanks for all the sponsors, who are <a href="https://www.apache.org/foundation/thanks.html">supporting Apache</a> or <a href="sponsors.html">supporting the HBase project</a>!</p></dd>
         <dt>Security and Vulnerability information</dt>
-        <dd><p>See the <a href="book.html#security">Security</a> chapter in the <a href="book.html#faq">Apache HBase Reference Guide</a>, and the general <a href="http://apache.org/security/">Apache Security information</a>!</p></dd>
+        <dd><p>See the <a href="book.html#security">Security</a> chapter in the <a href="book.html#faq">Apache HBase Reference Guide</a>, and the general <a href="https://apache.org/security/">Apache Security information</a>!</p></dd>
       </dl>
     </section>
 
@@ -79,7 +79,7 @@ under the License.
       <p>June 18th, 2018 <a href="https://hbase.apache.org/hbasecon-2018">HBaseCon North America West 2018</a> @ San Jose Convention Center, San Jose, CA, USA. registration still open, see site for details!</p>
       <p>August 4th, 2017 <a href="https://easychair.org/cfp/HBaseConAsia2017">HBaseCon Asia 2017</a> @ the Huawei Campus in Shenzhen, China</p>
       <p><small><a href="old_news.html">Old News</a></small></p>
-      <p><br/>The next Apache Event:<br/><a href="http://www.apache.org/events/current-event.html"><img src="http://www.apache.org/events/current-event-234x60.png"/></a></p>
+      <p><br/>The next Apache Event:<br/><a href="https://www.apache.org/events/current-event.html"><img src="https://www.apache.org/events/current-event-234x60.png"/></a></p>
     </section>
   </body>
 

--- a/src/site/xdoc/index.xml
+++ b/src/site/xdoc/index.xml
@@ -27,68 +27,59 @@ under the License.
 
   <body>
     <section name="Welcome to Apache HBase&#8482;">
-        <p><a href="http://www.apache.org/">Apache</a> HBase&#8482; is the <a href="http://hadoop.apache.org/">Hadoop</a> database, a distributed, scalable, big data store.
-    </p>
-    <p>Use Apache HBase&#8482; when you need random, realtime read/write access to your Big Data.
-    This project's goal is the hosting of very large tables -- billions of rows X millions of columns -- atop clusters of commodity hardware.
-Apache HBase is an open-source, distributed, versioned, non-relational database modeled after Google's <a href="http://research.google.com/archive/bigtable.html">Bigtable: A Distributed Storage System for Structured Data</a> by Chang et al.
- Just as Bigtable leverages the distributed data storage provided by the Google File System, Apache HBase provides Bigtable-like capabilities on top of Hadoop and HDFS.
-    </p>
-  </section>
+      <p><a href="http://www.apache.org/">Apache</a> HBase&#8482; is the <a href="http://hadoop.apache.org/">Hadoop</a> database, a distributed, scalable, big data store.</p>
+      <p>Use Apache HBase&#8482; when you need random, realtime read/write access to your Big Data.
+        This project's goal is the hosting of very large tables -- billions of rows X millions of columns -- atop clusters of commodity hardware.
+        Apache HBase is an open-source, distributed, versioned, non-relational database modeled after Google's <a href="http://research.google.com/archive/bigtable.html">Bigtable: A Distributed Storage System for Structured Data</a> by Chang et al.
+        Just as Bigtable leverages the distributed data storage provided by the Google File System, Apache HBase provides Bigtable-like capabilities on top of Hadoop and HDFS.
+      </p>
+    </section>
     <section name="Download">
-    <p>
-    Click <b><a href="downloads.html">here</a></b> to download Apache HBase&#8482;.
-    </p>
+      <p>Click <b><a href="downloads.html">here</a></b> to download Apache HBase&#8482;.</p>
     </section>
     <section name="Features">
-    <p>
-<ul>
-    <li>Linear and modular scalability.
-</li>
-    <li>Strictly consistent reads and writes.
-</li>
-    <li>Automatic and configurable sharding of tables
-</li>
-    <li>Automatic failover support between RegionServers.
-</li>
-    <li>Convenient base classes for backing Hadoop MapReduce jobs with Apache HBase tables.
-</li>
-    <li>Easy to use Java API for client access.
-</li>
-    <li>Block cache and Bloom Filters for real-time queries.
-</li>
-    <li>Query predicate push down via server side Filters
-</li>
-    <li>Thrift gateway and a REST-ful Web service that supports XML, Protobuf, and binary data encoding options
-</li>
-    <li>Extensible jruby-based (JIRB) shell
-</li>
-    <li>Support for exporting metrics via the Hadoop metrics subsystem to files or Ganglia; or via JMX
-</li>
-</ul>
-</p>
-</section>
-     <section name="More Info">
-   <p>See the <a href="http://hbase.apache.org/book.html#arch.overview">Architecture Overview</a>, the <a href="http://hbase.apache.org/book.html#faq">Apache HBase Reference Guide FAQ</a>,
-    and the other documentation links.
-   </p>
-   <dl>
-     <dt>Export Control</dt>
-   <dd><p>The HBase distribution includes cryptographic software. See the export control notice <a href="export_control.html">here</a>
-   </p></dd>
-     <dt>Code Of Conduct</dt>
-   <dd><p>We expect participants in discussions on the HBase project mailing lists, Slack and IRC channels, and JIRA issues to abide by the Apache Software Foundation's <a href="http://apache.org/foundation/policies/conduct.html">Code of Conduct</a>. More information can be found <a href="coc.html">here</a>.
-   </p></dd>
- </dl>
-</section>
+      <p>
+        <ul>
+          <li>Linear and modular scalability.</li>
+          <li>Strictly consistent reads and writes.</li>
+          <li>Automatic and configurable sharding of tables</li>
+          <li>Automatic failover support between RegionServers.</li>
+          <li>Convenient base classes for backing Hadoop MapReduce jobs with Apache HBase tables.</li>
+          <li>Easy to use Java API for client access.</li>
+          <li>Block cache and Bloom Filters for real-time queries.</li>
+          <li>Query predicate push down via server side Filters</li>
+          <li>Thrift gateway and a REST-ful Web service that supports XML, Protobuf, and binary data encoding options</li>
+          <li>Extensible jruby-based (JIRB) shell</li>
+          <li>Support for exporting metrics via the Hadoop metrics subsystem to files or Ganglia; or via JMX</li>
+        </ul>
+      </p>
+    </section>
+    <section name="More Info">
+      <p>See the <a href="book.html#arch.overview">Architecture Overview</a>, the <a href="book.html#faq">Apache HBase Reference Guide FAQ</a>, and the other documentation links.</p>
+      <dl>
+        <dt>Export Control</dt>
+        <dd><p>The HBase distribution includes cryptographic software. See the export control notice <a href="export_control.html">here</a></p></dd>
+        <dt>Code Of Conduct</dt>
+        <dd><p>We expect participants in discussions on the HBase project mailing lists, Slack and IRC channels, and JIRA issues to abide by the Apache Software Foundation's <a href="http://apache.org/foundation/policies/conduct.html">Code of Conduct</a>. More information can be found <a href="coc.html">here</a>.</p></dd>
+        <dt>License</dt>
+        <dd><p>Apache HBase is licensed under the <a href="licenses.html">Apache License, Version 2.0</a></p></dd>
+        <dt>Trademarks</dt>
+        <dd><p>Apache HBase, HBase, Apache, the Apache feather logo, and the Apache HBase project logo are either <a href="http://www.apache.org/foundation/marks/list/">registered trademarks or trademarks</a> of The Apache Software Foundation in the United States and other countries.</p></dd>
+        <dt>Thanks</dt>
+        <dd><p>Thanks for all the sponsors, who are <a href="http://www.apache.org/foundation/thanks.html">supporting Apache</a> or <a href="sponsors.html">supporting the HBase project</a>!</p></dd>
+        <dt>Security and Vulnerability information</dt>
+        <dd><p>See the <a href="book.html#security">Security</a> chapter in the <a href="book.html#faq">Apache HBase Reference Guide</a>, and the general <a href="http://apache.org/security/">Apache Security information</a>!</p></dd>
+      </dl>
+    </section>
 
-     <section name="News">
-       <p>July 20th, 2019 <a href="https://easychair.org/cfp/hbaseconasia-2019">HBaseCon, Asia 2019</a> Beijing, China</p>
-       <p>May 21st, 2019 <a href="https://dataworkssummit.com/nosql-day-2019/">NoSQL Day 2019</a> Washington DC.</p>
-       <p>August 17th, 2018 <a href="https://hbase.apache.org/hbaseconasia-2018/">HBaseCon Asia 2018</a> @ Gehua New Century Hotel, Beijing, China. CFP open, see site for details!</p>
-       <p>June 18th, 2018 <a href="https://hbase.apache.org/hbasecon-2018">HBaseCon North America West 2018</a> @ San Jose Convention Center, San Jose, CA, USA. registration still open, see site for details!</p>
-       <p>August 4th, 2017 <a href="https://easychair.org/cfp/HBaseConAsia2017">HBaseCon Asia 2017</a> @ the Huawei Campus in Shenzhen, China</p>
+    <section name="News">
+      <p>July 20th, 2019 <a href="https://easychair.org/cfp/hbaseconasia-2019">HBaseCon, Asia 2019</a> Beijing, China</p>
+      <p>May 21st, 2019 <a href="https://dataworkssummit.com/nosql-day-2019/">NoSQL Day 2019</a> Washington DC.</p>
+      <p>August 17th, 2018 <a href="https://hbase.apache.org/hbaseconasia-2018/">HBaseCon Asia 2018</a> @ Gehua New Century Hotel, Beijing, China. CFP open, see site for details!</p>
+      <p>June 18th, 2018 <a href="https://hbase.apache.org/hbasecon-2018">HBaseCon North America West 2018</a> @ San Jose Convention Center, San Jose, CA, USA. registration still open, see site for details!</p>
+      <p>August 4th, 2017 <a href="https://easychair.org/cfp/HBaseConAsia2017">HBaseCon Asia 2017</a> @ the Huawei Campus in Shenzhen, China</p>
       <p><small><a href="old_news.html">Old News</a></small></p>
+      <p><br/>The next Apache Event:<br/><a href="http://www.apache.org/events/current-event.html"><img src="http://www.apache.org/events/current-event-234x60.png"/></a></p>
     </section>
   </body>
 


### PR DESCRIPTION
there are 5 checks failing on https://whimsy.apache.org/site/project/hbase so I added the following information to the main page on the website:
- image and link about current Apache events
- link to HBase license
- link to apache sponsors
- link to security and vulnerability information
- legal text about trademarks

[link to the screenshot in jira](https://issues.apache.org/jira/secure/attachment/12973180/HBASE-20405.png)

I don't know if we can test this with Whimsy before merging to the master branch, so potentially it will require more tries... 

UPDATE: [link to the new screenshot in jira](https://issues.apache.org/jira/secure/attachment/12973640/HBASE-20405-v2.png)