### PR TITLE
HBASE-23262 Cannot load Master UI

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
@@ -224,7 +224,8 @@ AssignmentManager assignmentManager = master.getAssignmentManager();
           <& AssignmentManagerStatusTmpl; assignmentManager=master.getAssignmentManager()&>
         </%if>
         <%if !master.isInMaintenanceMode() %>
-          <%if master.getMasterCoprocessorHost().findCoprocessor("RSGroupAdminEndpoint") != null %>
+          <%if master.getMasterCoprocessorHost().findCoprocessor("RSGroupAdminEndpoint") != null &&
+            serverManager.getOnlineServersList().size() > 0 %>
             <section>
               <h2><a name="rsgroup">RSGroup</a></h2>
               <& RSGroupListTmpl; master= master; serverManager= serverManager&>


### PR DESCRIPTION
If no online regionservers then master UI can't be opened. This issue occurs when using RSGroupAdminEndpoint coprocessor(RSGrouping).  The master home page tries to load rsgroup info from "hbase:rsgroup" table but currently no regionservers up and running. 