### PR TITLE
[HBASE-22601] Misconfigured addition of peers leads to cluster shutdown.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
@@ -309,12 +309,7 @@ public class ReplicationSource extends Thread
       }
     }
 
-    if (peerClusterId == null) {
-      // In some cases, it is possible that peerClusterId is null because it couldn't read
-      // peer cluster id from zookeeper. One case this might happen is because 2 clusters don't
-      // have kerberos trust setup.
-      this.terminate("Peer ClusterId returned is null", null, false);
-      this.manager.closeQueue(this);
+    if (!this.isSourceActive()) {
       return;
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
@@ -309,6 +309,15 @@ public class ReplicationSource extends Thread
       }
     }
 
+    if (peerClusterId == null) {
+      // In some cases, it is possible that peerClusterId is null because it couldn't read
+      // peer cluster id from zookeeper. One case this might happen is because 2 clusters don't
+      // have kerberos trust setup.
+      this.terminate("Peer ClusterId returned is null", null, false);
+      this.manager.closeQueue(this);
+      return;
+    }
+
     // In rare case, zookeeper setting may be messed up. That leads to the incorrect
     // peerClusterId value, which is the same as the source clusterId
     if (clusterId.equals(peerClusterId) && !replicationEndpoint.canReplicateToSameCluster()) {


### PR DESCRIPTION
I have tested the change in our internal dev cluster. Before the change, all the RS used to crash and after the change it doesn't crash. Please review.