### PR TITLE
HBASE-24244 Move Region Command fails to move region of a table to another RS which is a part of different RSGroup without giving error.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -2085,6 +2085,10 @@ public class HMaster extends HRegionServer implements MasterServices {
         return;
       }
     }
+    if (dest.equals(LoadBalancer.BOGUS_SERVER_NAME)) {
+      LOG.debug("Unable to determine a server to assign {}.", hri);
+      return;
+    }
 
     if (dest.equals(regionState.getServerName())) {
       LOG.debug("Skipping move of region " + hri.getRegionNameAsString()

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupsAdmin2.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupsAdmin2.java
@@ -136,6 +136,7 @@ public class TestRSGroupsAdmin2 extends TestRSGroupsBase {
     });
 
     // Lets move this region to the new group.
+    long preOpCount = getRegionMoveProcCount();
     TEST_UTIL.getAdmin()
       .move(Bytes.toBytes(RegionInfo.encodeRegionName(Bytes.toBytes(targetRegion))), targetServer);
     TEST_UTIL.waitFor(WAIT_TIMEOUT, new Waiter.Predicate<Exception>() {
@@ -147,6 +148,8 @@ public class TestRSGroupsAdmin2 extends TestRSGroupsBase {
             .getRegionStatesInTransition().size() < 1;
       }
     });
+    long postOpCount = getRegionMoveProcCount();
+    assertEquals("Move region procedure should not have been submitted.", preOpCount, postOpCount);
 
     // verify that targetServer didn't open it
     for (RegionInfo region : ADMIN.getRegions(targetServer)) {
@@ -154,6 +157,11 @@ public class TestRSGroupsAdmin2 extends TestRSGroupsBase {
         fail("Target server opened region");
       }
     }
+  }
+
+  private long getRegionMoveProcCount() {
+    return TEST_UTIL.getHBaseCluster().getMaster().getAssignmentManager()
+      .getAssignmentManagerMetrics().getMoveProcMetrics().getSubmittedCounter().getCount();
   }
 
   @Test


### PR DESCRIPTION
HBASE-24244: Move region should fail fast when not able to assign a server.