### PR TITLE
HBASE-23566: Fix package/packet terminology problem in chaos monkeys

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/CorruptPacketsCommandAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/CorruptPacketsCommandAction.java
@@ -27,29 +27,29 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * Duplicate network packages on a random regionserver.
+ * Corrupt network packets on a random regionserver.
  */
-public class DuplicatePackagesCommandAction extends TCCommandAction {
-  private static final Logger LOG = LoggerFactory.getLogger(DuplicatePackagesCommandAction.class);
+public class CorruptPacketsCommandAction extends TCCommandAction {
+  private static final Logger LOG = LoggerFactory.getLogger(CorruptPacketsCommandAction.class);
   private float ratio;
   private long duration;
 
   /**
-   * Duplicate network packages on a random regionserver.
+   * Corrupt network packets on a random regionserver.
    *
-   * @param ratio the ratio of packages duplicated
+   * @param ratio the ratio of packets corrupted
    * @param duration the time this issue persists in milliseconds
    * @param timeout the timeout for executing required commands on the region server in milliseconds
    * @param network network interface the regionserver uses for communication
    */
-  public DuplicatePackagesCommandAction(float ratio, long duration, long timeout, String network) {
+  public CorruptPacketsCommandAction(float ratio, long duration, long timeout, String network) {
     super(timeout, network);
     this.ratio = ratio;
     this.duration = duration;
   }
 
   protected void localPerform() throws IOException {
-    LOG.info("Starting to execute DuplicatePackagesCommandAction");
+    LOG.info("Starting to execute CorruptPacketsCommandAction");
     ServerName server = PolicyBasedChaosMonkey.selectRandomItem(getCurrentServers());
     String hostname = server.getHostname();
 
@@ -62,11 +62,11 @@ public class DuplicatePackagesCommandAction extends TCCommandAction {
       clusterManager.execSudoWithRetries(hostname, timeout, getCommand(DELETE));
     }
 
-    LOG.info("Finished to execute DuplicatePackagesCommandAction");
+    LOG.info("Finished to execute CorruptPacketsCommandAction");
   }
 
   private String getCommand(String operation){
-    return String.format("tc qdisc %s dev %s root netem duplicate %s%%", operation, network,
+    return String.format("tc qdisc %s dev %s root netem corrupt %s%%", operation, network,
         ratio * 100);
   }
 }

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/DuplicatePacketsCommandAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/DuplicatePacketsCommandAction.java
@@ -27,29 +27,29 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * Lose network packages on a random regionserver.
+ * Duplicate network packets on a random regionserver.
  */
-public class LosePackagesCommandAction extends TCCommandAction {
-  private static final Logger LOG = LoggerFactory.getLogger(LosePackagesCommandAction.class);
+public class DuplicatePacketsCommandAction extends TCCommandAction {
+  private static final Logger LOG = LoggerFactory.getLogger(DuplicatePacketsCommandAction.class);
   private float ratio;
   private long duration;
 
   /**
-   * Lose network packages on a random regionserver.
+   * Duplicate network packets on a random regionserver.
    *
-   * @param ratio the ratio of packages lost
+   * @param ratio the ratio of packets duplicated
    * @param duration the time this issue persists in milliseconds
    * @param timeout the timeout for executing required commands on the region server in milliseconds
    * @param network network interface the regionserver uses for communication
    */
-  public LosePackagesCommandAction(float ratio, long duration, long timeout, String network) {
+  public DuplicatePacketsCommandAction(float ratio, long duration, long timeout, String network) {
     super(timeout, network);
     this.ratio = ratio;
     this.duration = duration;
   }
 
   protected void localPerform() throws IOException {
-    LOG.info("Starting to execute LosePackagesCommandAction");
+    LOG.info("Starting to execute DuplicatePacketsCommandAction");
     ServerName server = PolicyBasedChaosMonkey.selectRandomItem(getCurrentServers());
     String hostname = server.getHostname();
 
@@ -62,11 +62,11 @@ public class LosePackagesCommandAction extends TCCommandAction {
       clusterManager.execSudoWithRetries(hostname, timeout, getCommand(DELETE));
     }
 
-    LOG.info("Finished to execute LosePackagesCommandAction");
+    LOG.info("Finished to execute DuplicatePacketsCommandAction");
   }
 
   private String getCommand(String operation){
-    return String.format("tc qdisc %s dev %s root netem loss %s%%", operation, network,
+    return String.format("tc qdisc %s dev %s root netem duplicate %s%%", operation, network,
         ratio * 100);
   }
 }

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/ReorderPacketsCommandAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/ReorderPacketsCommandAction.java
@@ -27,24 +27,24 @@ import org.slf4j.LoggerFactory;
 
 /**
  *
- * Reorder network packages on a random regionserver.
+ * Reorder network packets on a random regionserver.
  */
-public class ReorderPackagesCommandAction extends TCCommandAction {
-  private static final Logger LOG = LoggerFactory.getLogger(ReorderPackagesCommandAction.class);
+public class ReorderPacketsCommandAction extends TCCommandAction {
+  private static final Logger LOG = LoggerFactory.getLogger(ReorderPacketsCommandAction.class);
   private float ratio;
   private long duration;
   private long delay;
 
   /**
-   * Reorder network packages on a random regionserver.
+   * Reorder network packets on a random regionserver.
    *
-   * @param ratio the ratio of packages reordered
+   * @param ratio the ratio of packets reordered
    * @param duration the time this issue persists in milliseconds
-   * @param delay the delay between reordered and non-reordered packages in milliseconds
+   * @param delay the delay between reordered and non-reordered packets in milliseconds
    * @param timeout the timeout for executing required commands on the region server in milliseconds
    * @param network network interface the regionserver uses for communication
    */
-  public ReorderPackagesCommandAction(float ratio, long duration, long delay, long timeout,
+  public ReorderPacketsCommandAction(float ratio, long duration, long delay, long timeout,
       String network) {
     super(timeout, network);
     this.ratio = ratio;
@@ -53,7 +53,7 @@ public class ReorderPackagesCommandAction extends TCCommandAction {
   }
 
   protected void localPerform() throws IOException {
-    LOG.info("Starting to execute ReorderPackagesCommandAction");
+    LOG.info("Starting to execute ReorderPacketsCommandAction");
     ServerName server = PolicyBasedChaosMonkey.selectRandomItem(getCurrentServers());
     String hostname = server.getHostname();
 
@@ -66,7 +66,7 @@ public class ReorderPackagesCommandAction extends TCCommandAction {
       clusterManager.execSudoWithRetries(hostname, timeout, getCommand(DELETE));
     }
 
-    LOG.info("Finished to execute ReorderPackagesCommandAction");
+    LOG.info("Finished to execute ReorderPacketsCommandAction");
   }
 
   private String getCommand(String operation){

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/factories/DistributedIssuesMonkeyFactory.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/factories/DistributedIssuesMonkeyFactory.java
@@ -20,13 +20,13 @@ package org.apache.hadoop.hbase.chaos.factories;
 
 import org.apache.hadoop.hbase.chaos.actions.Action;
 import org.apache.hadoop.hbase.chaos.actions.AddCPULoadAction;
-import org.apache.hadoop.hbase.chaos.actions.CorruptPackagesCommandAction;
-import org.apache.hadoop.hbase.chaos.actions.DelayPackagesCommandAction;
+import org.apache.hadoop.hbase.chaos.actions.CorruptPacketsCommandAction;
+import org.apache.hadoop.hbase.chaos.actions.DelayPacketsCommandAction;
 import org.apache.hadoop.hbase.chaos.actions.DumpClusterStatusAction;
-import org.apache.hadoop.hbase.chaos.actions.DuplicatePackagesCommandAction;
+import org.apache.hadoop.hbase.chaos.actions.DuplicatePacketsCommandAction;
 import org.apache.hadoop.hbase.chaos.actions.FillDiskCommandAction;
-import org.apache.hadoop.hbase.chaos.actions.LosePackagesCommandAction;
-import org.apache.hadoop.hbase.chaos.actions.ReorderPackagesCommandAction;
+import org.apache.hadoop.hbase.chaos.actions.LosePacketsCommandAction;
+import org.apache.hadoop.hbase.chaos.actions.ReorderPacketsCommandAction;
 import org.apache.hadoop.hbase.chaos.monkies.ChaosMonkey;
 import org.apache.hadoop.hbase.chaos.monkies.PolicyBasedChaosMonkey;
 import org.apache.hadoop.hbase.chaos.policies.PeriodicRandomActionPolicy;
@@ -57,15 +57,15 @@ public class DistributedIssuesMonkeyFactory extends MonkeyFactory {
 
     Action[] actions1 = new Action[] {
       new AddCPULoadAction(cpuLoadDuration, cpuLoadProcesses, networkIssueTimeout),
-      new CorruptPackagesCommandAction(networkIssueRation, networkIssueDuration,
+      new CorruptPacketsCommandAction(networkIssueRation, networkIssueDuration,
           networkIssueTimeout, networkIssueInterface),
-      new DuplicatePackagesCommandAction(networkIssueRation, networkIssueDuration,
+      new DuplicatePacketsCommandAction(networkIssueRation, networkIssueDuration,
           networkIssueTimeout, networkIssueInterface),
-      new LosePackagesCommandAction(networkIssueRation, networkIssueDuration,
+      new LosePacketsCommandAction(networkIssueRation, networkIssueDuration,
           networkIssueTimeout, networkIssueInterface),
-      new DelayPackagesCommandAction(networkIssueDelay, networkIssueDuration,
+      new DelayPacketsCommandAction(networkIssueDelay, networkIssueDuration,
           networkIssueTimeout, networkIssueInterface),
-      new ReorderPackagesCommandAction(networkIssueRation, networkIssueDuration,
+      new ReorderPacketsCommandAction(networkIssueRation, networkIssueDuration,
           networkIssueDelay, networkIssueTimeout, networkIssueInterface),
       new FillDiskCommandAction(fillDiskFileSize, fillDiskIssueduration, fillDiskPath,
           fillDiskTimeout)};


### PR DESCRIPTION
There is a terminology problem in some of the network issue related chaos monkey actions. The universally understood technical term for network packet is packet, not "package".