### PR TITLE
HBASE-23338 Prevent NPE running rsgroup balancer

### DIFF
--- a/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupAdminServer.java
+++ b/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupAdminServer.java
@@ -70,6 +70,7 @@ public class RSGroupAdminServer implements RSGroupAdmin {
   /** Define the default number of retries */
   //made package private for testing
   static final int DEFAULT_MAX_RETRY_VALUE = 50;
+  static final int DEFAULT_MIN_SERVER_REQUIRED = 2;
 
   private int moveMaxRetry;
 
@@ -460,6 +461,15 @@ public class RSGroupAdminServer implements RSGroupAdmin {
       if (getRSGroupInfo(groupName) == null) {
         throw new ConstraintException("RSGroup does not exist: "+groupName);
       }
+
+      int regionserversSize = getRSGroupInfo(groupName).getServers().size();
+      if (regionserversSize < DEFAULT_MIN_SERVER_REQUIRED) {
+        LOG.debug("Not running balancer because {} group contains {} regionserver."
+          + " Require minimum {} regionservers", groupName, regionserversSize,
+          DEFAULT_MIN_SERVER_REQUIRED);
+        return false;
+      }
+
       // Only allow one balance run at at time.
       Map<String, RegionState> groupRIT = rsGroupGetRegionsInTransition(groupName);
       if (groupRIT.size() > 0) {

--- a/hbase-shell/src/main/ruby/shell/commands/balance_rsgroup.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/balance_rsgroup.rb
@@ -35,7 +35,8 @@ EOF
         if ret
           puts 'Ran the balancer.'
         else
-          puts "Couldn't run the balancer."
+          puts "Couldn't run the balancer. Possibly region-in-transitions or processing
+           dead regionservers or group have less than 2 regionservers. Please check the master log."
         end
         ret
       end

--- a/hbase-shell/src/test/ruby/shell/rsgroup_shell_test.rb
+++ b/hbase-shell/src/test/ruby/shell/rsgroup_shell_test.rb
@@ -57,6 +57,9 @@ module Hbase
       assert_equal(1, @rsgroup_admin.getRSGroupInfo(group_name).getServers.count)
       assert_equal(group_name, @rsgroup_admin.getRSGroupOfServer(hostport).getName)
 
+      output = capture_stdout { @shell.command(:balance_rsgroup, group_name) }
+      assert(output.include?("Couldn't run the balancer"))
+
       @shell.command('move_tables_rsgroup',
                      group_name,
                      [table_name])


### PR DESCRIPTION
I think we should prevent NPE even if user trigger balancer on rsgroup that contains only a single regionserver.  Sometimes users trigger balancer on all groups even without knowing group info.

master log
```
2019-11-24
22:50:29,868 ERROR [RpcServer.default.FPBQ.Fifo.handler=22,queue=1,port=16000]
ipc.RpcServer: Unexpected throwable object
java.lang.NullPointerException
```

Shell
```
hbase(main):002:0> balance_rsgroup 'shva'
ERROR: java.io.IOException at org.apache.hadoop.hbase.ipc.RpcServer.call(RpcServer.java:433) at org.apache.hadoop.hbase.ipc.CallRunner.run(CallRunner.java:133) at org.apache.hadoop.hbase.ipc.RpcExecutor$Handler.run(RpcExecutor.java:338) at org.apache.hadoop.hbase.ipc.RpcExecutor$Handler.run(RpcExecutor.java:318)Caused by: java.lang.NullPointerException
For usage try 'help "balance_rsgroup"'
```