### PR TITLE
HBASE-24423 No need to get lock in canSplit because hasReferences wil…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -2075,17 +2075,12 @@ public class HStore implements Store, HeapSize, StoreConfigInformation,
 
   @Override
   public boolean canSplit() {
-    this.lock.readLock().lock();
-    try {
-      // Not split-able if we find a reference store file present in the store.
-      boolean result = !hasReferences();
-      if (!result) {
-        LOG.trace("Not splittable; has references: {}", this);
-      }
-      return result;
-    } finally {
-      this.lock.readLock().unlock();
+    // Not split-able if we find a reference store file present in the store.
+    boolean result = !hasReferences();
+    if (!result) {
+      LOG.trace("Not splittable; has references: {}", this);
     }
+    return result;
   }
 
   /**


### PR DESCRIPTION
…l get lock too

Signed-off-by: Bharath Vissapragada <bharathv@apache.org>