### PR TITLE
HBASE-22142 Space quota: If table inside namespace having space quota is dropped, data size usage is still considered for the drop table.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/MasterQuotaManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/MasterQuotaManager.java
@@ -740,5 +740,14 @@ public class MasterQuotaManager implements RegionStateListener {
       notifier.addArchivedFiles(filesWithSize);
     }
   }
+
+  /**
+   * Remove regionInfo entry for the table which is going to get dropped.
+   *
+   * @param tableName tableName.
+   */
+  public void removeTableRegions(TableName tableName) {
+    regionSizes.entrySet().removeIf(regionInfo -> regionInfo.getKey().getTable().equals(tableName));
+  }
 }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/MasterQuotaManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/MasterQuotaManager.java
@@ -742,12 +742,12 @@ public class MasterQuotaManager implements RegionStateListener {
   }
 
   /**
-   * Remove regionInfo entry for the table which is going to get dropped.
+   * Removes each region size entry where the RegionInfo references the provided TableName.
    *
    * @param tableName tableName.
    */
-  public void removeTableRegions(TableName tableName) {
-    regionSizes.entrySet().removeIf(regionInfo -> regionInfo.getKey().getTable().equals(tableName));
+  public void removeRegionSizesForTable(TableName tableName) {
+    regionSizes.keySet().removeIf(regionInfo -> regionInfo.getTable().equals(tableName));
   }
 }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/MasterQuotasObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/MasterQuotasObserver.java
@@ -24,10 +24,14 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorException;
+import org.apache.hadoop.hbase.coprocessor.CoreCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.HasMasterServices;
 import org.apache.hadoop.hbase.coprocessor.MasterCoprocessor;
 import org.apache.hadoop.hbase.coprocessor.MasterCoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.MasterObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.QuotaProtos.Quotas;
 
@@ -35,6 +39,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.QuotaProtos.Quotas;
  * An observer to automatically delete quotas when a table/namespace
  * is deleted.
  */
+@CoreCoprocessor
 @InterfaceAudience.Private
 public class MasterQuotasObserver implements MasterCoprocessor, MasterObserver {
   public static final String REMOVE_QUOTA_ON_TABLE_DELETE = "hbase.quota.remove.on.table.delete";
@@ -43,6 +48,7 @@ public class MasterQuotasObserver implements MasterCoprocessor, MasterObserver {
   private CoprocessorEnvironment cpEnv;
   private Configuration conf;
   private boolean quotasEnabled = false;
+  private MasterServices masterServices;
 
   @Override
   public Optional<MasterObserver> getMasterObserver() {
@@ -51,9 +57,19 @@ public class MasterQuotasObserver implements MasterCoprocessor, MasterObserver {
 
   @Override
   public void start(CoprocessorEnvironment ctx) throws IOException {
-    this.cpEnv = ctx;
-    this.conf = cpEnv.getConfiguration();
+    this.conf = ctx.getConfiguration();
     this.quotasEnabled = QuotaUtil.isQuotaEnabled(conf);
+
+    if (!(ctx instanceof MasterCoprocessorEnvironment)) {
+      throw new CoprocessorException("Must be loaded on master.");
+    }
+    // if running on master
+    MasterCoprocessorEnvironment mEnv = (MasterCoprocessorEnvironment) ctx;
+    if (mEnv instanceof HasMasterServices) {
+      this.masterServices = ((HasMasterServices) mEnv).getMasterServices();
+    } else {
+      throw new CoprocessorException("Must be loaded on a master having master services.");
+    }
   }
 
   @Override
@@ -65,8 +81,11 @@ public class MasterQuotasObserver implements MasterCoprocessor, MasterObserver {
     }
     final Connection conn = ctx.getEnvironment().getConnection();
     Quotas quotas = QuotaUtil.getTableQuota(conn, tableName);
+    Quotas quotasAtNamespace = QuotaUtil.getNamespaceQuota(conn, tableName.getNamespaceAsString());
     if (quotas != null){
       if (quotas.hasSpace()){
+        // Remove regions of table from space quota map.
+        this.masterServices.getMasterQuotaManager().removeTableRegions(tableName);
         QuotaSettings settings = QuotaSettingsFactory.removeTableSpaceLimit(tableName);
         try (Admin admin = conn.getAdmin()) {
           admin.setQuota(settings);
@@ -76,6 +95,13 @@ public class MasterQuotasObserver implements MasterCoprocessor, MasterObserver {
         QuotaSettings settings = QuotaSettingsFactory.unthrottleTable(tableName);
         try (Admin admin = conn.getAdmin()) {
           admin.setQuota(settings);
+        }
+      }
+    } else {
+      if (quotasAtNamespace != null) {
+        if (quotasAtNamespace.hasSpace()) {
+          // Remove regions of table from space quota map.
+          this.masterServices.getMasterQuotaManager().removeTableRegions(tableName);
         }
       }
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotaDropTable.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotaDropTable.java
@@ -114,17 +114,18 @@ public class TestSpaceQuotaDropTable {
       }
     });
 
-    boolean beforeDrop = false;
+    boolean hasRegionSize = false;
 
     // region report should be present before dropping the table.
     for (Map.Entry<RegionInfo, Long> entry : quotaManager.snapshotRegionSizes().entrySet()) {
       if (entry.getKey().getTable().equals(tn)) {
-        beforeDrop = true;
+        hasRegionSize = true;
         break;
       }
     }
 
-    Assert.assertTrue(beforeDrop);
+    // regionSize report for the given table should be present before dropping the table.
+    Assert.assertTrue(hasRegionSize);
 
     // drop the table
     TEST_UTIL.getAdmin().disableTable(tn);
@@ -133,7 +134,7 @@ public class TestSpaceQuotaDropTable {
     // check if deleted table region report still present in the map.
     for (Map.Entry<RegionInfo, Long> entry : quotaManager.snapshotRegionSizes().entrySet()) {
       if (entry.getKey().getTable().equals(tn)) {
-        Assert.fail("Not deleted during the drop command");
+        Assert.fail("Dropped table regionSizes were not deleted during the drop command");
       }
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotaDropTable.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotaDropTable.java
@@ -15,16 +15,23 @@
  */
 package org.apache.hadoop.hbase.quotas;
 
+import java.util.List;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicLong;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.AfterClass;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -85,6 +92,50 @@ public class TestSpaceQuotaDropTable {
   @Test
   public void testSetQuotaAndThenDropTableWithDisable() throws Exception {
     setQuotaAndThenDropTable(SpaceViolationPolicy.DISABLE);
+  }
+
+  @Test
+  public void testSetQuotaAndThenDropTableWithRegionReport() throws Exception {
+    final TableName tn = helper.createTable();
+    helper.setQuotaLimit(tn, SpaceViolationPolicy.NO_INSERTS, 1L);
+    helper.writeData(tn, 2L);
+
+    final HMaster master = TEST_UTIL.getMiniHBaseCluster().getMaster();
+    final MasterQuotaManager quotaManager = master.getMasterQuotaManager();
+
+    // Make sure the master has report for the table.
+    Waiter.waitFor(TEST_UTIL.getConfiguration(), 30 * 1000, new Waiter.Predicate<Exception>() {
+      @Override
+      public boolean evaluate() throws Exception {
+        Map<RegionInfo, Long> regionSizes = quotaManager.snapshotRegionSizes();
+        List<RegionInfo> tableRegions =
+            MetaTableAccessor.getTableRegions(TEST_UTIL.getConnection(), tn);
+        return regionSizes.containsKey(tableRegions.get(0));
+      }
+    });
+
+    boolean beforeDrop = false;
+
+    // region report should be present before dropping the table.
+    for (Map.Entry<RegionInfo, Long> entry : quotaManager.snapshotRegionSizes().entrySet()) {
+      if (entry.getKey().getTable().equals(tn)) {
+        beforeDrop = true;
+        break;
+      }
+    }
+
+    Assert.assertTrue(beforeDrop);
+
+    // drop the table
+    TEST_UTIL.getAdmin().disableTable(tn);
+    TEST_UTIL.getAdmin().deleteTable(tn);
+
+    // check if deleted table region report still present in the map.
+    for (Map.Entry<RegionInfo, Long> entry : quotaManager.snapshotRegionSizes().entrySet()) {
+      if (entry.getKey().getTable().equals(tn)) {
+        Assert.fail("Not deleted during the drop command");
+      }
+    }
   }
 
   private void setQuotaAndThenDropTable(SpaceViolationPolicy policy) throws Exception {


### PR DESCRIPTION
steps to follow:

1. create a quota at namespace level

2. create 2 tables t1 and t2 inside namespace and write data.

3. write 5 mb of data each in both t1 and t2.

4. data usage will be shown 10 mb for both table, since quota is set at namespace level.

5. drop t1.

6. data usage for t2 will be shown 10 mb for 10 minutes. And will come back to 5 mb after 10 minutes.

If table is dropped inside namespace, data size  usage is still shown for 10 minutes because of the configuration "hbase.master.quotas.region.report.retention.millis". This conf maintains the region report in cache(regionSizes) and old entry is used for 10 minutes. We can remove the entry from cache during the drop command as part of MasterCP hook only, so that correct usage is show instantaneously after the drop command.
