### PR TITLE
HBASE-22838 : assembly plugin should use posix

### DIFF
--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -76,7 +76,7 @@
           <finalName>hbase-${project.version}</finalName>
           <skipAssembly>false</skipAssembly>
           <appendAssemblyId>true</appendAssemblyId>
-          <tarLongFileMode>gnu</tarLongFileMode>
+          <tarLongFileMode>posix</tarLongFileMode>
           <descriptors>
             <descriptor>${assembly.file}</descriptor>
             <descriptor>src/main/assembly/client.xml</descriptor>


### PR DESCRIPTION
tarball build with assembly:single command fails with user id(mac) or group id(ubuntu) too big error:
```
$ mvn clean install package assembly:single -DskipTests
....
....
....
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single (default-cli) on project hbase-assembly: Execution default-cli of goal org.apache.maven.plugins:maven-assembly-plugin:3.0.0:single failed: user id 'xxxxxxxx' is too big ( > 2097151 ). -> [Help 1]

[ERROR]

[ERROR] To see the full stack trace of the errors, re-run Maven with the -e switch.

[ERROR] Re-run Maven using the -X switch to enable full debug logging.

[ERROR]

[ERROR] For more information about the errors and possible solutions, please read the following articles:

[ERROR] [Help 1] http://cwiki.apache.org/confluence/display/MAVEN/PluginExecutionException

[ERROR]

[ERROR] After correcting the problems, you can resume the build with the command

[ERROR]   mvn <goals> -rf :hbase-assembly
```
To avoid this error and to get better features for tarball build, we should upgrade tarLongFileMode from gnu to posix: [MPOM-132](https://issues.apache.org/jira/browse/MPOM-132)

