### PR TITLE
HBASE-23561 acquire lock before update regionsMap

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
@@ -71,6 +71,8 @@ public class RegionStates {
   public final static RegionStateStampComparator REGION_STATE_STAMP_COMPARATOR =
       new RegionStateStampComparator();
 
+  private final Object regionsMapLock = new Object();
+
   // TODO: Replace the ConcurrentSkipListMaps
   /**
    * RegionName -- i.e. RegionInfo.getRegionName() -- as bytes to {@link RegionStateNode}
@@ -125,11 +127,12 @@ public class RegionStates {
   // ==========================================================================
   @VisibleForTesting
   RegionStateNode createRegionStateNode(RegionInfo regionInfo) {
-    return regionsMap.computeIfAbsent(regionInfo.getRegionName(), key -> {
-      final RegionStateNode node = new RegionStateNode(regionInfo, regionInTransition);
+    synchronized (regionsMapLock) {
+      RegionStateNode node = regionsMap.computeIfAbsent(regionInfo.getRegionName(),
+        key -> new RegionStateNode(regionInfo, regionInTransition));
       encodedRegionsMap.putIfAbsent(regionInfo.getEncodedName(), node);
       return node;
-    });
+    }
   }
 
   public RegionStateNode getOrCreateRegionStateNode(RegionInfo regionInfo) {
@@ -146,8 +149,10 @@ public class RegionStates {
   }
 
   public void deleteRegion(final RegionInfo regionInfo) {
-    regionsMap.remove(regionInfo.getRegionName());
-    encodedRegionsMap.remove(regionInfo.getEncodedName());
+    synchronized (regionsMapLock) {
+      regionsMap.remove(regionInfo.getRegionName());
+      encodedRegionsMap.remove(regionInfo.getEncodedName());
+    }
     // See HBASE-20860
     // After master restarts, merged regions' RIT state may not be cleaned,
     // making sure they are cleaned here


### PR DESCRIPTION
- `computeIfAbsent` not guaranteed to be applied once atomically. therefore they can have a different value.
- I should acquire a lock before update two maps.