### PR TITLE
HBASE-24143 [JDK11] Switch default garbage collector from CMS

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -136,6 +136,21 @@ if [ -f "$HBASE_HOME/conf/hbase-env-$COMMAND.sh" ]; then
   . "$HBASE_HOME/conf/hbase-env-$COMMAND.sh"
 fi
 
+# establish a default value for HBASE_OPTS if it's not already set. For now,
+# all we set is the garbage collector.
+if [ -z "${HBASE_OPTS}" ] ; then
+  major_version_number="$(parse_java_major_version "$(read_java_version)")"
+  case "$major_version_number" in
+  8|9|10)
+    HBASE_OPTS="-XX:+UseConcMarkSweepGC"
+    ;;
+  11|*)
+    HBASE_OPTS="-XX:+UseG1GC"
+    ;;
+  esac
+  export HBASE_OPTS
+fi
+
 add_size_suffix() {
     # add an 'm' suffix if the argument is missing one, otherwise use whats there
     local val="$1"
@@ -706,18 +721,15 @@ if [ "${HBASE_JDK11}" != "" ]; then
   fi
 else
   # Use JDK detection
-  JAVA=$JAVA_HOME/bin/java
-
-  version=$($JAVA -version 2>&1 | awk -F '"' '/version/ {print $2}')
-  # '-' check is for cases such as "13-ea"
-  version_number=$(echo "$version" | cut -d'.' -f1 | cut -d'-' -f1)
+  version="$(read_java_version)"
+  major_version_number="$(parse_java_major_version "$version")"
 
   if [ "${DEBUG}" = "true" ]; then
     echo "HBASE_JDK11 not set hence using JDK detection."
-    echo "Extracted JDK version - ${version}, version_number - ${version_number}"
+    echo "Extracted JDK version - ${version}, major_version_number - ${major_version_number}"
   fi
 
-  if [[ "$version_number" -ge "11" ]]; then
+  if [[ "$major_version_number" -ge "11" ]]; then
     if [ "${DEBUG}" = "true" ]; then
       echo "Version ${version} is greater-than/equal to 11 hence adding JDK11 jars to classpath."
     fi

--- a/bin/hbase-config.sh
+++ b/bin/hbase-config.sh
@@ -168,3 +168,26 @@ if [ -z "$JAVA_HOME" ]; then
 EOF
     exit 1
 fi
+
+function read_java_version() {
+  properties="$("${JAVA_HOME}/bin/java" -XshowSettings:properties -version 2>&1)"
+  echo "${properties}" | "${GREP}" java.runtime.version | head -1 | "${SED}" -e 's/.* = \([^ ]*\)/\1/'
+}
+
+# Inspect the system properties exposed by this JVM to identify the major
+# version number. Normalize on the popular version number, thus consider JDK
+# 1.8 as version "8".
+function parse_java_major_version() {
+  complete_version=$1
+  # split off suffix version info like '-b10' or '+10' or '_10'
+  # careful to not use GNU Sed extensions
+  version="$(echo "$complete_version" | "${SED}" -e 's/+/_/g' -e 's/-/_/g' | cut -d'_' -f1)"
+  case "$version" in
+  1.*)
+    echo "$version" | cut -d'.' -f2
+    ;;
+  *)
+    echo "$version" | cut -d'.' -f1
+    ;;
+  esac
+}

--- a/conf/hbase-env.sh
+++ b/conf/hbase-env.sh
@@ -39,10 +39,10 @@
 # export HBASE_OFFHEAPSIZE=1G
 
 # Extra Java runtime options.
-# Below are what we set by default.  May only work with SUN JVM.
-# For more on why as well as other possible settings,
-# see http://hbase.apache.org/book.html#performance
-export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC"
+# Default settings are applied according to the detected JVM version. Override these default
+# settings by specifying a value here. For more details on possible settings,
+# see http://hbase.apache.org/book.html#_jvm_tuning
+# export HBASE_OPTS
 
 # Uncomment one of the below three options to enable java garbage collection logging for the server-side processes.
 
@@ -138,3 +138,7 @@ export HBASE_OPTS="$HBASE_OPTS -XX:+UseConcMarkSweepGC"
 # Tell HBase whether it should include Hadoop's lib when start up,
 # the default value is false,means that includes Hadoop's lib.
 # export HBASE_DISABLE_HADOOP_CLASSPATH_LOOKUP="true"
+
+# Override text processing tools for use by these launch scripts.
+export GREP="${GREP-grep}"
+export SED="${SED-sed}"


### PR DESCRIPTION
Per comments in Jira, be explicit about what collector we
use. Existing code simply hard-codes HBASE_OPTS in
`conf/hbase-env.sh`. We now need to be a little more clever than this,
so moves the definition into `bin/hbase`. Also consolidates logic
around JVM version detection into a reusable function.

This change also changes how we set `HBASE_OPTS`. Before, we would
accept an operator's value, but always append our GC
prescription. After this change, we defer entirely to the operator's
choice, only applying our values when they've not specified their
intentions.