### PR TITLE
HBase-22027: Split non-MR related parts of TokenUtil off into a Clien…

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
@@ -95,7 +95,7 @@ public final class ClientTokenUtil {
    * @return the authentication token instance
    */
   @InterfaceAudience.Private
-  public static Token<AuthenticationTokenIdentifier> obtainToken(
+  static Token<AuthenticationTokenIdentifier> obtainToken(
       Connection conn) throws IOException {
     Table meta = null;
     try {
@@ -127,7 +127,7 @@ public final class ClientTokenUtil {
    * @return the protobuf Token message
    */
   @InterfaceAudience.Private
-  public static AuthenticationProtos.Token toToken(Token<AuthenticationTokenIdentifier> token) {
+  static AuthenticationProtos.Token toToken(Token<AuthenticationTokenIdentifier> token) {
     AuthenticationProtos.Token.Builder builder = AuthenticationProtos.Token.newBuilder();
     builder.setIdentifier(ByteString.copyFrom(token.getIdentifier()));
     builder.setPassword(ByteString.copyFrom(token.getPassword()));
@@ -144,7 +144,7 @@ public final class ClientTokenUtil {
    * @return the Token instance
    */
   @InterfaceAudience.Private
-  public static Token<AuthenticationTokenIdentifier> toToken(AuthenticationProtos.Token proto) {
+  static Token<AuthenticationTokenIdentifier> toToken(AuthenticationProtos.Token proto) {
     return new Token<>(
         proto.hasIdentifier() ? proto.getIdentifier().toByteArray() : null,
         proto.hasPassword() ? proto.getPassword().toByteArray() : null,
@@ -159,7 +159,7 @@ public final class ClientTokenUtil {
    * @return the authentication token instance
    */
   @InterfaceAudience.Private
-  public static Token<AuthenticationTokenIdentifier> obtainToken(
+  static Token<AuthenticationTokenIdentifier> obtainToken(
       final Connection conn, User user) throws IOException, InterruptedException {
     return user.runAs(new PrivilegedExceptionAction<Token<AuthenticationTokenIdentifier>>() {
       @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
@@ -1,0 +1,200 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.security.token;
+
+import com.google.protobuf.ByteString;
+import com.google.protobuf.ServiceException;
+import java.io.IOException;
+import java.lang.reflect.UndeclaredThrowableException;
+import java.security.PrivilegedExceptionAction;
+import java.util.concurrent.CompletableFuture;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AsyncConnection;
+import org.apache.hadoop.hbase.client.AsyncTable;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
+import org.apache.hadoop.hbase.protobuf.generated.AuthenticationProtos;
+import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.token.Token;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+
+/**
+ * Utility methods for obtaining authentication tokens, that do not require hbase-server.
+ */
+@InterfaceAudience.Public
+public final class ClientTokenUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(ClientTokenUtil.class);
+
+  // Set in TestClientTokenUtil via reflection
+  private static ServiceException injectedException;
+
+  private ClientTokenUtil() {}
+
+  private static void injectFault() throws ServiceException {
+    if (injectedException != null) {
+      throw injectedException;
+    }
+  }
+
+  /**
+   * Obtain and return an authentication token for the current user.
+   * @param conn The async HBase cluster connection
+   * @return the authentication token instance, wrapped by a {@link CompletableFuture}.
+   */
+  @InterfaceAudience.Private
+  public static CompletableFuture<Token<AuthenticationTokenIdentifier>> obtainToken(
+      AsyncConnection conn) {
+    CompletableFuture<Token<AuthenticationTokenIdentifier>> future = new CompletableFuture<>();
+    if (injectedException != null) {
+      future.completeExceptionally(injectedException);
+      return future;
+    }
+    AsyncTable<?> table = conn.getTable(TableName.META_TABLE_NAME);
+    table.<AuthenticationProtos.AuthenticationService.Interface, AuthenticationProtos.GetAuthenticationTokenResponse> coprocessorService(
+      AuthenticationProtos.AuthenticationService::newStub,
+      (s, c, r) -> s.getAuthenticationToken(c,
+        AuthenticationProtos.GetAuthenticationTokenRequest.getDefaultInstance(), r),
+      HConstants.EMPTY_START_ROW).whenComplete((resp, error) -> {
+        if (error != null) {
+          future.completeExceptionally(ProtobufUtil.handleRemoteException(error));
+        } else {
+          future.complete(toToken(resp.getToken()));
+        }
+      });
+    return future;
+  }
+  
+  /**
+   * Obtain and return an authentication token for the current user.
+   * @param conn The HBase cluster connection
+   * @throws IOException if a remote error or serialization problem occurs.
+   * @return the authentication token instance
+   */
+  @InterfaceAudience.Private
+  public static Token<AuthenticationTokenIdentifier> obtainToken(
+      Connection conn) throws IOException {
+    Table meta = null;
+    try {
+      injectFault();
+
+      meta = conn.getTable(TableName.META_TABLE_NAME);
+      CoprocessorRpcChannel rpcChannel = meta.coprocessorService(
+              HConstants.EMPTY_START_ROW);
+      AuthenticationProtos.AuthenticationService.BlockingInterface service =
+          AuthenticationProtos.AuthenticationService.newBlockingStub(rpcChannel);
+      AuthenticationProtos.GetAuthenticationTokenResponse response =
+              service.getAuthenticationToken(null,
+          AuthenticationProtos.GetAuthenticationTokenRequest.getDefaultInstance());
+
+      return toToken(response.getToken());
+    } catch (ServiceException se) {
+      throw ProtobufUtil.handleRemoteException(se);
+    } finally {
+      if (meta != null) {
+        meta.close();
+      }
+    }
+  }
+
+  /**
+   * Converts a Token instance (with embedded identifier) to the protobuf representation.
+   *
+   * @param token the Token instance to copy
+   * @return the protobuf Token message
+   */
+  @InterfaceAudience.Private
+  public static AuthenticationProtos.Token toToken(Token<AuthenticationTokenIdentifier> token) {
+    AuthenticationProtos.Token.Builder builder = AuthenticationProtos.Token.newBuilder();
+    builder.setIdentifier(ByteString.copyFrom(token.getIdentifier()));
+    builder.setPassword(ByteString.copyFrom(token.getPassword()));
+    if (token.getService() != null) {
+      builder.setService(ByteString.copyFromUtf8(token.getService().toString()));
+    }
+    return builder.build();
+  }
+
+  /**
+   * Converts a protobuf Token message back into a Token instance.
+   *
+   * @param proto the protobuf Token message
+   * @return the Token instance
+   */
+  @InterfaceAudience.Private
+  public static Token<AuthenticationTokenIdentifier> toToken(AuthenticationProtos.Token proto) {
+    return new Token<>(
+        proto.hasIdentifier() ? proto.getIdentifier().toByteArray() : null,
+        proto.hasPassword() ? proto.getPassword().toByteArray() : null,
+        AuthenticationTokenIdentifier.AUTH_TOKEN_TYPE,
+        proto.hasService() ? new Text(proto.getService().toStringUtf8()) : null);
+  }
+
+  /**
+   * Obtain and return an authentication token for the given user.
+   * @param conn The HBase cluster connection
+   * @param user The user to obtain a token for
+   * @return the authentication token instance
+   */
+  @InterfaceAudience.Private
+  public static Token<AuthenticationTokenIdentifier> obtainToken(
+      final Connection conn, User user) throws IOException, InterruptedException {
+    return user.runAs(new PrivilegedExceptionAction<Token<AuthenticationTokenIdentifier>>() {
+      @Override
+      public Token<AuthenticationTokenIdentifier> run() throws Exception {
+        return obtainToken(conn);
+      }
+    });
+  }
+
+  /**
+   * Obtain an authentication token for the given user and add it to the
+   * user's credentials.
+   * @param conn The HBase cluster connection
+   * @param user The user for whom to obtain the token
+   * @throws IOException If making a remote call to the authentication service fails
+   * @throws InterruptedException If executing as the given user is interrupted
+   */
+  public static void obtainAndCacheToken(final Connection conn,
+      User user)
+      throws IOException, InterruptedException {
+    try {
+      Token<AuthenticationTokenIdentifier> token = obtainToken(conn, user);
+
+      if (token == null) {
+        throw new IOException("No token returned for user " + user.getName());
+      }
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Obtained token " + token.getKind().toString() + " for user " +
+            user.getName());
+      }
+      user.addToken(token);
+    } catch (IOException | InterruptedException | RuntimeException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new UndeclaredThrowableException(e,
+          "Unexpected exception obtaining token for user " + user.getName());
+    }
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
@@ -73,10 +73,11 @@ public final class ClientTokenUtil {
       return future;
     }
     AsyncTable<?> table = conn.getTable(TableName.META_TABLE_NAME);
-    table.<AuthenticationProtos.AuthenticationService.Interface, AuthenticationProtos.GetAuthenticationTokenResponse> coprocessorService(
+    table.<AuthenticationProtos.AuthenticationService.Interface,
+        AuthenticationProtos.GetAuthenticationTokenResponse> coprocessorService(
       AuthenticationProtos.AuthenticationService::newStub,
-      (s, c, r) -> s.getAuthenticationToken(c,
-        AuthenticationProtos.GetAuthenticationTokenRequest.getDefaultInstance(), r),
+          (s, c, r) -> s.getAuthenticationToken(c,
+              AuthenticationProtos.GetAuthenticationTokenRequest.getDefaultInstance(), r),
       HConstants.EMPTY_START_ROW).whenComplete((resp, error) -> {
         if (error != null) {
           future.completeExceptionally(ProtobufUtil.handleRemoteException(error));

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
@@ -86,7 +86,7 @@ public final class ClientTokenUtil {
       });
     return future;
   }
-  
+
   /**
    * Obtain and return an authentication token for the current user.
    * @param conn The HBase cluster connection

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestClientTokenUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestClientTokenUtil.java
@@ -46,7 +46,7 @@ public class TestClientTokenUtil {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-      HBaseClassTestRule.forClass(TestClientTokenUtil.class);
+    HBaseClassTestRule.forClass(TestClientTokenUtil.class);
 
   private URLClassLoader cl;
 

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestClientTokenUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestClientTokenUtil.java
@@ -43,19 +43,19 @@ import org.apache.hbase.thirdparty.com.google.common.io.Closeables;
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 
 @Category(SmallTests.class)
-public class TestTokenUtil {
+public class TestClientTokenUtil {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-    HBaseClassTestRule.forClass(TestTokenUtil.class);
+      HBaseClassTestRule.forClass(TestClientTokenUtil.class);
 
   private URLClassLoader cl;
 
   @Before
   public void setUp() {
     URL urlPU = ProtobufUtil.class.getProtectionDomain().getCodeSource().getLocation();
-    URL urlTU = TokenUtil.class.getProtectionDomain().getCodeSource().getLocation();
-    cl = new URLClassLoader(new URL[] { urlPU, urlTU }, getClass().getClassLoader());
+    URL urlCTU = ClientTokenUtil.class.getProtectionDomain().getCodeSource().getLocation();
+    cl = new URLClassLoader(new URL[] { urlPU, urlCTU }, getClass().getClassLoader());
   }
 
   @After
@@ -67,13 +67,14 @@ public class TestTokenUtil {
   public void testObtainToken() throws Exception {
     Throwable injected = new com.google.protobuf.ServiceException("injected");
 
-    Class<?> tokenUtil = cl.loadClass(TokenUtil.class.getCanonicalName());
-    Field shouldInjectFault = tokenUtil.getDeclaredField("injectedException");
+    Class<?> clientTokenUtil = cl.loadClass(ClientTokenUtil.class.getCanonicalName());
+    Field shouldInjectFault = clientTokenUtil.getDeclaredField("injectedException");
     shouldInjectFault.setAccessible(true);
     shouldInjectFault.set(null, injected);
 
     try {
-      tokenUtil.getMethod("obtainToken", Connection.class).invoke(null, new Object[] { null });
+      clientTokenUtil.getMethod("obtainToken", Connection.class)
+          .invoke(null, new Object[] { null });
       fail("Should have injected exception.");
     } catch (InvocationTargetException e) {
       Throwable t = e;
@@ -89,7 +90,7 @@ public class TestTokenUtil {
       }
     }
 
-    CompletableFuture<?> future = (CompletableFuture<?>) tokenUtil
+    CompletableFuture<?> future = (CompletableFuture<?>) clientTokenUtil
       .getMethod("obtainToken", AsyncConnection.class).invoke(null, new Object[] { null });
     try {
       future.get();

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestClientTokenUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestClientTokenUtil.java
@@ -23,7 +23,6 @@ import static org.junit.Assert.fail;
 
 import java.io.IOException;
 import java.lang.reflect.Field;
-import java.lang.reflect.InvocationTargetException;
 import java.net.URL;
 import java.net.URLClassLoader;
 import java.util.concurrent.CompletableFuture;
@@ -73,10 +72,9 @@ public class TestClientTokenUtil {
     shouldInjectFault.set(null, injected);
 
     try {
-      clientTokenUtil.getMethod("obtainToken", Connection.class)
-          .invoke(null, new Object[] { null });
+      ClientTokenUtil.obtainToken((Connection)null);
       fail("Should have injected exception.");
-    } catch (InvocationTargetException e) {
+    } catch (IOException e) {
       Throwable t = e;
       boolean serviceExceptionFound = false;
       while ((t = t.getCause()) != null) {
@@ -90,8 +88,7 @@ public class TestClientTokenUtil {
       }
     }
 
-    CompletableFuture<?> future = (CompletableFuture<?>) clientTokenUtil
-      .getMethod("obtainToken", AsyncConnection.class).invoke(null, new Object[] { null });
+    CompletableFuture<?> future = ClientTokenUtil.obtainToken((AsyncConnection)null);
     try {
       future.get();
       fail("Should have injected exception.");

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SecureBulkLoadManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SecureBulkLoadManager.java
@@ -43,8 +43,8 @@ import org.apache.hadoop.hbase.regionserver.HRegion.BulkLoadListener;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.security.token.AuthenticationTokenIdentifier;
+import org.apache.hadoop.hbase.security.token.ClientTokenUtil;
 import org.apache.hadoop.hbase.security.token.FsDelegationToken;
-import org.apache.hadoop.hbase.security.token.TokenUtil;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.FSHDFSUtils;
 import org.apache.hadoop.hbase.util.FSUtils;
@@ -231,7 +231,7 @@ public class SecureBulkLoadManager {
     final UserGroupInformation ugi = user.getUGI();
     if (userProvider.isHadoopSecurityEnabled()) {
       try {
-        Token<AuthenticationTokenIdentifier> tok = TokenUtil.obtainToken(conn).get();
+        Token<AuthenticationTokenIdentifier> tok = ClientTokenUtil.obtainToken(conn).get();
         if (tok != null) {
           boolean b = ugi.addToken(tok);
           LOG.debug("token added " + tok + " for user " + ugi + " return=" + b);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenProvider.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenProvider.java
@@ -129,7 +129,7 @@ public class TokenProvider implements AuthenticationProtos.AuthenticationService
 
       Token<AuthenticationTokenIdentifier> token =
           secretManager.generateToken(currentUser.getName());
-      response.setToken(TokenUtil.toToken(token)).build();
+      response.setToken(ClientTokenUtil.toToken(token)).build();
     } catch (IOException ioe) {
       CoprocessorRpcUtils.setControllerException(controller, ioe);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenUtil.java
@@ -47,8 +47,9 @@ public class TokenUtil {
 
     /**
      * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.AsyncConnection)}.
-     * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
-     * HBase code should use {@link ClientTokenUtil} instead.
+     * @deprecated External users should not use this method. Please post on
+     *   the HBase dev mailing list if you need this method. Internal
+     *   HBase code should use {@link ClientTokenUtil} instead.
      */
   @Deprecated
   public static CompletableFuture<Token<AuthenticationTokenIdentifier>> obtainToken(
@@ -58,8 +59,9 @@ public class TokenUtil {
 
   /**
    * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.Connection)}.
-   * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
-   * HBase code should use {@link ClientTokenUtil} instead.
+   * @deprecated External users should not use this method. Please post on
+   *   the HBase dev mailing list if you need this method. Internal
+   *   HBase code should use {@link ClientTokenUtil} instead.
    */
   @Deprecated
   public static Token<AuthenticationTokenIdentifier> obtainToken(Connection conn)
@@ -70,8 +72,9 @@ public class TokenUtil {
 
   /**
    * See {@link ClientTokenUtil#toToken(org.apache.hadoop.security.token.Token)}.
-   * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
-   * HBase code should use {@link ClientTokenUtil} instead.
+   * @deprecated External users should not use this method. Please post on
+   *   the HBase dev mailing list if you need this method. Internal
+   *   HBase code should use {@link ClientTokenUtil} instead.
    */
   @Deprecated
   public static AuthenticationProtos.Token toToken(Token<AuthenticationTokenIdentifier> token) {
@@ -81,8 +84,9 @@ public class TokenUtil {
   /**
    * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.Connection,
    * org.apache.hadoop.hbase.security.User)}.
-   * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
-   * HBase code should use {@link ClientTokenUtil} instead.
+   * @deprecated External users should not use this method. Please post on
+   *   the HBase dev mailing list if you need this method. Internal
+   *   HBase code should use {@link ClientTokenUtil} instead.
    */
   @Deprecated
   public static Token<AuthenticationTokenIdentifier> obtainToken(
@@ -102,8 +106,9 @@ public class TokenUtil {
 
   /**
    * See {@link ClientTokenUtil#toToken(org.apache.hadoop.security.token.Token)}.
-   * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
-   * HBase code should use {@link ClientTokenUtil} instead.
+   * @deprecated External users should not use this method. Please post on
+   *   the HBase dev mailing list if you need this method. Internal
+   *   HBase code should use {@link ClientTokenUtil} instead.
    */
   @Deprecated
   public static Token<AuthenticationTokenIdentifier> toToken(AuthenticationProtos.Token proto) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenUtil.java
@@ -134,7 +134,7 @@ public class TokenUtil {
       User user, Job job)
       throws IOException, InterruptedException {
     try {
-      Token<AuthenticationTokenIdentifier> token = obtainToken(conn, user);
+      Token<AuthenticationTokenIdentifier> token = ClientTokenUtil.obtainToken(conn, user);
 
       if (token == null) {
         throw new IOException("No token returned for user " + user.getName());
@@ -169,7 +169,7 @@ public class TokenUtil {
   public static void obtainTokenForJob(final Connection conn, final JobConf job, User user)
       throws IOException, InterruptedException {
     try {
-      Token<AuthenticationTokenIdentifier> token = obtainToken(conn, user);
+      Token<AuthenticationTokenIdentifier> token = ClientTokenUtil.obtainToken(conn, user);
 
       if (token == null) {
         throw new IOException("No token returned for user " + user.getName());
@@ -207,7 +207,7 @@ public class TokenUtil {
 
     Token<AuthenticationTokenIdentifier> token = getAuthToken(conn.getConfiguration(), user);
     if (token == null) {
-      token = obtainToken(conn, user);
+      token = ClientTokenUtil.obtainToken(conn, user);
     }
     job.getCredentials().addToken(token.getService(), token);
   }
@@ -226,7 +226,7 @@ public class TokenUtil {
       throws IOException, InterruptedException {
     Token<AuthenticationTokenIdentifier> token = getAuthToken(conn.getConfiguration(), user);
     if (token == null) {
-      token = obtainToken(conn, user);
+      token = ClientTokenUtil.obtainToken(conn, user);
     }
     job.getCredentials().addToken(token.getService(), token);
   }
@@ -245,7 +245,7 @@ public class TokenUtil {
       throws IOException, InterruptedException {
     Token<AuthenticationTokenIdentifier> token = getAuthToken(conn.getConfiguration(), user);
     if (token == null) {
-      token = obtainToken(conn, user);
+      token = ClientTokenUtil.obtainToken(conn, user);
       user.getUGI().addToken(token.getService(), token);
       return true;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenUtil.java
@@ -17,24 +17,13 @@
  */
 package org.apache.hadoop.hbase.security.token;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.ServiceException;
 import java.io.IOException;
 import java.lang.reflect.UndeclaredThrowableException;
-import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AsyncConnection;
-import org.apache.hadoop.hbase.client.AsyncTable;
 import org.apache.hadoop.hbase.client.Connection;
-import org.apache.hadoop.hbase.client.Table;
-import org.apache.hadoop.hbase.ipc.CoprocessorRpcChannel;
 import org.apache.hadoop.hbase.protobuf.generated.AuthenticationProtos;
-import org.apache.hadoop.hbase.protobuf.generated.AuthenticationProtos.AuthenticationService;
-import org.apache.hadoop.hbase.protobuf.generated.AuthenticationProtos.GetAuthenticationTokenRequest;
-import org.apache.hadoop.hbase.protobuf.generated.AuthenticationProtos.GetAuthenticationTokenResponse;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.zookeeper.ZKClusterId;
 import org.apache.hadoop.hbase.zookeeper.ZKWatcher;
@@ -47,7 +36,6 @@ import org.apache.zookeeper.KeeperException;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 
 /**
  * Utility methods for obtaining authentication tokens.
@@ -57,142 +45,70 @@ public class TokenUtil {
   // This class is referenced indirectly by User out in common; instances are created by reflection
   private static final Logger LOG = LoggerFactory.getLogger(TokenUtil.class);
 
-  // Set in TestTokenUtil via reflection
-  private static ServiceException injectedException;
-
-  private static void injectFault() throws ServiceException {
-    if (injectedException != null) {
-      throw injectedException;
-    }
-  }
-
   /**
-   * Obtain and return an authentication token for the current user.
-   * @param conn The async HBase cluster connection
-   * @return the authentication token instance, wrapped by a {@link CompletableFuture}.
+   * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.AsyncConnection)}.
+   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
    */
+  @Deprecated
   public static CompletableFuture<Token<AuthenticationTokenIdentifier>> obtainToken(
       AsyncConnection conn) {
-    CompletableFuture<Token<AuthenticationTokenIdentifier>> future = new CompletableFuture<>();
-    if (injectedException != null) {
-      future.completeExceptionally(injectedException);
-      return future;
-    }
-    AsyncTable<?> table = conn.getTable(TableName.META_TABLE_NAME);
-    table.<AuthenticationService.Interface, GetAuthenticationTokenResponse> coprocessorService(
-      AuthenticationProtos.AuthenticationService::newStub,
-      (s, c, r) -> s.getAuthenticationToken(c,
-        AuthenticationProtos.GetAuthenticationTokenRequest.getDefaultInstance(), r),
-      HConstants.EMPTY_START_ROW).whenComplete((resp, error) -> {
-        if (error != null) {
-          future.completeExceptionally(ProtobufUtil.handleRemoteException(error));
-        } else {
-          future.complete(toToken(resp.getToken()));
-        }
-      });
-    return future;
+    return ClientTokenUtil.obtainToken(conn);
   }
 
   /**
-   * Obtain and return an authentication token for the current user.
-   * @param conn The HBase cluster connection
-   * @throws IOException if a remote error or serialization problem occurs.
-   * @return the authentication token instance
+   * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.Connection)}.
+   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
    */
+  @Deprecated
   public static Token<AuthenticationTokenIdentifier> obtainToken(Connection conn)
       throws IOException {
-    Table meta = null;
-    try {
-      injectFault();
-
-      meta = conn.getTable(TableName.META_TABLE_NAME);
-      CoprocessorRpcChannel rpcChannel = meta.coprocessorService(HConstants.EMPTY_START_ROW);
-      AuthenticationProtos.AuthenticationService.BlockingInterface service =
-        AuthenticationService.newBlockingStub(rpcChannel);
-      GetAuthenticationTokenResponse response =
-        service.getAuthenticationToken(null, GetAuthenticationTokenRequest.getDefaultInstance());
-
-      return toToken(response.getToken());
-    } catch (ServiceException se) {
-      throw ProtobufUtil.handleRemoteException(se);
-    } finally {
-      if (meta != null) {
-        meta.close();
-      }
-    }
+    return ClientTokenUtil.obtainToken(conn);
   }
 
 
   /**
-   * Converts a Token instance (with embedded identifier) to the protobuf representation.
-   *
-   * @param token the Token instance to copy
-   * @return the protobuf Token message
+   * See {@link ClientTokenUtil#toToken(org.apache.hadoop.security.token.Token)}.
+   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
    */
+  @Deprecated
   public static AuthenticationProtos.Token toToken(Token<AuthenticationTokenIdentifier> token) {
-    AuthenticationProtos.Token.Builder builder = AuthenticationProtos.Token.newBuilder();
-    builder.setIdentifier(ByteString.copyFrom(token.getIdentifier()));
-    builder.setPassword(ByteString.copyFrom(token.getPassword()));
-    if (token.getService() != null) {
-      builder.setService(ByteString.copyFromUtf8(token.getService().toString()));
-    }
-    return builder.build();
+    return ClientTokenUtil.toToken(token);
   }
 
   /**
-   * Obtain and return an authentication token for the current user.
-   * @param conn The HBase cluster connection
-   * @return the authentication token instance
+   * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.Connection,
+   * org.apache.hadoop.hbase.security.User)}.
+   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
    */
+  @Deprecated
   public static Token<AuthenticationTokenIdentifier> obtainToken(
       final Connection conn, User user) throws IOException, InterruptedException {
-    return user.runAs(new PrivilegedExceptionAction<Token<AuthenticationTokenIdentifier>>() {
-      @Override
-      public Token<AuthenticationTokenIdentifier> run() throws Exception {
-        return obtainToken(conn);
-      }
-    });
+    return ClientTokenUtil.obtainToken(conn, user);
   }
 
+  /**
+   * See {@link ClientTokenUtil#obtainAndCacheToken(org.apache.hadoop.hbase.client.Connection,
+   * org.apache.hadoop.hbase.security.User)}.
+   */
+  public static void obtainAndCacheToken(final Connection conn,
+      User user)
+      throws IOException, InterruptedException {
+    ClientTokenUtil.obtainAndCacheToken(conn, user);
+  }
+
+  /**
+   * See {@link ClientTokenUtil#toToken(org.apache.hadoop.security.token.Token)}.
+   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
+   */
+  @Deprecated
+  public static Token<AuthenticationTokenIdentifier> toToken(AuthenticationProtos.Token proto) {
+    return ClientTokenUtil.toToken(proto);
+  }
 
   private static Text getClusterId(Token<AuthenticationTokenIdentifier> token)
       throws IOException {
     return token.getService() != null
         ? token.getService() : new Text("default");
-  }
-
-  /**
-   * Obtain an authentication token for the given user and add it to the
-   * user's credentials.
-   * @param conn The HBase cluster connection
-   * @param user The user for whom to obtain the token
-   * @throws IOException If making a remote call to the authentication service fails
-   * @throws InterruptedException If executing as the given user is interrupted
-   */
-  public static void obtainAndCacheToken(final Connection conn,
-      User user)
-      throws IOException, InterruptedException {
-    try {
-      Token<AuthenticationTokenIdentifier> token = obtainToken(conn, user);
-
-      if (token == null) {
-        throw new IOException("No token returned for user " + user.getName());
-      }
-      if (LOG.isDebugEnabled()) {
-        LOG.debug("Obtained token " + token.getKind().toString() + " for user " +
-            user.getName());
-      }
-      user.addToken(token);
-    } catch (IOException ioe) {
-      throw ioe;
-    } catch (InterruptedException ie) {
-      throw ie;
-    } catch (RuntimeException re) {
-      throw re;
-    } catch (Exception e) {
-      throw new UndeclaredThrowableException(e,
-          "Unexpected exception obtaining token for user " + user.getName());
-    }
   }
 
   /**
@@ -344,19 +260,5 @@ public class TokenUtil {
     } finally {
       zkw.close();
     }
-  }
-
-  /**
-   * Converts a protobuf Token message back into a Token instance.
-   *
-   * @param proto the protobuf Token message
-   * @return the Token instance
-   */
-  public static Token<AuthenticationTokenIdentifier> toToken(AuthenticationProtos.Token proto) {
-    return new Token<>(
-        proto.hasIdentifier() ? proto.getIdentifier().toByteArray() : null,
-        proto.hasPassword() ? proto.getPassword().toByteArray() : null,
-        AuthenticationTokenIdentifier.AUTH_TOKEN_TYPE,
-        proto.hasService() ? new Text(proto.getService().toStringUtf8()) : null);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/TokenUtil.java
@@ -45,10 +45,11 @@ public class TokenUtil {
   // This class is referenced indirectly by User out in common; instances are created by reflection
   private static final Logger LOG = LoggerFactory.getLogger(TokenUtil.class);
 
-  /**
-   * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.AsyncConnection)}.
-   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
-   */
+    /**
+     * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.AsyncConnection)}.
+     * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
+     * HBase code should use {@link ClientTokenUtil} instead.
+     */
   @Deprecated
   public static CompletableFuture<Token<AuthenticationTokenIdentifier>> obtainToken(
       AsyncConnection conn) {
@@ -57,7 +58,8 @@ public class TokenUtil {
 
   /**
    * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.Connection)}.
-   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
+   * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
+   * HBase code should use {@link ClientTokenUtil} instead.
    */
   @Deprecated
   public static Token<AuthenticationTokenIdentifier> obtainToken(Connection conn)
@@ -68,7 +70,8 @@ public class TokenUtil {
 
   /**
    * See {@link ClientTokenUtil#toToken(org.apache.hadoop.security.token.Token)}.
-   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
+   * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
+   * HBase code should use {@link ClientTokenUtil} instead.
    */
   @Deprecated
   public static AuthenticationProtos.Token toToken(Token<AuthenticationTokenIdentifier> token) {
@@ -78,7 +81,8 @@ public class TokenUtil {
   /**
    * See {@link ClientTokenUtil#obtainToken(org.apache.hadoop.hbase.client.Connection,
    * org.apache.hadoop.hbase.security.User)}.
-   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
+   * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
+   * HBase code should use {@link ClientTokenUtil} instead.
    */
   @Deprecated
   public static Token<AuthenticationTokenIdentifier> obtainToken(
@@ -98,7 +102,8 @@ public class TokenUtil {
 
   /**
    * See {@link ClientTokenUtil#toToken(org.apache.hadoop.security.token.Token)}.
-   * @deprecated Please use the corresponding method in {@link ClientTokenUtil} instead.
+   * @deprecated External users should not use this method. Please post on the HBase dev mailing list if you need this method. Internal
+   * HBase code should use {@link ClientTokenUtil} instead.
    */
   @Deprecated
   public static Token<AuthenticationTokenIdentifier> toToken(AuthenticationProtos.Token proto) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestDelegationTokenWithEncryption.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestDelegationTokenWithEncryption.java
@@ -67,7 +67,7 @@ public class TestDelegationTokenWithEncryption extends SecureTestCluster {
     TEST_UTIL.getConfiguration().set("hbase.rpc.protection", "privacy");
     SecureTestCluster.setUp();
     try (Connection conn = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration())) {
-      Token<? extends TokenIdentifier> token = TokenUtil.obtainToken(conn);
+      Token<? extends TokenIdentifier> token = ClientTokenUtil.obtainToken(conn);
       UserGroupInformation.getCurrentUser().addToken(token);
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestGenerateDelegationToken.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestGenerateDelegationToken.java
@@ -70,7 +70,7 @@ public class TestGenerateDelegationToken extends SecureTestCluster {
   public static void setUp() throws Exception {
     SecureTestCluster.setUp();
     try (Connection conn = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration())) {
-      Token<? extends TokenIdentifier> token = TokenUtil.obtainToken(conn);
+      Token<? extends TokenIdentifier> token = ClientTokenUtil.obtainToken(conn);
       UserGroupInformation.getCurrentUser().addToken(token);
     }
   }


### PR DESCRIPTION
…tTokenUtil, and move ClientTokenUtil to hbase-client

See https://issues.apache.org/jira/browse/HBASE-22027