### PR TITLE
HBASE-23123 Merge_region fails from shell

### DIFF
--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -533,9 +533,10 @@ module Hbase
     #----------------------------------------------------------------------------------------------
     # Merge two regions
     def merge_region(region_a_name, region_b_name, force)
-      @admin.mergeRegions(region_a_name.to_java_bytes,
+      @admin.mergeRegionsAsync(region_a_name.to_java_bytes,
                           region_b_name.to_java_bytes,
                           java.lang.Boolean.valueOf(force))
+       return nil
     end
 
     #----------------------------------------------------------------------------------------------

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -533,10 +533,12 @@ module Hbase
     #----------------------------------------------------------------------------------------------
     # Merge two regions
     def merge_region(region_a_name, region_b_name, force)
-      @admin.mergeRegionsAsync(region_a_name.to_java_bytes,
-                          region_b_name.to_java_bytes,
-                          java.lang.Boolean.valueOf(force))
-       return nil
+      @admin.mergeRegionsAsync(
+        region_a_name.to_java_bytes,
+        region_b_name.to_java_bytes,
+        java.lang.Boolean.valueOf(force)
+      )
+      return nil
     end
 
     #----------------------------------------------------------------------------------------------

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -543,6 +543,17 @@ module Hbase
     define_test "list regions should allow table name" do
       command(:list_regions, @test_name)
     end
+
+    define_test 'merge two regions' do
+      @t_name = 'hbase_shell_merge'
+      drop_test_table(@t_name)
+      admin.create(@t_name, 'a', NUMREGIONS => 10, SPLITALGO => 'HexStringSplit')
+      r1 = command(:locate_region, @test_name, '')
+      r2 = command(:locate_region, @test_name, '1')
+      region_name1 = r1.getRegion.getRegionNameAsString
+      region_name2 = r2.getRegion.getRegionNameAsString
+      command(:merge_region, region_name1, region_name2, true)
+    end
   end
 
   # Simple administration methods tests

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -548,11 +548,11 @@ module Hbase
       @t_name = 'hbase_shell_merge'
       drop_test_table(@t_name)
       admin.create(@t_name, 'a', NUMREGIONS => 10, SPLITALGO => 'HexStringSplit')
-      r1 = command(:locate_region, @test_name, '')
-      r2 = command(:locate_region, @test_name, '1')
-      region_name1 = r1.getRegion.getRegionNameAsString
-      region_name2 = r2.getRegion.getRegionNameAsString
-      command(:merge_region, region_name1, region_name2, true)
+      r1 = command(:locate_region, @t_name, '')
+      r2 = command(:locate_region, @t_name, '1')
+      region1 = r1.getRegion.getRegionNameAsString
+      region2 = r2.getRegion.getRegionNameAsString
+      command(:merge_region, region1, region2, true)
     end
   end
 


### PR DESCRIPTION
The deprecated method Admin#mergeRegions is removed in HBase 3.0 but we need to update new API in admin script.