### PR TITLE
HBASE-23090 Update start-hbase.sh and stop-hbase.sh

### DIFF
--- a/bin/start-hbase.sh
+++ b/bin/start-hbase.sh
@@ -52,7 +52,7 @@ fi
 # HBASE-6504 - only take the first line of the output in case verbose gc is on
 distMode=`$bin/hbase --config "$HBASE_CONF_DIR" org.apache.hadoop.hbase.util.HBaseConfTool hbase.cluster.distributed | head -n 1`
 
-if [ "$distMode" == 'false' ]
+if [ "$distMode" = 'false' ]
 then
   "$bin"/hbase-daemon.sh --config "${HBASE_CONF_DIR}" $commandToRun master
 else

--- a/bin/stop-hbase.sh
+++ b/bin/stop-hbase.sh
@@ -44,7 +44,7 @@ logout=$HBASE_LOG_DIR/$HBASE_LOG_PREFIX.out
 loglog="${HBASE_LOG_DIR}/${HBASE_LOGFILE}"
 pid=${HBASE_PID_DIR:-/tmp}/hbase-$HBASE_IDENT_STRING-master.pid
 
-if [[ -e $pid ]]; then
+if [ -e $pid ]; then
   echo -n stopping hbase
   echo "`date` Stopping hbase (via master)" >> $loglog
 
@@ -62,7 +62,7 @@ fi
 # distributed == false means that the HMaster will kill ZK when it exits
 # HBASE-6504 - only take the first line of the output in case verbose gc is on
 distMode=`$bin/hbase --config "$HBASE_CONF_DIR" org.apache.hadoop.hbase.util.HBaseConfTool hbase.cluster.distributed | head -n 1`
-if [ "$distMode" == 'true' ] 
+if [ "$distMode" = 'true' ] 
 then
   "$bin"/hbase-daemons.sh --config "${HBASE_CONF_DIR}" stop zookeeper
 fi


### PR DESCRIPTION
removed extra '=' sign which gave an error: "55: [: false: unexpected operator"