### PR TITLE
HBASE-24019: Correct exception messages for table null and namespace unavailable.

### DIFF
--- a/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupAdminEndpoint.java
+++ b/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupAdminEndpoint.java
@@ -491,7 +491,7 @@ public class RSGroupAdminEndpoint implements MasterCoprocessor, MasterObserver {
                                  NamespaceDescriptor ns) throws IOException {
     String group = ns.getConfigurationValue(RSGroupInfo.NAMESPACE_DESC_PROP_GROUP);
     if(group != null && groupAdminServer.getRSGroupInfo(group) == null) {
-      throw new ConstraintException("Region server group "+group+" does not exit");
+      throw new ConstraintException("Region server group "+group+" does not exist.");
     }
   }
 

--- a/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupAdminEndpoint.java
+++ b/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupAdminEndpoint.java
@@ -491,7 +491,7 @@ public class RSGroupAdminEndpoint implements MasterCoprocessor, MasterObserver {
                                  NamespaceDescriptor ns) throws IOException {
     String group = ns.getConfigurationValue(RSGroupInfo.NAMESPACE_DESC_PROP_GROUP);
     if(group != null && groupAdminServer.getRSGroupInfo(group) == null) {
-      throw new ConstraintException("Region server group "+group+" does not exist.");
+      throw new ConstraintException("Region server group " + group + " does not exist.");
     }
   }
 

--- a/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupAdminServer.java
+++ b/hbase-rsgroup/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupAdminServer.java
@@ -329,7 +329,7 @@ public class RSGroupAdminServer implements RSGroupAdmin {
   @Override
   public void moveTables(Set<TableName> tables, String targetGroup) throws IOException {
     if (tables == null) {
-      throw new ConstraintException("The list of servers cannot be null.");
+      throw new ConstraintException("The list of tables cannot be null.");
     }
     if (tables.size() < 1) {
       LOG.debug("moveTables() passed an empty set. Ignoring.");


### PR DESCRIPTION
HBASE-24019: Correct exception messages for table null and namespace unavailable.