### PR TITLE
HBASE-23152 Compaction_switch does not work by RegionServer name

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -3165,6 +3165,8 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
         if (serverName == null) {
           future.completeExceptionally(
             new IllegalArgumentException(String.format("Null ServerName: %s", regionServerName)));
+        } else {
+          serverList.add(serverName);
         }
       }
       future.complete(serverList);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
@@ -335,6 +335,26 @@ public class TestAsyncRegionAdminApi extends TestAsyncAdminBase {
       assertEquals("Last compaction state, expected=disabled actual=enabled",
           false, p.getValue());
     }
+    ServerName serverName = TEST_UTIL.getHBaseCluster().getRegionServer(0)
+        .getServerName();
+    List<String> serverNameList = new ArrayList<String>();
+    serverNameList.add(serverName.getServerName());
+    CompletableFuture<Map<ServerName, Boolean>> listCompletableFuture3 =
+        admin.compactionSwitch(false, serverNameList);
+    Map<ServerName, Boolean> pairs3 = listCompletableFuture3.get();
+    assertEquals(pairs3.entrySet().size(), 1);
+    for (Map.Entry<ServerName, Boolean> p : pairs3.entrySet()) {
+      assertEquals("Last compaction state, expected=enabled actual=disabled",
+          true, p.getValue());
+    }
+    CompletableFuture<Map<ServerName, Boolean>> listCompletableFuture4 =
+        admin.compactionSwitch(true, serverNameList);
+    Map<ServerName, Boolean> pairs4 = listCompletableFuture4.get();
+    assertEquals(pairs4.entrySet().size(), 1);
+    for (Map.Entry<ServerName, Boolean> p : pairs4.entrySet()) {
+      assertEquals("Last compaction state, expected=disabled actual=enabled",
+          false, p.getValue());
+    }
   }
 
   @Test

--- a/hbase-shell/src/main/ruby/shell/commands/compaction_switch.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/compaction_switch.rb
@@ -33,9 +33,9 @@ module Shell
             To disable compactions on all region servers
             hbase> compaction_switch false
             To enable compactions on specific region servers
-            hbase> compaction_switch true 'server2','server1'
+            hbase> compaction_switch true, 'server2','server1'
             To disable compactions on specific region servers
-            hbase> compaction_switch false 'server2','server1'
+            hbase> compaction_switch false, 'server2','server1'
           NOTE: A server name is its host, port plus startcode. For example:
           host187.example.com,60020,1289493121758
         EOF


### PR DESCRIPTION
Compaction_switch is used to stop running compaction on regionservers. This switch works good by using "compaction_switch true/false" but rather I want to stop compaction only for particular regionserver. In that case, the switch doesn't work because serverName that we want to stop is not added into CompletableFuture\<List\<ServerName\>\>. So we always get empty Future list by using RS name.

 https://github.com/apache/hbase/blob/master/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java#L3156