### PR TITLE
HBASE-23828 - Remove unused hadoop.guava.version from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1470,7 +1470,6 @@
          They ought to match the values found in our default hadoop profile, which is
          currently "hadoop-2.0". See HBASE-15925 for more info. -->
     <hadoop.version>${hadoop-two.version}</hadoop.version>
-    <hadoop.guava.version>11.0.2</hadoop.guava.version>
     <compat.module>hbase-hadoop2-compat</compat.module>
     <assembly.file>src/main/assembly/hadoop-two-compat.xml</assembly.file>
     <!--This property is for hadoops netty. HBase netty


### PR DESCRIPTION
<hadoop.guava.version>11.0.2</hadoop.guava.version> is not used anywhere. It was added in https://github.com/apache/hbase/commit/0e95a8a0ae24b0d19b391d49794d6716a8e86bcd , when hbase-backup was using it. When it got removed in hbase-backup, this was forgotten. Static analyzers is now flagging hbase as there is a CVE for guava older versions.