### PR TITLE
HBASE-24197 TestHttpServer.testBindAddress failure with latest jetty

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -1120,7 +1120,10 @@ public class HttpServer implements FilterContainer {
           listener.open();
           LOG.info("Jetty bound to port " + listener.getLocalPort());
           break;
-        } catch (BindException ex) {
+        } catch (IOException ex) {
+          if(!(ex instanceof BindException) && !(ex.getCause() instanceof BindException)) {
+            throw ex;
+          }
           if (port == 0 || !findPort) {
             BindException be = new BindException("Port in use: "
                 + listener.getHost() + ":" + listener.getPort());


### PR DESCRIPTION
use the findPort logic even if the BindException is wrapped in an IOException