### PR TITLE
HBASE-22715 Use scan queues/executors for scans, when RWQueueRpcExecutor used

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RWQueueRpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RWQueueRpcExecutor.java
@@ -350,12 +350,7 @@ public class RWQueueRpcExecutor extends RpcExecutor {
   }
 
   private boolean isScanRequest(final RequestHeader header, final Message param) {
-    if (param instanceof ScanRequest) {
-      // The first scan request will be executed as a "short read"
-      ScanRequest request = (ScanRequest)param;
-      return request.hasScannerId();
-    }
-    return false;
+    return param instanceof ScanRequest;
   }
 
   /*

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
@@ -291,7 +291,7 @@ public class TestSimpleRpcScheduler {
 
       CallRunner scanCallTask = mock(CallRunner.class);
       RpcServer.Call scanCall = mock(RpcServer.Call.class);
-      scanCall.param = ScanRequest.newBuilder().setScannerId(1).build();
+      scanCall.param = ScanRequest.newBuilder().build();
       RequestHeader scanHead = RequestHeader.newBuilder().setMethodName("scan").build();
       when(scanCallTask.getCall()).thenReturn(scanCall);
       when(scanCall.getHeader()).thenReturn(scanHead);


### PR DESCRIPTION
No extra RPC only for opening a scanner anymore. So, we don't need to use read queue/handler when opening scanner.

More details in [HBASE-22715](https://issues.apache.org/jira/browse/HBASE-22715)