### PR TITLE
HBASE-23862 Fix flaky TestSnapshotFromMaster in 1.x versions

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/cleaner/TestSnapshotFromMaster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/cleaner/TestSnapshotFromMaster.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hbase.master.cleaner;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -430,8 +429,11 @@ public class TestSnapshotFromMaster {
         return UTIL.getHBaseAdmin().listSnapshots(Pattern.compile(snapshotName)).size() == 1;
       }
     });
-    assertTrue(master.getSnapshotManager().isTakingAnySnapshot());
-    Thread.sleep(11 * 1000L);
-    assertFalse(master.getSnapshotManager().isTakingAnySnapshot());
+    UTIL.waitFor(30000, new Predicate<Exception>() {
+      @Override
+      public boolean evaluate() throws Exception {
+        return !master.getSnapshotManager().isTakingAnySnapshot();
+      }
+    });
   }
 }


### PR DESCRIPTION
Backport HBASE-23658 - Fix flaky TestSnapshotFromMaster
(cherry picked from commit 25654df98b939f077cb8e06f46c9c28705f86b84)

Signed-off-by: Guanghao Zhang <zghaobac@gmail.com>