### PR TITLE
HBASE-24238 Clean up root pom after removing hadoop-2.0 profile

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1484,11 +1484,10 @@
     <!-- These must be defined here for downstream build tools that don't look at profiles.
     -->
     <hadoop.version>${hadoop-three.version}</hadoop.version>
-    <hadoop.guava.version>11.0.2</hadoop.guava.version>
     <assembly.file>src/main/assembly/hadoop-two-compat.xml</assembly.file>
     <!--This property is for hadoops netty. HBase netty
          comes in via hbase-thirdparty hbase-shaded-netty-->
-    <netty.hadoop.version>3.6.2.Final</netty.hadoop.version>
+    <netty.hadoop.version>3.10.5.Final</netty.hadoop.version>
     <!-- end HBASE-15925 default hadoop compatibility values -->
     <audience-annotations.version>0.5.0</audience-annotations.version>
     <avro.version>1.7.7</avro.version>
@@ -2598,9 +2597,6 @@
       <properties>
         <hadoop.version>${hadoop-three.version}</hadoop.version>
         <assembly.file>src/main/assembly/hadoop-three-compat.xml</assembly.file>
-        <!--This property is for hadoops netty. HBase netty
-             comes in via hbase-thirdparty hbase-shaded-netty-->
-        <netty.hadoop.version>3.10.5.Final</netty.hadoop.version>
       </properties>
      <dependencyManagement>
        <dependencies>


### PR DESCRIPTION
(1) HBASE-24170 removed hadoop-2.0 profile and hadoop.guava.version is therefore not used afterwards.
(2) set netty.hadoop.version default to 3.10.5.Final which is set in the default hadoop-3.0 profile.