### PR TITLE
HBASE-23269 Hbase crashed due to two versions of regionservers when rolling upgrading

### DIFF
--- a/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupBasedLoadBalancer.java
+++ b/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupBasedLoadBalancer.java
@@ -274,6 +274,21 @@ public class RSGroupBasedLoadBalancer implements RSGroupableBalancer, LoadBalanc
     return this.internalBalancer.randomAssignment(region, filteredServers);
   }
 
+  @Override
+  public  Set<Address> getServersInDefaultOrGroup(HRegionInfo region) throws HBaseIOException {
+    try{
+      String groupName = infoManager.getRSGroupOfTable(region.getTable());
+      if (groupName == null) {
+        groupName = RSGroupInfo.DEFAULT_GROUP;
+      }
+      RSGroupInfo info = infoManager.getRSGroup(groupName);
+      Set<Address> serversInGroup = info.getServers();
+      return serversInGroup;
+    } catch (Exception e) {
+      throw new HBaseIOException("Failed to get servers ", e);
+    }
+  }
+
   private void generateGroupMaps(
     List<HRegionInfo> regions,
     List<ServerName> servers,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/AssignmentManager.java
@@ -89,6 +89,7 @@ import org.apache.hadoop.hbase.master.handler.ClosedRegionHandler;
 import org.apache.hadoop.hbase.master.handler.DisableTableHandler;
 import org.apache.hadoop.hbase.master.handler.EnableTableHandler;
 import org.apache.hadoop.hbase.master.handler.OpenedRegionHandler;
+import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.protobuf.generated.RegionServerStatusProtos.RegionStateTransition;
 import org.apache.hadoop.hbase.protobuf.generated.RegionServerStatusProtos.RegionStateTransition.TransitionCode;
 import org.apache.hadoop.hbase.protobuf.generated.ZooKeeperProtos;
@@ -2636,10 +2637,30 @@ public class AssignmentManager extends ZooKeeperListener {
             for (ServerName server : getExcludedServersForSystemTable()) {
               regionsShouldMove.addAll(getCarryingSystemTables(server));
             }
+            Set<Address> serverbygroup = new HashSet<>();
+            Set<Address> remainservers = new HashSet<>();
+            Set<Address> excludedAddresses = new HashSet<>();
             if (!regionsShouldMove.isEmpty()) {
               List<RegionPlan> plans = new ArrayList<>();
+              List<ServerName> names = getExcludedServersForSystemTable();
               for (HRegionInfo regionInfo : regionsShouldMove) {
                 RegionPlan plan = getRegionPlan(regionInfo, true);
+                serverbygroup = balancer.getServersInDefaultOrGroup(regionInfo);
+                excludedAddresses = getAddressFromServerName(names);
+                if (serverbygroup != null) {
+                  for (Address address : serverbygroup) {
+                    if ( !excludedAddresses.contains(address) &&
+                            getAddressFromServerName(serverManager.
+                                    getOnlineServersList()).contains(address)) {
+                      remainservers.add(address);
+                    }
+                  }
+                  if (remainservers.size() == 0) {
+                    LOG.info("The region("+regionInfo.getRegionNameAsString()+")" +
+                            "do not need to move to RS with the highest version ");
+                    continue;
+                  }
+                }
                 if (regionInfo.isMetaRegion()) {
                   // Must move meta region first.
                   balance(plan);
@@ -2659,6 +2680,16 @@ public class AssignmentManager extends ZooKeeperListener {
     }).start();
   }
 
+  public HashSet<Address> getAddressFromServerName(List<ServerName> servernames) {
+    HashSet<Address> addresses = new HashSet<>();
+    if (servernames == null) {
+      return addresses;
+    }
+    for (ServerName servername : servernames) {
+      addresses.add(servername.getAddress());
+    }
+    return addresses;
+  }
 
   /**
    * Unassigns the specified region.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/AssignmentManager.java
@@ -2637,19 +2637,17 @@ public class AssignmentManager extends ZooKeeperListener {
             for (ServerName server : getExcludedServersForSystemTable()) {
               regionsShouldMove.addAll(getCarryingSystemTables(server));
             }
-            Set<Address> serverbygroup = new HashSet<>();
             Set<Address> remainservers = new HashSet<>();
-            Set<Address> excludedAddresses = new HashSet<>();
             if (!regionsShouldMove.isEmpty()) {
               List<RegionPlan> plans = new ArrayList<>();
               List<ServerName> names = getExcludedServersForSystemTable();
               for (HRegionInfo regionInfo : regionsShouldMove) {
                 RegionPlan plan = getRegionPlan(regionInfo, true);
-                serverbygroup = balancer.getServersInDefaultOrGroup(regionInfo);
-                excludedAddresses = getAddressFromServerName(names);
+                Set<Address> serverbygroup = balancer.getServersInDefaultOrGroup(regionInfo);
+                Set<Address> excludedAddresses = getAddressFromServerName(names);
                 if (serverbygroup != null) {
                   for (Address address : serverbygroup) {
-                    if ( !excludedAddresses.contains(address) &&
+                    if (!excludedAddresses.contains(address) &&
                             getAddressFromServerName(serverManager.
                                     getOnlineServersList()).contains(address)) {
                       remainservers.add(address);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/LoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/LoadBalancer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.master;
 
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 
 import org.apache.hadoop.hbase.classification.InterfaceAudience;
 import org.apache.hadoop.hbase.conf.ConfigurationObserver;
@@ -31,6 +32,7 @@ import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.Stoppable;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.net.Address;
 
 /**
  * Makes decisions about the placement and movement of Regions across
@@ -126,6 +128,15 @@ public interface LoadBalancer extends Configurable, Stoppable, ConfigurationObse
   ServerName randomAssignment(
     HRegionInfo regionInfo, List<ServerName> servers
   ) throws HBaseIOException;
+
+  /**
+   * Get all the servers of this region's rs_group，and now only used in RSGroupBasedLoadBalancer
+   * @param region
+   * @return Set of Address
+   * @throws HBaseIOException
+   */
+  Set<Address> getServersInDefaultOrGroup(
+          HRegionInfo region) throws HBaseIOException;
 
   /**
    * Initialize the load balancer. Must be called after setters.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/LoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/LoadBalancer.java
@@ -131,9 +131,8 @@ public interface LoadBalancer extends Configurable, Stoppable, ConfigurationObse
 
   /**
    * Get all the servers of this region's rs_group，and now only used in RSGroupBasedLoadBalancer
-   * @param region
+   * @param region Get the servers of region's table
    * @return Set of Address
-   * @throws HBaseIOException
    */
   Set<Address> getServersInDefaultOrGroup(
           HRegionInfo region) throws HBaseIOException;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/FavoredNodeLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/FavoredNodeLoadBalancer.java
@@ -19,10 +19,7 @@
 package org.apache.hadoop.hbase.master.balancer;
 
 import java.io.IOException;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
+import java.util.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -40,6 +37,7 @@ import org.apache.hadoop.hbase.master.RegionPlan;
 import org.apache.hadoop.hbase.master.ServerManager;
 import org.apache.hadoop.hbase.master.SnapshotOfRegionAssignmentFromMeta;
 import org.apache.hadoop.hbase.master.balancer.FavoredNodesPlan.Position;
+import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.util.Pair;
 
 /**
@@ -223,6 +221,11 @@ public class FavoredNodeLoadBalancer extends BaseLoadBalancer {
           " Falling back to regular assignment");
       return super.randomAssignment(regionInfo, servers);
     }
+  }
+
+  @Override
+  public Set<Address> getServersInDefaultOrGroup(HRegionInfo region) throws HBaseIOException {
+    return null;
   }
 
   private Pair<Map<ServerName, List<HRegionInfo>>, List<HRegionInfo>>

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/SimpleLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/SimpleLoadBalancer.java
@@ -17,15 +17,7 @@
  */
 package org.apache.hadoop.hbase.master.balancer;
 
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collections;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import java.util.NavigableMap;
-import java.util.Random;
-import java.util.TreeMap;
+import java.util.*;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -38,6 +30,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.master.RegionPlan;
 
 import com.google.common.collect.MinMaxPriorityQueue;
+import org.apache.hadoop.hbase.net.Address;
 
 /**
  * Makes decisions about the placement and movement of Regions across
@@ -436,5 +429,10 @@ public class SimpleLoadBalancer extends BaseLoadBalancer {
   public List<RegionPlan> balanceCluster(TableName tableName,
       Map<ServerName, List<HRegionInfo>> clusterState) throws HBaseIOException {
     return balanceCluster(clusterState);
+  }
+
+  @Override
+  public Set<Address> getServersInDefaultOrGroup(HRegionInfo region) throws HBaseIOException {
+    return null;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/SimpleLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/SimpleLoadBalancer.java
@@ -17,7 +17,16 @@
  */
 package org.apache.hadoop.hbase.master.balancer;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Random;
+import java.util.Set;
+import java.util.TreeMap;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
@@ -28,9 +37,9 @@ import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.master.RegionPlan;
+import org.apache.hadoop.hbase.net.Address;
 
 import com.google.common.collect.MinMaxPriorityQueue;
-import org.apache.hadoop.hbase.net.Address;
 
 /**
  * Makes decisions about the placement and movement of Regions across

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -18,31 +18,15 @@
 package org.apache.hadoop.hbase.master.balancer;
 
 import com.google.common.annotations.VisibleForTesting;
-import java.util.ArrayDeque;
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Collections;
-import java.util.Deque;
-import java.util.HashMap;
-import java.util.LinkedList;
-import java.util.List;
-import java.util.Map;
+
+import java.util.*;
 import java.util.Map.Entry;
-import java.util.Random;
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.hbase.*;
 import org.apache.hadoop.hbase.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.ClusterStatus;
-import org.apache.hadoop.hbase.HBaseInterfaceAudience;
-import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.HRegionInfo;
-import org.apache.hadoop.hbase.RegionLoad;
-import org.apache.hadoop.hbase.ServerLoad;
-import org.apache.hadoop.hbase.ServerName;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.hadoop.hbase.master.RegionPlan;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.Action;
@@ -51,6 +35,7 @@ import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.AssignRe
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.LocalityType;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.MoveRegionAction;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.SwapRegionsAction;
+import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 
@@ -439,6 +424,11 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
           + step + " different configurations in " + (endTime - startTime)
           + "ms, and did not find anything with a computed cost less than " + initCost);
     }
+    return null;
+  }
+
+  @Override
+  public Set<Address> getServersInDefaultOrGroup(HRegionInfo region) throws HBaseIOException {
     return null;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -29,12 +29,23 @@ import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Random;
+import java.util.Set;
+
 
 import org.apache.commons.logging.Log;
 import org.apache.commons.logging.LogFactory;
-import org.apache.hadoop.hbase.*;
 import org.apache.hadoop.hbase.classification.InterfaceAudience;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ClusterStatus;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.HBaseIOException;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.RegionLoad;
+import org.apache.hadoop.hbase.ServerLoad;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.hadoop.hbase.master.RegionPlan;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.Action;
@@ -43,9 +54,9 @@ import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.AssignRe
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.LocalityType;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.MoveRegionAction;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.SwapRegionsAction;
+import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
-import org.apache.hadoop.hbase.net.Address;
 
 import com.google.common.base.Optional;
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -18,8 +18,16 @@
 package org.apache.hadoop.hbase.master.balancer;
 
 import com.google.common.annotations.VisibleForTesting;
-
-import java.util.*;
+import java.util.ArrayDeque;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Deque;
+import java.util.HashMap;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
 import java.util.Map.Entry;
 
 import org.apache.commons.logging.Log;
@@ -35,9 +43,9 @@ import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.AssignRe
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.LocalityType;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.MoveRegionAction;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.SwapRegionsAction;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.net.Address;
-import org.apache.hadoop.hbase.util.Bytes;
 
 import com.google.common.base.Optional;
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -54,9 +54,9 @@ import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.AssignRe
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.LocalityType;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.MoveRegionAction;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.SwapRegionsAction;
-import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hbase.net.Address;
 
 import com.google.common.base.Optional;
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -35,9 +35,9 @@ import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.AssignRe
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.LocalityType;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.MoveRegionAction;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer.Cluster.SwapRegionsAction;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 
 import com.google.common.base.Optional;
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBaseLoadBalancer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBaseLoadBalancer.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.HRegionInfo;
+import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
@@ -100,6 +101,10 @@ public class TestBaseLoadBalancer extends BalancerTestBase {
   }
 
   public static class MockBalancer extends BaseLoadBalancer {
+    @Override
+    public Set<Address> getServersInDefaultOrGroup(HRegionInfo region) throws HBaseIOException {
+      return null;
+    }
 
     @Override
     public List<RegionPlan> balanceCluster(Map<ServerName, List<HRegionInfo>> clusterState) {


### PR DESCRIPTION
HBASE-23269 Hbase crashed due to two versions of regionservers when rolling upgrading. JianzhenXu