### PR TITLE
HBASE-23753 Update of errorprone generated failures

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/HRegionInfo.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/HRegionInfo.java
@@ -74,7 +74,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
  */
 @Deprecated
 @InterfaceAudience.Public
-public class HRegionInfo implements RegionInfo, Comparable<HRegionInfo> {
+public class HRegionInfo implements RegionInfo {
   private static final Logger LOG = LoggerFactory.getLogger(HRegionInfo.class);
 
   /**
@@ -699,15 +699,6 @@ public class HRegionInfo implements RegionInfo, Comparable<HRegionInfo> {
   @Override
   public int hashCode() {
     return this.hashCode;
-  }
-
-  //
-  // Comparable
-  //
-
-  @Override
-  public int compareTo(HRegionInfo o) {
-    return RegionInfo.COMPARATOR.compare(this, o);
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfo.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfo.java
@@ -68,7 +68,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
  *
  */
 @InterfaceAudience.Public
-public interface RegionInfo {
+public interface RegionInfo extends Comparable<RegionInfo> {
   RegionInfo UNDEFINED = RegionInfoBuilder.newBuilder(TableName.valueOf("__UNDEFINED__")).build();
   /**
    * Separator used to demarcate the encodedName in a region name
@@ -821,5 +821,9 @@ public interface RegionInfo {
       return true;
     }
     return Bytes.compareTo(getStartKey(), other.getEndKey()) < 0;
+  }
+
+  default int compareTo(RegionInfo other) {
+    return RegionInfo.COMPARATOR.compare(this, other);
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfoBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfoBuilder.java
@@ -1,5 +1,4 @@
-/**
- *
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -130,7 +129,7 @@ public class RegionInfoBuilder {
    * An implementation of RegionInfo that adds mutable methods so can build a RegionInfo instance.
    */
   @InterfaceAudience.Private
-  static class MutableRegionInfo implements RegionInfo, Comparable<RegionInfo> {
+  static class MutableRegionInfo implements RegionInfo {
     /**
      * The new format for a region name contains its encodedName at the end.
      * The encoded name also serves as the directory name for the region
@@ -453,7 +452,7 @@ public class RegionInfoBuilder {
       if (!(o instanceof RegionInfo)) {
         return false;
       }
-      return this.compareTo((RegionInfo)o) == 0;
+      return compareTo((RegionInfo)o) == 0;
     }
 
     /**
@@ -463,11 +462,5 @@ public class RegionInfoBuilder {
     public int hashCode() {
       return this.hashCode;
     }
-
-    @Override
-    public int compareTo(RegionInfo other) {
-      return RegionInfo.COMPARATOR.compare(this, other);
-    }
-
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/protobuf/ProtobufUtil.java
@@ -1344,7 +1344,7 @@ public final class ProtobufUtil {
     List<CellProtos.Cell> values = proto.getCellList();
 
     if (proto.hasExists()) {
-      if ((values != null && !values.isEmpty()) ||
+      if (!values.isEmpty() ||
           (proto.hasAssociatedCellCount() && proto.getAssociatedCellCount() > 0)) {
         throw new IllegalArgumentException("bad proto: exists with cells is no allowed " + proto);
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.hbase.executor;
 
+import java.awt.*;
 import java.io.IOException;
 import java.util.concurrent.atomic.AtomicLong;
 
@@ -52,7 +53,7 @@ import org.slf4j.LoggerFactory;
  * @see ExecutorService
  */
 @InterfaceAudience.Private
-public abstract class EventHandler implements Runnable, Comparable<Runnable> {
+public abstract class EventHandler implements Runnable, Comparable<EventHandler> {
   private static final Logger LOG = LoggerFactory.getLogger(EventHandler.class);
 
   // type of event this object represents
@@ -152,12 +153,11 @@ public abstract class EventHandler implements Runnable, Comparable<Runnable> {
    * priority beyond FIFO, they should override {@link #getPriority()}.
    */
   @Override
-  public int compareTo(Runnable o) {
-    EventHandler eh = (EventHandler)o;
-    if(getPriority() != eh.getPriority()) {
-      return (getPriority() < eh.getPriority()) ? -1 : 1;
+  public int compareTo(EventHandler o) {
+    if(getPriority() != o.getPriority()) {
+      return (getPriority() < o.getPriority()) ? -1 : 1;
     }
-    return (this.seqid < eh.seqid) ? -1 : 1;
+    return (this.seqid < o.seqid) ? -1 : 1;
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRegionReplicasWithRestartScenarios.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRegionReplicasWithRestartScenarios.java
@@ -137,6 +137,7 @@ public class TestRegionReplicasWithRestartScenarios {
 
   private void assertReplicaDistributed() throws Exception {
     Collection<HRegion> onlineRegions = getRS().getOnlineRegionsLocalContext();
+    LOG.info("ASSERT DISTRIBUTED {}", onlineRegions);
     boolean res = checkDuplicates(onlineRegions);
     assertFalse(res);
     Collection<HRegion> onlineRegions2 = getSecondaryRS().getOnlineRegionsLocalContext();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestSnapshotScannerHDFSAclController.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestSnapshotScannerHDFSAclController.java
@@ -652,6 +652,7 @@ public class TestSnapshotScannerHDFSAclController {
       admin.restoreSnapshot(snapshot);
       admin.snapshot(snapshot3, table);
 
+      LOG.info("CHECK");
       TestHDFSAclHelper.canUserScanSnapshot(TEST_UTIL, grantUser, snapshot, -1);
       TestHDFSAclHelper.canUserScanSnapshot(TEST_UTIL, grantUser, snapshot2, -1);
       TestHDFSAclHelper.canUserScanSnapshot(TEST_UTIL, grantUser, snapshot3, -1);


### PR DESCRIPTION
hbase-client/src/main/java/org/apache/hadoop/hbase/HRegionInfo.java
hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventHandler.java
 Complains about mismatch in types when Compare. Implement Compare in
 base Interface.

hbase-client/src/main/java/org/apache/hadoop/hbase/protobuf/ProtobufUtil.java
 Complains pbs never return null.

hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSinkManager.java
 Needed redo because errorprone complains can't mock Service from guava.

hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRegionReplicasWithRestartScenarios.java
hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestSnapshotScannerHDFSAclController.java
 Unrelated...adding one-liner debug statements chasing other test
 failures.