### PR TITLE
HBASE-23128 Restore Region interface compatibility

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -684,6 +684,8 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
   private final Durability durability;
   private final boolean regionStatsEnabled;
 
+  private static final List<String> EMPTY_CLUSTERID_LIST = new ArrayList<String>();
+
   /**
    * HRegion constructor. This constructor should only be used for testing and
    * extensions.  Instances of HRegion should be instantiated with the
@@ -6035,6 +6037,15 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
       closeBulkRegionOperation();
     }
     return isSuccessful;
+  }
+
+  @Override
+  @Deprecated
+  public boolean bulkLoadHFiles(Collection<Pair<byte[], String>> familyPaths, boolean assignSeqId,
+      BulkLoadListener bulkLoadListener) throws IOException {
+    LOG.warn("Deprecated bulkLoadHFiles invoked. This does not pass through source cluster ids." +
+      " This is probably not what you want. See HBASE-22380.");
+    return bulkLoadHFiles(familyPaths, assignSeqId, bulkLoadListener, EMPTY_CLUSTERID_LIST);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/Region.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/Region.java
@@ -562,6 +562,22 @@ public interface Region extends ConfigurationObserver {
   boolean bulkLoadHFiles(Collection<Pair<byte[], String>> familyPaths, boolean assignSeqId,
     BulkLoadListener bulkLoadListener, List<String> clusterIds) throws IOException;
 
+  /**
+   * Attempts to atomically load a group of hfiles.  This is critical for loading
+   * rows with multiple column families atomically. Deprecated - do not use.
+   *
+   * @param familyPaths List of Pair&lt;byte[] column family, String hfilePath&gt;
+   * @param assignSeqId
+   * @param bulkLoadListener Internal hooks enabling massaging/preparation of a
+   * file about to be bulk loaded
+   * @return true if successful, false if failed recoverably
+   * @throws IOException if failed unrecoverably.
+   * @deprecated Do not use, see HBASE-22380
+   */
+  @Deprecated
+  boolean bulkLoadHFiles(Collection<Pair<byte[], String>> familyPaths, boolean assignSeqId,
+    BulkLoadListener bulkLoadListener) throws IOException;
+
   ///////////////////////////////////////////////////////////////////////////
   // Coprocessors
 


### PR DESCRIPTION
Restore and deprecate Region#bulkLoadHFiles(Collection<Pair<byte[],String>>, boolean,
  Region.BulkLoadListener).
Warn if invoked.