### PR TITLE
HBASE-23967 Improve the accuracy of the method sizeToString

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaSettings.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaSettings.java
@@ -173,12 +173,22 @@ public abstract class QuotaSettings {
   }
 
   protected static String sizeToString(final long size) {
-    if (size >= (1L << 50)) return String.format("%dP", size / (1L << 50));
-    if (size >= (1L << 40)) return String.format("%dT", size / (1L << 40));
-    if (size >= (1L << 30)) return String.format("%dG", size / (1L << 30));
-    if (size >= (1L << 20)) return String.format("%dM", size / (1L << 20));
-    if (size >= (1L << 10)) return String.format("%dK", size / (1L << 10));
-    return String.format("%dB", size);
+    if (size >= (1L << 50)) {
+      return String.format("%.2fP", (double)size / (1L << 50));
+    }
+    if (size >= (1L << 40)) {
+      return String.format("%.2fT", (double)size / (1L << 40));
+    }
+    if (size >= (1L << 30)) {
+      return String.format("%.2fG", (double)size / (1L << 30));
+    }
+    if (size >= (1L << 20)) {
+      return String.format("%.2fM", (double)size / (1L << 20));
+    }
+    if (size >= (1L << 10)) {
+      return String.format("%.2fK", (double)size / (1L << 10));
+    }
+    return String.format("%.2fB", (double)size);
   }
 
   protected static String timeToString(final TimeUnit timeUnit) {


### PR DESCRIPTION
In QuotaSettings，the method of sizeToString reserved integer. But, this is not very accurate.

`hbase(main):001:0> set_quota TYPE => SPACE, TABLE => 't1', LIMIT => '2000G', POLICY => NO_INSERTS
hbase(main):002:0> list_quotas
OWNER                                    QUOTAS                                                                                                              
 TABLE => t1                             TYPE => SPACE, TABLE => t1, LIMIT => 1T, VIOLATION_POLICY => NO_INSERTS                                             
1 row(s) in 0.0340 seconds`

after patch：

`hbase(main):001:0> set_quota TYPE => SPACE, TABLE => 't1', LIMIT => '2000G', POLICY => NO_INSERTS
hbase(main):002:0> list_quotas
OWNER                                    QUOTAS                                                                                                              
TABLE => t1                             TYPE => SPACE, TABLE => t1, LIMIT => 1.95T, VIOLATION_POLICY => NO_INSERTS                                       
1 row(s) in 0.0230 seconds`

