### PR TITLE
HBASE-23833. The relocated hadoop-thirdparty protobuf breaks HBase asyncwal	

### DIFF
--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
@@ -630,6 +630,20 @@ under the License.
   </supplement>
   <supplement>
     <project>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+
+      <licenses>
+        <license>
+          <name>Apache License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </project>
+  </supplement>
+  <supplement>
+    <project>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-client-impl</artifactId>
 

--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
@@ -630,20 +630,6 @@ under the License.
   </supplement>
   <supplement>
     <project>
-      <groupId>org.eclipse.jetty</groupId>
-      <artifactId>jetty-client</artifactId>
-
-      <licenses>
-        <license>
-          <name>Apache License, Version 2.0</name>
-          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </project>
-  </supplement>
-  <supplement>
-    <project>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-client-impl</artifactId>
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/FanOutOneBlockAsyncDFSOutput.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/FanOutOneBlockAsyncDFSOutput.java
@@ -68,7 +68,6 @@ import org.apache.hbase.thirdparty.io.netty.channel.ChannelHandler.Sharable;
 import org.apache.hbase.thirdparty.io.netty.channel.ChannelHandlerContext;
 import org.apache.hbase.thirdparty.io.netty.channel.ChannelId;
 import org.apache.hbase.thirdparty.io.netty.channel.SimpleChannelInboundHandler;
-import org.apache.hbase.thirdparty.io.netty.handler.codec.protobuf.ProtobufDecoder;
 import org.apache.hbase.thirdparty.io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
 import org.apache.hbase.thirdparty.io.netty.handler.timeout.IdleStateEvent;
 import org.apache.hbase.thirdparty.io.netty.handler.timeout.IdleStateHandler;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/FanOutOneBlockAsyncDFSOutputHelper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/FanOutOneBlockAsyncDFSOutputHelper.java
@@ -101,7 +101,6 @@ import org.apache.hbase.thirdparty.io.netty.channel.ChannelPipeline;
 import org.apache.hbase.thirdparty.io.netty.channel.EventLoop;
 import org.apache.hbase.thirdparty.io.netty.channel.EventLoopGroup;
 import org.apache.hbase.thirdparty.io.netty.channel.SimpleChannelInboundHandler;
-import org.apache.hbase.thirdparty.io.netty.handler.codec.protobuf.ProtobufDecoder;
 import org.apache.hbase.thirdparty.io.netty.handler.codec.protobuf.ProtobufVarint32FrameDecoder;
 import org.apache.hbase.thirdparty.io.netty.handler.timeout.IdleStateEvent;
 import org.apache.hbase.thirdparty.io.netty.handler.timeout.IdleStateHandler;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/FanOutOneBlockAsyncDFSOutputSaslHelper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/FanOutOneBlockAsyncDFSOutputSaslHelper.java
@@ -378,9 +378,10 @@ public final class FanOutOneBlockAsyncDFSOutputSaslHelper {
           // byteStringObject = new LiteralByteString(payload);
           byteStringObject = constructor.newInstance(payload);
           // builder.setPayload(byteStringObject);
-          setPayloadMethod.invoke(builder, byteStringObject);
+          setPayloadMethod.invoke(builder, constructor.getDeclaringClass().cast(byteStringObject));
         } catch (IllegalAccessException | InstantiationException e) {
           throw new RuntimeException(e);
+
         } catch (InvocationTargetException e) {
           Throwables.propagateIfPossible(e.getTargetException(), IOException.class);
           throw new RuntimeException(e.getTargetException());
@@ -406,7 +407,7 @@ public final class FanOutOneBlockAsyncDFSOutputSaslHelper {
         Class<?> literalByteStringClass;
         try {
           literalByteStringClass = Class.forName(
-            "org.apache.hadoop.thirdparty.protobuf.LiteralByteString");
+            "org.apache.hadoop.thirdparty.protobuf.ByteString$LiteralByteString");
           LOG.debug("Shaded LiteralByteString from hadoop-thirdparty is found.");
         } catch (ClassNotFoundException e) {
           try {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/ProtobufDecoder.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/asyncfs/ProtobufDecoder.java
@@ -1,0 +1,116 @@
+package org.apache.hadoop.hbase.io.asyncfs;
+
+import org.apache.hbase.thirdparty.io.netty.buffer.ByteBuf;
+import org.apache.hbase.thirdparty.io.netty.buffer.ByteBufUtil;
+import org.apache.hbase.thirdparty.io.netty.channel.ChannelHandlerContext;
+import org.apache.hbase.thirdparty.io.netty.handler.codec.MessageToMessageDecoder;
+import org.apache.hbase.thirdparty.io.netty.util.internal.ObjectUtil;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import java.util.List;
+
+/** Modified based on io.netty.handler.codec.protobuf.ProtobufDecoder */
+@InterfaceAudience.Private
+public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
+  private static final Logger LOG =
+    LoggerFactory.getLogger(ProtobufDecoder.class);
+
+  private static Class<?> shadedHadoopProtobufMessageLite = null;
+  private static final boolean HAS_PARSER;
+  private Object prototype;
+
+  private static Method getParserForTypeMethod;
+  private static Method newBuilderForTypeMethod;
+
+  private Method parseFromMethod;
+  private Method mergeFromMethod;
+
+  private Object parser;
+  private Object builder;
+
+
+  public ProtobufDecoder(Object prototype) {
+    try {
+      Method getDefaultInstanceForTypeMethod = shadedHadoopProtobufMessageLite.getMethod("getDefaultInstanceForType");
+      this.prototype = getDefaultInstanceForTypeMethod.invoke(ObjectUtil.checkNotNull(prototype, "prototype"));
+
+      parser = getParserForTypeMethod.invoke(this.prototype);
+      parseFromMethod = parser.getClass().getMethod("parseFrom", byte[].class, int.class, int.class);
+
+      builder = newBuilderForTypeMethod.invoke(this.prototype);
+      mergeFromMethod = builder.getClass().getMethod("mergeFrom", byte[].class, int.class, int.class);
+
+    } catch (IllegalAccessException e) {
+      e.printStackTrace();
+    } catch (InvocationTargetException e) {
+      e.printStackTrace();
+    } catch (NoSuchMethodException e) {
+      e.printStackTrace();
+    }
+
+  }
+
+  protected void decode(
+    ChannelHandlerContext ctx, ByteBuf msg, List<Object> out) throws Exception {
+    int length = msg.readableBytes();
+    byte[] array;
+    int offset;
+    if (msg.hasArray()) {
+      array = msg.array();
+      offset = msg.arrayOffset() + msg.readerIndex();
+    } else {
+      array = ByteBufUtil.getBytes(msg, msg.readerIndex(), length, false);
+      offset = 0;
+    }
+
+    Object addObj;
+    if (HAS_PARSER) {
+      addObj = parseFromMethod.invoke(parser, array, offset, length);
+    } else {
+      Object builderObj = mergeFromMethod.invoke(builder, array, offset, length);
+      Method buildMethod = builderObj.getClass().getDeclaredMethod("build");
+      addObj = buildMethod.invoke(builderObj);
+    }
+    out.add(addObj);
+  }
+
+  static {
+    boolean hasParser = false;
+
+    try {
+      shadedHadoopProtobufMessageLite = Class.forName("org.apache.hadoop.thirdparty.protobuf.MessageLite");
+      LOG.debug("Hadoop 3.3 and above shades protobuf.");
+    } catch (ClassNotFoundException e) {
+      e.printStackTrace();
+    }
+
+    if (shadedHadoopProtobufMessageLite == null) {
+      shadedHadoopProtobufMessageLite = com.google.protobuf.MessageLite.class;
+      LOG.debug("Hadoop 3.2 and below use unshaded protobuf.");
+    }
+
+    try {
+      getParserForTypeMethod = shadedHadoopProtobufMessageLite.getDeclaredMethod("getParserForType");
+    } catch (NoSuchMethodException e) {
+      e.printStackTrace();
+    }
+
+    try {
+      newBuilderForTypeMethod = shadedHadoopProtobufMessageLite.getDeclaredMethod("newBuilderForType");
+    } catch (NoSuchMethodException e) {
+      e.printStackTrace();
+    }
+
+    try {
+      shadedHadoopProtobufMessageLite.getDeclaredMethod("getParserForType");
+      hasParser = true;
+    } catch (Throwable var2) {
+    }
+
+    HAS_PARSER = hasParser;
+  }
+}


### PR DESCRIPTION
I've tried a few approaches. It turns out the quickest solution to this is with Java Reflection.

(1) Create a ProtobufDecoder that is inspired by io.netty.handler.codec.protobuf.ProtobufDecoder. The original ProtobufDecoder has dependency on protobuf. Use reflection to access the shaded protobuf in HDFS when applicable.

(2) Similarly, create a private class BuilderPayloadSetter that does ByteString.copyFrom() + DataTransferEncryptorMessageProto.Builder.setPayload().

Manually tested with Hadoop 3.1.2 and 3.3.0-SNAPSHOT (on top of HBASE-22103 and HBASE-23998 and set jetty.version=9.4.20)

Please let me know if this is the acceptable approach.