### PR TITLE
HBASE-22654 apache-rat complains on branch-1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -764,6 +764,8 @@
               <exclude>src/main/site/resources/repo/**</exclude>
               <exclude>**/dependency-reduced-pom.xml</exclude>
               <exclude>**/rat.txt</exclude>
+              <!-- hbase-error-prone module is in a profile which is not used for rat check -->
+              <exclude>hbase-error-prone/target/**</exclude>
             </excludes>
           </configuration>
         </plugin>


### PR DESCRIPTION
License check fails after build with errorProne profile activated. The hbase-error-prone module is added to the root pom only when the profile is active so running RAT check does not consider hbase-error-prone/target as a build directory.