### PR TITLE
HBASE-23176 delete_all_snapshot does not work with regex

### DIFF
--- a/hbase-shell/src/main/ruby/shell/commands/delete_all_snapshot.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/delete_all_snapshot.rb
@@ -54,7 +54,8 @@ EOF
         formatter.header(['SNAPSHOT', 'TABLE + CREATION TIME'])
         list.each do |snapshot|
           creation_time = Time.at(snapshot.getCreationTime / 1000).to_s
-          formatter.row([snapshot.getName, snapshot.getTable + ' (' + creation_time + ')'])
+          formatter.row([snapshot.getName, snapshot.getTableNameAsString +
+            ' (' + creation_time + ')'])
         end
       end
     end

--- a/hbase-shell/src/main/ruby/shell/commands/delete_all_snapshot.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/delete_all_snapshot.rb
@@ -34,7 +34,8 @@ EOF
         count = list.size
         list.each do |snapshot|
           creation_time = Time.at(snapshot.getCreationTime / 1000).to_s
-          formatter.row([snapshot.getName, snapshot.getTable + ' (' + creation_time + ')'])
+          formatter.row([snapshot.getName, snapshot.getTableNameAsString +
+            ' (' + creation_time + ')'])
         end
         puts "\nDelete the above #{count} snapshots (y/n)?" unless count == 0
         answer = 'n'

--- a/hbase-shell/src/main/ruby/shell/commands/delete_table_snapshots.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/delete_table_snapshots.rb
@@ -43,7 +43,8 @@ EOF
         count = list.size
         list.each do |snapshot|
           creation_time = Time.at(snapshot.getCreationTime / 1000).to_s
-          formatter.row([snapshot.getName, snapshot.getTable + ' (' + creation_time + ')'])
+          formatter.row([snapshot.getName, snapshot.getTableNameAsString +
+            ' (' + creation_time + ')'])
         end
         puts "\nDelete the above #{count} snapshots (y/n)?" unless count == 0
         answer = 'n'

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -449,6 +449,17 @@ module Hbase
 
     #-------------------------------------------------------------------------------
 
+    define_test 'delete_all_snapshot by regex' do
+      drop_test_table(@create_test_name)
+      admin.create(@create_test_name, 'a')
+      command(:snapshot, @create_test_name, 's1')
+      admin.delete_all_snapshot('s1.*')
+      output = capture_stdout { command(:list_snapshots) }
+      assert(output.include?('0 row'))
+    end
+
+    #-------------------------------------------------------------------------------
+
     define_test "list_regions should fail for disabled table" do
       drop_test_table(@create_test_name)
       admin.create(@create_test_name, 'a')

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -449,17 +449,6 @@ module Hbase
 
     #-------------------------------------------------------------------------------
 
-    define_test 'delete_all_snapshot by regex' do
-      drop_test_table(@create_test_name)
-      admin.create(@create_test_name, 'a')
-      command(:snapshot, @create_test_name, 's1')
-      admin.delete_all_snapshot('s1.*')
-      output = capture_stdout { command(:list_snapshots) }
-      assert(output.include?('0 row'))
-    end
-
-    #-------------------------------------------------------------------------------
-
     define_test "list_regions should fail for disabled table" do
       drop_test_table(@create_test_name)
       admin.create(@create_test_name, 'a')


### PR DESCRIPTION
Delete_all_snapshot.rb is using deprecated method SnapshotDescription#getTable but this method is already removed in 3.0.x.