### PR TITLE
HBASE-24280 No explicit Hadoop3 profile activation on master

### DIFF
--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -146,7 +146,7 @@ function personality_modules
   fi
 
   if [[ -n "${HADOOP_PROFILE}" ]]; then
-    extra="${extra} -Phadoop-${HADOOP_PROFILE}"
+    extra="${extra} -Dhadoop.profile=${HADOOP_PROFILE}"
   fi
 
   # BUILDMODE value is 'full' when there is no patch to be tested, and we are running checks on
@@ -459,7 +459,7 @@ function shadedjars_rebuild
     '-Dtest=NoUnitTests' '-DHBasePatchProcess' '-Prelease'
     '-Dmaven.javadoc.skip=true' '-Dcheckstyle.skip=true' '-Dspotbugs.skip=true')
   if [[ -n "${HADOOP_PROFILE}" ]]; then
-    maven_args+=("-Phadoop-${HADOOP_PROFILE}")
+    maven_args+=("-Dhadoop.profile=${HADOOP_PROFILE}")
   fi
 
   # disabled because "maven_executor" needs to return both command and args
@@ -644,7 +644,7 @@ function hadoopcheck_rebuild
       $(maven_executor) clean install \
         -DskipTests -DHBasePatchProcess \
         -Dhadoop-three.version="${hadoopver}" \
-        -Phadoop-3.0
+        -Dhadoop.profile="3.0"
     count=$(${GREP} -c '\[ERROR\]' "${logfile}")
     if [[ ${count} -gt 0 ]]; then
       add_vote_table -1 hadoopcheck "${BUILDMODEMSG} causes ${count} errors with Hadoop v${hadoopver}."

--- a/dev-support/hbase_nightly_yetus.sh
+++ b/dev-support/hbase_nightly_yetus.sh
@@ -76,7 +76,11 @@ fi
 
 # For testing with specific hadoop version. Activates corresponding profile in maven runs.
 if [[ -n "${HADOOP_PROFILE}" ]]; then
-  YETUS_ARGS=("--hadoop-profile=${HADOOP_PROFILE}" "${YETUS_ARGS[@]}")
+  # Master has only Hadoop3 support. We don't need to activate any profile.
+  # The Jenkinsfile should not attempt to run any Hadoop2 tests.
+  if [[ "${BRANCH_NAME}" != "master" ]]; then
+    YETUS_ARGS=("--hadoop-profile=${HADOOP_PROFILE}" "${YETUS_ARGS[@]}")
+  fi
 fi
 
 if [[ -n "${SKIP_ERROR_PRONE}" ]]; then

--- a/dev-support/hbase_nightly_yetus.sh
+++ b/dev-support/hbase_nightly_yetus.sh
@@ -78,7 +78,7 @@ fi
 if [[ -n "${HADOOP_PROFILE}" ]]; then
   # Master has only Hadoop3 support. We don't need to activate any profile.
   # The Jenkinsfile should not attempt to run any Hadoop2 tests.
-  if [[ "${BRANCH_NAME}" != "master" ]]; then
+  if [[ "${BRANCH_NAME}" =~ branch-2* ]]; then
     YETUS_ARGS=("--hadoop-profile=${HADOOP_PROFILE}" "${YETUS_ARGS[@]}")
   fi
 fi

--- a/dev-support/jenkins_precommit_github_yetus.sh
+++ b/dev-support/jenkins_precommit_github_yetus.sh
@@ -129,7 +129,7 @@ YETUS_ARGS+=("--skip-dirs=dev-support")
 if [[ -n "${HADOOP_PROFILE}" ]]; then
   # Master has only Hadoop3 support. We don't need to activate any profile.
   # The Jenkinsfile should not attempt to run any Hadoop2 tests.
-  if [[ "${BRANCH_NAME}" != "master" ]]; then
+  if [[ "${BRANCH_NAME}" =~ branch-2* ]]; then
     YETUS_ARGS+=("--hadoop-profile=${HADOOP_PROFILE}")
   fi
 fi

--- a/dev-support/jenkins_precommit_github_yetus.sh
+++ b/dev-support/jenkins_precommit_github_yetus.sh
@@ -127,7 +127,11 @@ YETUS_ARGS+=("--skip-errorprone")
 YETUS_ARGS+=("--skip-dirs=dev-support")
 # For testing with specific hadoop version. Activates corresponding profile in maven runs.
 if [[ -n "${HADOOP_PROFILE}" ]]; then
-  YETUS_ARGS+=("--hadoop-profile=${HADOOP_PROFILE}")
+  # Master has only Hadoop3 support. We don't need to activate any profile.
+  # The Jenkinsfile should not attempt to run any Hadoop2 tests.
+  if [[ "${BRANCH_NAME}" != "master" ]]; then
+    YETUS_ARGS+=("--hadoop-profile=${HADOOP_PROFILE}")
+  fi
 fi
 if [[ -n "${EXCLUDE_TESTS_URL}" ]]; then
   YETUS_ARGS+=("--exclude-tests-url=${EXCLUDE_TESTS_URL}")


### PR DESCRIPTION
On 2.x branches, we need to explicitly activate profiles for H3. On
master, all H2 support is dropped which means no special profiles are
required for H3 (though, there is still a profile there to encapsulate
H3 logic).

We need to make sure that the yetus invocation can correctly pass down
any profile information into the personality, so we activate the exact
profiles we want.