### PR TITLE
HBASE-23318 LoadTestTool doesn't start

### DIFF
--- a/hbase-assembly/src/main/assembly/components.xml
+++ b/hbase-assembly/src/main/assembly/components.xml
@@ -160,5 +160,13 @@
       </includes>
       <fileMode>0644</fileMode>
     </fileSet>
+    <fileSet>
+      <directory>${project.basedir}/../hbase-zookeeper/target/</directory>
+      <outputDirectory>lib</outputDirectory>
+      <includes>
+        <include>${zookeeper.test.jar}</include>
+      </includes>
+      <fileMode>0644</fileMode>
+    </fileSet>
   </fileSets>
 </component>


### PR DESCRIPTION
* Package the test jar from hbase-zookeeper into lib/