### PR TITLE
HBASE-23144 Compact_rs throw wrong number of arguments

### DIFF
--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -115,7 +115,11 @@ module Hbase
 
     # Requests to compact all regions on the regionserver
     def compact_regionserver(servername, major = false)
-      @admin.compactRegionServer(ServerName.valueOf(servername), major)
+      if major
+        @admin.majorCompactRegionServer(ServerName.valueOf(servername))
+      else
+        @admin.compactRegionServer(ServerName.valueOf(servername))
+      end
     end
 
     #----------------------------------------------------------------------------------------------

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -107,6 +107,16 @@ module Hbase
         command(:flush, s.toString)
       end
     end
+    #-------------------------------------------------------------------------------
+    define_test 'compact all regions by server name' do
+      servers = admin.list_liveservers
+      servers.each do |s|
+        command(:compact_rs, s.to_s)
+        # major compact
+        command(:compact_rs, s.to_s, true)
+        break
+      end
+    end
 
     #-------------------------------------------------------------------------------
 


### PR DESCRIPTION
Compact_rs command will call Admin#compactRegionServer(ServerName, boolean) but this is deprecated method and removed as part of HBASE-22002. 