### PR TITLE
HBASE-23742 Document that with split-to-hfile data over the MOB threshold will be treated as normal data

### DIFF
--- a/src/main/asciidoc/_chapters/hbase_mob.adoc
+++ b/src/main/asciidoc/_chapters/hbase_mob.adoc
@@ -613,6 +613,14 @@ $ hdfs dfs -count /hbase/mobdir/data/default/some_table
 This data is spurious and may be reclaimed. You should sideline it, verify your application’s view
 of the table, and then delete it.
 
+==== MOB data is written in the normal /hbase/data directory rather than in /hbase/mobdir
+
+Bulk load and WAL split-to-HFile feature write data into the normal /hbase/data directory irrespective of data over than the MOB threshold.
+
+[NOTE]
+====
+In both cases the next compaction to include those files and write the data out to MOB HFiles.
+
 === MOB Upgrade Considerations
 
 Generally, data stored using the MOB feature should transparently continue to work correctly across

--- a/src/main/asciidoc/_chapters/hbase_mob.adoc
+++ b/src/main/asciidoc/_chapters/hbase_mob.adoc
@@ -613,12 +613,12 @@ $ hdfs dfs -count /hbase/mobdir/data/default/some_table
 This data is spurious and may be reclaimed. You should sideline it, verify your application’s view
 of the table, and then delete it.
 
-==== MOB data is written in the normal /hbase/data directory rather than in /hbase/mobdir
+==== Data values over the MOB threshold show up stored in the non-MOB hfiles
 
 Bulk load and WAL split-to-HFile feature write data into the normal /hbase/data directory irrespective of data over than the MOB threshold.
 
 [NOTE]
-In both cases the next compaction to include those files and write the data out to MOB HFiles.
+In both cases the next compaction to include those files will write the data out to MOB hfiles.
 
 === MOB Upgrade Considerations
 

--- a/src/main/asciidoc/_chapters/hbase_mob.adoc
+++ b/src/main/asciidoc/_chapters/hbase_mob.adoc
@@ -618,7 +618,6 @@ of the table, and then delete it.
 Bulk load and WAL split-to-HFile feature write data into the normal /hbase/data directory irrespective of data over than the MOB threshold.
 
 [NOTE]
-====
 In both cases the next compaction to include those files and write the data out to MOB HFiles.
 
 === MOB Upgrade Considerations


### PR DESCRIPTION
Added the troubleshooting section for bulk load and WAL split-to-hfile behavior.