### PR TITLE
HBASE-23894 Support ErrorProne for both JDK8 and JDK11

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -517,8 +517,6 @@ pipeline {
             SET_JAVA_HOME = "/usr/lib/jvm/java-11"
             // Activates hadoop 3.0 profile in maven runs.
             HADOOP_PROFILE = '3.0'
-            // ErrorProne is broken on JDK11, see HBASE-23894
-            SKIP_ERROR_PRONE = 'true'
           }
           steps {
             // Must do prior to anything else, since if one of them timesout we'll stash the commentfile

--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -208,7 +208,17 @@ function personality_modules
 
   if [[ ${testtype} == compile ]] && [[ "${SKIP_ERRORPRONE}" != "true" ]] &&
       [[ "${PATCH_BRANCH}" != branch-1* ]] ; then
-    extra="${extra} -PerrorProne"
+    properties="$("${JAVA_HOME}/bin/java" -XshowSettings:properties -version 2>&1)"
+    runtime_version="$(echo "${properties}" | "${GREP}" java.runtime.version | head -1 | "${SED}" -e 's/.* = \([^ ]*\)/\1/')"
+    version="$(echo "$runtime_version" | "${SED}" -e 's/+/_/g' -e 's/-/_/g' | cut -d'_' -f1)"
+    case "$version" in
+    1.*)
+      extra="${extra} -PerrorProne-jdk8"
+      ;;
+    *)
+      extra="${extra} -PerrorProne-jdk9+"
+      ;;
+    esac
   fi
 
   # If EXCLUDE_TESTS_URL/INCLUDE_TESTS_URL is set, fetches the url

--- a/dev-support/jenkins_precommit_github_yetus.sh
+++ b/dev-support/jenkins_precommit_github_yetus.sh
@@ -122,7 +122,6 @@ YETUS_ARGS+=("--whitespace-tabs-ignore-list=.*/generated/.*")
 YETUS_ARGS+=("--tests-filter=${TESTS_FILTER}")
 YETUS_ARGS+=("--personality=${SOURCEDIR}/dev-support/hbase-personality.sh")
 YETUS_ARGS+=("--quick-hadoopcheck")
-YETUS_ARGS+=("--skip-errorprone")
 # effectively treat dev-support as a custom maven module
 YETUS_ARGS+=("--skip-dirs=dev-support")
 # For testing with specific hadoop version. Activates corresponding profile in maven runs.

--- a/hbase-build-configuration/pom.xml
+++ b/hbase-build-configuration/pom.xml
@@ -64,7 +64,53 @@
   </dependencies>
   <profiles>
     <profile>
-      <id>errorProne</id>
+      <id>errorProne-jdk9+</id>
+      <build>
+        <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <version>[9,)</version>
+                      <message>Running with `-P errorProne-jdk9+` on an unsupported JDK version.</message>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-compiler-plugin</artifactId>
+            <configuration>
+              <source>${compileSource}</source>
+              <target>${compileSource}</target>
+              <compilerArgs>
+                <arg>-XDcompilePolicy=simple</arg>
+                <arg>-Xplugin:ErrorProne</arg>
+              </compilerArgs>
+              <annotationProcessorPaths>
+                <path>
+                  <groupId>com.google.errorprone</groupId>
+                  <artifactId>error_prone_core</artifactId>
+                  <version>${error-prone.version}</version>
+                </path>
+              </annotationProcessorPaths>
+            </configuration>
+          </plugin>
+        </plugins>
+      </build>
+    </profile>
+    <profile>
+      <id>errorProne-jdk8</id>
       <activation>
         <activeByDefault>false</activeByDefault>
       </activation>
@@ -95,6 +141,26 @@
       </dependencies>
       <build>
         <plugins>
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-enforcer-plugin</artifactId>
+            <executions>
+              <execution>
+                <id>enforce-java</id>
+                <goals>
+                  <goal>enforce</goal>
+                </goals>
+                <configuration>
+                  <rules>
+                    <requireJavaVersion>
+                      <version>[1.8,9)</version>
+                      <message>Running with `-P errorProne-jdk8` on an unsupported JDK version.</message>
+                    </requireJavaVersion>
+                  </rules>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
           <!-- Turn on error-prone -->
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
ErrorProne uses an extension interface that's only available on javac
from JDK9+. Thus, its configuration for JDK8 is quite different from
later JVM versions. These configurations are mutually exclusive, I
haven't seen any documentation for project that compile on both javac
verions. Thus this implementation based on different maven profiles.

The situation is further complicated by maven not allowing profile
activation based on multiple conditions. In our case, we'd like to do
profile select based on both the active JDK and the presense of some
enablement flag, such as -DerrorProne. This seems to be impossible.

Thus, the solution presented here is to define two profiles, neither
active by default. When a user wishes to run Error Prone, they must
activate the profile that is appropriate to their version of javac.