### PR TITLE
HBASE-23998. Update license for jetty-client. (#1297) (#1498)

### DIFF
--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
@@ -1375,6 +1375,20 @@ under the License.
   </supplement>
   <supplement>
     <project>
+      <groupId>org.eclipse.jetty</groupId>
+      <artifactId>jetty-client</artifactId>
+
+      <licenses>
+        <license>
+          <name>Apache License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </project>
+  </supplement>
+  <supplement>
+    <project>
       <groupId>org.eclipse.jetty.websocket</groupId>
       <artifactId>javax-websocket-client-impl</artifactId>
 


### PR DESCRIPTION
Signed-off-by: stack <stack@apache.org>
Signed-off-by: Jan Hentschel <janh@apache.org>
Signed-off-by: Duo Zhang <zhangduo@apache.org>

Co-authored-by: Wei-Chiu Chuang <weichiu@apache.org>
(cherry picked from commit 5dfd0d8e0403ee3061fc316dc4d99e936063c1a4)