### PR TITLE
HBASE-23679 Use new FileSystem objects during bulk loads

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -6382,9 +6382,9 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
             store.bulkLoadHFile(familyName, path, commitedStoreFile);
             // Note the size of the store file
             try {
-              FileSystem fs = commitedStoreFile.getFileSystem(baseConf);
-              storeFilesSizes.put(commitedStoreFile.getName(), fs.getFileStatus(commitedStoreFile)
-                  .getLen());
+              // The store files are in the normal place now, so use the Region's FileSystem
+              storeFilesSizes.put(commitedStoreFile.getName(),
+                  fs.getFileSystem().getFileStatus(commitedStoreFile).getLen());
             } catch (IOException e) {
               LOG.warn("Failed to find the size of hfile " + commitedStoreFile, e);
               storeFilesSizes.put(commitedStoreFile.getName(), 0L);


### PR DESCRIPTION
Undoes lots of fanciness about FileSystem caching because of
an explicit bug that was present (FileSystem only closed on one
out of N regionservers, and not every time), but also because
the FS caching itself is dodgy and prone to error.

Each BulkLoad request will now get its own FileSystem instance
that it is responsible for closing.

The change to HRegion is because ${hbase.rootdir}/data is `chmod 700` which means that a normal user cannot get the size of those files (you'll see lots of AccessDenied exceptions in the RS log). Using HRegionFilesystem instead keeps this from being an issue (reading the filesize as HBase instead of the user).