### PR TITLE
HBASE-22828 Log a region close journal

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -1545,13 +1545,16 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
     MonitoredTask status = TaskMonitor.get().createStatus(
         "Closing region " + this.getRegionInfo().getEncodedName() +
         (abort ? " due to abort" : ""));
-
+    status.enableStatusJournal(false);
     status.setStatus("Waiting for close lock");
     try {
       synchronized (closeLock) {
         return doClose(abort, status);
       }
     } finally {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Region close journal:\n" + status.prettyPrintJournal());
+      }
       status.cleanup();
     }
   }


### PR DESCRIPTION
We already track region close activity with a MonitoredTask. Enable the status journal and dump it at DEBUG log level so if for some reasons region closes are taking a long time we have a timestamped journal of the activity and how long each step took.