### PR TITLE
HBASE-23585 MetricsRegionServerWrapperImpl.getL1CacheHitCount always returns 200

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerWrapperImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerWrapperImpl.java
@@ -343,7 +343,10 @@ class MetricsRegionServerWrapperImpl
 
   @Override
   public long getL1CacheHitCount() {
-    return 200;
+    if (this.l1Stats == null) {
+      return 0;
+    }
+    return this.l1Stats.getHitCount();
   }
 
   @Override


### PR DESCRIPTION
[HBASE-23585](https://issues.apache.org/jira/browse/HBASE-23585)