### PR TITLE
HBASE-24084 Fix missing jdk8 dependencies in hbase-assembly/hadoop-two-compat

### DIFF
--- a/hbase-assembly/src/main/assembly/hadoop-two-compat.xml
+++ b/hbase-assembly/src/main/assembly/hadoop-two-compat.xml
@@ -67,51 +67,50 @@
             <excludes>
             <!-- Exclude J2EE libraries that get pulled in when building on JDK11 -->
               <exclude>com.sun.activation:javax.activation</exclude>
-              <!-- The following artifacts are transitive dependencies of com.sun.xml.ws:jaxws-ri:pom
-                   They are needed to be included in lib/jdk11 to be added to classpath during
-                   Java 11 runtime hence excluding from main lib.
+              <!--
+                The following artifacts are transitive dependencies of com.sun.xml.ws:jaxws-ri:pom
+                They are needed to be included in lib/jdk11 to be added to classpath during
+                Java 11 runtime hence excluding from main lib.
               -->
-              <exclude>com.sun.xml.ws:*</exclude>
-              <exclude>jakarta.annotation:jakarta.annotation-api</exclude>
-              <exclude>org.glassfish.jaxb:*</exclude>
               <exclude>com.sun.istack:istack-commons-runtime</exclude>
-              <exclude>org.glassfish.gmbal:gmbal</exclude>
-              <exclude>org.glassfish.external:management-api</exclude>
-              <exclude>org.glassfish.pfl:*</exclude>
-              <exclude>org.jvnet.staxex:stax-ex</exclude>
-              <exclude>com.sun.xml.stream.buffer:streambuffer</exclude>
-              <exclude>org.jvnet.mimepull:mimepull</exclude>
-              <exclude>com.sun.xml.fastinfoset:FastInfoset</exclude>
-              <exclude>org.glassfish.ha:ha-api</exclude>
-              <exclude>com.sun.xml.messaging.saaj:saaj-impl</exclude>
-              <exclude>com.fasterxml.woodstox:woodstox-core</exclude>
-              <exclude>org.codehaus.woodstox:stax2-api</exclude>
-              <exclude>jakarta.activation:jakarta.activation-api</exclude>
-              <exclude>com.sun.xml.bind:jaxb-xjc</exclude>
               <exclude>com.sun.xml.bind:jaxb-jxc</exclude>
+              <exclude>com.sun.xml.bind:jaxb-xjc</exclude>
+              <exclude>com.sun.xml.fastinfoset:FastInfoset</exclude>
+              <exclude>com.sun.xml.messaging.saaj:saaj-impl</exclude>
+              <exclude>com.sun.xml.stream.buffer:streambuffer</exclude>
+              <exclude>com.sun.xml.ws:*</exclude>
+              <exclude>jakarta.activation:jakarta.activation-api</exclude>
+              <exclude>jakarta.annotation:jakarta.annotation-api</exclude>
+              <exclude>jakarta.jws:jakarta.jws-api</exclude>
               <exclude>jakarta.mail:jakarta.mail-api</exclude>
               <exclude>jakarta.persistence:jakarta.persistence-api</exclude>
-              <exclude>org.eclipse.persistence:*</exclude>
-              <exclude>jakarta.xml.ws:jakarta.xml.ws-api</exclude>
               <exclude>jakarta.xml.bind:jakarta.xml.bind-api</exclude>
               <exclude>jakarta.xml.soap:jakarta.xml.soap-api</exclude>
-              <exclude>jakarta.jws:jakarta.jws-api</exclude>
-            <!-- Exclude libraries that we put in their own dirs under lib/ -->
-              <exclude>org.jruby:jruby-complete</exclude>
-              <exclude>com.sun.jersey:*</exclude>
+              <exclude>jakarta.xml.ws:jakarta.xml.ws-api</exclude>
+              <exclude>org.eclipse.persistence:*</exclude>
+              <exclude>org.glassfish.external:management-api</exclude>
+              <exclude>org.glassfish.gmbal:gmbal</exclude>
+              <exclude>org.glassfish.ha:ha-api</exclude>
+              <exclude>org.glassfish.jaxb:*</exclude>
+              <exclude>org.glassfish.pfl:*</exclude>
+              <exclude>org.jvnet.mimepull:mimepull</exclude>
+              <exclude>org.jvnet.staxex:stax-ex</exclude>
+              <!-- Exclude libraries that we put in their own dirs under lib/ -->
+              <exclude>com.github.stephenc.findbugs:findbugs-annotations</exclude>
               <exclude>com.sun.jersey.contribs:*</exclude>
+              <exclude>com.sun.jersey:*</exclude>
+              <exclude>commons-logging:commons-logging</exclude>
               <exclude>jline:jline</exclude>
-        <exclude>org.apache.hbase:hbase-shaded-client</exclude>
-        <exclude>org.apache.hbase:hbase-shaded-client-byo-hadoop</exclude>
-        <exclude>org.apache.hbase:hbase-shaded-mapreduce</exclude>
-        <exclude>com.github.stephenc.findbugs:findbugs-annotations</exclude>
-        <exclude>commons-logging:commons-logging</exclude>
-        <exclude>log4j:log4j</exclude>
-        <exclude>org.apache.htrace:htrace-core4</exclude>
-        <exclude>org.apache.htrace:htrace-core</exclude>
-        <exclude>org.apache.yetus:audience-annotations</exclude>
-        <exclude>org.slf4j:slf4j-api</exclude>
-        <exclude>org.slf4j:slf4j-log4j12</exclude>
+              <exclude>log4j:log4j</exclude>
+              <exclude>org.apache.hbase:hbase-shaded-client-byo-hadoop</exclude>
+              <exclude>org.apache.hbase:hbase-shaded-client</exclude>
+              <exclude>org.apache.hbase:hbase-shaded-mapreduce</exclude>
+              <exclude>org.apache.htrace:htrace-core4</exclude>
+              <exclude>org.apache.htrace:htrace-core</exclude>
+              <exclude>org.apache.yetus:audience-annotations</exclude>
+              <exclude>org.jruby:jruby-complete</exclude>
+              <exclude>org.slf4j:slf4j-api</exclude>
+              <exclude>org.slf4j:slf4j-log4j12</exclude>
             </excludes>
           </dependencySet>
         </dependencySets>
@@ -218,40 +217,39 @@
         <include>jline:jline</include>
       </includes>
     </dependencySet>
-   <dependencySet>
-     <outputDirectory>lib/jdk11</outputDirectory>
-     <useTransitiveDependencies>true</useTransitiveDependencies>
-     <includes>
-         <include>com.sun.activation:javax.activation</include>
-       <!-- The following artifacts are transitive dependencies of com.sun.xml.ws:jaxws-ri:pom
-            They are needed to be included in lib/jdk11 to be added to classpath during
-            Java 11 runtime
-       -->
-       <include>com.sun.xml.ws:*</include>
-       <include>jakarta.annotation:jakarta.annotation-api</include>
-       <include>org.glassfish.jaxb:*</include>
-       <include>com.sun.istack:istack-commons-runtime</include>
-       <include>org.glassfish.gmbal:gmbal</include>
-       <include>org.glassfish.external:management-api</include>
-       <include>org.glassfish.pfl:*</include>
-       <include>org.jvnet.staxex:stax-ex</include>
-       <include>com.sun.xml.stream.buffer:streambuffer</include>
-       <include>org.jvnet.mimepull:mimepull</include>
-       <include>com.sun.xml.fastinfoset:FastInfoset</include>
-       <include>org.glassfish.ha:ha-api</include>
-       <include>com.sun.xml.messaging.saaj:saaj-impl</include>
-       <include>com.fasterxml.woodstox:woodstox-core</include>
-       <include>org.codehaus.woodstox:stax2-api</include>
-       <include>jakarta.activation:jakarta.activation-api</include>
-       <include>com.sun.xml.bind:jaxb-xjc</include>
-       <include>com.sun.xml.bind:jaxb-jxc</include>
-       <include>jakarta.mail:jakarta.mail-api</include>
-       <include>jakarta.persistence:jakarta.persistence-api</include>
-       <include>org.eclipse.persistence:*</include>
-       <include>jakarta.xml.ws:jakarta.xml.ws-api</include>
-       <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
-       <include>jakarta.xml.soap:jakarta.xml.soap-api</include>
-       <include>jakarta.jws:jakarta.jws-api</include>
+    <dependencySet>
+      <outputDirectory>lib/jdk11</outputDirectory>
+      <useTransitiveDependencies>true</useTransitiveDependencies>
+      <includes>
+        <include>com.sun.activation:javax.activation</include>
+        <!--
+          The following artifacts are transitive dependencies of com.sun.xml.ws:jaxws-ri:pom
+          They are needed to be included in lib/jdk11 to be added to classpath during
+          Java 11 runtime
+        -->
+        <include>com.sun.istack:istack-commons-runtime</include>
+        <include>com.sun.xml.bind:jaxb-jxc</include>
+        <include>com.sun.xml.bind:jaxb-xjc</include>
+        <include>com.sun.xml.fastinfoset:FastInfoset</include>
+        <include>com.sun.xml.messaging.saaj:saaj-impl</include>
+        <include>com.sun.xml.stream.buffer:streambuffer</include>
+        <include>com.sun.xml.ws:*</include>
+        <include>jakarta.activation:jakarta.activation-api</include>
+        <include>jakarta.annotation:jakarta.annotation-api</include>
+        <include>jakarta.jws:jakarta.jws-api</include>
+        <include>jakarta.mail:jakarta.mail-api</include>
+        <include>jakarta.persistence:jakarta.persistence-api</include>
+        <include>jakarta.xml.bind:jakarta.xml.bind-api</include>
+        <include>jakarta.xml.soap:jakarta.xml.soap-api</include>
+        <include>jakarta.xml.ws:jakarta.xml.ws-api</include>
+        <include>org.eclipse.persistence:*</include>
+        <include>org.glassfish.external:management-api</include>
+        <include>org.glassfish.gmbal:gmbal</include>
+        <include>org.glassfish.ha:ha-api</include>
+        <include>org.glassfish.jaxb:*</include>
+        <include>org.glassfish.pfl:*</include>
+        <include>org.jvnet.mimepull:mimepull</include>
+        <include>org.jvnet.staxex:stax-ex</include>
     </includes>
   </dependencySet>
 </dependencySets>


### PR DESCRIPTION
### sort lines and cleanup whitespace in hbase-assembly/hadoop-two-compat.xml

Simply cleanup the whitespace and readability of these include, exclude lists before making any subsequent changes. To be squished into the subsequent commit on merge.

### HBASE-24084 Fix missing jdk8 dependencies in hbase-assembly/hadoop-two-compat

After HBASE-23986, running on JDK8/Hadoop2 from the binary tarball
results in

```
Exception in thread "main" java.lang.NoClassDefFoundError: com/ctc/wstx/io/InputBootstrapper
        at org.apache.hadoop.hbase.util.ServerCommandLine.doMain(ServerCommandLine.java:149)
        at org.apache.hadoop.hbase.master.HMaster.main(HMaster.java:3062)
Caused by: java.lang.ClassNotFoundException: com.ctc.wstx.io.InputBootstrapper
        at java.net.URLClassLoader.findClass(URLClassLoader.java:382)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:424)
        at sun.misc.Launcher$AppClassLoader.loadClass(Launcher.java:349)
        at java.lang.ClassLoader.loadClass(ClassLoader.java:357)
        ... 2 more
```

The missing class is from `com.fasterxml.woodstox:woodstox-core`. This
and `org.codehaus.woodstox:stax2-api` are explicit dependencies of
`org.apache.hadoop:hadoop-common:jar:2.10.0`. Thus, include them in
the default jars provided under `lib`.