### PR TITLE
HBASE-22677 Add unit tests for org.apache.hadoop.hbase.util.ByteRangeUtils and Classes

### DIFF
--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteRangeUtils.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteRangeUtils.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hbase.util;
 
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
 
 import java.util.ArrayList;
 import java.util.Arrays;

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteRangeUtils.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteRangeUtils.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.util;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertArrayEquals;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({SmallTests.class})
+public class TestByteRangeUtils {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+          HBaseClassTestRule.forClass(TestByteRangeUtils.class);
+
+  @Test
+  public void testNumEqualPrefixBytes() {
+    assertEquals(0, ByteRangeUtils.numEqualPrefixBytes(
+            new SimpleByteRange(new byte[]{1, 2, 3}),
+            new SimpleByteRange(new byte[]{4, 5, 6}), 1));
+    assertEquals(2, ByteRangeUtils.numEqualPrefixBytes(
+            new SimpleByteRange(new byte[]{1, 2, 3}),
+            new SimpleByteRange(new byte[]{0, 1, 2}), 1));
+  }
+
+  @Test
+  public void testCopyToNewArrays() {
+    assertEquals(new ArrayList<>(),
+            ByteRangeUtils.copyToNewArrays(null));
+    assertArrayEquals(new byte[]{1, 2, 3},
+            ByteRangeUtils.copyToNewArrays(new ArrayList<>(Arrays.asList(
+                    new SimpleByteRange(new byte[]{1, 2, 3}),
+                    new SimpleByteRange(new byte[]{4, 5, 6})))).get(0));
+    assertArrayEquals(new byte[]{4, 5, 6},
+            ByteRangeUtils.copyToNewArrays(new ArrayList<>(Arrays.asList(
+                    new SimpleByteRange(new byte[]{1, 2, 3}),
+                    new SimpleByteRange(new byte[]{4, 5, 6})))).get(1));
+  }
+
+  @Test
+  public void testFromArrays() {
+    assertEquals(new ArrayList<>(), ByteRangeUtils.fromArrays(null));
+    assertEquals(new ArrayList<>(Arrays.asList(
+            new SimpleMutableByteRange(new byte[]{1, 2, 3}),
+            new SimpleMutableByteRange(new byte[]{4, 5, 6}))),
+            ByteRangeUtils.fromArrays(new ArrayList<>(
+                    Arrays.asList(new byte[]{1, 2, 3}, new byte[]{4, 5, 6}))));
+  }
+}

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestClasses.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestClasses.java
@@ -1,0 +1,64 @@
+/*
+ * Copyright The Apache Software Foundation
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.util;
+
+import static org.junit.Assert.assertEquals;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.ExpectedException;
+
+@Category({SmallTests.class})
+public class TestClasses {
+
+  @Rule
+  public final ExpectedException thrown = ExpectedException.none();
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+          HBaseClassTestRule.forClass(TestClasses.class);
+
+  @Test
+  public void testExtendedForName() throws ClassNotFoundException {
+    assertEquals(int.class, Classes.extendedForName("int"));
+    assertEquals(long.class, Classes.extendedForName("long"));
+    assertEquals(char.class, Classes.extendedForName("char"));
+    assertEquals(byte.class, Classes.extendedForName("byte"));
+    assertEquals(short.class, Classes.extendedForName("short"));
+    assertEquals(float.class, Classes.extendedForName("float"));
+    assertEquals(double.class, Classes.extendedForName("double"));
+    assertEquals(boolean.class, Classes.extendedForName("boolean"));
+
+    thrown.expect(ClassNotFoundException.class);
+    Classes.extendedForName("foo");
+  }
+
+  @Test
+  public void testStringify() {
+    assertEquals("", Classes.stringify(new Class[0]));
+    assertEquals("NULL", Classes.stringify(null));
+    assertEquals("java.lang.String,java.lang.Integer",
+            Classes.stringify(new Class[]{String.class, Integer.class}));
+  }
+}


### PR DESCRIPTION
I've analysed your codebase and noticed that `org.apache.hadoop.hbase.util.ByteRangeUtils` and `Classes` is not fully tested.
I've written some tests for the methods in this class with the help of [Diffblue Cover](https://www.diffblue.com/opensource).

Hopefully, these tests will help you detect any regressions caused by future code changes. If you would find it useful to have additional tests written for this repository, I would be more than happy to look at other classes that you consider important in a subsequent PR.