### PR TITLE
[HBASE-22879]user_permission command failed to show global permission

### DIFF
--- a/hbase-shell/src/main/ruby/hbase/security.rb
+++ b/hbase-shell/src/main/ruby/hbase/security.rb
@@ -150,7 +150,7 @@ module Hbase
         if !table_regex.nil? && isNamespace?(table_regex)
           nsPerm = permission.to_java(org.apache.hadoop.hbase.security.access.NamespacePermission)
           namespace = nsPerm.getNamespace
-        elsif !table_regex.nil?
+        elsif !table_regex.nil? && isTablePermission?(permission)
           tblPerm = permission.to_java(org.apache.hadoop.hbase.security.access.TablePermission)
           namespace = tblPerm.getNamespace
           table = !tblPerm.getTableName.nil? ? tblPerm.getTableName.getNameAsString : ''
@@ -181,6 +181,10 @@ module Hbase
 
     def isNamespace?(table_name)
       table_name.start_with?('@')
+    end
+
+    def isTablePermission?(permission)
+      permission.java_kind_of?(org.apache.hadoop.hbase.security.access.TablePermission)
     end
 
     # Does Namespace exist

--- a/hbase-shell/src/test/ruby/hbase/security_admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/security_admin_test.rb
@@ -91,6 +91,14 @@ module Hbase
       end
       assert(found_permission, 'Permission for user ' + global_user_name + ' was not found.')
 
+      security_admin.user_permission('.*') do |user, permission|
+        if user == global_user_name
+          assert_match(/WRITE/, permission.to_s)
+          found_permission = true
+        end
+      end
+      assert(found_permission, 'Permission for user ' + global_user_name + ' was not found.')
+
       found_permission = false
       security_admin.revoke(global_user_name)
       security_admin.user_permission do |user, _|


### PR DESCRIPTION
This exception is still occurred when we use '.*' as the argument of user_permission