### PR TITLE
HBASE-24413 HBASE-22259 Removed deprecated getTimeStampOfLastShippedO…

### DIFF
--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -915,7 +915,7 @@ module Hbase
     end
 
     def build_shipped_stats(source_load, r_source_string)
-      r_source_string << if source_load.getTimeStampOfLastShippedOp.zero?
+      r_source_string << if source_load.getTimestampOfLastShippedOp.zero?
                            "\n           " \
                            'No Ops shipped since last restart'
                          else
@@ -923,7 +923,7 @@ module Hbase
                            source_load.getAgeOfLastShippedOp.to_s +
                            ', TimeStampOfLastShippedOp=' +
                            java.util.Date.new(source_load
-                             .getTimeStampOfLastShippedOp).toString
+                             .getTimestampOfLastShippedOp).toString
                          end
     end
 


### PR DESCRIPTION
…p method from ReplicationLoadSource, but there were still references to this method on ruby admin.rb