### PR TITLE
HBASE-24166 Duplicate implementation for acquireLock between CreateTa…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/CreateTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/CreateTableProcedure.java
@@ -239,14 +239,6 @@ public class CreateTableProcedure
     return super.waitInitialized(env);
   }
 
-  @Override
-  protected LockState acquireLock(final MasterProcedureEnv env) {
-    if (env.getProcedureScheduler().waitTableExclusiveLock(this, getTableName())) {
-      return LockState.LOCK_EVENT_WAIT;
-    }
-    return LockState.LOCK_ACQUIRED;
-  }
-
   private boolean prepareCreate(final MasterProcedureEnv env) throws IOException {
     final TableName tableName = getTableName();
     if (MetaTableAccessor.tableExists(env.getMasterServices().getConnection(), tableName)) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/InitMetaProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/InitMetaProcedure.java
@@ -116,14 +116,6 @@ public class InitMetaProcedure extends AbstractStateMachineTableProcedure<InitMe
   }
 
   @Override
-  protected LockState acquireLock(MasterProcedureEnv env) {
-    if (env.getProcedureScheduler().waitTableExclusiveLock(this, getTableName())) {
-      return LockState.LOCK_EVENT_WAIT;
-    }
-    return LockState.LOCK_ACQUIRED;
-  }
-
-  @Override
   protected void rollbackState(MasterProcedureEnv env, InitMetaState state)
       throws IOException, InterruptedException {
     throw new UnsupportedOperationException();


### PR DESCRIPTION
…bleProcedure and its parent class

The override method acquireLock in CreateTableProcedure and InitMetaProcedure is the same as the implementation in its parent class AbstractStateMachineTableProcedure. So delete the override method in subclass.