### PR TITLE
HBASE-22370 ByteBuf LEAK ERROR

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/FanOutOneBlockAsyncDFSOutput.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/FanOutOneBlockAsyncDFSOutput.java
@@ -550,6 +550,10 @@ public class FanOutOneBlockAsyncDFSOutput implements AsyncFSOutput {
    */
   @Override
   public void recoverAndClose(CancelableProgressable reporter) throws IOException {
+    if (buf != null) {
+      buf.release();
+      buf = null;
+    }
     datanodeList.forEach(ch -> ch.close());
     datanodeList.forEach(ch -> ch.closeFuture().awaitUninterruptibly());
     endFileLease(client, fileId);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/CallRunner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/CallRunner.java
@@ -88,6 +88,7 @@ public class CallRunner {
    * Cleanup after ourselves... let go of references.
    */
   private void cleanup() {
+    this.call.cleanup();
     this.call = null;
     this.rpcServer = null;
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -166,7 +166,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   }
 
   @Override
-  public synchronized void cleanup() {
+  public void cleanup() {
     release(0b01);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -166,7 +166,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   }
 
   @Override
-  public void cleanup() {
+  public synchronized void cleanup() {
     release(0b01);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestCallRunner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestCallRunner.java
@@ -58,4 +58,17 @@ public class TestCallRunner {
     cr.run();
     Mockito.verify(mockCall, Mockito.times(1)).cleanup();
   }
+
+  @Test
+  public void testCallRunnerDrop() {
+    RpcServerInterface mockRpcServer = Mockito.mock(RpcServerInterface.class);
+    Mockito.when(mockRpcServer.isStarted()).thenReturn(true);
+    ServerCall mockCall = Mockito.mock(ServerCall.class);
+    Mockito.when(mockCall.disconnectSince()).thenReturn(1L);
+
+    CallRunner cr = new CallRunner(mockRpcServer, mockCall);
+    cr.setStatus(new MonitoredRPCHandlerImpl());
+    cr.drop();
+    Mockito.verify(mockCall, Mockito.times(1)).cleanup();
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestCallRunner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestCallRunner.java
@@ -45,4 +45,17 @@ public class TestCallRunner {
     cr.setStatus(new MonitoredRPCHandlerImpl());
     cr.run();
   }
+
+  @Test
+  public void testCallCleanup() {
+    RpcServerInterface mockRpcServer = Mockito.mock(RpcServerInterface.class);
+    Mockito.when(mockRpcServer.isStarted()).thenReturn(true);
+    ServerCall mockCall = Mockito.mock(ServerCall.class);
+    Mockito.when(mockCall.disconnectSince()).thenReturn(1L);
+
+    CallRunner cr = new CallRunner(mockRpcServer, mockCall);
+    cr.setStatus(new MonitoredRPCHandlerImpl());
+    cr.run();
+    Mockito.verify(mockCall, Mockito.times(1)).cleanup();
+  }
 }


### PR DESCRIPTION
If FanOutOneBlockAsyncDFSOutput#endBlock throw Exception before call "buf.release();", this buf has not chance to release.
In CallRunner if the call skipped or Dropping timed out call, the call do not call cleanup.