### PR TITLE
HBASE-22913 Use Hadoop label for nightly builds

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -17,7 +17,7 @@
 pipeline {
   agent {
     node {
-      label 'ubuntu'
+      label 'Hadoop'
     }
   }
   triggers {


### PR DESCRIPTION
HBase, a Hadoop related project, must use the Hadoop label please.
This build, and others are starving the 'ubuntu' label which other projects need to use.