### PR TITLE
HBASE-22942 move Snapshot verification to procedure

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RestoreSnapshotProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RestoreSnapshotProcedure.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hbase.snapshot.ClientSnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotHelper;
 import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.SnapshotManifest;
+import org.apache.hadoop.hbase.snapshot.SnapshotReferenceUtil;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
@@ -351,6 +352,12 @@ public class RestoreSnapshotProcedure
         mfs.getFileSystem(),
         SnapshotDescriptionUtils.getCompletedSnapshotDir(snapshot, mfs.getRootDir()),
         snapshot);
+
+      // Verify snapshot validity
+      SnapshotReferenceUtil
+          .verifySnapshot(env.getMasterServices().getConfiguration(), mfs.getFileSystem(),
+              manifest);
+
       int snapshotRegionCount = manifest.getRegionManifestsMap().size();
       int tableRegionCount =
           ProcedureSyncWait.getMasterQuotaManager(env).getRegionCountOfTable(tableName);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
@@ -835,9 +835,6 @@ public class SnapshotManager extends MasterProcedureManager implements Stoppable
     // stop tracking "abandoned" handlers
     cleanupSentinels();
 
-    // Verify snapshot validity
-    SnapshotReferenceUtil.verifySnapshot(master.getConfiguration(), fs, manifest);
-
     // Execute the restore/clone operation
     long procId;
     if (MetaTableAccessor.tableExists(master.getConnection(), tableName)) {


### PR DESCRIPTION
Problem : Right now we do snapshot verification prior to queueing the restore / clone request from the client. That means the initial call from the client has to block until we're done. On large manifests (~single digit millions) this easily takes longer than the default timeout of 20 minutes.

Solution: Instead we should handle verification as one of the steps in the relevant procedure (hbase 2+) or table handler (hbase 1) so that the master can do it in the background and report status.

