### PR TITLE
HBASE-23312 HBase Thrift SPNEGO configs (HBASE-19852) should be backwards compatible

### DIFF
--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftHttpServlet.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftHttpServlet.java
@@ -18,9 +18,6 @@
 
 package org.apache.hadoop.hbase.thrift;
 
-import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SPNEGO_KEYTAB_FILE_KEY;
-import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SPNEGO_PRINCIPAL_KEY;
-
 import java.io.IOException;
 import java.security.PrivilegedExceptionAction;
 import java.util.Base64;
@@ -29,7 +26,6 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.security.SecurityUtil;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.hadoop.security.authorize.AuthorizationException;
@@ -66,25 +62,14 @@ public class ThriftHttpServlet extends TServlet {
   public static final String NEGOTIATE = "Negotiate";
 
   public ThriftHttpServlet(TProcessor processor, TProtocolFactory protocolFactory,
-      UserGroupInformation serviceUGI, Configuration conf,
-      HBaseServiceHandler handler, boolean securityEnabled, boolean doAsEnabled)
-      throws IOException {
+      UserGroupInformation serviceUGI, UserGroupInformation httpUGI,
+      HBaseServiceHandler handler, boolean securityEnabled, boolean doAsEnabled) {
     super(processor, protocolFactory);
     this.serviceUGI = serviceUGI;
+    this.httpUGI = httpUGI;
     this.handler = handler;
     this.securityEnabled = securityEnabled;
     this.doAsEnabled = doAsEnabled;
-
-    if (securityEnabled) {
-      // login the spnego principal
-      UserGroupInformation.setConfiguration(conf);
-      this.httpUGI = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
-          conf.get(THRIFT_SPNEGO_PRINCIPAL_KEY),
-          conf.get(THRIFT_SPNEGO_KEYTAB_FILE_KEY)
-      );
-    } else {
-      this.httpUGI = null;
-    }
   }
 
   @Override

--- a/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift/TestThriftSpnegoHttpFallbackServer.java
+++ b/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift/TestThriftSpnegoHttpFallbackServer.java
@@ -72,17 +72,16 @@ import org.slf4j.LoggerFactory;
  * interface and talk to it from client side with SPNEGO security enabled.
  */
 @Category({ClientTests.class, LargeTests.class})
-public class TestThriftSpnegoHttpServer extends TestThriftHttpServer {
+public class TestThriftSpnegoHttpFallbackServer extends TestThriftHttpServer {
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-    HBaseClassTestRule.forClass(TestThriftSpnegoHttpServer.class);
+    HBaseClassTestRule.forClass(TestThriftSpnegoHttpFallbackServer.class);
 
   private static final Logger LOG =
-    LoggerFactory.getLogger(TestThriftSpnegoHttpServer.class);
+    LoggerFactory.getLogger(TestThriftSpnegoHttpFallbackServer.class);
 
   private static SimpleKdcServer kdc;
   private static File serverKeytab;
-  private static File spnegoServerKeytab;
   private static File clientKeytab;
 
   private static String clientPrincipal;
@@ -120,11 +119,11 @@ public class TestThriftSpnegoHttpServer extends TestThriftHttpServer {
     conf.set(Constants.THRIFT_KERBEROS_PRINCIPAL_KEY, serverPrincipal);
     conf.set(Constants.THRIFT_KEYTAB_FILE_KEY, serverKeytab.getAbsolutePath());
 
-    HBaseKerberosUtils.setSecuredConfiguration(conf, serverPrincipal, spnegoServerPrincipal);
-    conf.set("hadoop.proxyuser.hbase.hosts", "*");
-    conf.set("hadoop.proxyuser.hbase.groups", "*");
-    conf.set(Constants.THRIFT_SPNEGO_PRINCIPAL_KEY, spnegoServerPrincipal);
-    conf.set(Constants.THRIFT_SPNEGO_KEYTAB_FILE_KEY, spnegoServerKeytab.getAbsolutePath());
+    HBaseKerberosUtils.setSecuredConfiguration(conf, spnegoServerPrincipal,
+      spnegoServerPrincipal);
+    conf.set("hadoop.proxyuser.HTTP.hosts", "*");
+    conf.set("hadoop.proxyuser.HTTP.groups", "*");
+    conf.set(Constants.THRIFT_KERBEROS_PRINCIPAL_KEY, spnegoServerPrincipal);
   }
 
   @BeforeClass
@@ -142,11 +141,9 @@ public class TestThriftSpnegoHttpServer extends TestThriftHttpServer {
     serverPrincipal = "hbase/" + HConstants.LOCALHOST + "@" + kdc.getKdcConfig().getKdcRealm();
     serverKeytab = new File(keytabDir, serverPrincipal.replace('/', '_') + ".keytab");
 
-    // Setup separate SPNEGO keytab
     spnegoServerPrincipal = "HTTP/" + HConstants.LOCALHOST + "@" + kdc.getKdcConfig().getKdcRealm();
-    spnegoServerKeytab = new File(keytabDir, spnegoServerPrincipal.replace('/', '_') + ".keytab");
-    kdc.createAndExportPrincipals(spnegoServerKeytab, spnegoServerPrincipal);
-    kdc.createAndExportPrincipals(serverKeytab, serverPrincipal);
+    // Add SPNEGO principal to server keytab
+    kdc.createAndExportPrincipals(serverKeytab, serverPrincipal, spnegoServerPrincipal);
 
     TEST_UTIL.getConfiguration().setBoolean(Constants.USE_HTTP_CONF_KEY, true);
     TEST_UTIL.getConfiguration().setBoolean(TableDescriptorChecker.TABLE_SANITY_CHECKS, false);
@@ -173,8 +170,8 @@ public class TestThriftSpnegoHttpServer extends TestThriftHttpServer {
   protected void talkToThriftServer(String url, int customHeaderSize) throws Exception {
     // Close httpClient and THttpClient automatically on any failures
     try (
-        CloseableHttpClient httpClient = createHttpClient();
-        THttpClient tHttpClient = new THttpClient(url, httpClient)
+      CloseableHttpClient httpClient = createHttpClient();
+      THttpClient tHttpClient = new THttpClient(url, httpClient)
     ) {
       tHttpClient.open();
       if (customHeaderSize > 0) {
@@ -203,7 +200,7 @@ public class TestThriftSpnegoHttpServer extends TestThriftHttpServer {
     // Get a TGT for the subject (might have many, different encryption types). The first should
     // be the default encryption type.
     Set<KerberosTicket> privateCredentials =
-        clientSubject.getPrivateCredentials(KerberosTicket.class);
+      clientSubject.getPrivateCredentials(KerberosTicket.class);
     assertFalse("Found no private credentials in the clientSubject.",
       privateCredentials.isEmpty());
     KerberosTicket tgt = privateCredentials.iterator().next();
@@ -221,19 +218,19 @@ public class TestThriftSpnegoHttpServer extends TestThriftHttpServer {
         Oid oid = new Oid("1.2.840.113554.1.2.2");
         GSSName gssClient = gssManager.createName(clientPrincipalName, GSSName.NT_USER_NAME);
         GSSCredential credential = gssManager.createCredential(gssClient,
-            GSSCredential.DEFAULT_LIFETIME, oid, GSSCredential.INITIATE_ONLY);
+          GSSCredential.DEFAULT_LIFETIME, oid, GSSCredential.INITIATE_ONLY);
 
         Lookup<AuthSchemeProvider> authRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-            .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true, true))
-            .build();
+          .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true, true))
+          .build();
 
         BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
         credentialsProvider.setCredentials(AuthScope.ANY, new KerberosCredentials(credential));
 
         return HttpClients.custom()
-            .setDefaultAuthSchemeRegistry(authRegistry)
-            .setDefaultCredentialsProvider(credentialsProvider)
-            .build();
+          .setDefaultAuthSchemeRegistry(authRegistry)
+          .setDefaultCredentialsProvider(credentialsProvider)
+          .build();
       }
     });
   }


### PR DESCRIPTION
HBase Thrift SPNEGO configs should not be required.
The `hbase.thrift.spnego.keytab.file` and
`hbase.thrift.spnego.principal` configs should fall
back to the `hbase.thrift.keytab.file` and
`hbase.thrift.kerberos.principal` configs. This will
avoid any issues during upgrades.

Signed-off-by: Kevin Risden <krisden@apache.org>