### PR TITLE
HBASE-23242: [checkstyle] Make LineLength a child of Checker module.

### DIFF
--- a/hbase-checkstyle/src/main/resources/hbase/checkstyle.xml
+++ b/hbase-checkstyle/src/main/resources/hbase/checkstyle.xml
@@ -122,12 +122,6 @@
       <property name="lineWrappingIndentation" value="2"/>
     </module>
 
-    <!-- Size Violation Checks
-    http://checkstyle.sourceforge.net/config_sizes.html -->
-    <module name="LineLength">
-      <property name="max" value="100"/>
-      <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|org.apache.thrift.|com.google.protobuf.|hbase.protobuf.generated"/>
-    </module>
     <module name="MethodLength"/>
 
     <!-- Whitespace Checks
@@ -137,5 +131,11 @@
 
     <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
     <module name="SuppressWarningsHolder"/>
+  </module>
+  <!-- Size Violation Checks
+  http://checkstyle.sourceforge.net/config_sizes.html -->
+  <module name="LineLength">
+    <property name="max" value="100"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|org.apache.thrift.|com.google.protobuf.|hbase.protobuf.generated"/>
   </module>
 </module>


### PR DESCRIPTION
As per checkstyle docs[1], it should be placed under Checker. Otherwise
intellij complains to import this configuration.

[1] https://checkstyle.sourceforge.io/config_sizes.html#LineLength