### PR TITLE
HBASE-24165 maxPoolSize is logged incorrectly in ByteBufferPool

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBufferPool.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBufferPool.java
@@ -80,8 +80,9 @@ public class ByteBufferPool {
     this.maxPoolSize = maxPoolSize;
     this.directByteBuffer = directByteBuffer;
     // TODO can add initialPoolSize config also and make those many BBs ready for use.
-    LOG.info("Created with bufferSize={} and maxPoolSize={}",
-      org.apache.hadoop.util.StringUtils.byteDesc(bufferSize), maxPoolSize);
+    LOG.info("Created with bufferSize={}, maxPoolSize={} and totalBufferSize={}",
+      org.apache.hadoop.util.StringUtils.byteDesc(bufferSize), maxPoolSize,
+      org.apache.hadoop.util.StringUtils.byteDesc(bufferSize * maxPoolSize));
     this.count = new AtomicInteger(0);
   }
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBufferPool.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBufferPool.java
@@ -81,8 +81,7 @@ public class ByteBufferPool {
     this.directByteBuffer = directByteBuffer;
     // TODO can add initialPoolSize config also and make those many BBs ready for use.
     LOG.info("Created with bufferSize={} and maxPoolSize={}",
-        org.apache.hadoop.util.StringUtils.byteDesc(bufferSize),
-        org.apache.hadoop.util.StringUtils.byteDesc(maxPoolSize));
+      org.apache.hadoop.util.StringUtils.byteDesc(bufferSize), maxPoolSize);
     this.count = new AtomicInteger(0);
   }
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBufferPool.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBufferPool.java
@@ -82,7 +82,7 @@ public class ByteBufferPool {
     // TODO can add initialPoolSize config also and make those many BBs ready for use.
     LOG.info("Created with bufferSize={}, maxPoolSize={} and totalBufferSize={}",
       org.apache.hadoop.util.StringUtils.byteDesc(bufferSize), maxPoolSize,
-      org.apache.hadoop.util.StringUtils.byteDesc(bufferSize * maxPoolSize));
+      org.apache.hadoop.util.StringUtils.byteDesc((long) (bufferSize * maxPoolSize)));
     this.count = new AtomicInteger(0);
   }
 


### PR DESCRIPTION
maxPoolSize should be logged as a plain number.