### PR TITLE
HBASE-23683 Make HBaseInterClusterReplicationEndpoint more extensible…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/HBaseInterClusterReplicationEndpoint.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/HBaseInterClusterReplicationEndpoint.java
@@ -59,13 +59,14 @@ import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.util.Threads;
 import org.apache.hadoop.hbase.wal.WAL.Entry;
 import org.apache.hadoop.ipc.RemoteException;
-import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
+import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 import org.apache.hbase.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
 
 import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.AdminService.BlockingInterface;
 


### PR DESCRIPTION
… (#1027)

Had opened a separate PR for branch-2, as it doesn't have AsyncClusterConnection, requiring changes on basically the whole connection creation code. One thought I had just after I had already merged previous PR in master is that the two additional _create_ methods should refer to _Connection_, instead of _ClusterConnection_ or _AsyncClusterConnection_, as that would shield _HBaseInterClusterReplicationEndpoint_ extensions from changes between 2.x and 3.x.

Ping @bharathv 