### PR TITLE
HBASE-24297 release scripts should be able to use an existing project clone

### DIFF
--- a/dev-support/create-release/release-build.sh
+++ b/dev-support/create-release/release-build.sh
@@ -113,7 +113,7 @@ if [[ "$1" == "tag" ]]; then
   if [ -z "${GIT_REPO}" ]; then
     check_needed_vars ASF_USERNAME ASF_PASSWORD
   fi
-  git_force_clone
+  git_clone_overwrite
 
   # 'update_releasenotes' searches the project's Jira for issues where 'Fix Version' matches specified
   # $jira_fix_version. For most projects this is same as ${RELEASE_VERSION}. However, all the 'hbase-*'
@@ -183,7 +183,7 @@ fi
 if is_dry_run && [[ "${TAG_SAME_DRY_RUN:-}" == "true" && -d "${PROJECT}.tag" ]]; then
   ln -s "${PROJECT}.tag" "${PROJECT}"
 else
-  git_force_clone
+  git_clone_overwrite
 fi
 cd "${PROJECT}"
 git checkout "$GIT_REF"

--- a/dev-support/create-release/release-build.sh
+++ b/dev-support/create-release/release-build.sh
@@ -109,12 +109,11 @@ if [[ "$1" == "tag" ]]; then
   set -o pipefail
   set -x  # detailed logging during action
   check_get_passwords ASF_PASSWORD
-  check_needed_vars PROJECT ASF_USERNAME ASF_PASSWORD RELEASE_VERSION RELEASE_TAG NEXT_VERSION \
-      GIT_EMAIL GIT_NAME GIT_BRANCH
-  ASF_REPO="gitbox.apache.org/repos/asf/${PROJECT}.git"
-  encoded_username="$(python -c "import urllib; print urllib.quote('''$ASF_USERNAME''')")"
-  encoded_password="$(python -c "import urllib; print urllib.quote('''$ASF_PASSWORD''')")"
-  git clone "https://$encoded_username:$encoded_password@$ASF_REPO" -b "$GIT_BRANCH" "${PROJECT}"
+  check_needed_vars PROJECT RELEASE_VERSION RELEASE_TAG NEXT_VERSION GIT_EMAIL GIT_NAME GIT_BRANCH
+  if [ -z "${GIT_REPO}" ]; then
+    check_needed_vars ASF_USERNAME ASF_PASSWORD
+  fi
+  git_force_clone
 
   # 'update_releasenotes' searches the project's Jira for issues where 'Fix Version' matches specified
   # $jira_fix_version. For most projects this is same as ${RELEASE_VERSION}. However, all the 'hbase-*'
@@ -184,8 +183,7 @@ fi
 if is_dry_run && [[ "${TAG_SAME_DRY_RUN:-}" == "true" && -d "${PROJECT}.tag" ]]; then
   ln -s "${PROJECT}.tag" "${PROJECT}"
 else
-  ASF_REPO="${ASF_REPO:-https://gitbox.apache.org/repos/asf/${PROJECT}.git}"
-  git clone "$ASF_REPO" "${PROJECT}"
+  git_force_clone
 fi
 cd "${PROJECT}"
 git checkout "$GIT_REF"

--- a/dev-support/create-release/release-util.sh
+++ b/dev-support/create-release/release-util.sh
@@ -389,6 +389,40 @@ function configure_maven {
 EOF
 }
 
+# force a clone of the repo, optionally with auth details for pushing.
+function git_force_clone {
+  local asf_repo
+  if [ -d "${PROJECT}" ]; then
+    rm -rf "${PROJECT}"
+  fi
+
+  if [[ -z "${GIT_REPO}" ]]; then
+    asf_repo="gitbox.apache.org/repos/asf/${PROJECT}.git"
+    echo "[INFO] clone will be of the gitbox repo for ${PROJECT}."
+    if [ -n "${ASF_USERNAME}" ] && [ -n "${ASF_PASSWORD}" ]; then
+      # Ugly!
+      encoded_username=$(python -c "import urllib; print urllib.quote('''$ASF_USERNAME''')")
+      encoded_password=$(python -c "import urllib; print urllib.quote('''$ASF_PASSWORD''')")
+      GIT_REPO="https://$encoded_username:$encoded_password@${asf_repo}"
+    else
+      GIT_REPO="https://${asf_repo}"
+    fi
+  else
+    echo "[INFO] clone will be of provided git repo."
+  fi
+  # N.B. we use the shared flag because the clone is short lived and if a local repo repo was
+  #      given this will let us refer to objects there directly instead of hardlinks or copying.
+  #      The option is silently ignored for non-local repositories. see the note on git help clone
+  #      for the --shared option for details.
+  git clone --shared -b "${GIT_BRANCH}" -- "${GIT_REPO}" "${PROJECT}"
+  # If this was a host local git repo then add in an alterntes and remote that will
+  # work back on the host if the RM needs to do any post-processing steps, i.e. pushing the git tag
+  if [ -n "$HOST_GIT_REPO" ]; then
+    echo "${HOST_GIT_REPO}/objects" >> "${PROJECT}/.git/objects/info/alternates"
+    (cd "${PROJECT}"; git remote add host "${HOST_GIT_REPO}")
+  fi
+}
+
 # Writes report into cwd!
 function generate_api_report {
   local project="$1"

--- a/dev-support/create-release/release-util.sh
+++ b/dev-support/create-release/release-util.sh
@@ -389,12 +389,14 @@ function configure_maven {
 EOF
 }
 
-# force a clone of the repo, optionally with auth details for pushing.
-function git_force_clone {
+# clone of the repo, deleting anything that exists in the working directory named after the project.
+# optionally with auth details for pushing.
+function git_clone_overwrite {
   local asf_repo
-  if [ -d "${PROJECT}" ]; then
-    rm -rf "${PROJECT}"
+  if [ -z "${PROJECT}" ] || [ "${PROJECT}" != "${PROJECT#/}" ]; then
+    error "Project name must be defined and not start with a '/'. PROJECT='${PROJECT}'"
   fi
+  rm -rf "${PROJECT}"
 
   if [[ -z "${GIT_REPO}" ]]; then
     asf_repo="gitbox.apache.org/repos/asf/${PROJECT}.git"
@@ -415,8 +417,9 @@ function git_force_clone {
   #      The option is silently ignored for non-local repositories. see the note on git help clone
   #      for the --shared option for details.
   git clone --shared -b "${GIT_BRANCH}" -- "${GIT_REPO}" "${PROJECT}"
-  # If this was a host local git repo then add in an alterntes and remote that will
+  # If this was a host local git repo then add in an alternates and remote that will
   # work back on the host if the RM needs to do any post-processing steps, i.e. pushing the git tag
+  # for more info see 'git help remote' and 'git help repository-layout'.
   if [ -n "$HOST_GIT_REPO" ]; then
     echo "${HOST_GIT_REPO}/objects" >> "${PROJECT}/.git/objects/info/alternates"
     (cd "${PROJECT}"; git remote add host "${HOST_GIT_REPO}")


### PR DESCRIPTION
Adds the ability to specify the remote git repo for the release scripts, including a local clone.

* adds a optional `-r [repo]` arg
* if the passed repo is on the local filesystem, creates a container mount
* git clone operations consolidated into a function
* when cloning a local repo configure git to share objects with the local repo instead of copying
* when cloning a local repo in a container configure the clone to have a remote that will work back on the host.