### PR TITLE
HBASE-23930 Shell should attempt to format `timestamp` attributes as …

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/KeyValue.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/KeyValue.java
@@ -26,6 +26,7 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
+import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1217,7 +1218,7 @@ public class KeyValue implements ExtendedCell, Cloneable {
     if (timestamp == HConstants.OLDEST_TIMESTAMP) {
       return "OLDEST_TIMESTAMP";
     }
-    return String.valueOf(timestamp);
+    return Instant.ofEpochMilli(timestamp).toString();
   }
 
   //---------------------------------------------------------------------------

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/KeyValue.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/KeyValue.java
@@ -26,7 +26,6 @@ import java.io.DataOutput;
 import java.io.IOException;
 import java.io.OutputStream;
 import java.nio.ByteBuffer;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -1218,7 +1217,7 @@ public class KeyValue implements ExtendedCell, Cloneable {
     if (timestamp == HConstants.OLDEST_TIMESTAMP) {
       return "OLDEST_TIMESTAMP";
     }
-    return Instant.ofEpochMilli(timestamp).toString();
+    return String.valueOf(timestamp);
   }
 
   //---------------------------------------------------------------------------

--- a/hbase-shell/src/main/ruby/hbase/table.rb
+++ b/hbase-shell/src/main/ruby/hbase/table.rb
@@ -734,14 +734,19 @@ EOF
       [split[0], split.length > 1 ? split[1] : nil]
     end
 
+    def toISO8601(millis)
+      return java.time.Instant.ofEpochMilli(millis).toString
+    end
+
     # Make a String of the passed kv
     # Intercept cells whose format we know such as the info:regioninfo in hbase:meta
     def to_string(column, kv, maxlength = -1, converter_class = nil, converter = nil)
       if is_meta_table?
         if column == 'info:regioninfo' || column == 'info:splitA' || column == 'info:splitB'
           hri = org.apache.hadoop.hbase.HRegionInfo.parseFromOrNull(kv.getValueArray,
-                                                                    kv.getValueOffset, kv.getValueLength)
-          return format('timestamp=%d, value=%s', kv.getTimestamp, hri.nil? ? '' : hri.toString)
+            kv.getValueOffset, kv.getValueLength)
+          return format('timestamp=%s, value=%s', toISO8601(kv.getTimestamp),
+            hri.nil? ? '' : hri.toString)
         end
         if column == 'info:serverstartcode'
           if kv.getValueLength > 0
@@ -751,14 +756,14 @@ EOF
             str_val = org.apache.hadoop.hbase.util.Bytes.toStringBinary(kv.getValueArray,
                                                                         kv.getValueOffset, kv.getValueLength)
           end
-          return format('timestamp=%d, value=%s', kv.getTimestamp, str_val)
+          return format('timestamp=%s, value=%s', toISO8601(kv.getTimestamp), str_val)
         end
       end
 
       if org.apache.hadoop.hbase.CellUtil.isDelete(kv)
-        val = "timestamp=#{kv.getTimestamp}, type=#{org.apache.hadoop.hbase.KeyValue::Type.codeToType(kv.getTypeByte)}"
+        val = "timestamp=#{toISO8601(kv.getTimestamp)}, type=#{org.apache.hadoop.hbase.KeyValue::Type.codeToType(kv.getTypeByte)}"
       else
-        val = "timestamp=#{kv.getTimestamp}, value=#{convert(column, kv, converter_class, converter)}"
+        val = "timestamp=#{toISO8601(kv.getTimestamp)}, value=#{convert(column, kv, converter_class, converter)}"
       end
       maxlength != -1 ? val[0, maxlength] : val
     end


### PR DESCRIPTION
…ISO-8601

Make display of Cell timestamp be ISO8601 format instead of pure
milliseconds.