### PR TITLE
Backport "HBASE-24086 Disable output stream capability enforcement when running on LocalFileSystem" to branch-2.2

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
@@ -1,4 +1,4 @@
-/**
+/*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -33,6 +33,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
@@ -44,7 +45,6 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 
@@ -352,10 +352,18 @@ public abstract class CommonFSUtils {
   public static FileSystem getWALFileSystem(final Configuration c) throws IOException {
     Path p = getWALRootDir(c);
     FileSystem fs = p.getFileSystem(c);
-    // hadoop-core does fs caching, so need to propogate this if set
+    // hadoop-core does fs caching, so need to propagate this if set
     String enforceStreamCapability = c.get(UNSAFE_STREAM_CAPABILITY_ENFORCE);
     if (enforceStreamCapability != null) {
       fs.getConf().set(UNSAFE_STREAM_CAPABILITY_ENFORCE, enforceStreamCapability);
+    }
+    if (fs instanceof LocalFileSystem) {
+      // running on LocalFileSystem, which does not support the required capabilities `HSYNC`
+      // and `HFLUSH`. disable enforcement.
+      final boolean value = false;
+      LOG.warn("Cannot enforce durability guarantees while running on {}. Setting {}={} for"
+        + " this FileSystem.", fs.getUri(), UNSAFE_STREAM_CAPABILITY_ENFORCE, value);
+      fs.getConf().setBoolean(UNSAFE_STREAM_CAPABILITY_ENFORCE, value);
     }
     return fs;
   }


### PR DESCRIPTION
Signed-off-by: stack <stack@apache.org>
Signed-off-by: Bharath Vissapragada <bharathv@apache.org>
Signed-off-by: Duo Zhang <zhangduo@apache.org>