### PR TITLE
HBASE-22930 Set unique name to longCompactions/shortCompactions/split threads

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CompactSplit.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CompactSplit.java
@@ -120,8 +120,7 @@ public class CompactSplit implements CompactionRequester, PropagatingConfigurati
     final String n = Thread.currentThread().getName();
     int splitThreads = conf.getInt(SPLIT_THREADS, SPLIT_THREADS_DEFAULT);
     this.splits = (ThreadPoolExecutor) Executors.newFixedThreadPool(splitThreads,
-            new ThreadFactoryBuilder().setNameFormat(n + "-splits-" + System.currentTimeMillis())
-                .setDaemon(true).build());
+      new ThreadFactoryBuilder().setNameFormat(n + "-splits-%d").setDaemon(true).build());
   }
 
   private void createCompactionExecutors() {
@@ -138,18 +137,14 @@ public class CompactSplit implements CompactionRequester, PropagatingConfigurati
     final String n = Thread.currentThread().getName();
 
     StealJobQueue<Runnable> stealJobQueue = new StealJobQueue<Runnable>(COMPARATOR);
-    this.longCompactions = new ThreadPoolExecutor(largeThreads, largeThreads, 60,
-        TimeUnit.SECONDS, stealJobQueue,
-        new ThreadFactoryBuilder()
-            .setNameFormat(n + "-longCompactions-" + System.currentTimeMillis())
+    this.longCompactions = new ThreadPoolExecutor(largeThreads, largeThreads, 60, TimeUnit.SECONDS,
+        stealJobQueue, new ThreadFactoryBuilder().setNameFormat(n + "-longCompactions-%d")
             .setDaemon(true).build());
     this.longCompactions.setRejectedExecutionHandler(new Rejection());
     this.longCompactions.prestartAllCoreThreads();
-    this.shortCompactions = new ThreadPoolExecutor(smallThreads, smallThreads, 60,
-        TimeUnit.SECONDS, stealJobQueue.getStealFromQueue(),
-        new ThreadFactoryBuilder()
-            .setNameFormat(n + "-shortCompactions-" + System.currentTimeMillis())
-            .setDaemon(true).build());
+    this.shortCompactions = new ThreadPoolExecutor(smallThreads, smallThreads, 60, TimeUnit.SECONDS,
+        stealJobQueue.getStealFromQueue(), new ThreadFactoryBuilder()
+            .setNameFormat(n + "-shortCompactions-%d").setDaemon(true).build());
     this.shortCompactions.setRejectedExecutionHandler(new Rejection());
   }
 


### PR DESCRIPTION
ThreadFactoryBuilder internally has the its own counter, but to have the counter in the thread name we need to define the format in setNameFormat(),

new ThreadFactoryBuilder().setNameFormat(n + "-longCompactions-%d")