### PR TITLE
HBASE-22877 WebHDFS based export snapshot will fail if hfile is in archive directory

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/FileLink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/FileLink.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PositionedReadable;
 import org.apache.hadoop.fs.Seekable;
 import org.apache.hadoop.hbase.util.FSUtils;
+import org.apache.hadoop.hdfs.web.WebHdfsFileSystem;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.hadoop.security.AccessControlException;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -302,6 +303,8 @@ public class FileLink {
       for (Path path: fileLink.getLocations()) {
         if (path.equals(currentPath)) continue;
         try {
+          if(fs instanceof WebHdfsFileSystem && !fs.exists(path))
+            throw new FileNotFoundException("File not exists for path " + path.toString());
           in = fs.open(path, bufferSize);
           if (pos != 0) in.seek(pos);
           assert(in.getPos() == pos) : "Link unable to seek to the right position=" + pos;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/FileLink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/FileLink.java
@@ -303,8 +303,9 @@ public class FileLink {
       for (Path path: fileLink.getLocations()) {
         if (path.equals(currentPath)) continue;
         try {
-          if(fs instanceof WebHdfsFileSystem && !fs.exists(path))
+          if(fs instanceof WebHdfsFileSystem && !fs.exists(path)) {
             throw new FileNotFoundException("File not exists for path " + path.toString());
+          }
           in = fs.open(path, bufferSize);
           if (pos != 0) in.seek(pos);
           assert(in.getPos() == pos) : "Link unable to seek to the right position=" + pos;


### PR DESCRIPTION
The corresponding issue: [HBASE-22877](https://issues.apache.org/jira/browse/HBASE-22877)
The problem happened in the method `tryOpen` :
```
    /**
     * Try to open the file from one of the available locations.
     *
     * @return FSDataInputStream stream of the opened file link
     * @throws IOException on unexpected error, or file not found.
     */
    private FSDataInputStream tryOpen() throws IOException {
      IOException exception = null;
      for (Path path: fileLink.getLocations()) {
        if (path.equals(currentPath)) continue;
        try {
          if(fs instanceof WebHdfsFileSystem && !fs.exists(path))
            throw new FileNotFoundException("File not exists for path " + path.toString());
          in = fs.open(path, bufferSize);
          if (pos != 0) in.seek(pos);
          assert(in.getPos() == pos) : "Link unable to seek to the right position=" + pos;
          if (LOG.isTraceEnabled()) {
            if (currentPath == null) {
              LOG.debug("link open path=" + path);
            } else {
              LOG.trace("link switch from path=" + currentPath + " to path=" + path);
            }
          }
          currentPath = path;
          return(in);
        } catch (FileNotFoundException | AccessControlException | RemoteException e) {
          exception = FileLink.handleAccessLocationException(fileLink, e, exception);
        }
      }
      throw exception;
    }
```

`FileLink.tryOpen()`  depends on `fs.open(path, bufferSize)` to throw `FileNotFoundException`
to try the next file location; When we are using traditional HDFS, the `fs` is implements of  `DistributedFileSystem` OR `ViewFileSystem`, but when we are use webhdfs, the `fs` is implement of `WebHdfsFileSystem`, in this case,  no exception will be thrown even when
the file didn't exist when we are calling `fs.open(path, bufferSize)`; so, `ExportMapper` will think that hfile exists in the tmp directory, the FileLink will use this directory as the hfile directory by fault; Then finally, when mapper task trying to read this hfile, it found that this file doesn't exist in fact and mapper will fail:

```
Error: java.io.FileNotFoundException: File does not exist: /hbase/light-hbase/.tmp/data/subill/babylon_event_history/e24ce0b56feb626b4dfe4a0e1d4f3229/info/8bef474844ec42338e7481a1933cecbd
	at sun.reflect.GeneratedConstructorAccessor14.newInstance(Unknown Source)
	at sun.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.lang.reflect.Constructor.newInstance(Constructor.java:423)
	at org.apache.hadoop.ipc.RemoteException.instantiateException(RemoteException.java:106)
	at org.apache.hadoop.ipc.RemoteException.unwrapRemoteException(RemoteException.java:95)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem.toIOException(WebHdfsFileSystem.java:451)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem.access$600(WebHdfsFileSystem.java:108)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$AbstractRunner.shouldRetry(WebHdfsFileSystem.java:738)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$AbstractRunner.runWithRetry(WebHdfsFileSystem.java:704)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$AbstractRunner.access$100(WebHdfsFileSystem.java:524)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$AbstractRunner$1.run(WebHdfsFileSystem.java:554)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1924)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$AbstractRunner.run(WebHdfsFileSystem.java:550)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$ReadRunner.read(WebHdfsFileSystem.java:1824)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$WebHdfsInputStream.read(WebHdfsFileSystem.java:1682)
	at java.io.DataInputStream.read(DataInputStream.java:149)
	at org.apache.hadoop.hbase.io.FileLink$FileLinkInputStream.read(FileLink.java:152)
	at java.io.DataInputStream.read(DataInputStream.java:149)
	at java.io.BufferedInputStream.read1(BufferedInputStream.java:284)
	at java.io.BufferedInputStream.read(BufferedInputStream.java:345)
	at java.io.FilterInputStream.read(FilterInputStream.java:107)
	at org.apache.hadoop.hbase.io.hadoopbackport.ThrottledInputStream.read(ThrottledInputStream.java:79)
	at org.apache.hadoop.hbase.snapshot.ExportSnapshot$ExportMapper.copyData(ExportSnapshot.java:387)
	at org.apache.hadoop.hbase.snapshot.ExportSnapshot$ExportMapper.copyFile(ExportSnapshot.java:284)
	at org.apache.hadoop.hbase.snapshot.ExportSnapshot$ExportMapper.map(ExportSnapshot.java:212)
	at org.apache.hadoop.hbase.snapshot.ExportSnapshot$ExportMapper.map(ExportSnapshot.java:130)
	at org.apache.hadoop.mapreduce.Mapper.run(Mapper.java:145)
	at org.apache.hadoop.mapred.MapTask.runNewMapper(MapTask.java:793)
	at org.apache.hadoop.mapred.MapTask.run(MapTask.java:341)
	at org.apache.hadoop.mapred.YarnChild$2.run(YarnChild.java:164)
	at java.security.AccessController.doPrivileged(Native Method)
	at javax.security.auth.Subject.doAs(Subject.java:422)
	at org.apache.hadoop.security.UserGroupInformation.doAs(UserGroupInformation.java:1924)
	at org.apache.hadoop.mapred.YarnChild.main(YarnChild.java:158)
Caused by: org.apache.hadoop.ipc.RemoteException(java.io.FileNotFoundException): File does not exist: /hbase/light-hbase/.tmp/data/subill/babylon_event_history/e24ce0b56feb626b4dfe4a0e1d4f3229/info/8bef474844ec42338e7481a1933cecbd
	at org.apache.hadoop.hdfs.web.JsonUtil.toRemoteException(JsonUtil.java:124)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem.validateResponse(WebHdfsFileSystem.java:420)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem.access$200(WebHdfsFileSystem.java:108)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$AbstractRunner.connect(WebHdfsFileSystem.java:596)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$ReadRunner.connect(WebHdfsFileSystem.java:1875)
	at org.apache.hadoop.hdfs.web.WebHdfsFileSystem$AbstractRunner.runWithRetry(WebHdfsFileSystem.java:674)
	... 27 more
```

We should add an addition code to handle the `WebHDFS` case;