### PR TITLE
HBASE-22012 Space Quota: DisableTableViolationPolicy will cause cycles of enable/disable table

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaObserverChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaObserverChore.java
@@ -471,7 +471,7 @@ public class QuotaObserverChore extends ScheduledChore {
   void pruneOldRegionReports() {
     final long now = EnvironmentEdgeManager.currentTime();
     final long pruneTime = now - regionReportLifetimeMillis;
-    final int numRemoved = quotaManager.pruneEntriesOlderThan(pruneTime);
+    final int numRemoved = quotaManager.pruneEntriesOlderThan(pruneTime,this);
     if (LOG.isTraceEnabled()) {
       LOG.trace("Removed " + numRemoved + " old region size reports that were older than "
           + pruneTime + ".");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestMasterQuotaManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestMasterQuotaManager.java
@@ -17,12 +17,16 @@
  */
 package org.apache.hadoop.hbase.quotas;
 
+import static org.apache.hadoop.hbase.quotas.QuotaUtil.QUOTA_CONF_KEY;
 import static org.apache.hadoop.hbase.util.Bytes.toBytes;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.master.MasterServices;
@@ -51,6 +55,10 @@ public class TestMasterQuotaManager {
     MasterServices masterServices = mock(MasterServices.class);
     MasterQuotaManager manager = new MasterQuotaManager(masterServices);
     manager.initializeRegionSizes();
+    HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.set(QUOTA_CONF_KEY, "false");
+    when(masterServices.getConfiguration()).thenReturn(conf);
     // Mock out some regions
     TableName tableName = TableName.valueOf("foo");
     HRegionInfo region1 = new HRegionInfo(tableName, null, toBytes("a"));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotaBasicFunctioning.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotaBasicFunctioning.java
@@ -253,7 +253,8 @@ public class TestSpaceQuotaBasicFunctioning {
 
     // Check if disabled table region report present in the map after retention period expired.
     // It should be present after retention period expired.
-    Assert.assertTrue(quotaManager.snapshotRegionSizes().keySet().stream()
-        .filter(k -> k.getTable().equals(tableName)).count() > 0);
+    final long regionSizes = quotaManager.snapshotRegionSizes().keySet().stream()
+        .filter(k -> k.getTable().equals(tableName)).count();
+    Assert.assertTrue(regionSizes > 0);
   }
 }


### PR DESCRIPTION
Space Quota: Policy state is getting changed from disable to Observance after sometime automatically.

Steps:

1: Create a table with space quota policy as Disable
2: Put some data so that table state is in space quota violation
3: So observe that table state is in violation
4: Now wait for some time
5: Observe that after some time table state is changing to to Observance however table is still disabled

Solution:  it is better to not remove the entries from cache regionSizes if table is in violation and has DISABLE policy set on it to avoid this repeat cycle of enable/disable. If the entries are not removed from the cache for disable policy and violation tables the table will not go from disable to enable even though regions of the table are offline.