### PR TITLE
Backport "HBASE-24071 [JDK11] Remove `unit` filter from nightly and precommit jobs" to branch-2.3

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -519,8 +519,6 @@ pipeline {
             HADOOP_PROFILE = '3.0'
             // ErrorProne is broken on JDK11, see HBASE-23894
             SKIP_ERROR_PRONE = 'true'
-            // vote -0 on JDK11 unit failures until HBASE-22972
-            TESTS_FILTER = "${TESTS_FILTER},unit"
           }
           steps {
             // Must do prior to anything else, since if one of them timesout we'll stash the commentfile

--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -261,8 +261,6 @@ pipeline {
                         SET_JAVA_HOME = '/usr/lib/jvm/java-11'
                         HADOOP_PROFILE = '3.0'
                         WORKDIR_REL = "${WORKDIR_REL_JDK11_HADOOP3_CHECK}"
-                        // vote -0 on JDK11 unit failures until HBASE-22972
-                        TESTS_FILTER = "${TESTS_FILTER},unit"
                         // identical for all parallel stages
                         WORKDIR = "${WORKSPACE}/${WORKDIR_REL}"
                         YETUSDIR = "${WORKDIR}/${YETUS_REL}"


### PR DESCRIPTION
Signed-off-by: Bharath Vissapragada <bharathv@apache.org>
Signed-off-by: Jan Hentschel <jan.hentschel@ultratendency.com>
Signed-off-by: Duo Zhang <zhangduo@apache.org>