### PR TITLE
Downloads page archive link should be https

### DIFF
--- a/src/site/xdoc/downloads.xml
+++ b/src/site/xdoc/downloads.xml
@@ -194,7 +194,7 @@ under the License.
   </section>
 
   <p>If you are looking for an old release that is not present here or on the
-  mirror, check the <a href="http://archive.apache.org/dist/hbase/">Apache Archive</a>.
+  mirror, check the <a href="https://archive.apache.org/dist/hbase/">Apache Archive</a>.
   </p>
 </section>
 </body>


### PR DESCRIPTION
Noticed this while working on some automation. We're https everywhere else in this page, just not this link.