### PR TITLE
HBASE-23700 Upgrade checkstyle and plugin versions (#1056)

### DIFF
--- a/hbase-checkstyle/src/main/resources/hbase/checkstyle.xml
+++ b/hbase-checkstyle/src/main/resources/hbase/checkstyle.xml
@@ -122,12 +122,6 @@
       <property name="lineWrappingIndentation" value="2"/>
     </module>
 
-    <!-- Size Violation Checks
-    http://checkstyle.sourceforge.net/config_sizes.html -->
-    <module name="LineLength">
-      <property name="max" value="100"/>
-      <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|org.apache.thrift.|com.google.protobuf.|hbase.protobuf.generated"/>
-    </module>
     <module name="MethodLength"/>
 
     <!-- Whitespace Checks
@@ -137,5 +131,12 @@
 
     <!-- Make the @SuppressWarnings annotations available to Checkstyle -->
     <module name="SuppressWarningsHolder"/>
+  </module>
+
+  <!-- Size Violation Checks
+  http://checkstyle.sourceforge.net/config_sizes.html -->
+  <module name="LineLength">
+    <property name="max" value="100"/>
+    <property name="ignorePattern" value="^package.*|^import.*|a href|href|http://|https://|ftp://|org.apache.thrift.|com.google.protobuf.|hbase.protobuf.generated"/>
   </module>
 </module>

--- a/pom.xml
+++ b/pom.xml
@@ -1349,7 +1349,7 @@
     <asciidoctorj.pdf.version>1.5.0-alpha.15</asciidoctorj.pdf.version>
     <build.helper.maven.version>3.0.0</build.helper.maven.version>
     <buildnumber.maven.version>1.4</buildnumber.maven.version>
-    <checkstyle.version>8.11</checkstyle.version>
+    <checkstyle.version>8.28</checkstyle.version>
     <exec.maven.version>1.6.0</exec.maven.version>
     <error-prone.version>2.3.3</error-prone.version>
     <findbugs-annotations>1.3.9-1</findbugs-annotations>
@@ -1358,7 +1358,7 @@
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
     <maven.antrun.version>1.8</maven.antrun.version>
     <maven.bundle.version>3.3.0</maven.bundle.version>
-    <maven.checkstyle.version>3.0.0</maven.checkstyle.version>
+    <maven.checkstyle.version>3.1.0</maven.checkstyle.version>
     <maven.eclipse.version>2.10</maven.eclipse.version>
     <maven.warbucks.version>1.1.0</maven.warbucks.version>
     <os.maven.version>1.5.0.Final</os.maven.version>


### PR DESCRIPTION
Bump checkstyle version to 8.28, maven-checkstyle-plugin to 3.1.0.

As per HBASE-23242 and the updated checkstyle docs[1], the LineLength
check should be placed under an instance of Checker.

[1] https://checkstyle.sourceforge.io/config_sizes.html#LineLength

Co-authored-by: Bharath Vissapragada <bharathv@apache.org>
Signed-off-by: Jan Hentschel <janh@apache.org>
Signed-off-by: Viraj Jasani <vjasani@apache.org>