### PR TITLE
HBASE-23238: Remove 'static'ness of cell counter in LimitKVsReturnFil…

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestScannersFromClientSide.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestScannersFromClientSide.java
@@ -863,7 +863,7 @@ public class TestScannersFromClientSide {
       Result result;
       int expectedKvNumber = 6;
       int returnedKvNumber = 0;
-      while((result = rs.next()) != null){
+      while((result = rs.next()) != null) {
         returnedKvNumber += result.listCells().size();
       }
       rs.close();
@@ -873,24 +873,24 @@ public class TestScannersFromClientSide {
 
   public static class LimitKVsReturnFilter extends FilterBase {
 
-    private static int total = 0;
+    private int cellCount = 0;
 
     @Override
     public ReturnCode filterCell(Cell v) throws IOException {
-      if(total>=6) {
-        total++;
+      if (cellCount >= 6) {
+        cellCount++;
         return ReturnCode.SKIP;
       }
-      total++;
+      cellCount++;
       return ReturnCode.INCLUDE;
     }
 
     @Override
     public boolean filterAllRemaining() throws IOException {
-      if(total<7) {
+      if (cellCount < 7) {
         return false;
       }
-      total++;
+      cellCount++;
       return true;
     }
 
@@ -900,9 +900,8 @@ public class TestScannersFromClientSide {
     }
 
     public static LimitKVsReturnFilter parseFrom(final byte [] pbBytes)
-      throws DeserializationException {
+        throws DeserializationException {
       return new LimitKVsReturnFilter();
     }
   }
-
 }


### PR DESCRIPTION
…ter (addendum)

Having it as static means the test cannot be parameterized (ran into
this issue in HBASE-23305). That happens because the field is not
reset between parameterized runs.