### PR TITLE
HBASE-24073 [flakey test] client.TestAsyncRegionAdminApi messed up co…

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionAdminApi.java
@@ -32,6 +32,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
@@ -41,6 +42,7 @@ import org.apache.hadoop.hbase.master.RegionState;
 import org.apache.hadoop.hbase.master.ServerManager;
 import org.apache.hadoop.hbase.master.assignment.AssignmentManager;
 import org.apache.hadoop.hbase.master.assignment.RegionStates;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionConfiguration;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
@@ -358,10 +360,25 @@ public class TestAsyncRegionAdminApi extends TestAsyncAdminBase {
 
   @Test
   public void testCompact() throws Exception {
-    compactionTest(TableName.valueOf("testCompact1"), 8, CompactionState.MAJOR, false);
-    compactionTest(TableName.valueOf("testCompact2"), 15, CompactionState.MINOR, false);
-    compactionTest(TableName.valueOf("testCompact3"), 8, CompactionState.MAJOR, true);
-    compactionTest(TableName.valueOf("testCompact4"), 15, CompactionState.MINOR, true);
+    compactionTest(TableName.valueOf("testCompact1"), 15, CompactionState.MINOR, false);
+    compactionTest(TableName.valueOf("testCompact2"), 15, CompactionState.MINOR, true);
+
+    // For major compaction, set up a higher hbase.hstore.compaction.min to avoid
+    // minor compactions. It is a hack to avoid random delays introduced by Admins's
+    // updateConfiguration() method.
+    TEST_UTIL.getMiniHBaseCluster().getRegionServerThreads().forEach(thread -> {
+      Configuration conf = thread.getRegionServer().getConfiguration();
+      conf.setInt(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MIN_KEY, 25);
+    });
+
+    compactionTest(TableName.valueOf("testCompact3"), 8, CompactionState.MAJOR, false);
+    compactionTest(TableName.valueOf("testCompact4"), 8, CompactionState.MAJOR, true);
+
+    // Restore to default
+    TEST_UTIL.getMiniHBaseCluster().getRegionServerThreads().forEach(thread -> {
+      Configuration conf = thread.getRegionServer().getConfiguration();
+      conf.unset(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MIN_KEY);
+    });
   }
 
   private void compactionTest(final TableName tableName, final int flushes,


### PR DESCRIPTION
…mpaction state.

Addendum:
  For major compaction test, set hbase.hstore.compaction.min to a big number to
  avoid kicking in minor compactions, which will pollute compaction state and
  sometimes, cause major compaction cannot happen.