### PR TITLE
HBASE-21776: Avoid duplicate calls to setStoragePolicy which shows up in debug Logging

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
@@ -191,7 +191,9 @@ public class HRegionFileSystem {
    */
   public void setStoragePolicy(String familyName, String policyName) throws IOException {
     if (this.fs instanceof HFileSystem) {
-      FSUtils.setStoragePolicy(((HFileSystem) this.fs).getBackingFs(), getStoreDir(familyName), policyName);
+      FSUtils.setStoragePolicy(
+          ((HFileSystem) this.fs).getBackingFs(),
+          getStoreDir(familyName), policyName);
     } else {
       FSUtils.setStoragePolicy(this.fs, getStoreDir(familyName), policyName);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
@@ -189,8 +189,12 @@ public class HRegionFileSystem {
    * @param familyName The name of column family.
    * @param policyName The name of the storage policy
    */
-  public void setStoragePolicy(String familyName, String policyName) {
-    FSUtils.setStoragePolicy(this.fs, getStoreDir(familyName), policyName);
+  public void setStoragePolicy(String familyName, String policyName) throws IOException{
+    if (this.fs instanceof HFileSystem) {
+      FSUtils.setStoragePolicy(((HFileSystem) this.fs).getBackingFs(), getStoreDir(familyName), policyName);
+    } else {
+      FSUtils.setStoragePolicy(this.fs, getStoreDir(familyName), policyName);
+    }
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
@@ -189,7 +189,7 @@ public class HRegionFileSystem {
    * @param familyName The name of column family.
    * @param policyName The name of the storage policy
    */
-  public void setStoragePolicy(String familyName, String policyName) throws IOException{
+  public void setStoragePolicy(String familyName, String policyName) throws IOException {
     if (this.fs instanceof HFileSystem) {
       FSUtils.setStoragePolicy(((HFileSystem) this.fs).getBackingFs(), getStoreDir(familyName), policyName);
     } else {


### PR DESCRIPTION
In CommonFSUtils's ` invokeSetStoragePolicy(final FileSystem fs, final Path path,
      final String storagePolicy)`, we invoke the setStoragePolicy by the following:

```java
m = fs.getClass().getDeclaredMethod("setStoragePolicy",
        new Class<?>[] { Path.class, String.class });
...
m.invoke(fs, path, storagePolicy);
```

When the call is initiated by HRegionFileSystem and fs is HFileSystem, `m.invoke(fs, path, storagePolicy)`repeats the same function call `setStoragePolicy(final FileSystem fs, final Path path,
      final String storagePolicy)` with underneath file system. 

We can avoid this duplicate calls by checking in advance if the file system for HRegionFileSystem is HFileSystem call the setStoragePolicy with the underneath fs. 