### PR TITLE
HBASE-23709 Unwrap the real user to properly dispatch proxy-user auth'n

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/BuiltInProviderSelector.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/BuiltInProviderSelector.java
@@ -123,11 +123,16 @@ public class BuiltInProviderSelector implements AuthenticationProviderSelector {
         return new Pair<>(digestAuth, token);
       }
     }
-    if (user.getUGI().hasKerberosCredentials()) {
+    // Unwrap PROXY auth'n method if that's what we have coming in.
+    if (user.getUGI().hasKerberosCredentials() ||
+        user.getUGI().getRealUser().hasKerberosCredentials()) {
       return new Pair<>(krbAuth, null);
     }
-    LOG.debug(
-        "No matching SASL authentication provider and supporting token found from providers.");
+    // This indicates that a client is requesting some authentication mechanism which the servers
+    // don't know how to process (e.g. there is no provider which can support it). This may be
+    // a bug or simply a misconfiguration of client *or* server.
+    LOG.warn("No matching SASL authentication provider and supporting token found from providers"
+        + " for user: {}", user);
     return null;
   }
 

--- a/hbase-rest/pom.xml
+++ b/hbase-rest/pom.xml
@@ -543,3 +543,4 @@
     </profile>
   </profiles>
 </project>
+<!-- force module tests -->

--- a/hbase-thrift/pom.xml
+++ b/hbase-thrift/pom.xml
@@ -600,3 +600,4 @@
     </profile>
   </profiles>
 </project>
+<!-- force module tests -->


### PR DESCRIPTION
REST and Thrift servers started failing because the check in
BuiltinProviderSelector wasn't checking the "real" user for kerberos
credentials. This resulted in the KerberosAuthnProvider not being
invoked when it should have been.