### PR TITLE
HBASE-23007 UnsatisfiedLinkError when using hbase-shaded packages under linux

### DIFF
--- a/hbase-shaded/hbase-shaded-testing-util/pom.xml
+++ b/hbase-shaded/hbase-shaded-testing-util/pom.xml
@@ -133,9 +133,9 @@
         </dependency>
         <dependency>
             <groupId>org.codehaus.jackson</groupId>
-            <artifactId>jackson-mapper-asl</artifactId>
+            <artifactId>jackson-jaxrs</artifactId>
             <version>1.9.13</version>
-            <scope>test</scope>
+            <scope>compile</scope>
         </dependency>
 
         <dependency>

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -441,8 +441,8 @@
 
                                     <!-- top level net-->
                                     <relocation>
-                                        <pattern>net</pattern>
-                                        <shadedPattern>${shaded.prefix}.net</shadedPattern>
+                                        <pattern>net.</pattern>
+                                        <shadedPattern>${shaded.prefix}.net.</shadedPattern>
                                     </relocation>
 
                                 </relocations>

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -441,7 +441,7 @@
 
                                     <!-- top level net-->
                                     <relocation>
-                                        <pattern>net.</pattern>
+                                        <pattern>net/</pattern>
                                         <shadedPattern>${shaded.prefix}.net.</shadedPattern>
                                     </relocation>
 


### PR DESCRIPTION
* Relocation rule "net" has been changed to "net." because "netty"
applies to that rule.
* Added jackson dependencies for WebHdfs.