### PR TITLE
HBASE-22382 Refactor tests in TestFromClientSide

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
@@ -1156,20 +1156,28 @@ public class TestFromClientSide {
   }
 
   @Test
-  public void testNull() throws Exception {
-    final TableName tableName = TableName.valueOf(name.getMethodName());
-
+  public void testNull_TableName() {
     // Null table name (should NOT work)
     try {
       TEST_UTIL.createTable((TableName)null, FAMILY);
       fail("Creating a table with null name passed, should have failed");
     } catch(Exception e) {}
+  }
+
+  @Test
+  public void testNull_FamilyName() {
+    final TableName tableName = TableName.valueOf(name.getMethodName());
 
     // Null family (should NOT work)
     try {
       TEST_UTIL.createTable(tableName, new byte[][]{null});
       fail("Creating a table with a null family passed, should fail");
     } catch(Exception e) {}
+  }
+
+  @Test
+  public void testNull_RowAndQualifier() throws Exception {
+    final TableName tableName = TableName.valueOf(name.getMethodName());
 
     try (Table ht = TEST_UTIL.createTable(tableName, FAMILY)) {
 
@@ -1201,9 +1209,13 @@ public class TestFromClientSide {
         assertEmptyResult(result);
       }
     }
+  }
 
-    // Use a new table
-    try (Table ht = TEST_UTIL.createTable(TableName.valueOf(name.getMethodName() + "2"), FAMILY)) {
+  @Test
+  public void testNull_EmptyQualifier() throws Exception {
+    final TableName tableName = TableName.valueOf(name.getMethodName());
+
+    try (Table ht = TEST_UTIL.createTable(tableName, FAMILY)) {
 
       // Empty qualifier, byte[0] instead of null (should work)
       try {
@@ -1234,7 +1246,14 @@ public class TestFromClientSide {
       } catch (Exception e) {
         throw new IOException("Using a row with null qualifier threw exception, should ");
       }
+    }
+  }
 
+  @Test
+  public void testNull_Value() throws IOException {
+    final TableName tableName = TableName.valueOf(name.getMethodName());
+
+    try (Table ht = TEST_UTIL.createTable(tableName, FAMILY)) {
       // Null value
       try {
         Put put = new Put(ROW);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
@@ -1156,7 +1156,7 @@ public class TestFromClientSide {
   }
 
   @Test
-  public void testNull_TableName() {
+  public void testNullTableName() {
     // Null table name (should NOT work)
     try {
       TEST_UTIL.createTable((TableName)null, FAMILY);
@@ -1165,7 +1165,7 @@ public class TestFromClientSide {
   }
 
   @Test
-  public void testNull_FamilyName() {
+  public void testNullFamilyName() {
     final TableName tableName = TableName.valueOf(name.getMethodName());
 
     // Null family (should NOT work)
@@ -1176,7 +1176,7 @@ public class TestFromClientSide {
   }
 
   @Test
-  public void testNull_RowAndQualifier() throws Exception {
+  public void testNullRowAndQualifier() throws Exception {
     final TableName tableName = TableName.valueOf(name.getMethodName());
 
     try (Table ht = TEST_UTIL.createTable(tableName, FAMILY)) {
@@ -1212,7 +1212,7 @@ public class TestFromClientSide {
   }
 
   @Test
-  public void testNull_EmptyQualifier() throws Exception {
+  public void testNullEmptyQualifier() throws Exception {
     final TableName tableName = TableName.valueOf(name.getMethodName());
 
     try (Table ht = TEST_UTIL.createTable(tableName, FAMILY)) {
@@ -1250,7 +1250,7 @@ public class TestFromClientSide {
   }
 
   @Test
-  public void testNull_Value() throws IOException {
+  public void testNullValue() throws IOException {
     final TableName tableName = TableName.valueOf(name.getMethodName());
 
     try (Table ht = TEST_UTIL.createTable(tableName, FAMILY)) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
@@ -1569,6 +1569,7 @@ public class TestFromClientSide {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:MethodLength")
   public void testVersionLimits() throws Exception {
     final TableName tableName = TableName.valueOf(name.getMethodName());
     byte [][] FAMILIES = makeNAscii(FAMILY, 3);
@@ -5984,6 +5985,7 @@ public class TestFromClientSide {
   }
 
   @Test
+  @SuppressWarnings("checkstyle:MethodLength")
   public void testDeletesWithReverseScan() throws Exception {
     final TableName tableName = TableName.valueOf(name.getMethodName());
     byte[][] ROWS = makeNAscii(ROW, 6);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
@@ -1155,24 +1155,20 @@ public class TestFromClientSide {
     }
   }
 
-  @Test
-  public void testNullTableName() {
+  @Test(expected = IOException.class)
+  public void testNullTableName() throws IOException {
     // Null table name (should NOT work)
-    try {
-      TEST_UTIL.createTable((TableName)null, FAMILY);
-      fail("Creating a table with null name passed, should have failed");
-    } catch(Exception e) {}
+    TEST_UTIL.createTable((TableName)null, FAMILY);
+    fail("Creating a table with null name passed, should have failed");
   }
 
-  @Test
-  public void testNullFamilyName() {
+  @Test(expected = IOException.class)
+  public void testNullFamilyName() throws IOException {
     final TableName tableName = TableName.valueOf(name.getMethodName());
 
     // Null family (should NOT work)
-    try {
-      TEST_UTIL.createTable(tableName, new byte[][]{null});
-      fail("Creating a table with a null family passed, should fail");
-    } catch(Exception e) {}
+    TEST_UTIL.createTable(tableName, new byte[][]{null});
+    fail("Creating a table with a null family passed, should fail");
   }
 
   @Test
@@ -1244,7 +1240,7 @@ public class TestFromClientSide {
         assertEmptyResult(result);
 
       } catch (Exception e) {
-        throw new IOException("Using a row with null qualifier threw exception, should ");
+        throw new IOException("Using a row with null qualifier should not throw exception");
       }
     }
   }


### PR DESCRIPTION
- Refactored `testNull()` into multiple,
- Added suppress warning for `testVersionLimits()` - cannot split,
- Added suppress warning for `testDeletesWithReverseScan()` - cannot split