### PR TITLE
HBASE-22827 Expose multi-region merge in shell and Admin API

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -906,6 +906,8 @@ public interface Admin extends Abortable, Closeable {
    * @param forcible <code>true</code> if do a compulsory merge, otherwise we will only merge two
    *          adjacent regions
    * @throws IOException if a remote or network exception occurs
+   * @deprecated since 2.3.0 and will be removed in 4.0.0. Multi-region merge feature is now
+   *             supported. Use {@link #mergeRegionsAsync(byte[][], boolean)} instead.
    */
   default Future<Void> mergeRegionsAsync(byte[] nameOfRegionA, byte[] nameOfRegionB,
       boolean forcible) throws IOException {
@@ -916,11 +918,7 @@ public interface Admin extends Abortable, Closeable {
   }
 
   /**
-   * Merge regions. Asynchronous operation.
-   * <p/>
-   * You may get a {@code DoNotRetryIOException} if you pass more than two regions in but the master
-   * does not support merging more than two regions. At least till 2.2.0, we still only support
-   * merging two regions.
+   * Merge multiple regions (>=2). Asynchronous operation.
    * @param nameofRegionsToMerge encoded or full name of daughter regions
    * @param forcible <code>true</code> if do a compulsory merge, otherwise we will only merge
    *          adjacent regions

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -909,6 +909,7 @@ public interface Admin extends Abortable, Closeable {
    * @deprecated since 2.3.0 and will be removed in 4.0.0. Multi-region merge feature is now
    *             supported. Use {@link #mergeRegionsAsync(byte[][], boolean)} instead.
    */
+  @Deprecated
   default Future<Void> mergeRegionsAsync(byte[] nameOfRegionA, byte[] nameOfRegionB,
       boolean forcible) throws IOException {
     byte[][] nameofRegionsToMerge = new byte[2][];

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -513,8 +513,10 @@ public interface AsyncAdmin {
    * @param nameOfRegionB encoded or full name of region b
    * @param forcible true if do a compulsory merge, otherwise we will only merge two adjacent
    *          regions
-   * @deprecated since 2.3.0 and will be removed in 4.0.0. Use {@link #mergeRegions(List, boolean)} instead.
+   * @deprecated since 2.3.0 and will be removed in 4.0.0.Use {@link #mergeRegions(List, boolean)}
+   *             instead.
    */
+  @Deprecated
   default CompletableFuture<Void> mergeRegions(byte[] nameOfRegionA, byte[] nameOfRegionB,
       boolean forcible) {
     return mergeRegions(Arrays.asList(nameOfRegionA, nameOfRegionB), forcible);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -513,6 +513,7 @@ public interface AsyncAdmin {
    * @param nameOfRegionB encoded or full name of region b
    * @param forcible true if do a compulsory merge, otherwise we will only merge two adjacent
    *          regions
+   * @deprecated since 2.3.0 and will be removed in 4.0.0. Use {@link #mergeRegions(List, boolean)} instead.
    */
   default CompletableFuture<Void> mergeRegions(byte[] nameOfRegionA, byte[] nameOfRegionB,
       boolean forcible) {
@@ -520,11 +521,7 @@ public interface AsyncAdmin {
   }
 
   /**
-   * Merge regions.
-   * <p/>
-   * You may get a {@code DoNotRetryIOException} if you pass more than two regions in but the master
-   * does not support merging more than two regions. At least till 2.2.0, we still only support
-   * merging two regions.
+   * Merge multiple regions (>=2).
    * @param nameOfRegionsToMerge encoded or full name of daughter regions
    * @param forcible true if do a compulsory merge, otherwise we will only merge two adjacent
    *          regions

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -536,10 +536,19 @@ module Hbase
 
     #----------------------------------------------------------------------------------------------
     # Merge multiple regions
-    def merge_region(regions = [], force)
+    def merge_region(regions, force)
+      unless regions.is_a?(Array)
+        raise(ArgumentError, "Type of #{regions.inspect} is #{regions.class}, but expected Array")
+      end
       region_array = Java::byte[][regions.length].new
       i = 0
       while i < regions.length
+        unless regions[i].is_a?(String)
+          raise(
+              ArgumentError,
+              "Type of #{regions[i].inspect} is #{regions[i].class}, but expected String"
+          )
+        end
         region_array[i] = regions[i].to_java_bytes
         i += 1
       end

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -535,14 +535,20 @@ module Hbase
     end
 
     #----------------------------------------------------------------------------------------------
-    # Merge two regions
-    def merge_region(region_a_name, region_b_name, force)
-      @admin.mergeRegionsAsync(
-        region_a_name.to_java_bytes,
-        region_b_name.to_java_bytes,
-        java.lang.Boolean.valueOf(force)
+    # Merge multiple regions
+    def merge_region(regions = [], force)
+      region_array = Java::byte[][regions.length].new
+      i = 0
+      while i < regions.length
+        region_array[i] = regions[i].to_java_bytes
+        i += 1
+      end
+      org.apache.hadoop.hbase.util.FutureUtils.get(
+          @admin.mergeRegionsAsync(
+              region_array,
+              java.lang.Boolean.valueOf(force)
+          )
       )
-      return nil
     end
 
     #----------------------------------------------------------------------------------------------

--- a/hbase-shell/src/main/ruby/shell/commands.rb
+++ b/hbase-shell/src/main/ruby/shell/commands.rb
@@ -137,7 +137,11 @@ module Shell
           raise "Table #{cause.message} should be disabled!"
         end
         if cause.is_a?(org.apache.hadoop.hbase.UnknownRegionException)
-          raise "Unknown region #{args.first}!"
+          raise cause.message
+        end
+        if cause.is_a?(org.apache.hadoop.hbase.exceptions.MergeRegionException)
+          strs = cause.message.split("\n")
+          raise(strs[0]).to_s unless strs.empty?
         end
         if cause.is_a?(org.apache.hadoop.hbase.NamespaceNotFoundException)
           s = /.*NamespaceNotFoundException: (?<namespace>[^\n]+).*/.match(cause.message)

--- a/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
@@ -31,15 +31,26 @@ region name is the hash suffix on region names: e.g. if the region name were
 TestTable,0094429456,1289497600452.527db22f95c8a9e0116f0cc13c680396. then
 the encoded region name portion is 527db22f95c8a9e0116f0cc13c680396
 
+You can either pass the list of regions as comma separated values or as an
+array of regions as shown:
+
 Examples:
 
   hbase> merge_region 'FULL_REGIONNAME', 'FULL_REGIONNAME'
   hbase> merge_region 'FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...
   hbase> merge_region 'FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ..., true
 
+  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME']
+  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...]
+  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ..., true]
+
   hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME'
   hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...
   hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ..., true
+
+  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME']
+  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...]
+  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ..., true]
 EOF
       end
 

--- a/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
@@ -42,7 +42,7 @@ Examples:
 
   hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME']
   hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...]
-  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ..., true]
+  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...], true
 
   hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME'
   hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...
@@ -50,7 +50,7 @@ Examples:
 
   hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME']
   hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...]
-  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ..., true]
+  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...], true
 EOF
       end
 

--- a/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
@@ -57,7 +57,7 @@ EOF
       def command(*args)
         args = args.flatten.compact
         args_len = args.length
-        raise(ArgumentError, 'Must pass atleast 2 regions to merge') unless args_len > 1
+        raise(ArgumentError, 'Must pass at least 2 regions to merge') unless args_len > 1
         force = false
         if(args_len > 2)
           last = args[args_len-1]

--- a/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
@@ -33,18 +33,29 @@ the encoded region name portion is 527db22f95c8a9e0116f0cc13c680396
 
 Examples:
 
-  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME']
-  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...]
-  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...], true
+  hbase> merge_region 'FULL_REGIONNAME', 'FULL_REGIONNAME'
+  hbase> merge_region 'FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...
+  hbase> merge_region 'FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ..., true
 
-  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME']
-  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...]
-  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...], true
+  hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME'
+  hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...
+  hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ..., true
 EOF
       end
 
-      def command(regions = [], force = 'false')
-        admin.merge_region(regions, force)
+      def command(*args)
+        args = args.flatten.compact
+        args_len = args.length
+        raise(ArgumentError, 'Must pass atleast 2 regions to merge') unless args_len > 1
+        force = false
+        if(args_len > 2)
+          last = args[args_len-1]
+          if [true, false].include? last
+            force = last
+            args = args[0...-1]
+          end
+        end
+        admin.merge_region(args, force)
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/merge_region.rb
@@ -22,7 +22,7 @@ module Shell
     class MergeRegion < Command
       def help
         <<-EOF
-Merge two regions. Passing 'true' as the optional third parameter will force
+Merge multiple (2 or more) regions. Passing 'true' as the optional third parameter will force
 a merge ('force' merges regardless else merge will fail unless passed
 adjacent regions. 'force' is for expert use only).
 
@@ -33,16 +33,18 @@ the encoded region name portion is 527db22f95c8a9e0116f0cc13c680396
 
 Examples:
 
-  hbase> merge_region 'FULL_REGIONNAME', 'FULL_REGIONNAME'
-  hbase> merge_region 'FULL_REGIONNAME', 'FULL_REGIONNAME', true
+  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME']
+  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...]
+  hbase> merge_region ['FULL_REGIONNAME', 'FULL_REGIONNAME', 'FULL_REGIONNAME', ...], true
 
-  hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME'
-  hbase> merge_region 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', true
+  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME']
+  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...]
+  hbase> merge_region ['ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', 'ENCODED_REGIONNAME', ...], true
 EOF
       end
 
-      def command(region_a_name, region_b_name, force = 'false')
-        admin.merge_region(region_a_name, region_b_name, force)
+      def command(regions = [], force = 'false')
+        admin.merge_region(regions, force)
       end
     end
   end

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -612,28 +612,29 @@ module Hbase
       region5 = r5.getRegion.getRegionNameAsString
       region6 = r6.getRegion.getRegionNameAsString
       # only 1 region
-      begin
-        command(:merge_region, ['a'], true)
-        assert(false, "should have failed")
-      rescue java.lang.IllegalArgumentException => e
-        assert(true, "single region can't be merged")
+      assert_raise(ArgumentError) do
+        command(:merge_region, 'a')
+      end
+      # only 1 region with force=true
+      assert_raise(ArgumentError) do
+        command(:merge_region, 'a', true)
       end
       # non-existing region
       assert_raise(RuntimeError) do
-        command(:merge_region, ['a','b'])
+        command(:merge_region, 'a','b')
       end
       # duplicate regions
       assert_raise(RuntimeError) do
-        command(:merge_region, [region1,region1,region1])
+        command(:merge_region, region1,region1,region1)
       end
       # 3 non-adjacent regions without forcible=true
       assert_raise(RuntimeError) do
-        command(:merge_region, [region1,region2,region4])
+        command(:merge_region, region1,region2,region4)
       end
       # 2 adjacent regions
-      command(:merge_region, [region1,region2])
+      command(:merge_region, region1,region2)
       # 3 non-adjacent regions with forcible=true
-      command(:merge_region, [region3,region5,region6], true)
+      command(:merge_region, region3,region5,region6, true)
     end
   end
 

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -597,7 +597,9 @@ module Hbase
 
     define_test 'merge regions' do
       @t_name = 'hbase_shell_merge'
+      @t_name2 = 'hbase_shell_merge_2'
       drop_test_table(@t_name)
+      drop_test_table(@t_name2)
       admin.create(@t_name, 'a', NUMREGIONS => 10, SPLITALGO => 'HexStringSplit')
       r1 = command(:locate_region, @t_name, '1')
       r2 = command(:locate_region, @t_name, '2')
@@ -635,6 +637,17 @@ module Hbase
       command(:merge_region, region1,region2)
       # 3 non-adjacent regions with forcible=true
       command(:merge_region, region3,region5,region6, true)
+
+      admin.create(@t_name2, 'a', NUMREGIONS => 5, SPLITALGO => 'HexStringSplit')
+      r1 = command(:locate_region, @t_name2, '1')
+      r2 = command(:locate_region, @t_name2, '4')
+      r3 = command(:locate_region, @t_name2, '7')
+      region1 = r1.getRegion.getRegionNameAsString
+      region2 = r2.getRegion.getRegionNameAsString
+      region3 = r3.getRegion.getRegionNameAsString
+
+      # accept array of regions
+      command(:merge_region, [region1,region2,region3])
     end
   end
 


### PR DESCRIPTION
* mergeRegionsAsync with two regions as parameters, to be deprecated since 2.3.0 and removed from 4.0
* merge_region shell command syntax changed (as it goes into minor release & major release i.e. 2.3.0, 3.0.0). It now supports multiple region merge.