### PR TITLE
HBASE-23154 list_deadservers return incorrect no of rows

### DIFF
--- a/hbase-shell/src/main/ruby/shell/commands/list_deadservers.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/list_deadservers.rb
@@ -37,7 +37,7 @@ module Shell
           formatter.row([server.toString])
         end
 
-        formatter.footer(now, servers.size)
+        formatter.footer(servers.size)
       end
     end
   end

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -98,6 +98,11 @@ module Hbase
       assert(list.count > 0)
     end
 
+    define_test 'list_deadservers should return exact count of dead servers' do
+      output = capture_stdout { command(:list_deadservers) }
+      assert(output.include?('0 row(s)'))
+    end
+
     #-------------------------------------------------------------------------------
 
     define_test "flush should work" do


### PR DESCRIPTION
No of rows should be equivalent to no of dead region servers but mistakenly included current system time in it.