### PR TITLE
HBASE-22980 HRegionPartioner getPartition() method incorrectly partitions the regions of the table.

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/HRegionPartitioner.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/HRegionPartitioner.java
@@ -82,7 +82,7 @@ implements Partitioner<ImmutableBytesWritable, V2> {
     }
     for (int i = 0; i < this.startKeys.length; i++){
       if (Bytes.compareTo(region, this.startKeys[i]) == 0 ){
-        if (i >= numPartitions-1){
+        if (i >= numPartitions){
           // cover if we have less reduces then regions.
           return (Integer.toString(i).hashCode()
               & Integer.MAX_VALUE) % numPartitions;

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HRegionPartitioner.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HRegionPartitioner.java
@@ -89,7 +89,7 @@ implements Configurable {
     }
     for (int i = 0; i < this.startKeys.length; i++){
       if (Bytes.compareTo(region, this.startKeys[i]) == 0 ){
-        if (i >= numPartitions-1){
+        if (i >= numPartitions){
           // cover if we have less reduces then regions.
           return (Integer.toString(i).hashCode()
               & Integer.MAX_VALUE) % numPartitions;

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHRegionPartitioner.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHRegionPartitioner.java
@@ -87,11 +87,11 @@ public class TestHRegionPartitioner {
     TableName tableName = TableName.valueOf(name.getMethodName());
     UTIL.createTable(tableName, families, 1, Bytes.toBytes("aa"), Bytes.toBytes("cc"), 5);
 
-    int numberOfRegions = MetaTableAccessor.getRegionCount(UTIL.getConfiguration(), tableName);
+    Configuration configuration = UTIL.getConfiguration();
+    int numberOfRegions = MetaTableAccessor.getRegionCount(configuration, tableName);
     assertEquals(5, numberOfRegions);
 
     HRegionPartitioner<Long, Long> partitioner = new HRegionPartitioner<>();
-    Configuration configuration = UTIL.getConfiguration();
     configuration.set(TableOutputFormat.OUTPUT_TABLE, name.getMethodName());
     partitioner.setConf(configuration);
 

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHRegionPartitioner.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHRegionPartitioner.java
@@ -77,4 +77,24 @@ public class TestHRegionPartitioner {
     assertEquals(1, partitioner.getPartition(writable, 10L, 3));
     assertEquals(0, partitioner.getPartition(writable, 10L, 1));
   }
+
+  @Test
+  public void testHRegionPartitionerMoreRegions() throws Exception {
+
+    byte[][] families = { Bytes.toBytes("familyA"), Bytes.toBytes("familyB") };
+
+    UTIL.createTable(TableName.valueOf(name.getMethodName()), families, 1,
+        Bytes.toBytes("aa"), Bytes.toBytes("cc"), 5);
+
+    HRegionPartitioner<Long, Long> partitioner = new HRegionPartitioner<>();
+    Configuration configuration = UTIL.getConfiguration();
+    configuration.set(TableOutputFormat.OUTPUT_TABLE, name.getMethodName());
+    partitioner.setConf(configuration);
+
+    // Get some rowKey for the lastRegion
+    ImmutableBytesWritable writable = new ImmutableBytesWritable(Bytes.toBytes("df"));
+
+    // getPartition should return 4 since number of partition = number of reduces.
+    assertEquals(4, partitioner.getPartition(writable, 10L, 5));
+  }
 }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHRegionPartitioner.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHRegionPartitioner.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertEquals;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.testclassification.MapReduceTests;
@@ -83,8 +84,11 @@ public class TestHRegionPartitioner {
 
     byte[][] families = { Bytes.toBytes("familyA"), Bytes.toBytes("familyB") };
 
-    UTIL.createTable(TableName.valueOf(name.getMethodName()), families, 1,
-        Bytes.toBytes("aa"), Bytes.toBytes("cc"), 5);
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    UTIL.createTable(tableName, families, 1, Bytes.toBytes("aa"), Bytes.toBytes("cc"), 5);
+
+    int numberOfRegions = MetaTableAccessor.getRegionCount(UTIL.getConfiguration(), tableName);
+    assertEquals(5, numberOfRegions);
 
     HRegionPartitioner<Long, Long> partitioner = new HRegionPartitioner<>();
     Configuration configuration = UTIL.getConfiguration();


### PR DESCRIPTION
Partitioner class HRegionPartitioner in a HBase MapReduce job has a method getPartition(). In getPartition(), there is a scenario where we have check for less number of reducers than region. This scenario seems incorrect because for a rowKey present in last region(let us say nth region) , getPartition() should return value (n-1). But it is not returning n-1 for the last region as it is falling in the case where number of reducers < number of regions and returning some random value. 

So if a client uses this class as a partitioner class in HBase MapReduce jobs, this method incorrectly partitions the regions because rowKeys present in the last regions does not fall to the last region.

https://github.com/apache/hbase/blob/fbd5b5e32753104f88600b0f4c803ab5659bce64/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HRegionPartitioner.java#L92

Consider the following scenario:

if there are 5 regions for the table, partitions = 5 and number of reducers is also 5.
So in this case above check for reducers < regions should not return true.
But for the last region when i=4(last region, 5th region) , getPartition should return 4 but it returns 2 because it falls in the case of when we have less reduces than region and returns true for the above condition even though we have reducers = regions. So the condition is incorrect.
 
Solution:
Instead of

       if (i >= numPartitions-1){ 
It should be

       if (i >= numPartitions){ 