### PR TITLE
HBASE-23832 Old config hbase.hstore.compactionThreshold is ignored

### DIFF
--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -824,14 +824,15 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
     <name>hbase.hstore.compaction.min</name>
-    <value>3</value>
+    <value></value>
     <description>The minimum number of StoreFiles which must be eligible for compaction before
       compaction can run. The goal of tuning hbase.hstore.compaction.min is to avoid ending up with
       too many tiny StoreFiles to compact. Setting this value to 2 would cause a minor compaction
       each time you have two StoreFiles in a Store, and this is probably not appropriate. If you
       set this value too high, all the other values will need to be adjusted accordingly. For most
-      cases, the default value is appropriate. In previous versions of HBase, the parameter
-      hbase.hstore.compaction.min was named hbase.hstore.compactionThreshold.</description>
+      cases, the default value is appropriate  (empty value here, results in 3 by code logic). In 
+      previous versions of HBase, the parameter hbase.hstore.compaction.min was named 
+      hbase.hstore.compactionThreshold.</description>
   </property>
   <property>
     <name>hbase.hstore.compaction.max</name>


### PR DESCRIPTION
Updated default value hbase.hstore.compaction.min to null

With this change if user uses old key "hbase.hstore.compactionThreshold", then it will take effect. If user doesn't define any then default value of null, will result in 3 for minFilesToComapct, which is expected.