### PR TITLE
HBASE-24171 Removed 2.1.10 from download page

### DIFF
--- a/src/site/xdoc/downloads.xml
+++ b/src/site/xdoc/downloads.xml
@@ -68,29 +68,6 @@ under the License.
     </tr>
     <tr>
       <td style="test-align: left">
-        2.1.10
-      </td>
-      <td style="test-align: left">
-        2020/04/08
-      </td>
-      <td style="test-align: left">
-        <a href="https://apache.org/dist/hbase/2.1.10/api_compare_2.1.9_to_2.1.10RC1.html">2.1.9 vs 2.1.10</a>
-      </td>
-      <td style="test-align: left">
-        <a href="https://apache.org/dist/hbase/2.1.10/CHANGES.md">Changes</a>
-      </td>
-      <td style="test-align: left">
-        <a href="https://apache.org/dist/hbase/2.1.10/RELEASENOTES.md">Release Notes</a>
-      </td>
-      <td style="test-align: left">
-        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.1.10/hbase-2.1.10-src.tar.gz">src</a> (<a href="https://apache.org/dist/hbase/2.1.10/hbase-2.1.10-src.tar.gz.sha512">sha512</a> <a href="https://apache.org/dist/hbase/2.1.10/hbase-2.1.10-src.tar.gz.asc">asc</a>) <br />
-        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.1.10/hbase-2.1.10-bin.tar.gz">bin</a> (<a href="https://apache.org/dist/hbase/2.1.10/hbase-2.1.10-bin.tar.gz.sha512">sha512</a> <a href="https://apache.org/dist/hbase/2.1.10/hbase-2.1.10-bin.tar.gz.asc">asc</a>) <br />
-        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.1.10/hbase-2.1.10-client-bin.tar.gz">client-bin</a> (<a href="https://apache.org/dist/hbase/2.1.10/hbase-2.1.10-client-bin.tar.gz.sha512">sha512</a> <a href="https://apache.org/dist/hbase/2.1.10/hbase-2.1.10-client-bin.tar.gz.asc">asc</a>)
-      </td>
-      <td />
-    </tr>
-    <tr>
-      <td style="test-align: left">
         1.6.0
       </td>
       <td style="test-align: left">


### PR DESCRIPTION
This one should be merged at the end of April (see HBASE-24063).