### PR TITLE
HBASE-22841 Add more factory functions to TimeRange

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/TimeRange.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/TimeRange.java
@@ -28,9 +28,6 @@ import org.apache.yetus.audience.InterfaceAudience;
  * <p>
  * Evaluated according to minStamp &lt;= timestamp &lt; maxStamp
  * or [minStamp,maxStamp) in interval notation.
- * <p>
- * Can be returned and read by clients.  Should not be directly created by clients.
- * Thus, all constructors are purposely @InterfaceAudience.Private.
  *<p>Immutable. Thread-safe.
  */
 @InterfaceAudience.Public
@@ -49,6 +46,34 @@ public class TimeRange {
       throw new IllegalArgumentException("invalid ts:" + ts);
     }
     return new TimeRange(ts, ts + 1);
+  }
+
+  /**
+   * Represents the time interval [minStamp, Long.MAX_VALUE)
+   * @param minStamp the minimum timestamp value, inclusive
+   */
+  public static TimeRange from(long minStamp) {
+    check(minStamp, INITIAL_MAX_TIMESTAMP);
+    return new TimeRange(minStamp, INITIAL_MAX_TIMESTAMP);
+  }
+
+  /**
+   * Represents the time interval [0, maxStamp)
+   * @param maxStamp the minimum timestamp value, exclusive
+   */
+  public static TimeRange until(long maxStamp) {
+    check(INITIAL_MIN_TIMESTAMP, maxStamp);
+    return new TimeRange(INITIAL_MIN_TIMESTAMP, maxStamp);
+  }
+
+  /**
+   * Represents the time interval [minStamp, maxStamp)
+   * @param minStamp the minimum timestamp, inclusive
+   * @param maxStamp the maximum timestamp, exclusive
+   */
+  public static TimeRange between(long minStamp, long maxStamp) {
+    check(minStamp, maxStamp);
+    return new TimeRange(minStamp, maxStamp);
   }
 
   private final long minStamp;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSide.java
@@ -4867,7 +4867,43 @@ public class TestFromClientSide {
       assertFalse(ok);
 
       ok = table.checkAndMutate(ROW, FAMILY).qualifier(QUALIFIER)
+              .timeRange(TimeRange.from(ts + 10000))
+              .ifEquals(VALUE)
+              .thenPut(put);
+      assertFalse(ok);
+
+      ok = table.checkAndMutate(ROW, FAMILY).qualifier(QUALIFIER)
+              .timeRange(TimeRange.between(ts + 10000, ts + 20000))
+              .ifEquals(VALUE)
+              .thenPut(put);
+      assertFalse(ok);
+
+      ok = table.checkAndMutate(ROW, FAMILY).qualifier(QUALIFIER)
+              .timeRange(TimeRange.until(ts))
+              .ifEquals(VALUE)
+              .thenPut(put);
+      assertFalse(ok);
+
+      ok = table.checkAndMutate(ROW, FAMILY).qualifier(QUALIFIER)
               .timeRange(TimeRange.at(ts))
+              .ifEquals(VALUE)
+              .thenPut(put);
+      assertTrue(ok);
+
+      ok = table.checkAndMutate(ROW, FAMILY).qualifier(QUALIFIER)
+              .timeRange(TimeRange.from(ts))
+              .ifEquals(VALUE)
+              .thenPut(put);
+      assertTrue(ok);
+
+      ok = table.checkAndMutate(ROW, FAMILY).qualifier(QUALIFIER)
+              .timeRange(TimeRange.between(ts, ts + 20000))
+              .ifEquals(VALUE)
+              .thenPut(put);
+      assertTrue(ok);
+
+      ok = table.checkAndMutate(ROW, FAMILY).qualifier(QUALIFIER)
+              .timeRange(TimeRange.until(ts + 10000))
               .ifEquals(VALUE)
               .thenPut(put);
       assertTrue(ok);


### PR DESCRIPTION
These functions make it easier to possible to use
`org.apache.hadoop.hbase.client.Table.CheckAndMutateBuilder#timeRange`
with more interesting ranges, without being forced to use the
deprecated constructors.