### PR TITLE
HBASE-17115 Define UI admins via an ACL

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/AdminAuthorizedFilter.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/AdminAuthorizedFilter.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.http;
+
+import java.io.IOException;
+
+import javax.servlet.Filter;
+import javax.servlet.FilterChain;
+import javax.servlet.FilterConfig;
+import javax.servlet.ServletException;
+import javax.servlet.ServletRequest;
+import javax.servlet.ServletResponse;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.security.authorize.AccessControlList;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class AdminAuthorizedFilter implements Filter {
+
+  private Configuration conf;
+  private AccessControlList adminsAcl;
+
+  @Override public void init(FilterConfig filterConfig) throws ServletException {
+    adminsAcl = (AccessControlList) filterConfig.getServletContext().getAttribute(
+        HttpServer.ADMINS_ACL);
+    conf = (Configuration) filterConfig.getServletContext().getAttribute(
+        HttpServer.CONF_CONTEXT_ATTRIBUTE);
+  }
+
+  @Override
+  public void doFilter(ServletRequest request, ServletResponse response, FilterChain chain)
+      throws IOException, ServletException {
+    if (!(request instanceof HttpServletRequest) || !(response instanceof HttpServletResponse)) {
+      throw new UnsupportedOperationException("Only accepts HTTP");
+    }
+    HttpServletRequest httpReq = (HttpServletRequest) request;
+    HttpServletResponse httpResp = (HttpServletResponse) response;
+
+    if (!HttpServer.hasAdministratorAccess(conf, adminsAcl, httpReq, httpResp)) {
+      return;
+    }
+
+    chain.doFilter(request, response);
+  }
+
+  @Override public void destroy() {}
+}

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -79,7 +79,6 @@ import org.eclipse.jetty.servlet.DefaultServlet;
 import org.eclipse.jetty.servlet.FilterHolder;
 import org.eclipse.jetty.servlet.FilterMapping;
 import org.eclipse.jetty.servlet.ServletContextHandler;
-import org.eclipse.jetty.servlet.ServletHandler;
 import org.eclipse.jetty.servlet.ServletHolder;
 import org.eclipse.jetty.util.MultiException;
 import org.eclipse.jetty.util.ssl.SslContextFactory;

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -732,11 +732,11 @@ public class HttpServer implements FilterContainer {
     // Remove when we drop support for hbase on hadoop2.x.
     try {
       Class<?> clz = Class.forName("org.apache.hadoop.metrics.MetricsServlet");
-      addUnprivilegedServlet("metrics", "/metrics", clz.asSubclass(HttpServlet.class));
+      addPrivilegedServlet("metrics", "/metrics", clz.asSubclass(HttpServlet.class));
     } catch (Exception e) {
       // do nothing
     }
-    addUnprivilegedServlet("jmx", "/jmx", JMXJsonServlet.class);
+    addPrivilegedServlet("jmx", "/jmx", JMXJsonServlet.class);
     addUnprivilegedServlet("conf", "/conf", ConfServlet.class);
     final String asyncProfilerHome = ProfileServlet.getAsyncProfilerHome();
     if (asyncProfilerHome != null && !asyncProfilerHome.trim().isEmpty()) {

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -777,7 +777,9 @@ public class HttpServer implements FilterContainer {
   }
 
   /**
-   * Adds a servlet in the server that any user can access.
+   * Adds a servlet in the server that any user can access. This method differs from
+   * {@link #addPrivilegedServlet(String, String, Class)} in that any authenticated user
+   * can interact with the servlet added by this method.
    * @param name The name of the servlet (can be passed as null)
    * @param pathSpec The path spec for the servlet
    * @param clazz The servlet class
@@ -788,13 +790,20 @@ public class HttpServer implements FilterContainer {
   }
 
   /**
-   * Adds a servlet in the server that only administrators can access.
+   * Adds a servlet in the server that only administrators can access. This method differs from
+   * {@link #addUnprivilegedServlet(String, String, Class)} in that only those authenticated user
+   * who are identified as administrators can interact with the servlet added by this method.
    */
   public void addPrivilegedServlet(String name, String pathSpec,
       Class<? extends HttpServlet> clazz) {
     addServletWithAuth(name, pathSpec, clazz, true);
   }
 
+  /**
+   * Internal method to add a servlet to the HTTP server. Developers should not call this method
+   * directly, but invoke it via {@link #addUnprivilegedServlet(String, String, Class)} or
+   * {@link #addPrivilegedServlet(String, String, Class)}.
+   */
   void addServletWithAuth(String name, String pathSpec,
       Class<? extends HttpServlet> clazz, boolean requireAuth) {
     addInternalServlet(name, pathSpec, clazz, requireAuth);

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
@@ -99,7 +99,8 @@ public class InfoServer {
    */
   AccessControlList buildAdminAcl(Configuration conf) {
     final String userGroups = conf.get(HttpServer.HTTP_SPNEGO_AUTHENTICATION_ADMIN_USERS_KEY, null);
-    final String adminGroups = conf.get(HttpServer.HTTP_SPNEGO_AUTHENTICATION_ADMIN_GROUPS_KEY, null);
+    final String adminGroups = conf.get(
+        HttpServer.HTTP_SPNEGO_AUTHENTICATION_ADMIN_GROUPS_KEY, null);
     if (userGroups == null && adminGroups == null) {
       // Backwards compatibility - if the user doesn't have anything set, allow all users in.
       return new AccessControlList("*", null);

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
@@ -113,7 +113,7 @@ public class InfoServer {
    * {@link #addUnprivilegedServlet(String, String, Class)} instead of this method.
    * This method will add a servlet which any authenticated user can access.
    *
-   * @deprecated Use {@link #addUnprivilegedServet(String, String, Class)} or
+   * @deprecated Use {@link #addUnprivilegedServlet(String, String, Class)} or
    *    {@link #addPrivilegedServlet(String, String, Class)} instead of this
    *    method which does not state outwardly what kind of authz rules will
    *    be applied to this servlet.

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
@@ -112,6 +112,11 @@ public class InfoServer {
    * Explicitly invoke {@link #addPrivilegedServlet(String, String, Class)} or
    * {@link #addUnprivilegedServlet(String, String, Class)} instead of this method.
    * This method will add a servlet which any authenticated user can access.
+   *
+   * @deprecated Use {@link #addUnprivilegedServet(String, String, Class)} or
+   *    {@link #addPrivilegedServlet(String, String, Class)} instead of this
+   *    method which does not state outwardly what kind of authz rules will
+   *    be applied to this servlet.
    */
   @Deprecated
   public void addServlet(String name, String pathSpec,

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
@@ -107,9 +107,31 @@ public class InfoServer {
     return new AccessControlList(userGroups, adminGroups);
   }
 
+  /**
+   * Explicitly invoke {@link #addPrivilegedServlet(String, String, Class)} or
+   * {@link #addUnprivilegedServlet(String, String, Class)} instead of this method.
+   * This method will add a servlet which any authenticated user can access.
+   */
+  @Deprecated
   public void addServlet(String name, String pathSpec,
           Class<? extends HttpServlet> clazz) {
+    addUnprivilegedServlet(name, pathSpec, clazz);
+  }
+
+  /**
+   * @see HttpServer#addUnprivilegedServlet(String, String, Class)
+   */
+  public void addUnprivilegedServlet(String name, String pathSpec,
+          Class<? extends HttpServlet> clazz) {
     this.httpServer.addUnprivilegedServlet(name, pathSpec, clazz);
+  }
+
+  /**
+   * @see HttpServer#addPrivilegedServlet(String, String, Class)
+   */
+  public void addPrivilegedServlet(String name, String pathSpec,
+          Class<? extends HttpServlet> clazz) {
+    this.httpServer.addPrivilegedServlet(name, pathSpec, clazz);
   }
 
   public void setAttribute(String name, Object value) {

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/log/LogLevel.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/log/LogLevel.java
@@ -324,6 +324,14 @@ public final class LogLevel {
           response)) {
         return;
       }
+      // Disallow modification of the LogLevel if explicitly set to readonly
+      Configuration conf = (Configuration) getServletContext().getAttribute(
+          HttpServer.CONF_CONTEXT_ATTRIBUTE);
+      if (conf.getBoolean("hbase.master.ui.readonly", false)) {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN, "Modification of HBase via"
+            + " the UI is disallowed in configuration.");
+        return;
+      }
       response.setContentType("text/html");
       PrintWriter out;
       try {

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestHttpServer.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestHttpServer.java
@@ -150,10 +150,10 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     Configuration conf = new Configuration();
     conf.setInt(HttpServer.HTTP_MAX_THREADS, MAX_THREADS);
     server = createTestServer(conf);
-    server.addServlet("echo", "/echo", EchoServlet.class);
-    server.addServlet("echomap", "/echomap", EchoMapServlet.class);
-    server.addServlet("htmlcontent", "/htmlcontent", HtmlContentServlet.class);
-    server.addServlet("longheader", "/longheader", LongHeaderServlet.class);
+    server.addUnprivilegedServlet("echo", "/echo", EchoServlet.class);
+    server.addUnprivilegedServlet("echomap", "/echomap", EchoMapServlet.class);
+    server.addUnprivilegedServlet("htmlcontent", "/htmlcontent", HtmlContentServlet.class);
+    server.addUnprivilegedServlet("longheader", "/longheader", LongHeaderServlet.class);
     server.addJerseyResourcePackage(
         JerseyResource.class.getPackage().getName(), "/jersey/*");
     server.start();
@@ -582,7 +582,7 @@ public class TestHttpServer extends HttpServerFunctionalTest {
             .addEndpoint(new URI("http://localhost:0"))
             .setFindPort(true).setConf(conf).build();
     myServer.setAttribute(HttpServer.CONF_CONTEXT_ATTRIBUTE, conf);
-    myServer.addServlet("echo", "/echo", EchoServlet.class);
+    myServer.addUnprivilegedServlet("echo", "/echo", EchoServlet.class);
     myServer.start();
 
     String serverURL = "http://"

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestHttpServer.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestHttpServer.java
@@ -490,7 +490,7 @@ public class TestHttpServer extends HttpServerFunctionalTest {
     Mockito.when(acls.isUserAllowed(Mockito.<UserGroupInformation>any())).thenReturn(false);
     Mockito.when(context.getAttribute(HttpServer.ADMINS_ACL)).thenReturn(acls);
     Assert.assertFalse(HttpServer.hasAdministratorAccess(context, request, response));
-    Mockito.verify(response).sendError(Mockito.eq(HttpServletResponse.SC_UNAUTHORIZED),
+    Mockito.verify(response).sendError(Mockito.eq(HttpServletResponse.SC_FORBIDDEN),
             Mockito.anyString());
 
     //authorization ON & user NOT NULL & ACLs NOT NULL & user in in ACLs

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestSSLHttpServer.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestSSLHttpServer.java
@@ -95,7 +95,7 @@ public class TestSSLHttpServer extends HttpServerFunctionalTest {
         .trustStore(sslConf.get("ssl.server.truststore.location"),
             HBaseConfiguration.getPassword(sslConf, "ssl.server.truststore.password", null),
             sslConf.get("ssl.server.truststore.type", "jks")).build();
-    server.addServlet("echo", "/echo", TestHttpServer.EchoServlet.class);
+    server.addUnprivilegedServlet("echo", "/echo", TestHttpServer.EchoServlet.class);
     server.start();
     baseUrl = new URL("https://"
         + NetUtils.getHostPortString(server.getConnectorAddress(0)));

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestSpnegoHttpServer.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestSpnegoHttpServer.java
@@ -108,7 +108,7 @@ public class TestSpnegoHttpServer extends HttpServerFunctionalTest {
     Configuration conf = buildSpnegoConfiguration(serverPrincipal, infoServerKeytab);
 
     server = createTestServerWithSecurity(conf);
-    server.addServlet("echo", "/echo", EchoServlet.class);
+    server.addUnprivilegedServlet("echo", "/echo", EchoServlet.class);
     server.addJerseyResourcePackage(JerseyResource.class.getPackage().getName(), "/jersey/*");
     server.start();
     baseUrl = getServerURL(server);
@@ -252,7 +252,7 @@ public class TestSpnegoHttpServer extends HttpServerFunctionalTest {
     // Intentionally skip keytab and principal
 
     HttpServer customServer = createTestServerWithSecurity(conf);
-    customServer.addServlet("echo", "/echo", EchoServlet.class);
+    customServer.addUnprivilegedServlet("echo", "/echo", EchoServlet.class);
     customServer.addJerseyResourcePackage(JerseyResource.class.getPackage().getName(), "/jersey/*");
     customServer.start();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -742,7 +742,7 @@ public class HMaster extends HRegionServer implements MasterServices {
 
   @Override
   protected void configureInfoServer() {
-    infoServer.addServlet("master-status", "/master-status", MasterStatusServlet.class);
+    infoServer.addUnprivilegedServlet("master-status", "/master-status", MasterStatusServlet.class);
     infoServer.setAttribute(MASTER, this);
     if (LoadBalancer.isTablesOnMaster(conf)) {
       super.configureInfoServer();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -760,7 +760,7 @@ public class HRegionServer extends HasThread implements
   }
 
   protected void configureInfoServer() {
-    infoServer.addServlet("rs-status", "/rs-status", RSStatusServlet.class);
+    infoServer.addUnprivilegedServlet("rs-status", "/rs-status", RSStatusServlet.class);
     infoServer.setAttribute(REGIONSERVER, this);
   }
 
@@ -2124,7 +2124,7 @@ public class HRegionServer extends HasThread implements
     while (true) {
       try {
         this.infoServer = new InfoServer(getProcessName(), addr, port, false, this.conf);
-        infoServer.addServlet("dump", "/dump", getDumpServlet());
+        infoServer.addPrivilegedServlet("dump", "/dump", getDumpServlet());
         configureInfoServer();
         this.infoServer.start();
         break;

--- a/hbase-server/src/main/resources/hbase-webapps/master/snapshot.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/snapshot.jsp
@@ -22,6 +22,7 @@
   import="org.apache.hadoop.conf.Configuration"
   import="org.apache.hadoop.hbase.client.Admin"
   import="org.apache.hadoop.hbase.client.SnapshotDescription"
+  import="org.apache.hadoop.hbase.http.InfoServer"
   import="org.apache.hadoop.hbase.master.HMaster"
   import="org.apache.hadoop.hbase.snapshot.SnapshotInfo"
   import="org.apache.hadoop.util.StringUtils"
@@ -30,7 +31,7 @@
 <%
   HMaster master = (HMaster)getServletContext().getAttribute(HMaster.MASTER);
   Configuration conf = master.getConfiguration();
-  boolean readOnly = conf.getBoolean("hbase.master.ui.readonly", false);
+  boolean readOnly = !InfoServer.canUserModifyUI(request, getServletContext(), conf);
   String snapshotName = request.getParameter("name");
   SnapshotDescription snapshot = null;
   SnapshotInfo.SnapshotStats stats = null;

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -50,6 +50,7 @@
   import="org.apache.hadoop.hbase.client.RegionLocator"
   import="org.apache.hadoop.hbase.client.RegionReplicaUtil"
   import="org.apache.hadoop.hbase.client.Table"
+  import="org.apache.hadoop.hbase.http.InfoServer"
   import="org.apache.hadoop.hbase.master.HMaster"
   import="org.apache.hadoop.hbase.master.RegionState"
   import="org.apache.hadoop.hbase.master.assignment.RegionStates"
@@ -109,7 +110,7 @@
   Table table;
   boolean withReplica = false;
   boolean showFragmentation = conf.getBoolean("hbase.master.ui.fragmentation.enabled", false);
-  boolean readOnly = conf.getBoolean("hbase.master.ui.readonly", false);
+  boolean readOnly = !InfoServer.canUserModifyUI(request, getServletContext(), conf);
   int numMetaReplicas = conf.getInt(HConstants.META_REPLICAS_NUM,
                         HConstants.DEFAULT_META_REPLICA_NUM);
   Map<String, Integer> frags = null;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestInfoServersACL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestInfoServersACL.java
@@ -275,24 +275,21 @@ public class TestInfoServersACL {
   }
 
   private CloseableHttpClient createHttpClient(String clientPrincipal) throws Exception {
-      // Logs in with Kerberos via GSS
-      GSSManager gssManager = GSSManager.getInstance();
-      // jGSS Kerberos login constant
-      Oid oid = new Oid("1.2.840.113554.1.2.2");
-      GSSName gssClient = gssManager.createName(clientPrincipal, GSSName.NT_USER_NAME);
-      GSSCredential credential = gssManager.createCredential(gssClient,
-          GSSCredential.DEFAULT_LIFETIME, oid, GSSCredential.INITIATE_ONLY);
+    // Logs in with Kerberos via GSS
+    GSSManager gssManager = GSSManager.getInstance();
+    // jGSS Kerberos login constant
+    Oid oid = new Oid("1.2.840.113554.1.2.2");
+    GSSName gssClient = gssManager.createName(clientPrincipal, GSSName.NT_USER_NAME);
+    GSSCredential credential = gssManager.createCredential(
+        gssClient, GSSCredential.DEFAULT_LIFETIME, oid, GSSCredential.INITIATE_ONLY);
 
-      Lookup<AuthSchemeProvider> authRegistry = RegistryBuilder.<AuthSchemeProvider>create()
-          .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true, true))
-          .build();
+    Lookup<AuthSchemeProvider> authRegistry = RegistryBuilder.<AuthSchemeProvider>create()
+        .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true, true)).build();
 
-      BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
-      credentialsProvider.setCredentials(AuthScope.ANY, new KerberosCredentials(credential));
+    BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+    credentialsProvider.setCredentials(AuthScope.ANY, new KerberosCredentials(credential));
 
-      return HttpClients.custom()
-          .setDefaultAuthSchemeRegistry(authRegistry)
-          .setDefaultCredentialsProvider(credentialsProvider)
-          .build();
+    return HttpClients.custom().setDefaultAuthSchemeRegistry(authRegistry)
+        .setDefaultCredentialsProvider(credentialsProvider).build();
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestInfoServersACL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestInfoServersACL.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.File;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.security.PrivilegedExceptionAction;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.http.HttpServer;
+import org.apache.hadoop.hbase.security.HBaseKerberosUtils;
+import org.apache.hadoop.hbase.security.token.TokenProvider;
+import org.apache.hadoop.hbase.testclassification.MiscTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.FSUtils;
+import org.apache.hadoop.hbase.util.Pair;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.apache.http.auth.AuthSchemeProvider;
+import org.apache.http.auth.AuthScope;
+import org.apache.http.auth.KerberosCredentials;
+import org.apache.http.client.config.AuthSchemes;
+import org.apache.http.client.methods.CloseableHttpResponse;
+import org.apache.http.client.methods.HttpGet;
+import org.apache.http.config.Lookup;
+import org.apache.http.config.RegistryBuilder;
+import org.apache.http.impl.auth.SPNegoSchemeFactory;
+import org.apache.http.impl.client.BasicCredentialsProvider;
+import org.apache.http.impl.client.CloseableHttpClient;
+import org.apache.http.impl.client.HttpClients;
+import org.apache.http.util.EntityUtils;
+import org.ietf.jgss.GSSCredential;
+import org.ietf.jgss.GSSManager;
+import org.ietf.jgss.GSSName;
+import org.ietf.jgss.Oid;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Testing info servers for admin acl.
+ */
+@Category({ MiscTests.class, SmallTests.class })
+public class TestInfoServersACL {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestInfoServersACL.class);
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestInfoServersACL.class);
+  private final static HBaseTestingUtility UTIL = new HBaseTestingUtility();
+  private static Configuration conf;
+
+  protected static String USERNAME;
+  private static LocalHBaseCluster CLUSTER;
+  private static final File KEYTAB_FILE = new File(UTIL.getDataTestDir("keytab").toUri().getPath());
+  private static MiniKdc KDC;
+  private static String HOST = "localhost";
+  private static String PRINCIPAL;
+  private static String HTTP_PRINCIPAL;
+
+  @Rule
+  public TestName name = new TestName();
+
+  // user/group present in hbase.admin.acl
+  private static final String USER_ADMIN_STR = "admin";
+
+  // user with no permissions
+  private static final String USER_NONE_STR = "none";
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    conf = UTIL.getConfiguration();
+    KDC = UTIL.setupMiniKdc(KEYTAB_FILE);
+    USERNAME = UserGroupInformation.getLoginUser().getShortUserName();
+    PRINCIPAL = USERNAME + "/" + HOST;
+    HTTP_PRINCIPAL = "HTTP/" + HOST;
+    // Create principals for services and the test users
+    KDC.createPrincipal(KEYTAB_FILE, PRINCIPAL, HTTP_PRINCIPAL, USER_ADMIN_STR, USER_NONE_STR);
+    UTIL.startMiniZKCluster();
+
+    HBaseKerberosUtils.setSecuredConfiguration(conf,
+        PRINCIPAL + "@" + KDC.getRealm(), HTTP_PRINCIPAL + "@" + KDC.getRealm());
+    HBaseKerberosUtils.setSSLConfiguration(UTIL, TestInfoServersACL.class);
+
+    conf.setStrings(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,
+        TokenProvider.class.getName());
+    UTIL.startMiniDFSCluster(1);
+    Path rootdir = UTIL.getDataTestDirOnTestFS("TestInfoServersACL");
+    FSUtils.setRootDir(conf, rootdir);
+
+    // The info servers do not run in tests by default.
+    // Set them to ephemeral ports so they will start
+    // setup configuration
+    conf.setInt(HConstants.MASTER_INFO_PORT, 0);
+    conf.setInt(HConstants.REGIONSERVER_INFO_PORT, 0);
+
+    conf.set(HttpServer.HTTP_UI_AUTHENTICATION, "kerberos");
+    conf.set(HttpServer.HTTP_SPNEGO_AUTHENTICATION_PRINCIPAL_KEY, HTTP_PRINCIPAL);
+    conf.set(HttpServer.HTTP_SPNEGO_AUTHENTICATION_KEYTAB_KEY, KEYTAB_FILE.getAbsolutePath());
+
+    // ACL lists work only when "hadoop.security.authorization" is set to true
+    conf.setBoolean(CommonConfigurationKeys.HADOOP_SECURITY_AUTHORIZATION, true);
+    // only user admin will have acl access
+    conf.set(HttpServer.HTTP_SPNEGO_AUTHENTICATION_ADMIN_USERS_KEY, USER_ADMIN_STR);
+
+    CLUSTER = new LocalHBaseCluster(conf, 1);
+    CLUSTER.startup();
+  }
+
+  /**
+   * Helper method to shut down the cluster (if running)
+   */
+  @AfterClass
+  public static void shutDownMiniCluster() throws Exception {
+    if (CLUSTER != null) {
+      CLUSTER.shutdown();
+      CLUSTER.join();
+    }
+    if (KDC != null) {
+      KDC.stop();
+    }
+    UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testAuthorizedUser() throws Exception {
+    UserGroupInformation admin = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+        USER_ADMIN_STR, KEYTAB_FILE.getAbsolutePath());
+    admin.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override public Void run() throws Exception {
+        // Check the expected content is present in the http response
+        String expectedContent = "Get Log Level";
+        Pair<Integer,String> pair = getLogLevelPage();
+        assertEquals(HttpURLConnection.HTTP_OK, pair.getFirst().intValue());
+        assertTrue("expected=" + expectedContent + ", content=" + pair.getSecond(),
+          pair.getSecond().contains(expectedContent));
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testUnauthorizedUser() throws Exception {
+    UserGroupInformation nonAdmin = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+        USER_NONE_STR, KEYTAB_FILE.getAbsolutePath());
+    nonAdmin.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override public Void run() throws Exception {
+        Pair<Integer,String> pair = getLogLevelPage();
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, pair.getFirst().intValue());
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testTableActionsAvailableForAdmins() throws Exception {
+    final String expectedAuthorizedContent = "Actions:";
+    UserGroupInformation admin = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+        USER_ADMIN_STR, KEYTAB_FILE.getAbsolutePath());
+    admin.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override public Void run() throws Exception {
+        // Check the expected content is present in the http response
+        Pair<Integer,String> pair = getTablePage(TableName.META_TABLE_NAME);
+        assertEquals(HttpURLConnection.HTTP_OK, pair.getFirst().intValue());
+        assertTrue("expected=" + expectedAuthorizedContent + ", content=" + pair.getSecond(),
+          pair.getSecond().contains(expectedAuthorizedContent));
+        return null;
+      }
+    });
+
+    UserGroupInformation nonAdmin = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+        USER_NONE_STR, KEYTAB_FILE.getAbsolutePath());
+    nonAdmin.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override public Void run() throws Exception {
+        Pair<Integer,String> pair = getTablePage(TableName.META_TABLE_NAME);
+        assertEquals(HttpURLConnection.HTTP_OK, pair.getFirst().intValue());
+        assertFalse("should not find=" + expectedAuthorizedContent + ", content=" +
+            pair.getSecond(), pair.getSecond().contains(expectedAuthorizedContent));
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testLogsAvailableForAdmins() throws Exception {
+    final String expectedAuthorizedContent = "Directory: /logs/";
+    UserGroupInformation admin = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+        USER_ADMIN_STR, KEYTAB_FILE.getAbsolutePath());
+    admin.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override public Void run() throws Exception {
+        // Check the expected content is present in the http response
+        Pair<Integer,String> pair = getLogsPage();
+        assertEquals(HttpURLConnection.HTTP_OK, pair.getFirst().intValue());
+        assertTrue("expected=" + expectedAuthorizedContent + ", content=" + pair.getSecond(),
+          pair.getSecond().contains(expectedAuthorizedContent));
+        return null;
+      }
+    });
+
+    UserGroupInformation nonAdmin = UserGroupInformation.loginUserFromKeytabAndReturnUGI(
+        USER_NONE_STR, KEYTAB_FILE.getAbsolutePath());
+    nonAdmin.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override public Void run() throws Exception {
+        Pair<Integer,String> pair = getLogsPage();
+        assertEquals(HttpURLConnection.HTTP_FORBIDDEN, pair.getFirst().intValue());
+        return null;
+      }
+    });
+  }
+
+  private String getInfoServerHostAndPort() {
+    return "http://localhost:" + CLUSTER.getActiveMaster().getInfoServer().getPort();
+  }
+
+  private Pair<Integer,String> getLogLevelPage() throws Exception {
+    // Build the url which we want to connect to
+    URL url = new URL(getInfoServerHostAndPort() + "/logLevel");
+    return getUrlContent(url);
+  }
+
+  private Pair<Integer,String> getTablePage(TableName tn) throws Exception {
+    URL url = new URL(getInfoServerHostAndPort() + "/table.jsp?name=" + tn.getNameAsString());
+    return getUrlContent(url);
+  }
+
+  private Pair<Integer,String> getLogsPage() throws Exception {
+    URL url = new URL(getInfoServerHostAndPort() + "/logs/");
+    return getUrlContent(url);
+  }
+
+  /**
+   * Retrieves the content of the specified URL. The content will only be returned if the status
+   * code for the operation was HTTP 200/OK.
+   */
+  private Pair<Integer,String> getUrlContent(URL url) throws Exception {
+    try (CloseableHttpClient client = createHttpClient(
+        UserGroupInformation.getCurrentUser().getUserName())) {
+      CloseableHttpResponse resp = client.execute(new HttpGet(url.toURI()));
+      int code = resp.getStatusLine().getStatusCode();
+      if (code == HttpURLConnection.HTTP_OK) {
+        return new Pair<>(code, EntityUtils.toString(resp.getEntity()));
+      }
+      return new Pair<>(code, null);
+    }
+  }
+
+  private CloseableHttpClient createHttpClient(String clientPrincipal) throws Exception {
+      // Logs in with Kerberos via GSS
+      GSSManager gssManager = GSSManager.getInstance();
+      // jGSS Kerberos login constant
+      Oid oid = new Oid("1.2.840.113554.1.2.2");
+      GSSName gssClient = gssManager.createName(clientPrincipal, GSSName.NT_USER_NAME);
+      GSSCredential credential = gssManager.createCredential(gssClient,
+          GSSCredential.DEFAULT_LIFETIME, oid, GSSCredential.INITIATE_ONLY);
+
+      Lookup<AuthSchemeProvider> authRegistry = RegistryBuilder.<AuthSchemeProvider>create()
+          .register(AuthSchemes.SPNEGO, new SPNegoSchemeFactory(true, true))
+          .build();
+
+      BasicCredentialsProvider credentialsProvider = new BasicCredentialsProvider();
+      credentialsProvider.setCredentials(AuthScope.ANY, new KerberosCredentials(credential));
+
+      return HttpClients.custom()
+          .setDefaultAuthSchemeRegistry(authRegistry)
+          .setDefaultCredentialsProvider(credentialsProvider)
+          .build();
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/http/TestInfoServersACL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/http/TestInfoServersACL.java
@@ -318,12 +318,12 @@ public class TestInfoServersACL {
   }
 
   private Pair<Integer,String> getMasterDumpPage() throws Exception {
-    URL url = new URL (getInfoServerHostAndPort() + "/dump");
+    URL url = new URL(getInfoServerHostAndPort() + "/dump");
     return getUrlContent(url);
   }
 
   private Pair<Integer,String> getStacksPage() throws Exception {
-    URL url = new URL (getInfoServerHostAndPort() + "/stacks");
+    URL url = new URL(getInfoServerHostAndPort() + "/stacks");
     return getUrlContent(url);
   }
 

--- a/src/main/asciidoc/_chapters/security.adoc
+++ b/src/main/asciidoc/_chapters/security.adoc
@@ -179,7 +179,9 @@ Unix groups membership define that `alice` is a member of the group `admins`.
 Given the above configuration, `alice` is allowed to access sensitive endpoints in the Web UI
 as she is a member of the `admins` group. `charlie` is also allowed to access sensitive endpoints
 because he is explicitly listed as an admin in the configuration. `bob` is not allowed to access
-sensitive endpoints, but can still use any non-sensitive endpoints in the Web UI.
+sensitive endpoints because he is not a member of the `admins` group nor is listed as an explicit
+admin user via `hbase.security.authentication.spnego.admin.users`, but can still use any
+non-sensitive endpoints in the Web UI.
 
 If it doesn't go without saying: non-authenticated users cannot access any part of the Web UI.
 

--- a/src/main/asciidoc/_chapters/security.adoc
+++ b/src/main/asciidoc/_chapters/security.adoc
@@ -37,9 +37,11 @@ HBase adheres to the Apache Software Foundation's policy on reported vulnerabili
 If you wish to send an encrypted report, you can use the GPG details provided for the general ASF security list. This will likely increase the response time to your report.
 ====
 
+== Web UI Security
+
 HBase provides mechanisms to secure various components and aspects of HBase and how it relates to the rest of the Hadoop infrastructure, as well as clients and resources outside Hadoop.
 
-== Using Secure HTTP (HTTPS) for the Web UI
+=== Using Secure HTTP (HTTPS) for the Web UI
 
 A default HBase install uses insecure HTTP connections for Web UIs for the master and region servers.
 To enable secure HTTP (HTTPS) connections instead, set `hbase.ssl.enabled` to `true` in _hbase-site.xml_.
@@ -70,7 +72,7 @@ If you know how to fix this without opening a second port for HTTPS, patches are
 ====
 
 [[hbase.secure.spnego.ui]]
-== Using SPNEGO for Kerberos authentication with Web UIs
+=== Using SPNEGO for Kerberos authentication with Web UIs
 
 Kerberos-authentication to HBase Web UIs can be enabled via configuring SPNEGO with the `hbase.security.authentication.ui`
 property in _hbase-site.xml_. Enabling this authentication requires that HBase is also configured to use Kerberos authentication
@@ -121,6 +123,65 @@ A number of properties exist to configure SPNEGO authentication for the web serv
   will be used for the secret.</description>
 </property>
 ----
+
+=== Defining administrators of the Web UI
+
+In the previous section, we cover how to enable authentication for the Web UI via SPNEGO.
+However, some portions of the Web UI could be used to impact the availability and performance
+of an HBase cluster. As such, it is desirable to ensure that only those with proper authority
+can interact with these sensitive endpoints.
+
+HBase allows the adminstrators to be defined via a list of usernames or groups in hbase-site.xml
+
+[source,xml]
+----
+<property>
+  <name>hbase.security.authentication.spnego.admin.users</name>
+  <value></value>
+</property>
+<property>
+  <name>hbase.security.authentication.spnego.admin.groups</name>
+  <value></value>
+</property>
+----
+
+The usernames are those which the Kerberos identity maps to, given the Hadoop `auth_to_local` rules
+in core-site.xml. The groups here are the Unix groups associated with the mapped usernames.
+
+Consider the following scenario to describe how the configuration properties operate. Consider
+three users which are defined in the Kerberos KDC:
+
+* `alice@COMPANY.COM`
+* `bob@COMPANY.COM`
+* `charlie@COMPANY.COM`
+
+The default Hadoop `auth_to_local` rules map these principals to the "shortname":
+
+* `alice`
+* `bob`
+* `charlie`
+
+Unix groups membership define that `alice` is a member of the group `admins`.
+`bob` and `charlie` are not members of the `admins` group.
+
+[source,xml]
+----
+<property>
+  <name>hbase.security.authentication.spnego.admin.users</name>
+  <value>charlie</value>
+</property>
+<property>
+  <name>hbase.security.authentication.spnego.admin.groups</name>
+  <value>admins</value>
+</property>
+----
+
+Given the above configuration, `alice` is allowed to access sensitive endpoints in the Web UI
+as she is a member of the `admins` group. `charlie` is also allowed to access sensitive endpoints
+because he is explicitly listed as an admin in the configuration. `bob` is not allowed to access
+sensitive endpoints, but can still use any non-sensitive endpoints in the Web UI.
+
+If it doesn't go without saying: non-authenticated users cannot access any part of the Web UI.
 
 [[hbase.secure.configuration]]
 == Secure Client Access to Apache HBase

--- a/src/main/asciidoc/_chapters/security.adoc
+++ b/src/main/asciidoc/_chapters/security.adoc
@@ -185,6 +185,24 @@ non-sensitive endpoints in the Web UI.
 
 If it doesn't go without saying: non-authenticated users cannot access any part of the Web UI.
 
+=== Other UI security-related configuration
+
+While it is a clear anti-pattern for HBase developers, the developers acknowledge that the HBase
+configuration (including Hadoop configuration files) may contain sensitive information. As such,
+a user may find that they do not want to expose the HBase service-level configuration to all
+authenticated users. They may configure HBase to require a user must be an admin to access
+the service-level configuration via the HBase UI. This configuration is *false* by default
+(any authenticated user may access the configuration).
+
+Users who wish to change this would set the following in their hbase-site.xml:
+[source,xml]
+----
+<property>
+  <name>hbase.security.authentication.ui.config.protected</name>
+  <value>true</value>
+</property>
+----
+
 [[hbase.secure.configuration]]
 == Secure Client Access to Apache HBase
 


### PR DESCRIPTION
The Hadoop AccessControlList allows us to specify admins of the webUI
via a list of users and/or groups. Admins of the WebUI can mutate the
system, potentially seeing sensitive data or modifying the system.

hbase.security.authentication.spnego.admin.users is a comma-separated
list of users who are admins.
hbase.security.authentication.spnego.admin.groups is a comma-separated
list of groups whose membership are admins. Either of these
configuration properties may also contain an asterisk (*) which denotes
"anything" (any user or group).

To maintain previous semantics, the UI defaults to accepting any user as an
admin. Previously, when a user was denied from some endpoint that was
designated for admins, they received an HTTP/401. In this case, it is
more correct to return HTTP/403 as they were correctly authenticated,
but they were disallowed from fetching the given resource.

The test is based off of work by Nihal Jain in HBASE-20472.

Co-authored-by: Nihal Jain <nihaljain.cs@gmail.com>