### PR TITLE
HBASE-24034 [Flakey Tests] A couple of fixes and cleanups

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionUtils.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionUtils.java
@@ -643,7 +643,7 @@ public final class ConnectionUtils {
       }
       LOG.trace("{} cache is null, try fetching from registry", type);
       if (futureRef.compareAndSet(null, new CompletableFuture<>())) {
-        LOG.debug("Start fetching{} from registry", type);
+        LOG.debug("Start fetching {} from registry", type);
         CompletableFuture<T> future = futureRef.get();
         addListener(fetch.get(), (value, error) -> {
           if (error != null) {

--- a/hbase-rsgroup/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupMajorCompactionTTL.java
+++ b/hbase-rsgroup/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupMajorCompactionTTL.java
@@ -88,8 +88,6 @@ public class TestRSGroupMajorCompactionTTL extends TestMajorCompactorTTL {
     for (TableName tableName : tableNames) {
       int numberOfRegions = admin.getRegions(tableName).size();
       int numHFiles = utility.getNumHFiles(tableName, FAMILY);
-      // we should have a table with more store files than we would before we major compacted.
-      assertTrue(numberOfRegions < numHFiles);
       modifyTTL(tableName);
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/HFileCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/HFileCleaner.java
@@ -101,7 +101,7 @@ public class HFileCleaner extends CleanerChore<BaseHFileCleanerDelegate>
   private long cleanerThreadTimeoutMsec;
   private long cleanerThreadCheckIntervalMsec;
   private List<Thread> threads = new ArrayList<Thread>();
-  private boolean running;
+  private volatile boolean running;
 
   private AtomicLong deletedLargeFiles = new AtomicLong();
   private AtomicLong deletedSmallFiles = new AtomicLong();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
@@ -434,11 +434,11 @@ public class TestAsyncRegionAdminApi extends TestAsyncAdminBase {
     } else {
       int singleFamDiff = countBeforeSingleFamily - countAfterSingleFamily;
       // assert only change was to single column family
-      assertTrue(singleFamDiff == (countBefore - countAfter));
+      assertEquals(singleFamDiff, (countBefore - countAfter));
       if (expectedState == CompactionState.MAJOR) {
-        assertTrue(1 == countAfterSingleFamily);
+        assertEquals(1, countAfterSingleFamily);
       } else {
-        assertTrue(1 < countAfterSingleFamily);
+        assertTrue("" + countAfterSingleFamily, 1 <= countAfterSingleFamily);
       }
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestBlockEvictionFromClient.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestBlockEvictionFromClient.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
@@ -583,11 +584,17 @@ public class TestBlockEvictionFromClient {
       region.flush(true);
       ServerName rs = Iterables.getOnlyElement(TEST_UTIL.getAdmin().getRegionServers());
       int regionCount = TEST_UTIL.getAdmin().getRegions(rs).size();
-      LOG.info("About to SPLIT on {} {}", Bytes.toString(ROW1), region.getRegionInfo());
+      LOG.info("About to SPLIT on {} {}, count={}", Bytes.toString(ROW1), region.getRegionInfo(),
+        regionCount);
       TEST_UTIL.getAdmin().split(tableName, ROW1);
       // Wait for splits
       TEST_UTIL.waitFor(60000, () -> TEST_UTIL.getAdmin().getRegions(rs).size() > regionCount);
-      LOG.info("Split finished, is region closed {}", region.isClosed());
+      List<HRegion> regions = TEST_UTIL.getMiniHBaseCluster().getRegionServer(rs).getRegions();
+      for (HRegion r: regions) {
+        LOG.info("" + r.getCompactionState());
+        TEST_UTIL.waitFor(30000, () -> r.getCompactionState().equals(CompactionState.NONE));
+      }
+      LOG.info("Split finished, is region closed {} {}", region.isClosed(), cache);
       Iterator<CachedBlock> iterator = cache.iterator();
       // Though the split had created the HalfStorefileReader - the firstkey and lastkey scanners
       // should be closed inorder to return those blocks
@@ -1189,11 +1196,11 @@ public class TestBlockEvictionFromClient {
       CachedBlock next = iterator.next();
       BlockCacheKey cacheKey = new BlockCacheKey(next.getFilename(), next.getOffset());
       if (cache instanceof BucketCache) {
-        LOG.info("BucketCache {}", cacheKey);
         refCount = ((BucketCache) cache).getRpcRefCount(cacheKey);
+        LOG.info("BucketCache {} {}", cacheKey, refCount);
       } else if (cache instanceof CombinedBlockCache) {
-        LOG.info("CombinedBlockCache {}", cacheKey);
         refCount = ((CombinedBlockCache) cache).getRpcRefCount(cacheKey);
+        LOG.info("CombinedBlockCache {} {}", cacheKey, refCount);
       } else {
         continue;
       }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterShutdown.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterShutdown.java
@@ -85,8 +85,8 @@ public class TestMasterShutdown {
       htu = new HBaseTestingUtility(conf);
       StartMiniClusterOption option = StartMiniClusterOption.builder()
         .numMasters(3)
-        .numRegionServers(3)
-        .numDataNodes(3)
+        .numRegionServers(1)
+        .numDataNodes(1)
         .build();
       final MiniHBaseCluster cluster = htu.startMiniCluster(option);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestDefaultLoadBalancer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestDefaultLoadBalancer.java
@@ -129,17 +129,16 @@ public class TestDefaultLoadBalancer extends BalancerTestBase {
    *
    * Invariant is that all servers should be hosting either floor(average) or
    * ceiling(average) at both table level and cluster level
-   *
-   * @throws Exception
    */
   @Test
   public void testBalanceClusterOverall() throws Exception {
     Map<TableName, Map<ServerName, List<RegionInfo>>> clusterLoad = new TreeMap<>();
     for (int[] mockCluster : clusterStateMocks) {
-      Map<ServerName, List<RegionInfo>> clusterServers = mockClusterServers(mockCluster, 50);
+      Map<ServerName, List<RegionInfo>> clusterServers = mockClusterServers(mockCluster, 30);
       List<ServerAndLoad> clusterList = convertToList(clusterServers);
       clusterLoad.put(TableName.valueOf(name.getMethodName()), clusterServers);
-      HashMap<TableName, TreeMap<ServerName, List<RegionInfo>>> result = mockClusterServersWithTables(clusterServers);
+      HashMap<TableName, TreeMap<ServerName, List<RegionInfo>>> result =
+        mockClusterServersWithTables(clusterServers);
       loadBalancer.setClusterLoad(clusterLoad);
       List<RegionPlan> clusterplans = new ArrayList<>();
       List<Pair<TableName, Integer>> regionAmountList = new ArrayList<>();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEndToEndSplitTransaction.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEndToEndSplitTransaction.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -42,6 +41,7 @@ import org.apache.hadoop.hbase.NotServingRegionException;
 import org.apache.hadoop.hbase.ScheduledChore;
 import org.apache.hadoop.hbase.Stoppable;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Connection;
@@ -69,7 +69,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hbase.thirdparty.com.google.common.collect.Iterators;
 import org.apache.hbase.thirdparty.com.google.common.collect.Maps;
 import org.apache.hbase.thirdparty.com.google.common.io.Closeables;
@@ -402,6 +401,17 @@ public class TestEndToEndSplitTransaction {
   public static void compactAndBlockUntilDone(Admin admin, HRegionServer rs, byte[] regionName)
       throws IOException, InterruptedException {
     log("Compacting region: " + Bytes.toStringBinary(regionName));
+    // Wait till its online before we do compact else it comes back with NoServerForRegionException
+    try {
+      TEST_UTIL.waitFor(10000, new Waiter.Predicate<Exception>() {
+        @Override public boolean evaluate() throws Exception {
+          return rs.getServerName().equals(MetaTableAccessor.
+            getRegionLocation(admin.getConnection(), regionName).getServerName());
+        }
+      });
+    } catch (Exception e) {
+      throw new IOException(e);
+    }
     admin.majorCompactRegion(regionName);
     log("blocking until compaction is complete: " + Bytes.toStringBinary(regionName));
     Threads.sleepWithoutInterrupt(500);


### PR DESCRIPTION
hbase-rsgroup/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupMajorCompactionTTL.java
 Remove spurious assert. Just before this it waits an arbitrary 10
 seconds. Compactions could have completed inside this time. The spirit
 of the test remains.

hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/HFileCleaner.java
 Get log cleaner to go down promptly; its sticking around. See if this
 helps with TestMasterShutdown

hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/FSHLog.java
 We get a rare NPE trying to sync. Make local copy of SyncFuture and see
 if that helps.

hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
 Compaction  may have completed when not expected; allow for it.

hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestBlockEvictionFromClient.java
 Add wait before testing. Compaction may not have completed. Let
 compaction complete before progressing and then test for empty cache.

hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterShutdown.java
 Less resources.

hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestDefaultLoadBalancer.java
 Less resources.

hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEndToEndSplitTransaction.java
 Wait till online before we try and do compaction (else request is
 ignored)

hbase-server/src/test/java/org/apache/hadoop/hbase/tool/TestCanaryTool.java
 Disable test that fails randomly w/ mockito complaint on some mac os
 x's.