### PR TITLE
HBASE-23191 EOFE log spam

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogReader.java
@@ -418,7 +418,7 @@ public class ProtobufLogReader extends ReaderBase {
               "current position and original position match at {}", originalPosition);
             seekOnFs(0);
           } else {
-            LOG.info("Reached the end of file at position {}", originalPosition);
+            LOG.debug("Reached the end of file at position {}", originalPosition);
           }
         } else {
           // Else restore our position to original location in hope that next time through we will


### PR DESCRIPTION
If no new active writes in WAL edit, then WALEntryStream#hasNext -> ReaderBase -> ProtobufLogReader#readNext will reach end of file. It would be a good idea for changing the log level from INFO to DEBUG. 