### PR TITLE
HBASE-22739 ArrayIndexOutOfBoundsException when balance

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/BaseLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/BaseLoadBalancer.java
@@ -142,6 +142,7 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
     int[]   serverIndexToRackIndex;      //serverIndex -> rack index
 
     int[][] regionsPerServer;            //serverIndex -> region list
+    int[]   serverIndexToRegionsOffset;  //serverIndex -> offset of region list
     int[][] regionsPerHost;              //hostIndex -> list of regions
     int[][] regionsPerRack;              //rackIndex -> region list
     int[][] primariesOfRegionsPerServer; //serverIndex -> sorted list of regions by primary region index
@@ -276,6 +277,7 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
       serverIndexToHostIndex = new int[numServers];
       serverIndexToRackIndex = new int[numServers];
       regionsPerServer = new int[numServers][];
+      serverIndexToRegionsOffset = new int[numServers];
       regionsPerHost = new int[numHosts][];
       regionsPerRack = new int[numRacks][];
       primariesOfRegionsPerServer = new int[numServers][];
@@ -321,7 +323,7 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
 
       for (Entry<ServerName, List<RegionInfo>> entry : clusterState.entrySet()) {
         int serverIndex = serversToIndex.get(entry.getKey().getHostAndPort());
-        regionPerServerIndex = 0;
+        regionPerServerIndex = serverIndexToRegionsOffset[serverIndex];
 
         int hostIndex = hostsToIndex.get(entry.getKey().getHostname());
         serverIndexToHostIndex[serverIndex] = hostIndex;
@@ -334,6 +336,7 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
           regionsPerServer[serverIndex][regionPerServerIndex++] = regionIndex;
           regionIndex++;
         }
+        serverIndexToRegionsOffset[serverIndex] = regionPerServerIndex;
       }
 
       for (RegionInfo region : unassignedRegions) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBaseLoadBalancer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBaseLoadBalancer.java
@@ -473,7 +473,7 @@ public class TestBaseLoadBalancer extends BalancerTestBase {
     // sharing same host and port
     List<ServerName> servers = getListOfServerNames(randomServers(10, 10));
     List<RegionInfo> regions = randomRegions(101);
-    Map<ServerName, List<RegionInfo>> clusterState = new HashMap<>();
+    Map<ServerName, List<RegionInfo>> clusterState = new TreeMap<>();
 
     assignRegions(regions, servers, clusterState);
 
@@ -491,6 +491,13 @@ public class TestBaseLoadBalancer extends BalancerTestBase {
     BaseLoadBalancer.Cluster cluster = new Cluster(clusterState, null, null, null);
     assertEquals(101 + 9, cluster.numRegions);
     assertEquals(10, cluster.numServers); // only 10 servers because they share the same host + port
+
+    // test move
+    ServerName sn = oldServers.get(0);
+    int r0 = ArrayUtils.indexOf(cluster.regions, clusterState.get(sn).get(0));
+    int f0 = cluster.serversToIndex.get(sn.getHostAndPort());
+    int t0 = cluster.serversToIndex.get(servers.get(1).getHostAndPort());
+    cluster.doAction(new MoveRegionAction(r0, f0, t0));
   }
 
   private void assignRegions(List<RegionInfo> regions, List<ServerName> servers,


### PR DESCRIPTION
When multiple ServerNames having same hostname and port, the Cluster build wrong with regionPerServerIndex. 