### PR TITLE
HBASE-23694 After RegionProcedureStore completes migration of WALProcedureStore, …

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/procedure2/store/region/RegionProcedureStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/procedure2/store/region/RegionProcedureStore.java
@@ -364,6 +364,7 @@ public class RegionProcedureStore extends ProcedureStoreBase {
       throw new IOException("Failed to delete the WALProcedureStore migrated proc wal directory " +
         procWALDir);
     }
+    store.stop(true);
     LOG.info("Migration of WALProcedureStore finished");
   }
 


### PR DESCRIPTION
…still running WALProcedureStore.syncThread keeps trying to delete now inexistent log files.

Ping @Apache9 , would think stopping WPS here is safe? Had not faced any issues on my tests, but you have been working on this new procedure store feature, so let me know if you think of any potential problems.