### PR TITLE
HBASE-24215 [Flakey Tests] [ERROR] TestSecureRESTServer java.lang.NoC…

### DIFF
--- a/hbase-rest/pom.xml
+++ b/hbase-rest/pom.xml
@@ -507,6 +507,18 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-auth</artifactId>
         </dependency>
+        <dependency>
+          <!--Fixes complaint when running TestSecureRESTServer-->
+          <groupId>com.sun.jersey</groupId>
+          <artifactId>jersey-servlet</artifactId>
+          <version>1.19.4</version>
+          <exclusions>
+            <exclusion>
+             <groupId>javax.ws.rs</groupId>
+             <artifactId>jsr311-api</artifactId>
+            </exclusion>
+          </exclusions>
+        </dependency>
       </dependencies>
     </profile>
     <profile>

--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
@@ -118,7 +118,7 @@ public class RESTServer implements Constants {
     HelpFormatter formatter = new HelpFormatter();
     formatter.printHelp("hbase rest start", "", options,
       "\nTo run the REST server as a daemon, execute " +
-      "hbase-daemon.sh start|stop rest [--infoport <port>] [-p <port>] [-ro]\n", true);
+      "hbase-daemon.sh start|stop rest [-i <port>] [-p <port>] [-ro]\n", true);
     System.exit(exitCode);
   }
 
@@ -186,7 +186,7 @@ public class RESTServer implements Constants {
     options.addOption("p", "port", true, "Port to bind to [default: " + DEFAULT_LISTEN_PORT + "]");
     options.addOption("ro", "readonly", false, "Respond only to GET HTTP " +
       "method requests [default: false]");
-    options.addOption(null, "infoport", true, "Port for web UI");
+    options.addOption("i", "infoport", true, "Port for WEB UI");
 
     CommandLine commandLine = null;
     try {
@@ -218,7 +218,7 @@ public class RESTServer implements Constants {
       String val = commandLine.getOptionValue("infoport");
       conf.setInt("hbase.rest.info.port", Integer.parseInt(val));
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Web UI port set to " + val);
+        LOG.debug("WEB UI port set to " + val);
       }
     }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
@@ -731,6 +731,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
     // Frustrate yarn's and hdfs's attempts at writing /tmp.
     // Below is fragile. Make it so we just interpolate any 'tmp' reference.
     createDirAndSetProperty("yarn.node-labels.fs-store.root-dir");
+    createDirAndSetProperty("yarn.node-attribute.fs-store.root-dir");
     createDirAndSetProperty("yarn.nodemanager.log-dirs");
     createDirAndSetProperty("yarn.nodemanager.remote-app-log-dir");
     createDirAndSetProperty("yarn.timeline-service.entity-group-fs-store.active-dir");

--- a/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift/TestBindExceptionHandling.java
+++ b/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift/TestBindExceptionHandling.java
@@ -42,7 +42,9 @@ public class TestBindExceptionHandling {
         createBoundServer(true, false);
       assertNotNull(thriftServer.tserver);
     } finally {
-      thriftServer.stop();
+      if (thriftServer != null) {
+        thriftServer.stop();
+      }
     }
   }
 
@@ -57,7 +59,9 @@ public class TestBindExceptionHandling {
         createBoundServer(false, true);
       assertNotNull(thriftServer.tserver);
     } finally {
-      thriftServer.stop();
+      if (thriftServer != null) {
+        thriftServer.stop();
+      }
     }
   }
 }


### PR DESCRIPTION
…lassDefFoundError: com/sun/jersey/core/spi/factory/AbstractRuntimeDelegate

Test patch to see how it does on hadoopqa.

Purges transitive jaxb includes so I can specify jaxb when needed.
Also, can specify implementation for jdk11. Otherwise, implementation
clashes w/ jaxb transitively included.

Purge transitive includes of jsr311-api. Otherwise, we pickup
version1 and we get

 java.lang.NoSuchMethodError: javax.ws.rs.core.Application.getProperties()Ljava/util/Map;

when we try to run the REST server.

TODO: Do better edit of when we add excludes.. make it hadoop3 only.

Adds a few jersey1 excludes in top-level poms.

In hbase-rest, do more exclusions of jersey1 includes.

Add a jaxb impl for REST and include jersey1 servlet explicitly.