### PR TITLE
HBASE-23829 Get `-PrunSmallTests` passing on JDK11

### DIFF
--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestFutureUtils.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestFutureUtils.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.util;
 
+import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.CoreMatchers.startsWith;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThat;
@@ -69,7 +70,7 @@ public class TestFutureUtils {
     } catch (HBaseIOException e) {
       assertEquals("Inject error!", e.getMessage());
       StackTraceElement[] elements = e.getStackTrace();
-      assertThat(elements[0].toString(), startsWith("java.lang.Thread.getStackTrace"));
+      assertThat(elements[0].toString(), containsString("java.lang.Thread.getStackTrace"));
       assertThat(elements[1].toString(),
         startsWith("org.apache.hadoop.hbase.util.FutureUtils.setStackTrace"));
       assertThat(elements[2].toString(),

--- a/hbase-hadoop2-compat/pom.xml
+++ b/hbase-hadoop2-compat/pom.xml
@@ -139,6 +139,14 @@ limitations under the License.
       <version>${hadoop.version}</version>
     </dependency>
     <dependency>
+      <!--
+        a missing transitive dependency on JDK9+ (obsoleted by Hadoop-3.3.0+, HADOOP-15775)
+      -->
+      <groupId>javax.activation</groupId>
+      <artifactId>javax.activation-api</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-lang3</artifactId>
     </dependency>

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
@@ -480,7 +480,7 @@ public class TestLogLevel {
     Throwable t = throwable;
     while (t != null) {
       String msg = t.toString();
-      if (msg != null && msg.contains(substr)) {
+      if (msg != null && msg.toLowerCase().contains(substr.toLowerCase())) {
         return;
       }
       t = t.getCause();

--- a/hbase-shaded/hbase-shaded-check-invariants/pom.xml
+++ b/hbase-shaded/hbase-shaded-check-invariants/pom.xml
@@ -88,13 +88,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>extra-enforcer-rules</artifactId>
-            <version>${extra.enforcer.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>enforce-banned-dependencies</id>

--- a/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/pom.xml
+++ b/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/pom.xml
@@ -77,13 +77,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>extra-enforcer-rules</artifactId>
-            <version>${extra.enforcer.version}</version>
-          </dependency>
-        </dependencies>
         <executions>
           <execution>
             <id>enforce-banned-dependencies</id>

--- a/pom.xml
+++ b/pom.xml
@@ -983,6 +983,23 @@
             </execution>
           </executions>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-enforcer-plugin</artifactId>
+          <version>${enforcer.version}</version>
+          <dependencies>
+            <dependency>
+              <groupId>org.codehaus.mojo</groupId>
+              <artifactId>extra-enforcer-rules</artifactId>
+              <version>${extra.enforcer.version}</version>
+            </dependency>
+            <dependency>
+              <groupId>de.skuzzle.enforcer</groupId>
+              <artifactId>restrict-imports-enforcer-rule</artifactId>
+              <version>${restrict-imports.enforcer.version}</version>
+            </dependency>
+          </dependencies>
+        </plugin>
       </plugins>
     </pluginManagement>
     <plugins>
@@ -1021,20 +1038,6 @@
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-enforcer-plugin</artifactId>
-        <version>${enforcer.version}</version>
-        <dependencies>
-          <dependency>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>extra-enforcer-rules</artifactId>
-            <version>${extra.enforcer.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>de.skuzzle.enforcer</groupId>
-            <artifactId>restrict-imports-enforcer-rule</artifactId>
-            <version>${restrict-imports.enforcer.version}</version>
-          </dependency>
-        </dependencies>
-        <!-- version set by parent -->
         <executions>
           <execution>
             <id>hadoop-profile-min-maven-min-java-banned-xerces</id>
@@ -2390,10 +2393,45 @@
       <activation>
         <jdk>[1.11,)</jdk>
       </activation>
-      <dependencyManagement>
-        <dependencies>
-        </dependencies>
-      </dependencyManagement>
+      <properties>
+        <!-- TODO: replicate logic for windows support -->
+        <argLine>--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED ${hbase-surefire.argLine}</argLine>
+      </properties>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>hadoop3-profile-required</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireProperty>
+                      <!--
+                        $ JAVA_HOME=... mvn -Dhadoop.profile=3.0 -PrunSmallTests help:active-profiles enforcer:display-info clean test
+                        enforcer plugin does not see active profiles on sub-modules, so enforce based
+                        on the presence of the activation property and value.
+                      -->
+                      <property>hadoop.profile</property>
+                      <regex>.*3\.0$</regex>
+                      <message>
+                        HBase with JDK11 requires Hadoop3. Activate the profile with `-Dhadoop.profile=3.0`.
+                      </message>
+                      <regexMessage>
+                        HBase with JDK11 requires Hadoop3. Activate the profile with `-Dhadoop.profile=3.0`.
+                      </regexMessage>
+                    </requireProperty>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+        </plugins>
+      </build>
     </profile>
     <!-- profile activated by the Jenkins patch testing job -->
     <profile>
@@ -2867,6 +2905,16 @@
             </exclusions>
           </dependency>
           <dependency>
+            <!--
+              a missing transitive dependency on JDK9+ (obsoleted by Hadoop-3.3.0+, HADOOP-15775)
+              duplicated here because hadoop-3.0 piggy-backs off the hadoop-2.0 profile.
+            -->
+            <groupId>javax.activation</groupId>
+            <artifactId>javax.activation-api</artifactId>
+            <version>1.2.0</version>
+            <scope>test</scope>
+          </dependency>
+          <dependency>
             <groupId>org.apache.hadoop</groupId>
             <artifactId>hadoop-client</artifactId>
             <version>${hadoop-two.version}</version>
@@ -3207,6 +3255,15 @@
                <artifactId>jackson-mapper-asl</artifactId>
              </exclusion>
            </exclusions>
+         </dependency>
+         <dependency>
+           <!--
+             a missing transitive dependency on JDK9+ (obsoleted by Hadoop-3.3.0+, HADOOP-15775)
+           -->
+           <groupId>javax.activation</groupId>
+           <artifactId>javax.activation-api</artifactId>
+           <version>1.2.0</version>
+           <scope>test</scope>
          </dependency>
          <dependency>
            <groupId>org.apache.hadoop</groupId>


### PR DESCRIPTION
Making progress here. `-Dhadoop.profile=3.0` is required. Current issues include:

- `TestBackupSmallTests` fails due to HADOOP-15775.
- can't build vs. Hadoop 3.3.0-SNAPSHOT due to HBASE-23833.