### PR TITLE
HBASE-23896 Snapshot owner cannot delete snapshot when ACL is enabled…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
@@ -635,7 +635,7 @@ public class SnapshotManager extends MasterProcedureManager implements Stoppable
       builder.setVersion(SnapshotDescriptionUtils.SNAPSHOT_LAYOUT_VERSION);
     }
     RpcServer.getRequestUser().ifPresent(user -> {
-      if (User.isHBaseSecurityEnabled(master.getConfiguration())) {
+      if (AccessChecker.isAuthorizationSupported(master.getConfiguration())) {
         builder.setOwner(user.getShortName());
       }
     });


### PR DESCRIPTION
… and Kerberos is not enabled