### PR TITLE
HBASE-24403 FsDelegationToken Should Cache Token After Acquired A New One

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/FsDelegationToken.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/FsDelegationToken.java
@@ -126,7 +126,7 @@ public class FsDelegationToken {
           userProvider.getCurrent().addToken(userToken);
         } catch (InterruptedException | NullPointerException e) {
           // we need to handle NullPointerException in case HADOOP-10009 is missing
-          LOG.error("Failed to get token for " + renewer);
+          LOG.error("Failed to get token for " + renewer, e);
         }
       } else {
         hasForwardedToken = true;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/FsDelegationToken.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/FsDelegationToken.java
@@ -65,7 +65,8 @@ public class FsDelegationToken {
    * @param renewer the account name that is allowed to renew the token.
    * @param renewAheadTime how long in millis
    */
-  public FsDelegationToken(final UserProvider userProvider, final String renewer, long renewAheadTime) {
+  public FsDelegationToken(final UserProvider userProvider, final String renewer,
+    long renewAheadTime) {
     this.userProvider = userProvider;
     this.renewer = renewer;
     this.renewAheadTime = renewAheadTime;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/FsDelegationToken.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/FsDelegationToken.java
@@ -104,6 +104,7 @@ public class FsDelegationToken {
         hasForwardedToken = false;
         try {
           userToken = fs.getDelegationToken(renewer);
+          userProvider.getCurrent().addToken(userToken);
         } catch (NullPointerException npe) {
           // we need to handle NullPointerException in case HADOOP-10009 is missing
           LOG.error("Failed to get token for " + renewer);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -126,7 +126,8 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
   public static final String BULK_LOAD_HFILES_BY_FAMILY = "hbase.mapreduce.bulkload.by.family";
 
   //HDFS DelegationToken is cached and should be renewed before token expiration
-  public static final String BULK_LOAD_RENEW_TOKEN_TIME_BUFFER = "hbase.bulkload.renew.token.time.buffer";
+  public static final String BULK_LOAD_RENEW_TOKEN_TIME_BUFFER
+    = "hbase.bulkload.renew.token.time.buffer";
 
   // We use a '.' prefix which is ignored when walking directory trees
   // above. It is invalid family name.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -125,6 +125,9 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
    */
   public static final String BULK_LOAD_HFILES_BY_FAMILY = "hbase.mapreduce.bulkload.by.family";
 
+  //HDFS DelegationToken is cached and should be renewed before token expiration
+  public static final String BULK_LOAD_RENEW_TOKEN_TIME_BUFFER = "hbase.bulkload.renew.token.time.buffer";
+
   // We use a '.' prefix which is ignored when walking directory trees
   // above. It is invalid family name.
   static final String TMP_DIR = ".tmp";
@@ -142,6 +145,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
 
   private List<String> clusterIds = new ArrayList<>();
   private boolean replicate = true;
+  private final long retryAheadTime;
 
   public BulkLoadHFilesTool(Configuration conf) {
     // make a copy, just to be sure we're not overriding someone else's config
@@ -149,7 +153,8 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
     // disable blockcache for tool invocation, see HBASE-10500
     conf.setFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY, 0);
     userProvider = UserProvider.instantiate(conf);
-    fsDelegationToken = new FsDelegationToken(userProvider, "renewer");
+    retryAheadTime = conf.getLong(BULK_LOAD_RENEW_TOKEN_TIME_BUFFER, 60000L);
+    fsDelegationToken = new FsDelegationToken(userProvider, "renewer", retryAheadTime);
     assignSeqIds = conf.getBoolean(ASSIGN_SEQ_IDS, true);
     maxFilesPerRegionPerFamily = conf.getInt(MAX_FILES_PER_REGION_PER_FAMILY, 32);
     nrThreads = conf.getInt("hbase.loadincremental.threads.max",

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestFsDelegationToken.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestFsDelegationToken.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenId
 import static org.apache.hadoop.hdfs.web.WebHdfsConstants.SWEBHDFS_TOKEN_KIND;
 import static org.apache.hadoop.hdfs.web.WebHdfsConstants.WEBHDFS_TOKEN_KIND;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
@@ -88,6 +89,10 @@ public class TestFsDelegationToken {
     fsDelegationToken.acquireDelegationToken(fileSystem);
     assertEquals(
         fsDelegationToken.getUserToken().getKind(), HDFS_DELEGATION_KIND);
+    assertNotNull(
+      "HDFS Token should exist in cache after acquired",
+      userProvider.getCurrent()
+        .getToken(HDFS_DELEGATION_KIND.toString(), fileSystem.getCanonicalServiceName()));
   }
 
   @Test
@@ -95,6 +100,10 @@ public class TestFsDelegationToken {
     fsDelegationToken.acquireDelegationToken(webHdfsFileSystem);
     assertEquals(
         fsDelegationToken.getUserToken().getKind(), WEBHDFS_TOKEN_KIND);
+    assertNotNull(
+      "Webhdfs token should exist in cache after acquired",
+      userProvider.getCurrent()
+        .getToken(WEBHDFS_TOKEN_KIND.toString(), webHdfsFileSystem.getCanonicalServiceName()));
   }
 
   @Test
@@ -102,6 +111,10 @@ public class TestFsDelegationToken {
     fsDelegationToken.acquireDelegationToken(swebHdfsFileSystem);
     assertEquals(
         fsDelegationToken.getUserToken().getKind(), SWEBHDFS_TOKEN_KIND);
+    assertNotNull(
+      "Swebhdfs token should exist in cache after acquired",
+      userProvider.getCurrent()
+        .getToken(SWEBHDFS_TOKEN_KIND.toString(), swebHdfsFileSystem.getCanonicalServiceName()));
   }
 
   @Test(expected = NullPointerException.class)
@@ -114,6 +127,10 @@ public class TestFsDelegationToken {
     fsDelegationToken
         .acquireDelegationToken(WEBHDFS_TOKEN_KIND.toString(), webHdfsFileSystem);
     assertEquals(fsDelegationToken.getUserToken().getKind(), WEBHDFS_TOKEN_KIND);
+    assertNotNull(
+      "Webhdfs token should exist in cache after acquired",
+      userProvider.getCurrent()
+        .getToken(WEBHDFS_TOKEN_KIND.toString(), webHdfsFileSystem.getCanonicalServiceName()));
   }
 
   @Test
@@ -122,5 +139,9 @@ public class TestFsDelegationToken {
         .acquireDelegationToken(
             SWEBHDFS_TOKEN_KIND.toString(), swebHdfsFileSystem);
     assertEquals(fsDelegationToken.getUserToken().getKind(), SWEBHDFS_TOKEN_KIND);
+    assertNotNull(
+      "Swebhdfs token should exist in cache after acquired",
+      userProvider.getCurrent()
+        .getToken(SWEBHDFS_TOKEN_KIND.toString(), swebHdfsFileSystem.getCanonicalServiceName()));
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestFsDelegationToken.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestFsDelegationToken.java
@@ -82,6 +82,9 @@ public class TestFsDelegationToken {
     when(hdfsToken.getKind()).thenReturn(new Text("HDFS_DELEGATION_TOKEN"));
     when(webhdfsToken.getKind()).thenReturn(WEBHDFS_TOKEN_KIND);
     when(swebhdfsToken.getKind()).thenReturn(SWEBHDFS_TOKEN_KIND);
+    when(fileSystem.getDelegationToken("Renewer")).thenReturn(hdfsToken);
+    when(webHdfsFileSystem.getDelegationToken("Renewer")).thenReturn(webhdfsToken);
+    when(swebHdfsFileSystem.getDelegationToken("Renewer")).thenReturn(swebhdfsToken);
   }
 
   @Test


### PR DESCRIPTION
# Problem Description
When doing Bulkload, we find that `FsDelegationToken` will acquire token of NameNode every time for a single file, although, from the comment of `acquireDelegationToken()`, it claims that it is trying to find token in cache firstly, but the newly requested token is never put to cache and thus the cache is still empty for the following request;

In cases there are many files to do the bulk load,  the token request will cause big shock to NameNode.

```
  public void acquireDelegationToken(final String tokenKind, final FileSystem fs)
      throws IOException {
    Objects.requireNonNull(tokenKind, "tokenKind:null");
    if (userProvider.isHadoopSecurityEnabled()) {
      this.fs = fs;
      userToken = userProvider.getCurrent().getToken(tokenKind, fs.getCanonicalServiceName());
      if (userToken == null) {
        hasForwardedToken = false;
        try {
          userToken = fs.getDelegationToken(renewer);
          userProvider.getCurrent().addToken(userToken);
        } catch (NullPointerException npe) {
          // we need to handle NullPointerException in case HADOOP-10009 is missing
          LOG.error("Failed to get token for " + renewer);
        }
      } else {
        hasForwardedToken = true;
        LOG.info("Use the existing token: " + userToken);
      }
    }
  }
```

----------
# Token Expiration Processing Logic
If we use a cached token, we must renew or apply for new token before token is expired;
My solution is:
## When Should We Apply for New Token
When and only below condition, we will apply for a new DelegationToken from HDFS:
1. We cannot find corresponding token in cache
2. We could find the cached token, but the token is expiring or already expired.

## How to figure out whether or not the cached token is expiring? 
Everything we apply for a brand new token, we quickly renew the token to get the token expiration time. Then, we configured a time buffer(By default 10min), which means that everytime we want to use the cached token, we need to confirm that current time has not reached the `tokenExpiration time - timebuffer`. If reached, we need to acquire a new token.