### PR TITLE
HBASE-22944 Space Quota: TableNotFoundException: hbase:quota is thrown when region server is restarted.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SpaceQuotaRefresherChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SpaceQuotaRefresherChore.java
@@ -76,7 +76,7 @@ public class SpaceQuotaRefresherChore extends ScheduledChore {
   protected void chore() {
     try {
       // check whether Quota table is present or not.
-      if (!MetaTableAccessor.tableExists(getConnection(), QuotaUtil.QUOTA_TABLE_NAME)) {
+      if (!checkQuotaTableExists()) {
         LOG.warn("Quota table not found, skipping quota manager cache refresh.");
         return;
       }
@@ -148,6 +148,16 @@ public class SpaceQuotaRefresherChore extends ScheduledChore {
       LOG.warn(
           "Caught exception while refreshing enforced quota violation policies, will retry.", e);
     }
+  }
+
+  /**
+   * Checks if hbase:quota exists in hbase:meta
+   *
+   * @return true if hbase:quota table is in meta, else returns false.
+   * @throws IOException throws IOException
+   */
+  boolean checkQuotaTableExists() throws IOException {
+    return MetaTableAccessor.tableExists(getConnection(), QuotaUtil.QUOTA_TABLE_NAME);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SpaceQuotaRefresherChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SpaceQuotaRefresherChore.java
@@ -61,6 +61,7 @@ public class SpaceQuotaRefresherChore extends ScheduledChore {
 
   private final RegionServerSpaceQuotaManager manager;
   private final Connection conn;
+  private boolean quotaTablePresent = false;
 
   public SpaceQuotaRefresherChore(RegionServerSpaceQuotaManager manager, Connection conn) {
     super(SpaceQuotaRefresherChore.class.getSimpleName(),
@@ -76,8 +77,9 @@ public class SpaceQuotaRefresherChore extends ScheduledChore {
   protected void chore() {
     try {
       // check whether Quota table is present or not.
-      if (!checkQuotaTableExists()) {
-        LOG.warn("Quota table not found, skipping quota manager cache refresh.");
+      if (!quotaTablePresent && !checkQuotaTableExists()) {
+        LOG.info("Quota table not found, skipping quota manager cache refresh.");
+        quotaTablePresent = true;
         return;
       }
       if (LOG.isTraceEnabled()) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SpaceQuotaRefresherChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SpaceQuotaRefresherChore.java
@@ -76,12 +76,13 @@ public class SpaceQuotaRefresherChore extends ScheduledChore {
   @Override
   protected void chore() {
     try {
-      // check whether Quota table is present or not.
+      // check whether quotaTable is present or not.
       if (!quotaTablePresent && !checkQuotaTableExists()) {
         LOG.info("Quota table not found, skipping quota manager cache refresh.");
-        quotaTablePresent = true;
         return;
       }
+      // since quotaTable is present so setting the flag as true.
+      quotaTablePresent = true;
       if (LOG.isTraceEnabled()) {
         LOG.trace("Reading current quota snapshots from hbase:quota.");
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SpaceQuotaRefresherChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SpaceQuotaRefresherChore.java
@@ -23,6 +23,7 @@ import java.util.Map.Entry;
 import java.util.concurrent.TimeUnit;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.ScheduledChore;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -74,6 +75,11 @@ public class SpaceQuotaRefresherChore extends ScheduledChore {
   @Override
   protected void chore() {
     try {
+      // check whether Quota table is present or not.
+      if (!MetaTableAccessor.tableExists(getConnection(), QuotaUtil.QUOTA_TABLE_NAME)) {
+        LOG.warn("Quota table not found, skipping quota manager cache refresh.");
+        return;
+      }
       if (LOG.isTraceEnabled()) {
         LOG.trace("Reading current quota snapshots from hbase:quota.");
       }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotaViolationPolicyRefresherChore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotaViolationPolicyRefresherChore.java
@@ -82,6 +82,7 @@ public class TestSpaceQuotaViolationPolicyRefresherChore {
     chore = mock(SpaceQuotaRefresherChore.class);
     when(chore.getConnection()).thenReturn(conn);
     when(chore.getManager()).thenReturn(manager);
+    when(chore.checkQuotaTableExists()).thenReturn(true);
     doCallRealMethod().when(chore).chore();
     when(chore.isInViolation(any())).thenCallRealMethod();
     doCallRealMethod().when(chore).extractQuotaSnapshot(any(), any());


### PR DESCRIPTION
During Master startup if quota feature is enabled and region server is running TableNotFoundException occurs in regionServer logs

SpaceQuotaRefresherChore does not checks whether hbase:quota table is present,before starting its operation which sometimes may result to TableNotFoundExceptions.

This is because master has not created the hbase:quota table and SpaceQuotaRefresherChore is running.

This is little tricky and will happen in below scenario:
----------------------------------------------------------------
1. HM & RSs are restarted after enabling Space Quota feature. 
2. SpaceQuotaRefresher chore interval is set as very low say 5 sec
3. So by the time HMaster creates quota table SpaceQuotaRefresherChore executes and throws TNFE