### PR TITLE
HBASE-23246 Fix error prone warning in TestMetricsUserSourceImpl

### DIFF
--- a/hbase-hadoop2-compat/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsUserSourceImpl.java
+++ b/hbase-hadoop2-compat/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsUserSourceImpl.java
@@ -47,9 +47,7 @@ public class TestMetricsUserSourceImpl {
     assertTrue(one.compareTo(two) != 0);
     assertTrue(two.compareTo(one) != 0);
     assertTrue(two.compareTo(one) != one.compareTo(two));
-    assertTrue(two.compareTo(two) == 0);
   }
-
 
   @Test (expected = RuntimeException.class)
   public void testNoGetRegionServerMetricsSourceImpl() throws Exception {


### PR DESCRIPTION
The self comparison check in TestMetricsUserSourceImpl triggers error-prone and is of little value, remove it. 