### PR TITLE
HBASE-22822 : Un/Re-schedule balancer chore with balance_switch

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1680,7 +1680,7 @@ public class HMaster extends HRegionServer implements MasterServices {
    *
    * @param on boolean value indicates whether to turn the balancer on
    */
-  void turnBalancer(boolean on) {
+  void switchBalancer(boolean on) {
     if (on) {
       scheduleBalancerChore();
     } else {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1673,6 +1673,29 @@ public class HMaster extends HRegionServer implements MasterServices {
     if (interrupted) Thread.currentThread().interrupt();
   }
 
+  /**
+   * Turn the balancer on/off
+   *
+   * @param on boolean value indicates whether to turn the balancer on
+   */
+  void turnBalancer(boolean on) {
+    if (on) {
+      scheduleBalancerChore();
+    } else {
+      cancelBalancerChore();
+    }
+  }
+
+  private synchronized void scheduleBalancerChore() {
+    if (!getChoreService().isChoreScheduled(this.balancerChore)) {
+      getChoreService().scheduleChore(this.balancerChore);
+    }
+  }
+
+  private void cancelBalancerChore() {
+    getChoreService().cancelChore(this.balancerChore);
+  }
+
   public boolean balance() throws IOException {
     return balance(false);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1104,7 +1104,9 @@ public class HMaster extends HRegionServer implements MasterServices {
     this.clusterStatusChore = new ClusterStatusChore(this, balancer);
     getChoreService().scheduleChore(clusterStatusChore);
     this.balancerChore = new BalancerChore(this);
-    getChoreService().scheduleChore(balancerChore);
+    if (this.loadBalancerTracker.isBalancerOn()) {
+      getChoreService().scheduleChore(balancerChore);
+    }
     this.normalizerChore = new RegionNormalizerChore(this);
     getChoreService().scheduleChore(normalizerChore);
     this.catalogJanitorChore = new CatalogJanitor(this);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -447,9 +447,11 @@ public class MasterRpcServices extends RSRpcServices
         if (mode == BalanceSwitchMode.SYNC) {
           synchronized (master.getLoadBalancer()) {
             master.loadBalancerTracker.setBalancerOn(newValue);
+            master.turnBalancer(newValue);
           }
         } else {
           master.loadBalancerTracker.setBalancerOn(newValue);
+          master.turnBalancer(newValue);
         }
       } catch (KeeperException ke) {
         throw new IOException(ke);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -447,11 +447,11 @@ public class MasterRpcServices extends RSRpcServices
         if (mode == BalanceSwitchMode.SYNC) {
           synchronized (master.getLoadBalancer()) {
             master.loadBalancerTracker.setBalancerOn(newValue);
-            master.turnBalancer(newValue);
+            master.switchBalancer(newValue);
           }
         } else {
           master.loadBalancerTracker.setBalancerOn(newValue);
-          master.turnBalancer(newValue);
+          master.switchBalancer(newValue);
         }
       } catch (KeeperException ke) {
         throw new IOException(ke);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
@@ -173,7 +173,6 @@ public class TestAsyncRegionAdminApi extends TestAsyncAdminBase {
       }
       Thread.sleep(100);
     }
-    admin.balancerSwitch(true).join();
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSplitTransactionOnCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSplitTransactionOnCluster.java
@@ -224,7 +224,6 @@ public class TestSplitTransactionOnCluster {
       }
       assertTrue(cluster.getMaster().getAssignmentManager().getRegionStates().isRegionOnline(hri));
     } finally {
-      admin.balancerSwitch(true, false);
       master.setCatalogJanitorEnabled(true);
       abortAndWaitForMaster();
       TESTING_UTIL.deleteTable(tableName);
@@ -346,7 +345,6 @@ public class TestSplitTransactionOnCluster {
       checkAndGetDaughters(tableName);
       // OK, so split happened after we cleared the blocking node.
     } finally {
-      admin.balancerSwitch(true, false);
       cluster.getMaster().setCatalogJanitorEnabled(true);
       t.close();
     }
@@ -423,7 +421,6 @@ public class TestSplitTransactionOnCluster {
       }
     } finally {
       LOG.info("EXITING");
-      admin.balancerSwitch(true, false);
       cluster.getMaster().setCatalogJanitorEnabled(true);
       t.close();
     }
@@ -549,7 +546,6 @@ public class TestSplitTransactionOnCluster {
       ServerName regionServerOfRegion = regionStates.getRegionServerOfRegion(hri);
       assertEquals(null, regionServerOfRegion);
     } finally {
-      TESTING_UTIL.getAdmin().balancerSwitch(true, false);
       cluster.getMaster().setCatalogJanitorEnabled(true);
     }
   }
@@ -621,7 +617,6 @@ public class TestSplitTransactionOnCluster {
       SlowMeCopro.getPrimaryCdl().get().countDown();
     } finally {
       SlowMeCopro.getPrimaryCdl().get().countDown();
-      admin.balancerSwitch(true, false);
       cluster.getMaster().setCatalogJanitorEnabled(true);
       t.close();
     }
@@ -730,7 +725,6 @@ public class TestSplitTransactionOnCluster {
       assertFalse("Split region can't be unassigned", regionStates.isRegionInTransition(hri));
       assertTrue(regionStates.isRegionInState(hri, State.SPLIT));
     } finally {
-      admin.balancerSwitch(true, false);
       cluster.getMaster().setCatalogJanitorEnabled(true);
     }
   }


### PR DESCRIPTION
balance_switch turns on/off balancer. When it is turned off, we don't remove balancer chore from scheduled chores hence it keeps running only to eventually find out that it is not supposed to perform any action(if balancer was turned off). We can unschedule the chore to prevent the chore() execution and reschedule it when it is turned on by balance_switch.

This should also facilitate running balancer immediately after triggering balance_switch true(due to default initial delay: 0), and then chore would continue running as per duration provided in hbase.balancer.period.