### PR TITLE
HBASE-23752: Fix remaining test failures from nightly runs

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSideWithCoprocessor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFromClientSideWithCoprocessor.java
@@ -49,10 +49,7 @@ public class TestFromClientSideWithCoprocessor extends TestFromClientSide {
   }
 
   public TestFromClientSideWithCoprocessor(Class registry, int numHedgedReqs) throws Exception {
-    if (TEST_UTIL == null) {
-      // It is ok to initialize once because the test is parameterized for a single dimension.
-      initialize(registry, numHedgedReqs, NoOpScanPolicyObserver.class,
-          MultiRowMutationEndpoint.class);
-    }
+    initialize(registry, numHedgedReqs, NoOpScanPolicyObserver.class,
+        MultiRowMutationEndpoint.class);
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestSnapshotScannerHDFSAclController.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestSnapshotScannerHDFSAclController.java
@@ -910,6 +910,11 @@ public class TestSnapshotScannerHDFSAclController {
     TEST_UTIL.restartHBaseCluster(1);
     TEST_UTIL.waitUntilNoRegionsInTransition();
 
+    // reset the cached configs after restart
+    conf = TEST_UTIL.getConfiguration();
+    admin = TEST_UTIL.getAdmin();
+    helper = new SnapshotScannerHDFSAclHelper(conf, admin.getConnection());
+
     Path tmpNsDir = helper.getPathHelper().getTmpNsDir(namespace);
     assertTrue(fs.exists(tmpNsDir));
     // check all regions in tmp table2 dir are archived
@@ -917,7 +922,6 @@ public class TestSnapshotScannerHDFSAclController {
 
     // create table1 and snapshot
     TestHDFSAclHelper.createTableAndPut(TEST_UTIL, table);
-    admin = TEST_UTIL.getAdmin();
     aclTable = TEST_UTIL.getConnection().getTable(PermissionStorage.ACL_TABLE_NAME);
     admin.snapshot(snapshot, table);
     TestHDFSAclHelper.canUserScanSnapshot(TEST_UTIL, grantUser, snapshot, 6);


### PR DESCRIPTION
TestFromClientSideWithCoprocessor: Initialization bug causing parameterized
runs to fail.
TestCustomSaslAuthenticationProvider: Test config had to be fixed because
it was written pre-master registry implementation.
