### PR TITLE
HBASE-23764: Switch to IP address for ZK ensemble

### DIFF
--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -72,7 +72,10 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
     <name>hbase.zookeeper.quorum</name>
-    <value>localhost</value>
+    <!--Ideally we should be using a hostname here instead of IP address. Please refer to
+    https://issues.apache.org/jira/browse/HBASE-23764 for why we switched to IP address. Should be
+    changed once we fix the underlying ZK issue.-->
+    <value>127.0.0.1</value>
     <description>Comma separated list of servers in the ZooKeeper ensemble
     (This config. should have been named hbase.zookeeper.ensemble).
     For example, "host1.mydomain.com,host2.mydomain.com,host3.mydomain.com".

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestZKAsyncRegistry.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestZKAsyncRegistry.java
@@ -101,7 +101,7 @@ public class TestZKAsyncRegistry {
   public void testIndependentZKConnections() throws IOException {
     try (ReadOnlyZKClient zk1 = REGISTRY.getZKClient()) {
       Configuration otherConf = new Configuration(TEST_UTIL.getConfiguration());
-      otherConf.set(HConstants.ZOOKEEPER_QUORUM, "127.0.0.1");
+      otherConf.set(HConstants.ZOOKEEPER_QUORUM, "localhost");
       try (ZKAsyncRegistry otherRegistry = new ZKAsyncRegistry(otherConf)) {
         ReadOnlyZKClient zk2 = otherRegistry.getZKClient();
         assertNotSame("Using a different configuration / quorum should result in different " +

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterNoCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterNoCluster.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.master;
 
+import static org.apache.hadoop.hbase.HConstants.ZOOKEEPER_QUORUM;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Abortable;
@@ -113,7 +114,7 @@ public class TestMasterNoCluster {
   @Test
   public void testMasterInitWithSameClientServerZKQuorum() throws Exception {
     Configuration conf = new Configuration(TESTUTIL.getConfiguration());
-    conf.set(HConstants.CLIENT_ZOOKEEPER_QUORUM, HConstants.LOCALHOST);
+    conf.set(HConstants.CLIENT_ZOOKEEPER_QUORUM, conf.get(ZOOKEEPER_QUORUM));
     conf.setInt(HConstants.CLIENT_ZOOKEEPER_CLIENT_PORT, TESTUTIL.getZkCluster().getClientPort());
     HMaster master = new HMaster(conf);
     master.start();

--- a/hbase-zookeeper/src/test/java/org/apache/hadoop/hbase/zookeeper/TestHQuorumPeer.java
+++ b/hbase-zookeeper/src/test/java/org/apache/hadoop/hbase/zookeeper/TestHQuorumPeer.java
@@ -74,7 +74,7 @@ public class TestHQuorumPeer {
     assertEquals(dataDir.toString(), (String)properties.get("dataDir"));
     assertEquals(Integer.valueOf(PORT_NO),
       Integer.valueOf(properties.getProperty("clientPort")));
-    assertEquals("localhost:2888:3888", properties.get("server.0"));
+    assertEquals("127.0.0.1:2888:3888", properties.get("server.0"));
     assertNull(properties.get("server.1"));
 
     String oldValue = conf.get(HConstants.ZOOKEEPER_QUORUM);

--- a/hbase-zookeeper/src/test/java/org/apache/hadoop/hbase/zookeeper/TestZKMainServer.java
+++ b/hbase-zookeeper/src/test/java/org/apache/hadoop/hbase/zookeeper/TestZKMainServer.java
@@ -102,7 +102,7 @@ public class TestZKMainServer {
   public void testHostPortParse() {
     ZKMainServer parser = new ZKMainServer();
     Configuration c = HBaseConfiguration.create();
-    assertEquals("localhost:" + c.get(HConstants.ZOOKEEPER_CLIENT_PORT), parser.parse(c));
+    assertEquals("127.0.0.1:" + c.get(HConstants.ZOOKEEPER_CLIENT_PORT), parser.parse(c));
     final String port = "1234";
     c.set(HConstants.ZOOKEEPER_CLIENT_PORT, port);
     c.set("hbase.zookeeper.quorum", "example.com");

--- a/pom.xml
+++ b/pom.xml
@@ -28,6 +28,7 @@
   https://issues.apache.org/jira/browse/HBASE-6795.
 
 -->
+    <!-- Faking a change to trigger full test suite -->
   <modelVersion>4.0.0</modelVersion>
   <parent>
     <groupId>org.apache</groupId>


### PR DESCRIPTION
Tests showed that using IP address is much faster for mini cluster
and a lot less flakier. See the jira for more details.