### PR TITLE
HBASE-23779 Up the default fork count to make builds complete faster;…

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1409,17 +1409,18 @@
     <!-- default: run small & medium, medium with 2 threads -->
     <surefire.skipFirstPart>false</surefire.skipFirstPart>
     <surefire.skipSecondPart>false</surefire.skipSecondPart>
-      <!-- Fork count varies w/ CPU count. Setting is conservative mostly determined
-        by what apache jenkins nightly builds will tolerate (See HBASE-24072). Up this
+      <!--
+      Fork count varies w/ CPU count. Setting is conservative mostly determined
+      by what apache jenkins nightly builds will tolerate (See HBASE-24072). Up this
       value is you want to burn through tests faster (could make for more failures
-      if more contention around resources). There is a matching MAVEN_ARG
-      in our yetus personality where we set the maven -T command to 0.25C too.
-      For example, to run at a rate that is more furious than our 0.25C, do
-      something like this:
-         f="0.5C" ;  mvn -T$f -Dsurefire.firstPartForkCount=$f -Dsurefire.secondPartForkCount=$f test -PrunAllTests
+      if more contention around resources). For example, to run at a rate that is
+      more furious than our 0.5C, do something like this:
+         f="0.75C" ;  mvn -Dsurefire.firstPartForkCount=$f -Dsurefire.secondPartForkCount=$f test -PrunAllTests
+      Note, tests seem to crash or fail nonsensically if the fork count is set too
+      high. On high-CPU boxes, a fork count of 1.0 doesn't always 'work'.
     -->
-    <surefire.firstPartForkCount>0.25C</surefire.firstPartForkCount>
-    <surefire.secondPartForkCount>0.25C</surefire.secondPartForkCount>
+    <surefire.firstPartForkCount>0.5C</surefire.firstPartForkCount>
+    <surefire.secondPartForkCount>0.5C</surefire.secondPartForkCount>
     <surefire.firstPartGroups>org.apache.hadoop.hbase.testclassification.SmallTests</surefire.firstPartGroups>
     <surefire.secondPartGroups>org.apache.hadoop.hbase.testclassification.MediumTests</surefire.secondPartGroups>
     <surefire.testFailureIgnore>false</surefire.testFailureIgnore>


### PR DESCRIPTION
… make count relative to CPU count

Halve the build speed by doubling the -C count from 0.25C to 0.5C.
Pass mvn a -T of 0.5C too.