### PR TITLE
HBASE-22904 NPE occurs when RS send space quota usage report during HMaster init

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -2227,10 +2227,12 @@ public class MasterRpcServices extends RSRpcServices
         return RegionSpaceUseReportResponse.newBuilder().build();
       }
       MasterQuotaManager quotaManager = this.master.getMasterQuotaManager();
-      final long now = EnvironmentEdgeManager.currentTime();
-      for (RegionSpaceUse report : request.getSpaceUseList()) {
-        quotaManager.addRegionSize(ProtobufUtil.toRegionInfo(
-            report.getRegionInfo()), report.getRegionSize(), now);
+      if (quotaManager != null) {
+        final long now = EnvironmentEdgeManager.currentTime();
+        for (RegionSpaceUse report : request.getSpaceUseList()) {
+          quotaManager.addRegionSize(ProtobufUtil.toRegionInfo(report.getRegionInfo()),
+            report.getRegionSize(), now);
+        }
       }
       return RegionSpaceUseReportResponse.newBuilder().build();
     } catch (Exception e) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -2233,6 +2233,9 @@ public class MasterRpcServices extends RSRpcServices
           quotaManager.addRegionSize(ProtobufUtil.toRegionInfo(report.getRegionInfo()),
             report.getRegionSize(), now);
         }
+      } else {
+        LOG.debug(
+          "Received region space usage report but HMaster is not ready to process it, skipping");
       }
       return RegionSpaceUseReportResponse.newBuilder().build();
     } catch (Exception e) {
@@ -2267,6 +2270,9 @@ public class MasterRpcServices extends RSRpcServices
               .setSize(tableSize.getValue()).build());
         }
         return builder.build();
+      } else {
+        LOG.debug(
+          "Received space quota region size report but HMaster is not ready to process it, skipping");
       }
       return builder.build();
     } catch (Exception e) {


### PR DESCRIPTION
During HMaster failover, if RegionServer send space quota report to HMaster and MasterQuotaManager is not yet initialized then NPE will occur.

https://github.com/apache/hbase/blob/767bb1511285ae67dae15e8a2aab62c38244c797/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java#L2229
