### PR TITLE
HBASE-24057 Add modules to mapreduce job classpaths

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java
@@ -811,22 +811,25 @@ public class TableMapReduceUtil {
       org.apache.hadoop.hbase.ipc.RpcServer.class,                   // hbase-server
       org.apache.hadoop.hbase.CompatibilityFactory.class,            // hbase-hadoop-compat
       org.apache.hadoop.hbase.mapreduce.JobUtil.class,               // hbase-hadoop2-compat
-      org.apache.hadoop.hbase.mapreduce.TableMapper.class,           // hbase-server
+      org.apache.hadoop.hbase.mapreduce.TableMapper.class,           // hbase-mapreduce
       org.apache.hadoop.hbase.metrics.impl.FastLongHistogram.class,  // hbase-metrics
       org.apache.hadoop.hbase.metrics.Snapshot.class,                // hbase-metrics-api
+      org.apache.hadoop.hbase.replication.ReplicationUtils.class,    // hbase-replication
+      org.apache.hadoop.hbase.http.HttpServer.class,                 // hbase-http
+      org.apache.hadoop.hbase.procedure2.Procedure.class,            // hbase-procedure
+      org.apache.hadoop.hbase.zookeeper.ZKWatcher.class,             // hbase-zookeeper
+      org.apache.hbase.thirdparty.com.google.common.collect.Lists.class, // hb-shaded-miscellaneous
       org.apache.hbase.thirdparty.com.google.gson.GsonBuilder.class, // hbase-shaded-gson
-      org.apache.zookeeper.ZooKeeper.class,
-      org.apache.hbase.thirdparty.io.netty.channel.Channel.class,
-      com.google.protobuf.Message.class,
-      org.apache.hbase.thirdparty.com.google.protobuf.UnsafeByteOperations.class,
-      org.apache.hbase.thirdparty.com.google.common.collect.Lists.class,
-      org.apache.htrace.core.Tracer.class,
-      com.codahale.metrics.MetricRegistry.class,
-      org.apache.commons.lang3.ArrayUtils.class,
-      com.fasterxml.jackson.databind.ObjectMapper.class,
-      com.fasterxml.jackson.core.Versioned.class,
-      com.fasterxml.jackson.annotation.JsonView.class,
-      org.apache.hadoop.hbase.zookeeper.ZKWatcher.class);
+      org.apache.hbase.thirdparty.com.google.protobuf.UnsafeByteOperations.class, // hb-sh-protobuf
+      org.apache.hbase.thirdparty.io.netty.channel.Channel.class,    // hbase-shaded-netty
+      com.fasterxml.jackson.databind.ObjectMapper.class,             // jackson-databind
+      com.fasterxml.jackson.core.Versioned.class,                    // jackson-core
+      com.fasterxml.jackson.annotation.JsonView.class,               // jackson-annotations
+      org.apache.zookeeper.ZooKeeper.class,                          // zookeeper
+      com.google.protobuf.Message.class,                             // protobuf
+      org.apache.htrace.core.Tracer.class,                           // htrace
+      com.codahale.metrics.MetricRegistry.class,                     // metrics-core
+      org.apache.commons.lang3.ArrayUtils.class);                    // commons-lang
   }
 
   /**


### PR DESCRIPTION
Branch-2.1 did not move to thirdparty GSON in HBASE-20587 so Jackson dependencies need to stay. 