### PR TITLE
HBASE-24066 Let HBase master UI act as a maven repo

### DIFF
--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -142,6 +142,7 @@
               <includes>**\/NOTICE,**\/NOTICE.txt</includes>
             </configuration>
           </execution>
+          <!-- Create a mini Maven repository so that the Master UI can serve these jars like a Maven repo -->
           <execution>
             <id>prepare-shaded-client-repo</id>
             <phase>package</phase>

--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -142,6 +142,19 @@
               <includes>**\/NOTICE,**\/NOTICE.txt</includes>
             </configuration>
           </execution>
+          <execution>
+            <id>prepare-shaded-client-repo</id>
+            <phase>package</phase>
+            <goals>
+              <goal>copy-dependencies</goal>
+            </goals>
+            <configuration>
+              <includeArtifactIds>hbase-shaded-client,hbase-shaded-client-byo-hadoop,hbase-shaded-mapreduce,hbase-shaded-testing-util</includeArtifactIds>
+              <outputDirectory>${project.build.directory}/maven-repo</outputDirectory>
+              <overWriteIfNewer>true</overWriteIfNewer>
+              <useRepositoryLayout>true</useRepositoryLayout>
+            </configuration>
+           </execution>
         </executions>
       </plugin>
       <plugin>

--- a/hbase-assembly/src/main/assembly/components.xml
+++ b/hbase-assembly/src/main/assembly/components.xml
@@ -168,5 +168,11 @@
       </includes>
       <fileMode>0644</fileMode>
     </fileSet>
+    <fileSet>
+      <directory>${project.build.directory}/maven-repo</directory>
+      <outputDirectory>hbase-webapps/maven-repo</outputDirectory>
+      <fileMode>0644</fileMode>
+      <directoryMode>0755</directoryMode>
+    </fileSet>
   </fileSets>
 </component>

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -728,6 +728,7 @@ public class HttpServer implements FilterContainer {
       LOG.info("ASYNC_PROFILER_HOME environment variable and async.profiler.home system property " +
         "not specified. Disabling /prof endpoint.");
     }
+    addUnprivilegedServlet("versoin", "/version", VersionServlet.class);
   }
 
   /**

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -728,7 +728,7 @@ public class HttpServer implements FilterContainer {
       LOG.info("ASYNC_PROFILER_HOME environment variable and async.profiler.home system property " +
         "not specified. Disabling /prof endpoint.");
     }
-    addUnprivilegedServlet("versoin", "/version", VersionServlet.class);
+    addUnprivilegedServlet("version", "/version", VersionServlet.class);
   }
 
   /**

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/VersionServlet.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/VersionServlet.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.http;
+
+import java.io.IOException;
+
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+
+import org.apache.hadoop.hbase.util.VersionInfo;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Servlet which returns the HBase version.
+ */
+@InterfaceAudience.Private
+public class VersionServlet extends HttpServlet {
+
+  private static final long serialVersionUID = 1L;
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    response.setContentType("text/plain");
+    response.getWriter().append(VersionInfo.getVersion());
+  }
+}


### PR DESCRIPTION
Advertise the version of HBase over the web UI and have a well-known
location from which users can pull shaded client jars from.

Rooted against branch-2.2, but that's just what I was working against when hacking this together. Intention would be for master, and any 2.x branches which want it.