### PR TITLE
HBASE-23361 Limit two decimals in total average load

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/RSGroupListTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/RSGroupListTmpl.jamon
@@ -151,7 +151,7 @@ if (master.getServerManager() != null) {
 <td><% totalTables %></td>
 <td><% totalRequests %></td>
 <td><% totalRegions %></td>
-<td><% master.getServerManager().getAverageLoad() %></td>
+<td><% StringUtils.limitDecimalTo2(master.getServerManager().getAverageLoad()) %></td>
 </tr>
 </table>
 </%def>


### PR DESCRIPTION
We somehow missed limiting decimal points in the total average load.

It is related to https://issues.apache.org/jira/browse/HBASE-23325

