### PR TITLE
HBASE-24074 ConcurrentModificationException occured in ReplicationSourceManager while refreshing the peer

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceManager.java
@@ -496,11 +496,13 @@ public class ReplicationSourceManager implements ReplicationListener {
     // synchronized on oldsources to avoid race with NodeFailoverWorker
     synchronized (this.oldsources) {
       List<String> previousQueueIds = new ArrayList<>();
-      for (ReplicationSourceInterface oldSource : this.oldsources) {
+      for (Iterator<ReplicationSourceInterface> iter = this.oldsources.iterator(); iter
+          .hasNext();) {
+        ReplicationSourceInterface oldSource = iter.next();
         if (oldSource.getPeerId().equals(peerId)) {
           previousQueueIds.add(oldSource.getQueueId());
           oldSource.terminate(terminateMessage);
-          this.oldsources.remove(oldSource);
+          iter.remove();
         }
       }
       for (String queueId : previousQueueIds) {


### PR DESCRIPTION
CME occurred while removing the list item from the same list which is iterated in foreach loop.

Use Iterator instead and delete the list item safely.