### PR TITLE
HBASE-22920 github pr testing job should use dev-support script

### DIFF
--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -85,17 +85,7 @@ pipeline {
                         mvn --offline --version  || true
                         echo "getting machine specs, find in ${BUILD_URL}/artifact/patchprocess/machine/"
                         mkdir "${PATCHDIR}/machine"
-                        cat /proc/cpuinfo >"${PATCHDIR}/machine/cpuinfo" 2>&1 || true
-                        cat /proc/meminfo >"${PATCHDIR}/machine/meminfo" 2>&1 || true
-                        cat /proc/diskstats >"${PATCHDIR}/machine/diskstats" 2>&1 || true
-                        cat /sys/block/sda/stat >"${PATCHDIR}/machine/sys-block-sda-stat" 2>&1 || true
-                        df -h >"${PATCHDIR}/machine/df-h" 2>&1 || true
-                        ps -Awwf >"${PATCHDIR}/machine/ps-Awwf" 2>&1 || true
-                        ifconfig -a >"${PATCHDIR}/machine/ifconfig-a" 2>&1 || true
-                        lsblk -ta >"${PATCHDIR}/machine/lsblk-ta" 2>&1 || true
-                        lsblk -fa >"${PATCHDIR}/machine/lsblk-fa" 2>&1 || true
-                        cat /proc/loadavg >"${output}/loadavg" 2>&1 || true
-                        ulimit -a >"${PATCHDIR}/machine/ulimit-a" 2>&1 || true
+                       "${SOURCEDIR}/dev-support/gather_machine_environment.sh" "${PATCHDIR}/machine"
                         ## /H*
 
                         # If CHANGE_URL is set (e.g., Github Branch Source plugin), process it.

--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -83,7 +83,6 @@ pipeline {
                         echo "MAVEN_HOME: ${MAVEN_HOME}"
                         echo "maven version:"
                         mvn --offline --version  || true
-                        echo "getting machine specs, find in ${BUILD_URL}/artifact/patchprocess/machine/"
                         mkdir "${PATCHDIR}/machine"
                        "${SOURCEDIR}/dev-support/gather_machine_environment.sh" "${PATCHDIR}/machine"
                         ## /H*


### PR DESCRIPTION
the PR tester Jenkinsfile_GitHub has its own set of commands for gathering information about the build environment it runs in. Instead it should rely on the dev-support/gather_machine_environment.sh that gets used by nightly