### PR TITLE
HBASE-23336 [CLI] Incorrect row(s) count 'clear_deadservers'

### DIFF
--- a/hbase-shell/src/main/ruby/shell/commands/clear_deadservers.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/clear_deadservers.rb
@@ -37,7 +37,6 @@ module Shell
       # rubocop:disable Metrics/AbcSize
       # rubocop:disable Metrics/MethodLength
       def command(*dead_servers)
-        now = Time.now
         servers = admin.clear_deadservers(dead_servers)
         if servers.size <= 0
           formatter.row(['true'])
@@ -47,7 +46,7 @@ module Shell
           servers.each do |server|
             formatter.row([server.toString])
           end
-          formatter.footer(now, servers.size)
+          formatter.footer(servers.size)
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -103,6 +103,11 @@ module Hbase
       assert(output.include?('0 row(s)'))
     end
 
+    define_test 'clear_deadservers should show exact row(s) count' do
+      output = capture_stdout { command(:clear_deadservers, 'test.server.com,16020,1574583397867') }
+      assert(output.include?('1 row(s)'))
+    end
+
     #-------------------------------------------------------------------------------
 
     define_test "flush should work" do


### PR DESCRIPTION
HBASE-15849 simplified the format of command total runtime but clear_deadservers caller has not modified so it prints current timestamp instead of no of rows. 

```
hbase(main):015:0>  clear_deadservers 'kpalanisamy-apache302.openstacklocal,16020'
SERVERNAME
kpalanisamy-apache302.openstacklocal,16020,16020
1574585488 row(s)
Took 0.0145 seconds
```