### PR TITLE
HBASE-23325 [UI]rsgoup average load keep two decimals

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/RSGroupListTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/RSGroupListTmpl.jamon
@@ -37,6 +37,7 @@ ServerManager serverManager;
     org.apache.hadoop.hbase.master.ServerManager;
     org.apache.hadoop.hbase.net.Address;
     org.apache.hadoop.hbase.rsgroup.RSGroupInfo;
+    org.apache.hadoop.util.StringUtils;
     org.apache.hadoop.util.StringUtils.TraditionalBinaryPrefix;
 </%import>
 <%java>
@@ -139,7 +140,7 @@ if (master.getServerManager() != null) {
     <td><% tables %></td>
     <td><% requestsPerSecond %></td>
     <td><% numRegionsOnline %></td>
-    <td><% avgLoad %></td>
+    <td><% StringUtils.limitDecimalTo2(avgLoad) %></td>
 </tr>
 <%java>
 }


### PR DESCRIPTION
In /master-status, rsgoup average load keep two decimals.