### PR TITLE
HBASE-22716:upgrade zookeeper version to 3.5.5

### DIFF
--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/HQuorumPeer.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/HQuorumPeer.java
@@ -23,7 +23,6 @@ import java.io.IOException;
 import java.io.PrintWriter;
 import java.net.InetAddress;
 import java.net.NetworkInterface;
-import java.net.UnknownHostException;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Enumeration;

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/HQuorumPeer.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/HQuorumPeer.java
@@ -42,6 +42,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 import org.apache.zookeeper.server.ServerConfig;
 import org.apache.zookeeper.server.ZooKeeperServerMain;
+import org.apache.zookeeper.server.admin.AdminServer.AdminServerException;
 import org.apache.zookeeper.server.quorum.QuorumPeerConfig;
 import org.apache.zookeeper.server.quorum.QuorumPeerMain;
 import org.slf4j.Logger;
@@ -87,7 +88,7 @@ public final class HQuorumPeer {
   }
 
   private static void runZKServer(QuorumPeerConfig zkConfig)
-          throws UnknownHostException, IOException {
+          throws IOException, AdminServerException {
     if (zkConfig.isDistributed()) {
       QuorumPeerMain qp = new QuorumPeerMain();
       qp.runFromConfig(zkConfig);

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKMainServer.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKMainServer.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.KeeperException;
 import org.apache.zookeeper.ZooKeeperMain;
+import org.apache.zookeeper.cli.CliException;
 
 
 /**
@@ -61,7 +62,7 @@ public class ZKMainServer {
      * @throws IOException in case of a network failure
      * @throws InterruptedException if the ZooKeeper client closes
      */
-    void runCmdLine() throws KeeperException, IOException, InterruptedException {
+    void runCmdLine() throws CliException, IOException, InterruptedException {
       processCmd(this.cl);
       System.exit(0);
     }

--- a/pom.xml
+++ b/pom.xml
@@ -1471,7 +1471,7 @@
     <protobuf.plugin.version>0.5.0</protobuf.plugin.version>
     <thrift.path>thrift</thrift.path>
     <thrift.version>0.12.0</thrift.version>
-    <zookeeper.version>3.4.10</zookeeper.version>
+    <zookeeper.version>3.5.5</zookeeper.version>
     <!-- What ZooKeeper 3.4.x depends on and nothing more -->
     <jline.version>0.9.94</jline.version>
     <slf4j.version>1.7.25</slf4j.version>


### PR DESCRIPTION
- This zookeeper [3.5.5](http://zookeeper.apache.org/releases.html) release is a stable one and recommended for production use, which has no compatibility issues for the native java client api which hbase used.
- Let's listen to the QA report before reviewing.
- more details in the [HBASE-22716](https://issues.apache.org/jira/browse/HBASE-22716)