### PR TITLE
check regionIndex

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/BaseLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/BaseLoadBalancer.java
@@ -868,6 +868,9 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
       int[] newRegions = new int[regions.length - 1];
       int i = 0;
       for (i = 0; i < regions.length; i++) {
+        if (i == regions.length - 1) {
+          return Arrays.copyOf(regions, regions.length);
+        }
         if (regions[i] == regionIndex) {
           break;
         }


### PR DESCRIPTION
if regionIndex not in regions, there will be ArrayIndexOutOfBoundsException.
such as 
 2019-07-25 15:19:59,828 ERROR [master/nna:16000.Chore.1] hbase.ScheduledChore: Caught error
 java.lang.ArrayIndexOutOfBoundsException: 3171
     at org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer$Cluster.removeRegion(BaseLoadBalancer.java:873)
     at org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer$Cluster.doAction(BaseLoadBalancer.java:716)
     at org.apache.hadoop.hbase.master.balancer.StochasticLoadBalancer.balanceCluster(StochasticLoadBalancer.java:407)
     at org.apache.hadoop.hbase.master.balancer.StochasticLoadBalancer.balanceCluster(StochasticLoadBalancer.java:318)
     at org.apache.hadoop.hbase.master.HMaster.balance(HMaster.java:1650)
     at org.apache.hadoop.hbase.master.HMaster.balance(HMaster.java:1567)
     at org.apache.hadoop.hbase.master.balancer.BalancerChore.chore(BalancerChore.java:49)
     at org.apache.hadoop.hbase.ScheduledChore.run(ScheduledChore.java:186)
     at java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:511)
     at java.util.concurrent.FutureTask.runAndReset(FutureTask.java:308)
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.access$301(ScheduledThreadPoolExecutor.java:180)
     at java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:294)
     at org.apache.hadoop.hbase.JitterScheduledThreadPoolExecutorImpl$JitteredRunnableScheduledFuture.run(JitterScheduledThreadPoolExecutorImpl.java:111)
     at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1142)
     at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:617)
     at java.lang.Thread.run(Thread.java:745)