### PR TITLE
HBASE-23199 Error populating Table-Attribute fields

### DIFF
--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -368,8 +368,7 @@ if (fqtn != null && master.isInitialized()) {
   </tr>
 <%
     }
- if ( quota != null) {
-  if (quota.hasThrottle()) {
+  if (quota != null && quota.hasThrottle()) {
     List<ThrottleSettings> throttles = QuotaSettingsFactory.fromTableThrottles(table.getName(), quota.getThrottle());
     if (throttles.size() > 0) {
 %>
@@ -402,7 +401,6 @@ if (fqtn != null && master.isInitialized()) {
 <%
     }
    }
-  }
  }
 %>
 </table>

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -368,7 +368,7 @@ if (fqtn != null && master.isInitialized()) {
   </tr>
 <%
     }
-
+ if ( quota != null) {
   if (quota.hasThrottle()) {
     List<ThrottleSettings> throttles = QuotaSettingsFactory.fromTableThrottles(table.getName(), quota.getThrottle());
     if (throttles.size() > 0) {
@@ -401,8 +401,9 @@ if (fqtn != null && master.isInitialized()) {
   </tr>
 <%
     }
+   }
   }
-  }
+ }
 %>
 </table>
 <h2>Table Schema</h2>


### PR DESCRIPTION
if quota is enabled, then we fetch table and namespace quota info. It is not necessary both table and namespace will have a quota set.  Sometimes, users only have table level quota or namespace level quota or both un-set.  So we must add Quota "null" check before getting Throttle info(Limit, Type, TimeUnit, Scope). 

```Table Attributes
org.apache.hadoop.hbase.generated.master.table_jsp._jspService(table_jsp.java:385)org.apache.jasper.runtime.HttpJspBase.service(HttpJspBase.java:111)javax.servlet.http.HttpServlet.service(HttpServlet.java:790)org.eclipse.jetty.servlet.ServletHolder.handle(ServletHolder.java:840)org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1780)org.apache.hadoop.hbase.http.lib.StaticUserWebFilter$StaticUserFilter.doFilter(StaticUserWebFilter.java:112)org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1767)org.apache.hadoop.hbase.http.ClickjackingPreventionFilter.doFilter(ClickjackingPreventionFilter.java:48)org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1767)org.apache.hadoop.hbase.http.HttpServer$QuotingInputFilter.doFilter(HttpServer.java:1429)org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1767)org.apache.hadoop.hbase.http.NoCacheFilter.doFilter(NoCacheFilter.java:50)org.eclipse.jetty.servlet.ServletHandler$CachedChain.doFilter(ServletHandler.java:1767)org.apache.hadoop.hbase.http.NoCacheFilter.doFilter(NoCacheFilter.java:50)```