### PR TITLE
HBASE-24065 Enable SpotBugs in PreCommit

### DIFF
--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -46,6 +46,7 @@ pipeline {
         TESTS_FILTER = 'cc,checkstyle,javac,javadoc,pylint,shellcheck,whitespace,perlcritic,ruby-lint,rubocop,mvnsite'
         EXCLUDE_TESTS_URL = "${JENKINS_URL}/job/HBase-Find-Flaky-Tests/job/${CHANGE_TARGET}/lastSuccessfulBuild/artifact/excludes"
 
+        ////
         // a global view of paths. parallel stages can land on the same host concurrently, so each
         // stage works in its own subdirectory. there is an "output" under each of these
         // directories, which we retrieve after the build is complete.
@@ -70,11 +71,15 @@ pipeline {
                         }
                     }
                     environment {
+                        ////
                         // customized per parallel stage
+                        //
                         PLUGINS = "${GENERAL_CHECK_PLUGINS}"
                         SET_JAVA_HOME = '/usr/lib/jvm/java-8'
                         WORKDIR_REL = "${WORKDIR_REL_GENERAL_CHECK}"
+                        ////
                         // identical for all parallel stages
+                        //
                         WORKDIR = "${WORKSPACE}/${WORKDIR_REL}"
                         YETUSDIR = "${WORKDIR}/${YETUS_REL}"
                         SOURCEDIR = "${WORKDIR}/${SRC_REL}"
@@ -156,11 +161,16 @@ pipeline {
                         }
                     }
                     environment {
+                        ////
                         // customized per parallel stage
-                        PLUGINS = "${JDK_SPECIFIC_PLUGINS}"
+                        //
+                        // run SpotBugs only once, and run it on JDK8.
+                        PLUGINS = "${JDK_SPECIFIC_PLUGINS},spotbugs"
                         SET_JAVA_HOME = '/usr/lib/jvm/java-8'
                         WORKDIR_REL = "${WORKDIR_REL_JDK8_HADOOP2_CHECK}"
+                        ////
                         // identical for all parallel stages
+                        //
                         WORKDIR = "${WORKSPACE}/${WORKDIR_REL}"
                         YETUSDIR = "${WORKDIR}/${YETUS_REL}"
                         SOURCEDIR = "${WORKDIR}/${SRC_REL}"
@@ -256,14 +266,18 @@ pipeline {
                         }
                     }
                     environment {
+                        ////
                         // customized per parallel stage
+                        //
                         PLUGINS = "${JDK_SPECIFIC_PLUGINS}"
                         SET_JAVA_HOME = '/usr/lib/jvm/java-11'
                         HADOOP_PROFILE = '3.0'
                         WORKDIR_REL = "${WORKDIR_REL_JDK11_HADOOP3_CHECK}"
                         // vote -0 on JDK11 unit failures until HBASE-22972
                         TESTS_FILTER = "${TESTS_FILTER},unit"
+                        ////
                         // identical for all parallel stages
+                        //
                         WORKDIR = "${WORKSPACE}/${WORKDIR_REL}"
                         YETUSDIR = "${WORKDIR}/${YETUS_REL}"
                         SOURCEDIR = "${WORKDIR}/${SRC_REL}"

--- a/dev-support/jenkins_precommit_github_yetus.sh
+++ b/dev-support/jenkins_precommit_github_yetus.sh
@@ -111,7 +111,7 @@ YETUS_ARGS+=("--archive-list=${ARCHIVE_PATTERN_LIST}")
 # URL for user-side presentation in reports and such to our artifacts
 YETUS_ARGS+=("--build-url-artifacts=${BUILD_URL_ARTIFACTS}")
 # plugins to enable
-YETUS_ARGS+=("--plugins=${PLUGINS},-findbugs")
+YETUS_ARGS+=("--plugins=${PLUGINS}")
 # run in docker mode and specifically point to our
 # Dockerfile since we don't want to use the auto-pulled version.
 YETUS_ARGS+=("--docker")

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -246,6 +246,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProto
 @SuppressWarnings({ "deprecation"})
 public class HRegionServer extends HasThread implements
     RegionServerServices, LastSequenceId, ConfigurationObserver {
+  // tickle build
   private static final Logger LOG = LoggerFactory.getLogger(HRegionServer.class);
 
   /**


### PR DESCRIPTION
Yetus's SpotBugs module depends on `maven_add_install`. In
`Jenkinsfile_GitHub`, I'm pretty strict on my module definitions, with

```
GENERAL_CHECK_PLUGINS = 'all,-compile,-javac,-javadoc,-jira,-shadedjars,-unit'
JDK_SPECIFIC_PLUGINS = 'compile,github,htmlout,javac,javadoc,maven,mvninstall,shadedjars,unit'
```

The general check requests all but omits `compile` and `maven`, which
I think means the `spotbugs` check gets dropped. Before HBASE-23767,
we had just a single yetus that did all, so spotbugs would have been
run.