### PR TITLE
HBASE-23250 Log message about CleanerChore delegate initialization should be at INFO

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/CleanerChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/CleanerChore.java
@@ -154,7 +154,7 @@ public abstract class CleanerChore<T extends FileCleanerDelegate> extends Schedu
       for (String className : logCleaners) {
         T logCleaner = newFileCleaner(className, conf);
         if (logCleaner != null) {
-          LOG.debug("Initialize cleaner={}", className);
+          LOG.info("Initialize cleaner={}", className);
           this.cleanersChain.add(logCleaner);
         }
       }


### PR DESCRIPTION
Changed log.debug present inside private void initCleanerChain() to log.info as per the description mentioned in ticket.