### PR TITLE
HBASE-22929 - MemStoreLAB ChunkCreator may memory leak(ram)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreLABImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreLABImpl.java
@@ -270,6 +270,11 @@ public class MemStoreLABImpl implements MemStoreLAB {
     }
   }
 
+  @VisibleForTesting
+  int getOpenScannerCount() {
+    return this.openScannerCount.get();
+  }
+
   /**
    * Called when opening a scanner on the data of this MemStoreLAB
    */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -895,12 +895,14 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
         // need for the updateReaders() to happen.
         LOG.debug("StoreScanner already has the close lock. There is no need to updateReaders");
         // no lock acquired.
+        clearAndClose(memStoreScanners);
         return;
       }
       // lock acquired
       updateReaders = true;
       if (this.closing) {
         LOG.debug("StoreScanner already closing. There is no need to updateReaders");
+        clearAndClose(memStoreScanners);
         return;
       }
       flushed = true;


### PR DESCRIPTION
The leak is caused as said by @binlijin. The updateReaders() has already the memstoreScanners() list and so that is not getting closed. 
We need to close the scanners if the close()  has already happened. The test case added here helps to identify the problem. Without the patch the test fails and with patch the test passes. 
@chenxu14 - Pls take a look if this will solve the problem.
@binlijin  - I just realised that the memstoreScanners() were passed by the Hstore#notifyChangedReadersObservers() and not got from the updateReaders(). 