### PR TITLE
HBASE-23365 Minor change MemStoreFlusher's log

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreFlusher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreFlusher.java
@@ -280,10 +280,10 @@ class MemStoreFlusher implements FlushRequester {
       } else {
         LOG.info("Flush of region " + regionToFlush + " due to global heap pressure. " +
             "Flush type=" + flushType.toString() +
-            "Total Memstore Heap size=" +
+            ", Total Memstore Heap size=" +
             TraditionalBinaryPrefix.long2String(
                 server.getRegionServerAccounting().getGlobalMemStoreHeapSize(), "", 1) +
-            "Total Memstore Off-Heap size=" +
+            ", Total Memstore Off-Heap size=" +
             TraditionalBinaryPrefix.long2String(
                 server.getRegionServerAccounting().getGlobalMemStoreOffHeapSize(), "", 1) +
             ", Region memstore size=" +


### PR DESCRIPTION
2019-12-04 15:11:25,868 INFO [MemStoreFlusher.2] regionserver.MemStoreFlusher: Flush of region table_100B_10,user4346,1575440696268.a159ed24ac2b198c9cd5434f3bfe2ab6. due to global heap pressure. Flush type=ABOVE_ONHEAP_LOWER_MARKTotal Memstore Heap size=5.6 GTotal Memstore Off-Heap size=0, Region memstore size=229.8 M

Change the log to be more human-readable and friendly.