### PR TITLE
Backport HBASE-20467 and HBASE-24078 to branch-2.3

### DIFF
--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -153,7 +153,8 @@ function personality_modules
   # If BUILDMODE is 'patch', for unit and compile testtypes, there is no need to run individual
   # modules if root is included. HBASE-18505
   if [[ "${BUILDMODE}" == "full" ]] || \
-     [[ ( "${testtype}" == unit || "${testtype}" == compile ) && "${MODULES[*]}" =~ \. ]]; then
+     ( ( [[ "${testtype}" == unit ]] || [[ "${testtype}" == compile ]] || [[ "${testtype}" == checkstyle ]] ) && \
+     [[ "${MODULES[*]}" =~ \. ]] ); then
     MODULES=(.)
   fi
 


### PR DESCRIPTION
* HBASE-20467 Precommit personality should only run checkstyle once if we're going to run it at the root.
* HBASE-24078 SpotBugs check automatically skip inapplicable modules

HBASE-20467 is a good thing to have for PR builds, and is a prerequisite of the checkstyle cleanup performed in HBASE-24078.