### PR TITLE
Backport HBASE-23896 to branch-1: Snapshot owner cannot delete snapshot when ACL is enabled and Kerberos is not enabled

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
@@ -607,7 +607,8 @@ public class SnapshotManager extends MasterProcedureManager implements Stoppable
       builder.setVersion(SnapshotDescriptionUtils.SNAPSHOT_LAYOUT_VERSION);
     }
     User user = RpcServer.getRequestUser();
-    if (User.isHBaseSecurityEnabled(master.getConfiguration()) && user != null) {
+    if (master.getConfiguration().
+      getBoolean(User.HBASE_SECURITY_AUTHORIZATION_CONF_KEY, false) && user != null) {
       builder.setOwner(user.getShortName());
     }
     snapshot = builder.build();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestSnapshotWithAcl.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestSnapshotWithAcl.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hbase.client;
 
+import static org.junit.Assert.assertNotSame;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Coprocessor;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -26,6 +28,7 @@ import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
 import org.apache.hadoop.hbase.master.MasterCoprocessorHost;
+import org.apache.hadoop.hbase.protobuf.generated.HBaseProtos;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.access.AccessControlConstants;
 import org.apache.hadoop.hbase.security.access.AccessControlLists;
@@ -42,6 +45,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import java.io.IOException;
+import java.util.List;
 import java.util.UUID;
 
 @Category(MediumTests.class)
@@ -242,5 +246,17 @@ public class TestSnapshotWithAcl extends SecureTestUtil {
     verifyDenied(new AccessReadAction(TEST_TABLE), USER_NONE);
     verifyAllowed(new AccessWriteAction(TEST_TABLE), USER_OWNER, USER_RW);
     verifyDenied(new AccessWriteAction(TEST_TABLE), USER_RO, USER_NONE);
+  }
+
+  @Test
+  public void testListSnapshot() throws Exception {
+    String snapshotName1 = UUID.randomUUID().toString();
+    admin.snapshot(snapshotName1, TEST_TABLE);
+    List<HBaseProtos.SnapshotDescription> snapshotDescriptions = admin.listSnapshots();
+    for (HBaseProtos.SnapshotDescription snapshotDescription:
+      snapshotDescriptions) {
+      assertNotSame(snapshotDescription.getOwner(), "");
+    }
+    admin.deleteSnapshot(snapshotName1);
   }
 }


### PR DESCRIPTION
[https://issues.apache.org/jira/browse/HBASE-24184](url)
The code in AccessController.preListSnapshot:

if (SnapshotDescriptionUtils.isSnapshotOwner(snapshot, user)) {
// list it, if user is the owner of snapshot
AuthResult result = AuthResult.allow("listSnapshot " + snapshot.getName(),
"Snapshot owner check allowed", user, null, null, null);
accessChecker.logResult(result);
}

So i think the logic of setOwner is used for **authorization**, not **authentication**, SnapshotManager should not only setOwner when hbase.security.authentication = kerberos, which cause listSnapshots returns empty when i just use simple acls.