### PR TITLE
HBASE-23945 Dockerfiles showing hadolint check failures

### DIFF
--- a/dev-support/Dockerfile
+++ b/dev-support/Dockerfile
@@ -22,8 +22,12 @@
 # dev-support/flaky-tests/flaky-reporting.Jenkinsfile
 FROM ubuntu:18.04
 
-ADD . /hbase/dev-support
+COPY . /hbase/dev-support
 
-RUN apt-get -y update \
-    && apt-get -y install curl python-pip \
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y update \
+    && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --no-install-recommends \
+      curl=7.58.0-2ubuntu3.8 \
+      python-pip=9.0.1-2.3~ubuntu1.18.04.1 \
+    && apt-get clean \
+    && rm -rf /var/lib/apt/lists/* \
     && pip install -r /hbase/dev-support/python-requirements.txt

--- a/dev-support/create-release/hbase-rm/Dockerfile
+++ b/dev-support/create-release/hbase-rm/Dockerfile
@@ -21,22 +21,28 @@
 # * Java 8
 FROM ubuntu:18.04
 
-# These arguments are just for reuse and not really meant to be customized.
-ARG APT_INSTALL="apt-get install --no-install-recommends -y"
-
 # Install extra needed repos and refresh.
 #
 # This is all in a single "RUN" command so that if anything changes, "apt update" is run to fetch
 # the most current package versions (instead of potentially using old versions cached by docker).
-RUN apt-get clean && \
-  apt-get update && \
-  # Install openjdk 8.
-  $APT_INSTALL openjdk-8-jdk && \
-  update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java && \
-  # Install build / source control tools
-  $APT_INSTALL curl gnupg python-pip wget git maven subversion lsof \
-    libcurl4-openssl-dev libxml2-dev && \
-  pip install python-dateutil
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y update \
+  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --no-install-recommends \
+    curl=7.58.0-2ubuntu3.8 \
+    git=1:2.17.1-1ubuntu0.5 \
+    gnupg=2.2.4-1ubuntu1.2 \
+    libcurl4-openssl-dev=7.58.0-2ubuntu3.8 \
+    libxml2-dev=2.9.4+dfsg1-6.1ubuntu1.3 \
+    lsof=4.89+dfsg-0.1 \
+    maven=3.6.0-1~18.04.1 \
+    openjdk-8-jdk=8u242-b08-0ubuntu3~18.04 \
+    python-pip=9.0.1-2.3~ubuntu1.18.04.1 \
+    subversion=1.9.7-4ubuntu1 \
+    wget=1.19.4-1ubuntu2.2 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/* \
+  && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \
+  && pip install \
+    python-dateutil==2.8.1
 
 WORKDIR /opt/hbase-rm/output
 

--- a/dev-support/hbase_docker/Dockerfile
+++ b/dev-support/hbase_docker/Dockerfile
@@ -17,21 +17,25 @@
 FROM ubuntu:14.04
 
 # Install Git, which is missing from the Ubuntu base images.
-RUN apt-get update && apt-get install -y git
+RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y update \
+  && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --no-install-recommends \
+    git=1:1.9.1-1ubuntu0.10 \
+  && apt-get clean \
+  && rm -rf /var/lib/apt/lists/*
 
 # Add the dependencies from the hbase_docker folder and delete ones we don't need.
 WORKDIR /root
-ADD . /root
+COPY . /root
 RUN find . -not -name "*tar.gz" -delete
 
 # Install Java.
 RUN mkdir -p /usr/java
-RUN tar xzf *jdk* --strip-components 1 -C /usr/java
+RUN tar xzf ./*jdk* --strip-components 1 -C /usr/java
 ENV JAVA_HOME /usr/java
 
 # Install Maven.
 RUN mkdir -p /usr/local/apache-maven
-RUN tar xzf *maven* --strip-components 1 -C /usr/local/apache-maven
+RUN tar xzf ./*maven* --strip-components 1 -C /usr/local/apache-maven
 ENV MAVEN_HOME /usr/local/apache-maven
 
 # Add Java and Maven to the path.


### PR DESCRIPTION
With this patch, `find . -iname '*Dockerfile*' -exec hadolint {} +` reports nothing. Let's see what buildbot says.