### PR TITLE
Backport "HBASE-24007 Get `-PrunLargeTests` passing on JDK11 (#1351)" to branch-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1422,7 +1422,10 @@
     <test.output.tofile>true</test.output.tofile>
     <surefire.timeout>900</surefire.timeout>
     <test.exclude.pattern></test.exclude.pattern>
-    <!-- default Xmx value is 2800m. Use -Dsurefire.Xmx=xxg to run tests with different JVM Xmx value -->
+    <!--
+      default Xmx value is 2800m. Use -Dsurefire.Xmx=xxg to run tests with different JVM Xmx value.
+      this value is managed separately for jdk11.
+    -->
     <surefire.Xmx>2800m</surefire.Xmx>
     <surefire.cygwinXmx>2800m</surefire.cygwinXmx>
     <!--Mark our test runs with '-Dhbase.build.id' so we can identify a surefire test as ours in a process listing
@@ -2236,6 +2239,15 @@
       <properties>
         <!-- TODO: replicate logic for windows support -->
         <argLine>--add-opens=java.base/jdk.internal.ref=ALL-UNNAMED ${hbase-surefire.argLine}</argLine>
+        <!-- We need a minimum HDFS version of 3.2.0 for HADOOP-12760 -->
+        <hadoop-three.version>3.2.0</hadoop-three.version>
+        <!--
+          JDK11 appears to consume more heap than JDK8 does; OOME are more common in
+          -PrunLargeTests on this platform. Bump up heap allocated to tests (current default for
+          JDK8 is 2800m.
+          TODO: replicate logic for windows
+        -->
+        <surefire.Xmx>3200m</surefire.Xmx>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
Minor tweaks required to get passing runs of `-PrunLargeTests`.
* Minimum Hadoop version is 3.2.0 due to
  [HADOOP-12760](https://issues.apache.org/jira/browse/HADOOP-12760).
* JDK11 looks like it consumes more memory than JDK8, so failures due
  to OOME see more common here. Bumping heap allocated to surefire
  forks allows better pass rate.

Signed-off-by: Jan Hentschel <jan.hentschel@ultratendency.com>