### PR TITLE
HBASE-23218 Increase the flexibility of replication walentry filter interface

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
@@ -179,7 +179,7 @@ public class ReplicationSink {
       for (WALEntry entry : entries) {
         TableName table = TableName.valueOf(entry.getKey().getTableName().toByteArray());
         if (this.walEntrySinkFilter != null) {
-          if (this.walEntrySinkFilter.filter(table, entry.getKey().getWriteTime())) {
+          if (this.walEntrySinkFilter.filter(entry)) {
             // Skip Cells in CellScanner associated with this entry.
             int count = entry.getAssociatedCellCount();
             for (int i = 0; i < count; i++) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntrySinkFilter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntrySinkFilter.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hbase.replication.regionserver;
 
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AsyncConnection;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.WALEntry;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
@@ -51,9 +51,8 @@ public interface WALEntrySinkFilter {
   void init(AsyncConnection conn);
 
   /**
-   * @param table Table edit is destined for.
-   * @param writeTime Time at which the edit was created on the source.
+   * @param entry WALEntry.
    * @return True if we are to filter out the edit.
    */
-  boolean filter(TableName table, long writeTime);
+  boolean filter(WALEntry entry);
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
@@ -181,7 +181,8 @@ public class TestWALEntrySinkFilter {
     }
 
     @Override
-    public boolean filter(TableName table, long writeTime) {
+    public boolean filter(AdminProtos.WALEntry entry) {
+      long writeTime = entry.getKey().getWriteTime();
       boolean b = writeTime <= BOUNDARY;
       if (b) {
         FILTERED.incrementAndGet();


### PR DESCRIPTION
jira : https://jira.apache.org/jira/browse/HBASE-23218

The current WALEntrySinkFilter filter interface can only filter **table** and **writetime**, which is not flexible enough. It often needs to get all the attributes of entry for comprehensive judgment and filtering.