### PR TITLE
HBASE-24257 Exclude jsr311-api from classpath

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2941,6 +2941,11 @@
                <groupId>com.google.code.findbugs</groupId>
                <artifactId>jsr305</artifactId>
              </exclusion>
+             <exclusion>
+               <!-- conflicts with javax.ws.rs:javax.ws.rs-api:jar:2.0.1 -->
+               <groupId>javax.ws.rs</groupId>
+               <artifactId>jsr311-api</artifactId>
+             </exclusion>
            </exclusions>
          </dependency>
          <dependency>


### PR DESCRIPTION
We still have `jsr311-api` in our dependency tree, but it's behind
`hbase-shaded-testing-util`, so I believe it's safely masked away.