### PR TITLE
HBASE-23708 Support metrics for region traffic

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSource.java
@@ -397,19 +397,28 @@ public interface MetricsRegionServerSource extends BaseSource, JvmPauseMonitorSo
   String UPDATES_BLOCKED_DESC =
       "Number of MS updates have been blocked so that the memstore can be flushed.";
   String DELETE_KEY = "delete";
+  String DELETE_BYTES_KEY = "deleteBytes";
   String CHECK_AND_DELETE_KEY = "checkAndDelete";
   String CHECK_AND_PUT_KEY = "checkAndPut";
   String DELETE_BATCH_KEY = "deleteBatch";
   String GET_SIZE_KEY = "getSize";
   String GET_KEY = "get";
+  String GET_BYTES_KEY = "getBytes";
   String INCREMENT_KEY = "increment";
+  String INCREMENT_BYTES_KEY = "incrementBytes";
   String PUT_KEY = "put";
+  String PUT_BYTES_KEY = "putBytes";
   String PUT_BATCH_KEY = "putBatch";
   String APPEND_KEY = "append";
+  String APPEND_BYTES_KEY = "appendBytes";
   String REPLAY_KEY = "replay";
   String SCAN_KEY = "scan";
   String SCAN_SIZE_KEY = "scanSize";
+  String SCAN_BYTES_KEY = "scanBytes";
   String SCAN_TIME_KEY = "scanTime";
+  String BULKLOAD_BYTES_KEY = "bulkLoadBytes";
+  String RECEIVED_BYTES_KEY = "receivedBytes";
+  String SENT_BYTES_KEY = "sentBytes";
 
   String SLOW_PUT_KEY = "slowPutCount";
   String SLOW_GET_KEY = "slowGetCount";

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionSource.java
@@ -91,6 +91,51 @@ public interface MetricsRegionSource extends Comparable<MetricsRegionSource> {
   void updateAppend();
 
   /**
+   * Update related bytes of all sent.
+   */
+  void updateSentBytes(long size);
+
+  /**
+   * Update related bytes of all received.
+   */
+  void updateReceivedBytes(long size);
+
+  /**
+   * Update related bytes of gets.
+   */
+  void updateGetBytes(long size);
+
+  /**
+   * Update related bytes of puts.
+   */
+  void updatePutBytes(long size);
+
+  /**
+   * Update related bytes of scans.
+   */
+  void updateScanBytes(long size);
+
+  /**
+   * Update related bytes of deletes.
+   */
+  void updateDeleteBytes(long size);
+
+  /**
+   * Update related bytes of increments.
+   */
+  void updateIncrementBytes(long size);
+
+  /**
+   * Update related bytes of appends.
+   */
+  void updateAppendBytes(long size);
+
+  /**
+   * Update related bytes of bulkloads.
+   */
+  void updateBulkLoadBytes(long size);
+
+  /**
    * Get the aggregate source to which this reports.
    */
   MetricsRegionAggregateSource getAggregateSource();

--- a/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionSourceImpl.java
+++ b/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionSourceImpl.java
@@ -51,6 +51,16 @@ public class MetricsRegionSourceImpl implements MetricsRegionSource {
   private final String regionIncrementKey;
   private final String regionAppendKey;
   private final String regionScanKey;
+  private final String regionSentBytesKey;
+  private final String regionReceivedBytesKey;
+  private final String regionGetBytesKey;
+  private final String regionPutBytesKey;
+  private final String regionScanBytesKey;
+  private final String regionDeleteBytesKey;
+  private final String regionIncrementBytesKey;
+  private final String regionAppendBytesKey;
+  private final String regionBulkLoadBytesKey;
+
 
   /*
    * Implementation note: Do not put histograms per region. With hundreds of regions in a server
@@ -62,6 +72,15 @@ public class MetricsRegionSourceImpl implements MetricsRegionSource {
   private final MutableFastCounter regionAppend;
   private final MutableFastCounter regionGet;
   private final MutableFastCounter regionScan;
+  private final MutableFastCounter regionSentBytes;
+  private final MutableFastCounter regionReceivedBytes;
+  private final MutableFastCounter regionGetBytes;
+  private final MutableFastCounter regionPutBytes;
+  private final MutableFastCounter regionScanBytes;
+  private final MutableFastCounter regionDeleteBytes;
+  private final MutableFastCounter regionIncrementBytes;
+  private final MutableFastCounter regionAppendBytes;
+  private final MutableFastCounter regionBulkLoadBytes;
 
   private final int hashCode;
 
@@ -101,6 +120,34 @@ public class MetricsRegionSourceImpl implements MetricsRegionSource {
 
     regionScanKey = regionNamePrefix + MetricsRegionServerSource.SCAN_KEY + suffix;
     regionScan = registry.getCounter(regionScanKey, 0L);
+
+    regionSentBytesKey = regionNamePrefix + MetricsRegionServerSource.SENT_BYTES_KEY;
+    regionSentBytes = registry.getCounter(regionSentBytesKey, 0L);
+
+    regionReceivedBytesKey = regionNamePrefix + MetricsRegionServerSource.RECEIVED_BYTES_KEY;
+    regionReceivedBytes = registry.getCounter(regionReceivedBytesKey, 0L);
+
+    regionGetBytesKey = regionNamePrefix + MetricsRegionServerSource.GET_BYTES_KEY;
+    regionGetBytes = registry.getCounter(regionGetBytesKey, 0L);
+
+    regionPutBytesKey = regionNamePrefix + MetricsRegionServerSource.PUT_BYTES_KEY;
+    regionPutBytes = registry.getCounter(regionPutBytesKey, 0L);
+
+    regionScanBytesKey = regionNamePrefix + MetricsRegionServerSource.SCAN_BYTES_KEY;
+    regionScanBytes = registry.getCounter(regionScanBytesKey, 0L);
+
+    regionDeleteBytesKey = regionNamePrefix + MetricsRegionServerSource.DELETE_BYTES_KEY;
+    regionDeleteBytes = registry.getCounter(regionDeleteBytesKey, 0L);
+
+    regionIncrementBytesKey = regionNamePrefix + MetricsRegionServerSource.INCREMENT_BYTES_KEY;
+    regionIncrementBytes = registry.getCounter(regionIncrementBytesKey, 0L);
+
+    regionAppendBytesKey = regionNamePrefix + MetricsRegionServerSource.APPEND_BYTES_KEY;
+    regionAppendBytes = registry.getCounter(regionAppendBytesKey, 0L);
+
+    regionBulkLoadBytesKey = regionNamePrefix + MetricsRegionServerSource.BULKLOAD_BYTES_KEY;
+    regionBulkLoadBytes = registry.getCounter(regionBulkLoadBytesKey, 0L);
+
   }
 
   @Override
@@ -129,6 +176,16 @@ public class MetricsRegionSourceImpl implements MetricsRegionSource {
       registry.removeMetric(regionAppendKey);
       registry.removeMetric(regionGetKey);
       registry.removeMetric(regionScanKey);
+
+      registry.removeMetric(regionSentBytesKey);
+      registry.removeMetric(regionReceivedBytesKey);
+      registry.removeMetric(regionGetBytesKey);
+      registry.removeMetric(regionPutBytesKey);
+      registry.removeMetric(regionScanBytesKey);
+      registry.removeMetric(regionDeleteBytesKey);
+      registry.removeMetric(regionIncrementBytesKey);
+      registry.removeMetric(regionAppendBytesKey);
+      registry.removeMetric(regionBulkLoadBytesKey);
 
       regionWrapper = null;
     }
@@ -162,6 +219,51 @@ public class MetricsRegionSourceImpl implements MetricsRegionSource {
   @Override
   public void updateAppend() {
     regionAppend.incr();
+  }
+
+  @Override
+  public void updateSentBytes(long size) {
+    regionSentBytes.incr(size);
+  }
+
+  @Override
+  public void updateReceivedBytes(long size) {
+    regionReceivedBytes.incr(size);
+  }
+
+  @Override
+  public void updateGetBytes(long size) {
+    regionGetBytes.incr(size);
+  }
+
+  @Override
+  public void updatePutBytes(long size) {
+    regionPutBytes.incr(size);
+  }
+
+  @Override
+  public void updateScanBytes(long size) {
+    regionScanBytes.incr(size);
+  }
+
+  @Override
+  public void updateDeleteBytes(long size) {
+    regionDeleteBytes.incr(size);
+  }
+
+  @Override
+  public void updateIncrementBytes(long size) {
+    regionIncrementBytes.incr(size);
+  }
+
+  @Override
+  public void updateAppendBytes(long size) {
+    regionAppendBytes.incr(size);
+  }
+
+  @Override
+  public void updateBulkLoadBytes(long size) {
+    regionBulkLoadBytes.incr(size);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegion.java
@@ -44,31 +44,48 @@ public class MetricsRegion {
     source.close();
   }
 
-  public void updatePut() {
+  public void updatePut(final long size) {
     source.updatePut();
+    source.updatePutBytes(size);
+    source.updateReceivedBytes(size);
   }
 
-  public void updateDelete() {
+  public void updateDelete(final long size) {
     source.updateDelete();
+    source.updateDeleteBytes(size);
+    source.updateReceivedBytes(size);
   }
 
-  public void updateGet(final long t) {
+  public void updateGet(final long t, final long size) {
     source.updateGet(t);
+    source.updateGetBytes(size);
+    source.updateSentBytes(size);
   }
 
-  public void updateScanTime(final long t) {
+  public void updateScan(final long t, final long size) {
     source.updateScanTime(t);
+    source.updateScanBytes(size);
+    source.updateSentBytes(size);
   }
 
   public void updateFilteredRecords(){
     userAggregate.updateFilteredReadRequests();
   }
-  public void updateAppend() {
+  public void updateAppend(final long size) {
     source.updateAppend();
+    source.updateAppendBytes(size);
+    source.updateReceivedBytes(size);
   }
 
-  public void updateIncrement() {
+  public void updateIncrement(final long size) {
     source.updateIncrement();
+    source.updateIncrementBytes(size);
+    source.updateReceivedBytes(size);
+  }
+
+  public void updateBulkLoad(final long size) {
+    source.updateBulkLoadBytes(size);
+    source.updateReceivedBytes(size);
   }
 
   MetricsRegionSource getSource() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MiniBatchOperationInProgress.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MiniBatchOperationInProgress.java
@@ -45,6 +45,8 @@ public class MiniBatchOperationInProgress<T> {
   private int cellCount = 0;
   private int numOfPuts = 0;
   private int numOfDeletes = 0;
+  private long bytesForPuts = 0;
+  private long bytesForDeletes = 0;
 
 
   public MiniBatchOperationInProgress(T[] operations, OperationStatus[] retCodeDetails,
@@ -168,5 +170,21 @@ public class MiniBatchOperationInProgress<T> {
 
   public void incrementNumOfDeletes() {
     this.numOfDeletes += 1;
+  }
+
+  public long getBytesForPuts() {
+    return bytesForPuts;
+  }
+
+  public void incrementBytesForPuts(long size) {
+    this.bytesForPuts += size;
+  }
+
+  public long getBytesForDeletes() {
+    return bytesForDeletes;
+  }
+
+  public void incrementBytesForDeletes(long size) {
+    this.bytesForDeletes += size;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -3385,7 +3385,7 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
       }
       long end = EnvironmentEdgeManager.currentTime();
       long responseCellSize = context != null ? context.getResponseCellSize() : 0;
-      region.getMetrics().updateScanTime(end - before);
+      region.getMetrics().updateScan(end - before, responseCellSize);
       final MetricsRegionServer metricsRegionServer = regionServer.getMetrics();
       if (metricsRegionServer != null) {
         metricsRegionServer.updateScanSize(


### PR DESCRIPTION
I think we need some metrics to measure the amount of traffic being read and written to each region, which can help us more clearly analyze how much network resources are consumed by each region.

putBytes/getBytes/scanBytes/deleteBytes/incrementBytes/appendBytes/bulkLoadBytes