### PR TITLE
HBASE-23259: Ability to start minicluster with pre-determined master ports

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -171,6 +171,11 @@ public final class HConstants {
   /** Configuration key for master web API port */
   public static final String MASTER_INFO_PORT = "hbase.master.info.port";
 
+  /** Configuration key for the list of master host:ports **/
+  public static final String MASTER_ADDRS_KEY = "hbase.master.addrs";
+
+  public static final String MASTER_ADDRS_DEFAULT =  "localhost:" + DEFAULT_MASTER_PORT;
+
   /** Parameter name for the master type being backup (waits for primary to go inactive). */
   public static final String MASTER_TYPE_BACKUP = "hbase.master.backup";
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestHBaseTestingUtility.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestHBaseTestingUtility.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -447,10 +447,14 @@ public class TestHBaseTestingUtility {
     HBaseTestingUtility htu = new HBaseTestingUtility(defaultConfig);
     try {
       MiniHBaseCluster defaultCluster = htu.startMiniCluster();
+      final String masterHostPort =
+          defaultCluster.getMaster().getServerName().getAddress().toString();
       assertNotEquals(HConstants.DEFAULT_MASTER_INFOPORT,
           defaultCluster.getConfiguration().getInt(HConstants.MASTER_INFO_PORT, 0));
       assertNotEquals(HConstants.DEFAULT_REGIONSERVER_INFOPORT,
           defaultCluster.getConfiguration().getInt(HConstants.REGIONSERVER_INFO_PORT, 0));
+      assertEquals(masterHostPort,
+          defaultCluster.getConfiguration().get(HConstants.MASTER_ADDRS_KEY));
     } finally {
       htu.shutdownMiniCluster();
     }
@@ -464,10 +468,14 @@ public class TestHBaseTestingUtility {
     htu = new HBaseTestingUtility(altConfig);
     try {
       MiniHBaseCluster customCluster = htu.startMiniCluster();
+      final String masterHostPort =
+          customCluster.getMaster().getServerName().getAddress().toString();
       assertEquals(nonDefaultMasterInfoPort,
-              customCluster.getConfiguration().getInt(HConstants.MASTER_INFO_PORT, 0));
+          customCluster.getConfiguration().getInt(HConstants.MASTER_INFO_PORT, 0));
       assertEquals(nonDefaultRegionServerPort,
           customCluster.getConfiguration().getInt(HConstants.REGIONSERVER_INFO_PORT, 0));
+      assertEquals(masterHostPort,
+          customCluster.getConfiguration().get(HConstants.MASTER_ADDRS_KEY));
     } finally {
       htu.shutdownMiniCluster();
     }


### PR DESCRIPTION
This patch adds the plumbing needed to start the mini cluster with
a pre-determined set of master ports. This is required for HBASE-18095
because the internal client 'Connection's from region servers need
to know the master RPC end points in their configuration even before
the mini cluster starts.

Following patches on HBASE-18095 will use this plumbing for unit tests.