### PR TITLE
HBASE-23116: Fix a couple of load balancer logging nits.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -348,9 +348,11 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     if (total <= 0 || sumMultiplier <= 0
         || (sumMultiplier > 0 && (total / sumMultiplier) < minCostNeedBalance)) {
       if (LOG.isTraceEnabled()) {
-        LOG.trace("Skipping load balancing because balanced cluster; " + "total cost is " + total
-          + ", sum multiplier is " + sumMultiplier + " min cost which need balance is "
-          + minCostNeedBalance);
+        final String loadBalanceTarget =
+            isByTable ? String.format("table (%s)", tableName) : "cluster";
+        LOG.trace("Skipping load balancing because the {} is balanced. Total cost: {}, "
+            + "Sum multiplier: {}, Minimum cost needed for balance: {}", loadBalanceTarget, total,
+            sumMultiplier, minCostNeedBalance);
       }
       return false;
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancer.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ClusterMetrics;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.RegionMetrics;
 import org.apache.hadoop.hbase.ServerMetrics;
 import org.apache.hadoop.hbase.ServerName;
@@ -242,15 +243,24 @@ public class TestStochasticLoadBalancer extends BalancerTestBase {
   public void testNeedBalance() {
     float minCost = conf.getFloat("hbase.master.balancer.stochastic.minCostNeedBalance", 0.05f);
     conf.setFloat("hbase.master.balancer.stochastic.minCostNeedBalance", 1.0f);
-    loadBalancer.setConf(conf);
-    for (int[] mockCluster : clusterStateMocks) {
-      Map<ServerName, List<RegionInfo>> servers = mockClusterServers(mockCluster);
-      List<RegionPlan> plans = loadBalancer.balanceCluster(servers);
-      assertNull(plans);
+    try {
+      // Test with/without per table balancer.
+      boolean[] perTableBalancerConfigs = {true, false};
+      for (boolean isByTable : perTableBalancerConfigs) {
+        conf.setBoolean(HConstants.HBASE_MASTER_LOADBALANCE_BYTABLE, isByTable);
+        loadBalancer.setConf(conf);
+        for (int[] mockCluster : clusterStateMocks) {
+          Map<ServerName, List<RegionInfo>> servers = mockClusterServers(mockCluster);
+          List<RegionPlan> plans = loadBalancer.balanceCluster(servers);
+          assertNull(plans);
+        }
+      }
+    } finally {
+      // reset config
+      conf.unset(HConstants.HBASE_MASTER_LOADBALANCE_BYTABLE);
+      conf.setFloat("hbase.master.balancer.stochastic.minCostNeedBalance", minCost);
+      loadBalancer.setConf(conf);
     }
-    // reset config
-    conf.setFloat("hbase.master.balancer.stochastic.minCostNeedBalance", minCost);
-    loadBalancer.setConf(conf);
   }
 
   @Test


### PR DESCRIPTION
Fixes a typo and adds table name to the logging context when
StochasticLoadBalancer is configured "per table". Added some
test coverage with per-table balancer enabled and manually
verified the logs to make sure the table name is formatted
correctly.