### PR TITLE
HBASE-24134 Down forked JVM heap size from 2800m to 2200m for jdk8 an…

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -178,7 +178,7 @@ RUN mkdir -p /usr/lib/jvm && \
 # TODO (nd): is this really true? investigate and file a ticket.
 ENV SPOTBUGS_HOME '/opt/spotbugs'
 ENV MAVEN_HOME '/opt/maven'
-ENV MAVEN_OPTS '-Xmx4G'
+ENV MAVEN_OPTS '-Xmx3.6G'
 
 CMD ["/bin/bash"]
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMultiRespectsLimits.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMultiRespectsLimits.java
@@ -64,7 +64,7 @@ public class TestMultiRespectsLimits {
   private static final MetricsAssertHelper METRICS_ASSERT =
       CompatibilityFactory.getInstance(MetricsAssertHelper.class);
   private final static byte[] FAMILY = Bytes.toBytes("D");
-  public static final int MAX_SIZE = 500;
+  public static final int MAX_SIZE = 100;
 
   @Rule
   public TestName name = new TestName();

--- a/pom.xml
+++ b/pom.xml
@@ -1427,11 +1427,11 @@
     <surefire.timeout>900</surefire.timeout>
     <test.exclude.pattern></test.exclude.pattern>
     <!--
-      default Xmx value is 2800m. Use -Dsurefire.Xmx=xxg to run tests with different JVM Xmx value.
-      this value is managed separately for jdk11.
+      Use -Dsurefire.Xmx=xxg to run tests with different JVM Xmx value.
+      This value is managed separately for jdk11. See below.
     -->
-    <surefire.Xmx>2800m</surefire.Xmx>
-    <surefire.cygwinXmx>2800m</surefire.cygwinXmx>
+    <surefire.Xmx>2200m</surefire.Xmx>
+    <surefire.cygwinXmx>2200m</surefire.cygwinXmx>
     <!--Mark our test runs with '-Dhbase.build.id' so we can identify a surefire test as ours in a process listing
 
       And for netty eventloops that have no explicit configuration, netty sets
@@ -2246,12 +2246,10 @@
         <!-- We need a minimum HDFS version of 3.2.0 for HADOOP-12760 -->
         <hadoop-three.version>3.2.0</hadoop-three.version>
         <!--
-          JDK11 appears to consume more heap than JDK8 does; OOME are more common in
-          -PrunLargeTests on this platform. Bump up heap allocated to tests (current default for
-          JDK8 is 2800m.
+          Value to use for surefire when running jdk11.
           TODO: replicate logic for windows
         -->
-        <surefire.Xmx>3200m</surefire.Xmx>
+        <surefire.Xmx>2200m</surefire.Xmx>
       </properties>
       <build>
         <plugins>


### PR DESCRIPTION
…d jdk11

Down jdk8 forked jvm heap from 2800 to 2200 and the jdk11 heap from
3200 to 2200. Down the mvn size from 4G to 3.6G

Change how many puts done by TestMultiRespectsLimits because made
the test run the forked heap over 2.5G in size.

Running against branch-2 because I know the state of this branch.