### PR TITLE
HBASE-23116 LoadBalancer should log table name when balancing per table

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -346,9 +346,11 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
 
     if (total <= 0 || sumMultiplier <= 0
         || (sumMultiplier > 0 && (total / sumMultiplier) < minCostNeedBalance)) {
-      LOG.info("Skipping load balancing because balanced cluster; " + "total cost is " + total
-          + ", sum multiplier is " + sumMultiplier + " min cost which need balance is "
-          + minCostNeedBalance);
+      final String loadBalanceTarget =
+          isByTable ? String.format("table (%s)", tableName) : "cluster";
+      LOG.info(String.format("Skipping load balancing because the %s is balanced. Total cost: %s, "
+          + "Sum multiplier: %s, Minimum cost needed for balance: %s", loadBalanceTarget, total,
+          sumMultiplier, minCostNeedBalance));
       return false;
     }
     return true;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancer.java
@@ -160,15 +160,18 @@ public class TestStochasticLoadBalancer extends BalancerTestBase {
   public void testNeedBalance() {
     float minCost = conf.getFloat("hbase.master.balancer.stochastic.minCostNeedBalance", 0.05f);
     conf.setFloat("hbase.master.balancer.stochastic.minCostNeedBalance", 1.0f);
-    loadBalancer.setConf(conf);
-    for (int[] mockCluster : clusterStateMocks) {
-      Map<ServerName, List<HRegionInfo>> servers = mockClusterServers(mockCluster);
-      List<RegionPlan> plans = loadBalancer.balanceCluster(servers);
-      assertNull(plans);
+    try {
+      loadBalancer.setConf(conf);
+      for (int[] mockCluster : clusterStateMocks) {
+        Map<ServerName, List<HRegionInfo>> servers = mockClusterServers(mockCluster);
+        List<RegionPlan> plans = loadBalancer.balanceCluster(servers);
+        assertNull(plans);
+      }
+    } finally {
+      // reset config
+      conf.setFloat("hbase.master.balancer.stochastic.minCostNeedBalance", minCost);
+      loadBalancer.setConf(conf);
     }
-    // reset config
-    conf.setFloat("hbase.master.balancer.stochastic.minCostNeedBalance", minCost);
-    loadBalancer.setConf(conf);
   }
 
   /**


### PR DESCRIPTION
This commit adds table name to the logging context when
StochasticLoadBalancer is configured "per table".

Signed-off-by: Andrew Purtell <apurtell@apache.org>