### PR TITLE
HBASE-23343 Thrift Resolve FQDN from SPNEGO principal

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/SecurityUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/SecurityUtil.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hbase.security;
 
+import java.net.InetAddress;
+import java.net.UnknownHostException;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
@@ -26,7 +28,9 @@ import org.apache.yetus.audience.InterfaceStability;
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
-public class SecurityUtil {
+public final class SecurityUtil {
+
+  private SecurityUtil() {}
 
   /**
    * Get the user name from a principal
@@ -45,5 +49,15 @@ public class SecurityUtil {
   public static String getPrincipalWithoutRealm(final String principal) {
     int i = principal.indexOf("@");
     return (i > -1) ? principal.substring(0, i) : principal;
+  }
+
+  public static String getServicePrincipalWithFQDN(String principal) throws UnknownHostException {
+    if (principal != null && !principal.isEmpty()) {
+      String[] components = principal.split("[/@]");
+      if (components[1].equals("_HOST")) {
+        return components[0] + '/' + InetAddress.getLocalHost().getHostName() + '@' + components[2];
+      }
+    }
+    return principal;
   }
 }

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftHttpServlet.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftHttpServlet.java
@@ -79,7 +79,7 @@ public class ThriftHttpServlet extends TServlet {
       // login the spnego principal
       UserGroupInformation.setConfiguration(conf);
       this.httpUGI = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
-          conf.get(THRIFT_SPNEGO_PRINCIPAL_KEY),
+          SecurityUtil.getServicePrincipalWithFQDN(conf.get(THRIFT_SPNEGO_PRINCIPAL_KEY)),
           conf.get(THRIFT_SPNEGO_KEYTAB_FILE_KEY)
       );
     } else {

--- a/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift/TestThriftHttpServer.java
+++ b/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift/TestThriftHttpServer.java
@@ -19,17 +19,21 @@ package org.apache.hadoop.hbase.thrift;
 
 import static org.apache.hadoop.hbase.thrift.Constants.INFOPORT_OPTION;
 import static org.apache.hadoop.hbase.thrift.Constants.PORT_OPTION;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.fail;
 
 import java.net.HttpURLConnection;
+import java.net.InetAddress;
 import java.net.URL;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.security.SecurityUtil;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.thrift.generated.Hbase;
@@ -153,6 +157,14 @@ public class TestThriftHttpServer {
   @Test
   public void testRunThriftServer() throws Exception {
     runThriftServer(0);
+  }
+
+  @Test
+  public void testServicePrincipal() throws UnknownHostException {
+    String hostname = InetAddress.getLocalHost().getHostName();
+    String principalName = "HTTP/_HOST@HBASE.COM";
+    String principalNameWFQDN = "HTTP/" + hostname + "@HBASE.COM";
+    assertEquals(principalNameWFQDN, SecurityUtil.getServicePrincipalWithFQDN(principalName));
   }
 
   void runThriftServer(int customHeaderSize) throws Exception {


### PR DESCRIPTION
We need to manage different config groups in Ambari to run multiple thrift servers. This is because hbase thrift server will not able to resolve _HOST pattern from hbase.thrift.spnego.principal. so we explicitly specify the hostname for each group now.