### PR TITLE
HBASE-24138 log more details about balancer decisions for StochasticLoadBalancer

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/ServerAndLoad.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/ServerAndLoad.java
@@ -65,4 +65,9 @@ class ServerAndLoad implements Comparable<ServerAndLoad>, Serializable {
     }
     return false;
   }
+
+  @Override
+  public String toString() {
+    return "server=" + sn + " , load=" + load;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -331,28 +331,29 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     for (CostFunction c : costFunctions) {
       float multiplier = c.getMultiplier();
       if (multiplier <= 0) {
+        LOG.trace("{} not needed because multiplier is <= 0", c.getClass().getSimpleName());
         continue;
       }
       if (!c.isNeeded()) {
-        LOG.debug("{} not needed", c.getClass().getSimpleName());
+        LOG.trace("{} not needed", c.getClass().getSimpleName());
         continue;
       }
       sumMultiplier += multiplier;
       total += c.cost() * multiplier;
     }
 
-    if (total <= 0 || sumMultiplier <= 0
-        || (sumMultiplier > 0 && (total / sumMultiplier) < minCostNeedBalance)) {
+    boolean balanced = total <= 0 || sumMultiplier <= 0 ||
+        (sumMultiplier > 0 && (total / sumMultiplier) < minCostNeedBalance);
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("{} {}; total cost={}, sum multiplier={}; min cost/multiplier which needs balance is {}",
+          balanced ? "Skipping load balancing because balanced" : "We need to load balance",
+          isByTable ? String.format("table (%s)", tableName) : "cluster",
+          total, sumMultiplier, minCostNeedBalance);
       if (LOG.isTraceEnabled()) {
-        final String loadBalanceTarget =
-            isByTable ? String.format("table (%s)", tableName) : "cluster";
-        LOG.trace("Skipping load balancing because the {} is balanced. Total cost: {}, "
-            + "Sum multiplier: {}, Minimum cost needed for balance: {}", loadBalanceTarget, total,
-            sumMultiplier, minCostNeedBalance);
+        LOG.trace("Balance decision detailed function costs={}", functionCost());
       }
-      return false;
     }
-    return true;
+    return !balanced;
   }
 
   @VisibleForTesting
@@ -1190,15 +1191,26 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     }
 
     @Override
+    void init(Cluster cluster) {
+      super.init(cluster);
+      LOG.debug("{} sees a total of {} servers and {} regions.", getClass().getSimpleName(),
+          cluster.numServers, cluster.numRegions);
+      if (LOG.isTraceEnabled()) {
+        for (int i =0; i < cluster.numServers; i++) {
+          LOG.trace("{} sees server '{}' has {} regions", getClass().getSimpleName(),
+              cluster.servers[i], cluster.regionsPerServer[i].length);
+        }
+      }
+    }
+
+    @Override
     protected double cost() {
       if (stats == null || stats.length != cluster.numServers) {
         stats = new double[cluster.numServers];
       }
-
       for (int i =0; i < cluster.numServers; i++) {
         stats[i] = cluster.regionsPerServer[i].length;
       }
-
       return costFromArray(stats);
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -345,7 +345,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     boolean balanced = total <= 0 || sumMultiplier <= 0 ||
         (sumMultiplier > 0 && (total / sumMultiplier) < minCostNeedBalance);
     if (LOG.isDebugEnabled()) {
-      LOG.debug("{} {}; total cost={}, sum multiplier={}; min cost/multiplier which needs balance is {}",
+      LOG.debug("{} {}; total cost={}, sum multiplier={}; cost/multiplier to need a balance is {}",
           balanced ? "Skipping load balancing because balanced" : "We need to load balance",
           isByTable ? String.format("table (%s)", tableName) : "cluster",
           total, sumMultiplier, minCostNeedBalance);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/BalancerTestBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/BalancerTestBase.java
@@ -201,9 +201,11 @@ public class BalancerTestBase {
     int max = numRegions % numServers == 0 ? min : min + 1;
 
     for (ServerAndLoad server : servers) {
-      assertTrue(server.getLoad() >= 0);
-      assertTrue(server.getLoad() <= max);
-      assertTrue(server.getLoad() >= min);
+      assertTrue("All servers should have a positive load. " + server, server.getLoad() >= 0);
+      assertTrue("All servers should have load no more than " + max + ". " + server,
+          server.getLoad() <= max);
+      assertTrue("All servers should have load no less than " + min + ". " + server,
+          server.getLoad() >= min);
     }
   }
 
@@ -561,7 +563,7 @@ public class BalancerTestBase {
     Map<TableName, Map<ServerName, List<RegionInfo>>> LoadOfAllTable =
         (Map) mockClusterServersWithTables(serverMap);
     List<RegionPlan> plans = loadBalancer.balanceCluster(LoadOfAllTable);
-    assertNotNull(plans);
+    assertNotNull("Initial cluster balance should produce plans.", plans);
 
     // Check to see that this actually got to a stable place.
     if (assertFullyBalanced || assertFullyBalancedForReplicas) {
@@ -575,7 +577,8 @@ public class BalancerTestBase {
         assertClusterAsBalanced(balancedCluster);
         LoadOfAllTable = (Map) mockClusterServersWithTables(serverMap);
         List<RegionPlan> secondPlans = loadBalancer.balanceCluster(LoadOfAllTable);
-        assertNull(secondPlans);
+        assertNull("Given a requirement to be fully balanced, second attempt at plans should " +
+            "produce none.", secondPlans);
       }
 
       if (assertFullyBalancedForReplicas) {


### PR DESCRIPTION
Based on logs needed when troubleshooting some balancer decisions.

when the log level on `StochasticLoadBalancer` is set to DEBUG messages look like this:
```
2020-04-08 09:57:39,515 DEBUG [Time-limited test] balancer.StochasticLoadBalancer$RegionCountSkewCostFunction(1196): RegionCountSkewCostFunction sees a total of 3 servers and 9 regions.
2020-04-08 09:57:39,527 DEBUG [Time-limited test] balancer.StochasticLoadBalancer(348): We need to load balance cluster; total cost=10005.833333333334, sum multiplier=10602.0; min cost/multiplier which needs balance is 0.05
```

when it is TRACE it looks like:
```
2020-04-08 10:49:48,416 DEBUG [Time-limited test] balancer.StochasticLoadBalancer$RegionCountSkewCostFunction(1196): RegionCountSkewCostFunction sees a total of 3 servers and 9 regions.
2020-04-08 10:49:48,417 TRACE [Time-limited test] balancer.StochasticLoadBalancer$RegionCountSkewCostFunction(1200): RegionCountSkewCostFunction sees server 'server11855,19031,-1' has 3 regions
2020-04-08 10:49:48,418 TRACE [Time-limited test] balancer.StochasticLoadBalancer$RegionCountSkewCostFunction(1200): RegionCountSkewCostFunction sees server 'server15849,14000,-1' has 3 regions
2020-04-08 10:49:48,418 TRACE [Time-limited test] balancer.StochasticLoadBalancer$RegionCountSkewCostFunction(1200): RegionCountSkewCostFunction sees server 'server87321,54683,-1' has 3 regions
2020-04-08 10:49:48,446 TRACE [Time-limited test] balancer.StochasticLoadBalancer(338): PrimaryRegionCountSkewCostFunction not needed
2020-04-08 10:49:48,447 TRACE [Time-limited test] balancer.StochasticLoadBalancer(338): RegionReplicaHostCostFunction not needed
2020-04-08 10:49:48,450 TRACE [Time-limited test] balancer.StochasticLoadBalancer(338): RegionReplicaRackCostFunction not needed
2020-04-08 10:49:48,451 DEBUG [Time-limited test] balancer.StochasticLoadBalancer(348): We need to load balance cluster; total cost=10005.833333333334, sum multiplier=10602.0; min cost/multiplier which needs balance is 0.05
2020-04-08 10:49:48,452 TRACE [Time-limited test] balancer.StochasticLoadBalancer(353): Balance decision detailed function costs=RegionCountSkewCostFunction : (500.0, 0.0); PrimaryRegionCountSkewCostFunction : (500.0, 0.0); MoveCostFunction : (7.0, 0.0); ServerLocalityCostFunction : (25.0, 0.0); RackLocalityCostFunction : (15.0, 0.0); TableSkewCostFunction : (35.0, 0.16666666666666666); RegionReplicaHostCostFunction : (100000.0, 0.0); RegionReplicaRackCostFunction : (10000.0, 0.0); ReadRequestCostFunction : (10000.0, 1.0); CPRequestCostFunction : (5.0, 0.0); WriteRequestCostFunction : (5.0, 0.0); MemStoreSizeCostFunction : (5.0, 0.0); StoreFileCostFunction : (5.0, 0.0);
```