### PR TITLE
HBASE-24261: Initial version of ASF infra integration configuration

### DIFF
--- a/.asf.yaml
+++ b/.asf.yaml
@@ -1,0 +1,41 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This file controls the integration of HBase project with ASF infrastructure. Refer to
+# https://cwiki.apache.org/confluence/display/INFRA/.asf.yaml+features+for+git+repositories for
+# details. Be careful when changing the contents of this file since it may affect many developers
+# of the project and make sure to discuss the changes with dev@ before committing.
+
+github:
+  description: "Apache HBase"
+  homepage: https://hbase.apache.org/
+  labels:
+    - database
+    - java
+    - hbase
+  features:
+    wiki: false
+    issues: false
+    projects: false
+  enabled_merge_buttons:
+    squash:  true
+    merge:   false
+    rebase:  true
+  notifications:
+    commits:      commits@hbase.apache.org
+    issues:       issues@hbase.apache.org
+    pullrequests: issues@hbase.apache.org
+    jira_options: link


### PR DESCRIPTION
This is an initial version of the yaml config for ASF infra
integration. We might have some hiccups in the beginning but we
can iteratively improve until the old (desired) setup is back
in place.

We will have to do separate commits for other repositories like
hbase-site etc, for now this is for the main hbase source code
repo.