### PR TITLE
HBASE-23337 Release scripts should rely on maven for deploy.

### DIFF
--- a/dev-support/create-release/release-build.sh
+++ b/dev-support/create-release/release-build.sh
@@ -229,7 +229,7 @@ if [[ "$1" == "publish-release" ]]; then
     mvn_goals=("${mvn_goals[@]}" deploy)
   fi
   echo "Staging release in nexus"
-  if ! MAVEN_OPTS="${MAVEN_OPTS}" ${MVN} --settings $tmp_settings \
+  if ! MAVEN_OPTS="${MAVEN_OPTS}" ${MVN} --settings "$tmp_settings" \
       -DskipTests -Dcheckstyle.skip=true "${PUBLISH_PROFILES}" \
       -Dmaven.repo.local="${tmp_repo}" \
       "${mvn_goals[@]}" > "${BASE_DIR}/mvn_deploy.log"; then

--- a/dev-support/create-release/release-build.sh
+++ b/dev-support/create-release/release-build.sh
@@ -95,12 +95,7 @@ export LANG=C.UTF-8
 
 # Commit ref to checkout when building
 GIT_REF=${GIT_REF:-master}
-
 RELEASE_STAGING_LOCATION="https://dist.apache.org/repos/dist/dev/hbase"
-
-GPG="gpg --pinentry-mode loopback -u $GPG_KEY --no-tty --batch"
-NEXUS_ROOT=https://repository.apache.org/service/local/staging
-NEXUS_PROFILE=8e226b97c0c82 # Profile for project staging uploads via INFRA-17900 Need nexus "staging profile id" for the hbase project
 BASE_DIR=$(pwd)
 
 init_java
@@ -148,13 +143,13 @@ cd ..
 tmp_repo="${REPO:-`pwd`/$(mktemp -d hbase-repo-XXXXX)}"
 # Reexamine. Not sure this working. Pass as arg? That don't seem to work either!
 tmp_settings="/${tmp_repo}/tmp-settings.xml"
-echo "<settings><servers>" > $tmp_settings
-echo "<server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username>" >> $tmp_settings
-echo "<password>$ASF_PASSWORD</password></server>" >> $tmp_settings
-echo "<server><id>apache-release</id><username>$ASF_USERNAME</username>" >> $tmp_settings
-echo "<password>$ASF_PASSWORD</password></server>" >> $tmp_settings
-echo "</servers>" >> $tmp_settings
-echo "</settings>" >> $tmp_settings
+echo "<settings><servers>" > "$tmp_settings"
+echo "<server><id>apache.snapshots.https</id><username>$ASF_USERNAME</username>" >> "$tmp_settings"
+echo "<password>$ASF_PASSWORD</password></server>" >> "$tmp_settings"
+echo "<server><id>apache.releases.https</id><username>$ASF_USERNAME</username>" >> "$tmp_settings"
+echo "<password>$ASF_PASSWORD</password></server>" >> "$tmp_settings"
+echo "</servers>" >> "$tmp_settings"
+echo "</settings>" >> "$tmp_settings"
 export tmp_settings
 
 if [[ "$1" == "build" ]]; then
@@ -216,91 +211,30 @@ if [[ "$1" == "publish-snapshot" ]]; then
 fi
 
 if [[ "$1" == "publish-release" ]]; then
+  (
   cd "${PROJECT}"
-  # Get list of modules from parent pom but filter out 'assembly' modules.
-  # Used below in a few places.
-  modules=`sed -n 's/<module>\(.*\)<.*$/\1/p' pom.xml | grep -v '-assembly' |  tr '\n' ' '`
-  # Need to add the 'parent' module too. Its the SECOND artifactId instance in pom
-  artifactid=`sed -n 's/<artifactId>\(.*\)<.*$/\1/p' pom.xml | tr '\n' ' '| awk '{print $2}'`
-  modules="${artifactid} ${modules}"
-  # Get the second groupId in the pom. This is the groupId for these artifacts.
-  groupid=`sed -n 's/<groupId>\(.*\)<.*$/\1/p' pom.xml | tr '\n' ' '| awk '{print $2}'`
-  # Convert groupid to a dir path for use below reaching into repo for jars.
-  groupid_as_dir=`echo $groupid | sed -n 's/\./\//gp'`
-  echo "pwd=`pwd`, groupid_as_dir=${groupid_as_dir}"
   # Publish ${PROJECT} to Maven release repo
   echo "Publishing ${PROJECT} checkout at '$GIT_REF' ($git_hash)"
   echo "Publish version is $VERSION"
   # Coerce the requested version
   $MVN versions:set -DnewVersion=$VERSION
+  declare -a mvn_goals=(clean install)
+  if ! is_dry_run; then
+    mvn_goals=("${mvn_goals[@]}" deploy)
+  fi
+  echo "Staging release in nexus"
   MAVEN_OPTS="${MAVEN_OPTS}" ${MVN} --settings $tmp_settings \
-    clean install -DskipTests \
-    -Dcheckstyle.skip=true "${PUBLISH_PROFILES}" \
-    -Dmaven.repo.local="${tmp_repo}"
-  pushd "${tmp_repo}/${groupid_as_dir}"
-  # Remove any extra files generated during install
-  # Remove extaneous files from module subdirs
-  find $modules -type f | grep -v \.jar | grep -v \.pom | xargs rm -rf
-
-  # Using Nexus API documented here:
-  # https://support.sonatype.com/entries/39720203-Uploading-to-a-Staging-Repository-via-REST-API
+      -DskipTests -Dcheckstyle.skip=true "${PUBLISH_PROFILES}" \
+      -Dmaven.repo.local="${tmp_repo}" \
+      "${mvn_goals[@]}" > "${BASE_DIR}/mvn_deploy.log"
   if ! is_dry_run; then
-    echo "Creating Nexus staging repository"
-    repo_request="<promoteRequest><data><description>Apache ${PROJECT} $VERSION (commit $git_hash)</description></data></promoteRequest>"
-    out=$(curl -X POST -d "$repo_request" -u $ASF_USERNAME:$ASF_PASSWORD \
-      -H "Content-Type:application/xml" -v \
-      $NEXUS_ROOT/profiles/$NEXUS_PROFILE/start)
-    staged_repo_id=$(echo $out | sed -e "s/.*\(orgapachehbase-[0-9]\{4\}\).*/\1/")
-    echo "Created Nexus staging repository: $staged_repo_id"
+    staged_repo_id=$(grep -o "Closing staging repository with ID .*" "${BASE_DIR}/mvn_deploy.log" \
+        | sed -e 's/Closing staging repository with ID "\([^"]*\)"./\1/')
+    echo "Artifacts successfully staged to repo ${staged_repo_id}"
+  else
+    echo "Artifacts successfully built. not staged due to dry run."
   fi
-
-  # this must have .asc, and .sha1 - it really doesn't like anything else there
-  for file in $(find $modules -type f)
-  do
-    if [[ "$file" == *.asc ]]; then
-      continue
-    fi
-    if [ ! -f $file.asc ]; then
-      echo "$GPG_PASSPHRASE" | $GPG --passphrase-fd 0 --output "$file.asc" \
-        --detach-sig --armour $file;
-    fi
-    if [ $(command -v md5)  ]; then
-      # Available on OS X; -q to keep only hash
-      md5 -q "$file" > "$file.md5"
-    else
-      # Available on Linux; cut to keep only hash
-      md5sum "$file" | cut -f1 -d' ' > "$file.md5"
-    fi
-    if [ $(command -v sha1sum)  ]; then
-      sha1sum "$file" | cut -f1 -d' ' > "$file.sha1"
-    else
-      shasum "$file" | cut -f1 -d' ' > "$file.sha1"
-    fi
-  done
-
-  if ! is_dry_run; then
-    nexus_upload=$NEXUS_ROOT/deployByRepositoryId/$staged_repo_id
-    echo "Uploading files to $nexus_upload"
-    for file in $(find ${modules} -type f)
-    do
-      # strip leading ./
-      file_short=$(echo $file | sed -e "s/\.\///")
-      dest_url="$nexus_upload/$groupid_as_dir/$file_short"
-      echo "  Uploading $file to $dest_url"
-      curl -u "$ASF_USERNAME:$ASF_PASSWORD" --upload-file "${file_short}" "${dest_url}"
-    done
-
-    echo "Closing nexus staging repository"
-    repo_request="<promoteRequest><data><stagedRepositoryId>$staged_repo_id</stagedRepositoryId><description>Apache ${PROJECT} $VERSION (commit $git_hash)</description></data></promoteRequest>"
-    out=$(curl -X POST -d "$repo_request" -u $ASF_USERNAME:$ASF_PASSWORD \
-      -H "Content-Type:application/xml" -v \
-      $NEXUS_ROOT/profiles/$NEXUS_PROFILE/finish)
-    echo "Closed Nexus staging repository: $staged_repo_id"
-  fi
-
-  popd
-  rm -rf "$tmp_repo"
-  cd ..
+  )
   # Dump out email to send. Where we find vote.tmpl depends
   # on where this script is run from
   export PROJECT_TEXT=$(echo "${PROJECT}" | sed "s/-/ /g")

--- a/pom.xml
+++ b/pom.xml
@@ -545,17 +545,17 @@
       <name>Tak-Lon (Stephen) Wu</name>
       <email>taklwu@apache.org</email>
       <timezone>-8</timezone>
-    </developer>	  
+    </developer>
     <developer>
       <id>tedyu</id>
       <name>Ted Yu</name>
       <email>yuzhihong@gmail.com</email>
       <timezone>-8</timezone>
     </developer>
-	<developer>
-	  <id>tianjy</id>
-	  <email>tianjy@apache.org</email>
-	  <timezone>+8</timezone>
+    <developer>
+      <id>tianjy</id>
+      <email>tianjy@apache.org</email>
+      <timezone>+8</timezone>
     </developer>
     <developer>
       <id>todd</id>
@@ -2481,6 +2481,28 @@
         <argLine>${hbase-surefire.cygwin-argLine}</argLine>
       </properties>
     </profile>
+    <!-- this profile should match the name of the release profile in the root asf pom -->
+    <profile>
+      <id>apache-release</id>
+      <build>
+        <plugins>
+          <!-- This should insert itself in place of the normal deploy plugin and then
+               handle either closing or dropping the staging repository for us depending
+               on if the build succeeds.
+            -->
+          <plugin>
+            <groupId>org.sonatype.plugins</groupId>
+            <artifactId>nexus-staging-maven-plugin</artifactId>
+            <version>1.6.8</version>
+            <extensions>true</extensions>
+            <configuration>
+              <nexusUrl>https://repository.apache.org/</nexusUrl>
+              <serverId>apache.releases.https</serverId>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
     <!-- this profile should be activated for release builds -->
     <profile>
       <id>release</id>
@@ -2729,7 +2751,7 @@
           <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-auth</artifactId>
-	    <version>${hadoop-two.version}</version>
+            <version>${hadoop-two.version}</version>
             <exclusions>
               <exclusion>
                 <groupId>com.google.guava</groupId>


### PR DESCRIPTION
    - switch to nexus-staging-maven-plugin for asf-release
    - refactor release-build to use mvn deploy and its output.
    - cleaned up some tabs in the root pom


first commit corresponds to a rebase of v1 from jira.