### PR TITLE
HBASE-22955 Properly set jdk7 as JAVA_HOME for branches-1 precommit and nightly.

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -131,9 +131,8 @@ curl -L  -o personality.sh "${env.PROJECT_PERSONALITY}"
             // TODO does hadoopcheck need to be jdk specific?
             // Should be things that work with multijdk
             TESTS = 'all,-unit,-findbugs'
-            // on branches that don't support jdk7, this will already be JAVA_HOME, so we'll end up not
-            // doing multijdk there.
-            MULTIJDK = '/usr/lib/jvm/java-8-openjdk-amd64'
+            // this is only elevant on branches-1. on branches with default jdk8, the relevant jdk will be JAVA_HOME
+            MULTIJDK = '/usr/lib/jvm/zulu-8-amd64'
             OUTPUT_DIR_RELATIVE = "${env.OUTPUT_DIR_RELATIVE_GENERAL}"
             OUTPUT_DIR = "${env.WORKSPACE}/${env.OUTPUT_DIR_RELATIVE_GENERAL}"
           }
@@ -280,9 +279,8 @@ curl -L  -o personality.sh "${env.PROJECT_PERSONALITY}"
             TESTS = 'maven,mvninstall,compile,javac,unit,findbugs,htmlout'
             OUTPUT_DIR_RELATIVE = "${env.OUTPUT_DIR_RELATIVE_HADOOP2}"
             OUTPUT_DIR = "${env.WORKSPACE}/${env.OUTPUT_DIR_RELATIVE_HADOOP2}"
-            // This isn't strictly needed on branches that only support jdk8, but doesn't hurt
-            // and is needed on branches that do both jdk7 and jdk8
-            SET_JAVA_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
+            // this is branch-1 specific. the branch-2+ version uses openjdk artifacts
+            SET_JAVA_HOME = '/usr/lib/jvm/zulu-8-amd64'
           }
           steps {
             // Must do prior to anything else, since if one of them timesout we'll stash the commentfile
@@ -365,9 +363,8 @@ curl -L  -o personality.sh "${env.PROJECT_PERSONALITY}"
             TESTS = 'maven,mvninstall,compile,javac,unit,htmlout'
             OUTPUT_DIR_RELATIVE = "${env.OUTPUT_DIR_RELATIVE_HADOOP3}"
             OUTPUT_DIR = "${env.WORKSPACE}/${env.OUTPUT_DIR_RELATIVE_HADOOP3}"
-            // This isn't strictly needed on branches that only support jdk8, but doesn't hurt
-            // and is needed on branches that do both jdk7 and jdk8
-            SET_JAVA_HOME = '/usr/lib/jvm/java-8-openjdk-amd64'
+            // this is branch-1 specific. the branch-2+ version uses openjdk artifacts
+            SET_JAVA_HOME = '/usr/lib/jvm/zulu-8-amd64'
             // Activates hadoop 3.0 profile in maven runs.
             HADOOP_PROFILE = '3.0'
           }

--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -131,8 +131,11 @@ curl -L  -o personality.sh "${env.PROJECT_PERSONALITY}"
             // TODO does hadoopcheck need to be jdk specific?
             // Should be things that work with multijdk
             TESTS = 'all,-unit,-findbugs'
-            // this is only elevant on branches-1. on branches with default jdk8, the relevant jdk will be JAVA_HOME
-            MULTIJDK = '/usr/lib/jvm/zulu-8-amd64'
+            // all jdks tested on this stage for this branch
+            // note that JAVA_HOME still needs to be set for tests
+            // that don't support multijdk. JAVA_HOME will also
+            // determine which jvm will be tested last.
+            MULTIJDK = '/usr/lib/jvm/zulu-8-amd64,/usr/lib/jvm/zulu-7-amd64'
             OUTPUT_DIR_RELATIVE = "${env.OUTPUT_DIR_RELATIVE_GENERAL}"
             OUTPUT_DIR = "${env.WORKSPACE}/${env.OUTPUT_DIR_RELATIVE_GENERAL}"
           }

--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -156,7 +156,7 @@ pipeline {
                         YETUS_ARGS+=("--dockerfile=${DOCKERFILE}")
                         YETUS_ARGS+=("--mvn-custom-repos")
                         # Branch-1 specific, look at the Zulu jdk8
-                        YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/zulu-8-amd64")
+                        YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/zulu-8-amd64,/usr/lib/jvm/zulu-7-amd64")
                         YETUS_ARGS+=("--findbugs-home=/usr")
                         YETUS_ARGS+=("--whitespace-eol-ignore-list=.*/generated/.*")
                         YETUS_ARGS+=("--whitespace-tabs-ignore-list=.*/generated/.*")

--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -110,6 +110,10 @@ pipeline {
                         if [[ "true" = "${DEBUG}" ]]; then
                             YETUS_ARGS+=("--debug")
                         fi
+                        # If we're doing docker, make sure we don't accidentally pollute the image with a host java path
+                        if [ -n "${JAVA_HOME}" ]; then
+                          unset JAVA_HOME
+                        fi
                         YETUS_ARGS+=("--patch-dir=${WORKSPACE}/${PATCHDIR}")
                         # where the source is located
                         YETUS_ARGS+=("--basedir=${WORKSPACE}/${SOURCEDIR}")
@@ -151,7 +155,8 @@ pipeline {
                         YETUS_ARGS+=("--docker")
                         YETUS_ARGS+=("--dockerfile=${DOCKERFILE}")
                         YETUS_ARGS+=("--mvn-custom-repos")
-                        YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/java-8-openjdk-amd64")
+                        # Branch-1 specific, look at the Zulu jdk8
+                        YETUS_ARGS+=("--multijdkdirs=/usr/lib/jvm/zulu-8-amd64")
                         YETUS_ARGS+=("--findbugs-home=/usr")
                         YETUS_ARGS+=("--whitespace-eol-ignore-list=.*/generated/.*")
                         YETUS_ARGS+=("--whitespace-tabs-ignore-list=.*/generated/.*")

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -83,10 +83,7 @@ RUN apt-get -q update && apt-get -q install --no-install-recommends -y \
 # See HBASE-19204. So, we use the azul jdks because they are available, and
 # later versions of openjdk (openjdk-7 161). Below we add the azul repo and
 # then install its jdks. We then move aside the headless jdk7 added above
-# when we added maven and ant and rename the azul jvms as
-# though they were from openjdk (otherwise yetus won't set JAVA_HOME;
-# it does find /usr/lib/jvm/ -name java-* -type d so a symlink to the zulu jvms
-# won't work).
+# when we added maven and ant
 RUN echo "dot_style = mega" > "/root/.wgetrc"
 RUN echo "quiet = on" >> "/root/.wgetrc"
 RUN apt-key adv --keyserver hkp://keyserver.ubuntu.com:80 --recv-keys 0x219BD9C9
@@ -97,9 +94,7 @@ RUN apt-get -q install --no-install-recommends -y zulu-8 zulu-7
 RUN update-alternatives --config java
 RUN update-alternatives --config javac
 RUN mv /usr/lib/jvm/java-7-openjdk-amd64 /usr/lib/jvm/moved.java-7-openjdk-amd64
-RUN mv /usr/lib/jvm/zulu-7-amd64 /usr/lib/jvm/java-7-openjdk-amd64 
-RUN mv /usr/lib/jvm/zulu-8-amd64 /usr/lib/jvm/java-8-openjdk-amd64 
-
+ENV JAVA_HOME /usr/lib/jvm/zulu-7-amd64
 
 # Fixing the Apache commons / Maven dependency problem under Ubuntu:
 # See http://wiki.apache.org/commons/VfsProblems

--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -45,6 +45,23 @@ if ! declare -f "yetus_info" >/dev/null; then
 
 fi
 
+# work around yetus overwriting JAVA_HOME from our docker image
+function docker_do_env_adds
+{
+  declare k
+
+  for k in "${DOCKER_EXTRAENVS[@]}"; do
+    if [[ "JAVA_HOME" == "${k}" ]]; then
+      if [ -n "${JAVA_HOME}" ]; then
+        DOCKER_EXTRAARGS+=("--env=JAVA_HOME=${JAVA_HOME}")
+      fi
+    else
+      DOCKER_EXTRAARGS+=("--env=${k}=${!k}")
+    fi
+  done
+}
+
+
 ## @description  Globals specific to this personality
 ## @audience     private
 ## @stability    evolving

--- a/dev-support/hbase_nightly_yetus.sh
+++ b/dev-support/hbase_nightly_yetus.sh
@@ -40,6 +40,10 @@ if [[ -n "${MULTIJDK}" ]]; then
   YETUS_ARGS=("--multijdkdirs=${MULTIJDK}" "${YETUS_ARGS[@]}")
 fi
 
+# If we're doing docker, make sure we don't accidentally pollute the image with a host java path
+if [ -n "${JAVA_HOME}" ]; then
+  unset JAVA_HOME
+fi
 if [[ -n "${SET_JAVA_HOME}" ]]; then
   YETUS_ARGS=("--java-home=${SET_JAVA_HOME}" "${YETUS_ARGS[@]}")
 fi


### PR DESCRIPTION

* leave Zulu JDKs at their normal location
* set JAVA_HOME in the dockerfile
* work around yetus setting a different JAVA_HOME

Manually tested locally with Yetus 0.11.0
```
 test-patch --docker --dockerfile=dev-support/docker/Dockerfile --mvn-custom-repos --multijdkdirs=/usr/lib/jvm/zulu-8-amd64 --empty-patch --personality=dev-support/hbase-personality.sh
...
|| Subsystem || Report/Notes ||
============================================================================
| Docker | Client=19.03.1 Server=19.03.1 base: /private/tmp/yetus-27665.32767/Dockerfile |
| Optional Tests | dupname asflicense yamllint rubocop shellcheck shelldocs xml hadolint pylint markdownlint javac javadoc unit shadedjars hadoopcheck compile spotbugs findbugs hbaseanti checkstyle refguide cc checkmake golang perlcritic hbaseprotoc prototool jshint |
| uname | Linux 532f4e654c89 4.9.184-linuxkit #1 SMP Tue Jul 2 22:58:16 UTC 2019 x86_64 x86_64 x86_64 GNU/Linux |
| Build tool | maven |
| Personality | dev-support/hbase-personality.sh |
| git revision | branch-1 / 4454204 |
| Default Java | 1.7.0_232 |
| Multi-JDK versions | /usr/lib/jvm/zulu-8-amd64:1.8.0_222 /usr/lib/jvm/zulu-7-amd64:1.7.0_232 |
...
```

The hbase-personality change and the stuff to unset JAVA_HOME in the host environment will need to go to all branches. The rest I think just goes to branches-1.