### PR TITLE
HBASE-24051 Allows indirect inheritance to CanUnbuffer

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/FSDataInputStreamWrapper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/FSDataInputStreamWrapper.java
@@ -25,6 +25,7 @@ import java.lang.reflect.Method;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.commons.io.IOUtils;
+import org.apache.hadoop.fs.CanUnbuffer;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -331,22 +332,18 @@ public class FSDataInputStreamWrapper implements Closeable {
       if (this.instanceOfCanUnbuffer == null) {
         // To ensure we compute whether the stream is instance of CanUnbuffer only once.
         this.instanceOfCanUnbuffer = false;
-        Class<?>[] streamInterfaces = streamClass.getInterfaces();
-        for (Class c : streamInterfaces) {
-          if (c.getCanonicalName().toString().equals("org.apache.hadoop.fs.CanUnbuffer")) {
-            try {
-              this.unbuffer = streamClass.getDeclaredMethod("unbuffer");
-            } catch (NoSuchMethodException | SecurityException e) {
-              if (isLogTraceEnabled) {
-                LOG.trace("Failed to find 'unbuffer' method in class " + streamClass
-                    + " . So there may be a TCP socket connection "
-                    + "left open in CLOSE_WAIT state.", e);
-              }
-              return;
+        if(wrappedStream instanceof CanUnbuffer){
+          try {
+            this.unbuffer = streamClass.getDeclaredMethod("unbuffer");
+          } catch (NoSuchMethodException | SecurityException e) {
+            if (isLogTraceEnabled) {
+              LOG.trace("Failed to find 'unbuffer' method in class " + streamClass
+                      + " . So there may be a TCP socket connection "
+                      + "left open in CLOSE_WAIT state.", e);
             }
-            this.instanceOfCanUnbuffer = true;
-            break;
+            return;
           }
+          this.instanceOfCanUnbuffer = true;
         }
       }
       if (this.instanceOfCanUnbuffer) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/TestFSDataInputStreamWrapper.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/TestFSDataInputStreamWrapper.java
@@ -1,0 +1,60 @@
+package org.apache.hadoop.hbase.io;
+
+import org.apache.hadoop.fs.CanUnbuffer;
+import org.junit.Assert;
+import org.junit.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.lang.reflect.Method;
+
+public class TestFSDataInputStreamWrapper {
+    private Method unbuffer = null;
+
+    @Test
+    public void unbuffer() {
+        InputStream wrappedStream = new SonStream();
+        final Class<? extends InputStream> streamClass = wrappedStream.getClass();
+        Class<?>[] streamInterfaces = streamClass.getInterfaces();
+        for (Class c : streamInterfaces) {
+            if (c.getCanonicalName().toString().equals("org.apache.hadoop.fs.CanUnbuffer")) {
+                try {
+                    this.unbuffer = streamClass.getDeclaredMethod("unbuffer");
+                } catch (NoSuchMethodException | SecurityException e) {
+                    return;
+                }
+                break;
+            }
+        }
+        Assert.assertEquals(false, unbuffer != null);
+        unbuffer = null;
+        if (wrappedStream instanceof CanUnbuffer) {
+            try {
+                this.unbuffer = streamClass.getDeclaredMethod("unbuffer");
+            } catch (NoSuchMethodException | SecurityException e) {
+                return;
+            }
+        }
+        Assert.assertEquals(true, unbuffer != null);
+    }
+
+    public class SonStream extends FatherStream {
+        @Override
+        public void unbuffer() {
+
+        }
+    }
+
+    public class FatherStream extends InputStream implements CanUnbuffer {
+
+        @Override
+        public void unbuffer() {
+
+        }
+
+        @Override
+        public int read() throws IOException {
+            return 0;
+        }
+    }
+}


### PR DESCRIPTION
If you have an inherited parent class that implements CanUnbuffer instead of directly implementing CanUnbuffer, you cannot get unbuffer