### PR TITLE
HBASE-23297 [RSGROUP] build RegionPlan per group not per table

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1794,7 +1794,8 @@ public class HMaster extends HRegionServer implements MasterServices {
         }
       }
 
-      boolean isByTable = getConfiguration().getBoolean("hbase.master.loadbalance.bytable", false);
+      boolean isByTable = getConfiguration().getBoolean(
+          HConstants.HBASE_MASTER_LOADBALANCE_BYTABLE, false);
       Map<TableName, Map<ServerName, List<RegionInfo>>> assignments =
           this.assignmentManager.getRegionStates().getAssignmentsForBalancer(isByTable);
       for (Map<ServerName, List<RegionInfo>> serverMap : assignments.values()) {


### PR DESCRIPTION
RSGroupAdminServer#balanceRSGroup will take too long time, if the target group has thousands of tables, because we will build RegionPlan for each table, I think it’s better to balance per group instead of per table.