### PR TITLE
Backport "HBASE-24002 shadedjars check does not propagate --hadoop-profile" to branch-2

### DIFF
--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -463,13 +463,17 @@ function shadedjars_rebuild
 
   start_clock
 
+  local -a maven_args=('clean' 'verify' '-fae' '--batch-mode'
+    '-pl' 'hbase-shaded/hbase-shaded-check-invariants' '-am'
+    '-Dtest=NoUnitTests' '-DHBasePatchProcess' '-Prelease'
+    '-Dmaven.javadoc.skip=true' '-Dcheckstyle.skip=true' '-Dspotbugs.skip=true')
+  if [[ -n "${HADOOP_PROFILE}" ]]; then
+    maven_args+=("-Dhadoop.profile=${HADOOP_PROFILE}")
+  fi
+
   # disabled because "maven_executor" needs to return both command and args
   # shellcheck disable=2046
-  echo_and_redirect "${logfile}" \
-    $(maven_executor) clean verify -fae --batch-mode \
-      -pl hbase-shaded/hbase-shaded-check-invariants -am \
-      -Dtest=NoUnitTests -DHBasePatchProcess -Prelease \
-      -Dmaven.javadoc.skip=true -Dcheckstyle.skip=true -Dspotbugs.skip=true
+  echo_and_redirect "${logfile}" $(maven_executor) "${maven_args[@]}"
 
   count=$(${GREP} -c '\[ERROR\]' "${logfile}")
   if [[ ${count} -gt 0 ]]; then


### PR DESCRIPTION
This implementation is almost surely incorrect. Personality
initialization parses the `--hadoop-profile` argument and sets
`HADOOP_PROFILE`. That value is then used to build an `extras` value
that is passed  along to module initialization. I'm guessing that the
`extras` value need to be honored down in the shadedjars module. I'm
not clear on how to make that work (need to study the interfaces at
play here), so taking the more ham-handed approach of referring to
`HADOOP_PROFILE`. I'm not sure if this will even work, or if it will
only work because the `foo_yetus.sh` scripts happen to use a variable
of the same name.

Signed-off-by: Jan Hentschel <jan.hentschel@ultratendency.com>
Signed-off-by: stack <stack@apache.org>