### PR TITLE
HBASE-24409: Exposing a function in HBase WALKey to set the table name

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALKey.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALKey.java
@@ -58,6 +58,14 @@ public interface WALKey extends SequenceId, Comparable<WALKey> {
   TableName getTableName();
 
   /**
+   * set the table name for WALKey. This is mainly for the purpose of
+   * when we want to change the table name in the WALKey.
+   * For example:
+   * replicating across different table names in two different clusters
+   */
+  void setTableName(TableName tableName);
+
+  /**
    * @return the write time
    */
   long getWriteTime();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALKeyImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALKeyImpl.java
@@ -329,7 +329,7 @@ public class WALKeyImpl implements WALKey {
    *
    * @param encodedRegionName Encoded name of the region as returned by
    *                          <code>HRegionInfo#getEncodedNameAsBytes()</code>.
-   * @param tablename
+   * @param tablename table name to which this WALKey belongs to
    * @param logSeqNum
    * @param nonceGroup
    * @param nonce
@@ -408,6 +408,11 @@ public class WALKeyImpl implements WALKey {
   @Override
   public TableName getTableName() {
     return tablename;
+  }
+
+  @Override
+  public void setTableName(TableName tablename) {
+    this.tablename = tablename;
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALMethods.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALMethods.java
@@ -142,6 +142,20 @@ public class TestWALMethods {
   }
 
   @Test
+  public void testWALSetTable() {
+    WAL.Entry entry = createTestLogEntry(0);
+    assertEquals("Table name in the WALKey is not correct",
+      TEST_TABLE, entry.getKey().getTableName());
+
+    TableName tableName = TableName.valueOf("TEST_TABLE2");
+    entry.getKey().setTableName(tableName);
+    assertEquals("Table name in the WALKey is not correct",
+      tableName, entry.getKey().getTableName());
+    assertEquals("Table name in the WALKey is not correct",
+      "TEST_TABLE2", entry.getKey().getTableName().getNameAsString());
+  }
+
+  @Test
   public void testEntrySink() throws Exception {
     EntryBuffers sink = new EntryBuffers(new PipelineController(), 1*1024*1024);
     for (int i = 0; i < 1000; i++) {


### PR DESCRIPTION
Currently, the table name in WALKey can not be changed once set. But exposing this function to change the table name can be very helpful for Customized WAL filters since they can flip the table name and make replication possible between different table names in source and sink clusters. 