### PR TITLE
HBASE-22033 Update to maven-javadoc-plugin 3.2.0 and switch to non-forking aggregate goals

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -721,6 +721,11 @@
             <compilerArgument>-Xlint:-options</compilerArgument>
           </configuration>
         </plugin>
+        <plugin>
+          <groupId>org.apache.maven.plugins</groupId>
+          <artifactId>maven-javadoc-plugin</artifactId>
+          <version>${maven.javadoc.version}</version>
+        </plugin>
         <!-- Test oriented plugins -->
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
@@ -1591,6 +1596,7 @@
     <maven.bundle.version>3.3.0</maven.bundle.version>
     <maven.checkstyle.version>3.1.0</maven.checkstyle.version>
     <maven.eclipse.version>2.10</maven.eclipse.version>
+    <maven.javadoc.version>3.2.0</maven.javadoc.version>
     <maven.warbucks.version>1.1.0</maven.warbucks.version>
     <maven.project.info.report.version>2.9</maven.project.info.report.version>
     <os.maven.version>1.5.0.Final</os.maven.version>
@@ -3736,7 +3742,7 @@
           <reportSet>
             <id>devapi</id>
             <reports>
-              <report>aggregate</report>
+              <report>aggregate-no-fork</report>
             </reports>
             <configuration>
               <destDir>devapidocs</destDir>
@@ -3785,7 +3791,7 @@
           <reportSet>
             <id>testdevapi</id>
             <reports>
-              <report>test-aggregate</report>
+              <report>test-aggregate-no-fork</report>
             </reports>
             <configuration>
               <destDir>testdevapidocs</destDir>
@@ -3836,7 +3842,7 @@
           <reportSet>
             <id>userapi</id>
             <reports>
-              <report>aggregate</report>
+              <report>aggregate-no-fork</report>
             </reports>
             <configuration>
               <doclet>
@@ -3896,7 +3902,7 @@
           <reportSet>
             <id>testuserapi</id>
             <reports>
-              <report>test-aggregate</report>
+              <report>test-aggregate-no-fork</report>
             </reports>
             <configuration>
               <doclet>

--- a/pom.xml
+++ b/pom.xml
@@ -3772,6 +3772,12 @@
                   <artifactId>hamcrest-core</artifactId>
                   <version>${hamcrest.version}</version>
                 </additionalDependency>
+                <!-- javadoc tooling requires jsr305 due to references to it from things we rely on -->
+                <additionalDependency>
+                  <groupId>com.google.code.findbugs</groupId>
+                  <artifactId>jsr305</artifactId>
+                  <version>3.0.2</version>
+                </additionalDependency>
               </additionalDependencies>
               <inherited>false</inherited>
             </configuration>
@@ -3814,6 +3820,12 @@
                   <groupId>org.hamcrest</groupId>
                   <artifactId>hamcrest-core</artifactId>
                   <version>${hamcrest.version}</version>
+                </additionalDependency>
+                <!-- javadoc tooling requires jsr305 due to references to it from things we rely on -->
+                <additionalDependency>
+                  <groupId>com.google.code.findbugs</groupId>
+                  <artifactId>jsr305</artifactId>
+                  <version>3.0.2</version>
                 </additionalDependency>
               </additionalDependencies>
               <inherited>false</inherited>
@@ -3870,6 +3882,12 @@
                   <artifactId>hamcrest-core</artifactId>
                   <version>${hamcrest.version}</version>
                 </additionalDependency>
+                <!-- javadoc tooling requires jsr305 due to references to it from things we rely on -->
+                <additionalDependency>
+                  <groupId>com.google.code.findbugs</groupId>
+                  <artifactId>jsr305</artifactId>
+                  <version>3.0.2</version>
+                </additionalDependency>
               </additionalDependencies>
               <inherited>false</inherited>
             </configuration>
@@ -3923,6 +3941,12 @@
                   <groupId>org.hamcrest</groupId>
                   <artifactId>hamcrest-core</artifactId>
                   <version>${hamcrest.version}</version>
+                </additionalDependency>
+                <!-- javadoc tooling requires jsr305 due to references to it from things we rely on -->
+                <additionalDependency>
+                  <groupId>com.google.code.findbugs</groupId>
+                  <artifactId>jsr305</artifactId>
+                  <version>3.0.2</version>
                 </additionalDependency>
               </additionalDependencies>
               <inherited>false</inherited>


### PR DESCRIPTION
- needs a forward port of HBASE-19663 on master (previously only on branch-1)
- updates our maven-javadoc-plugin to latest (3.2.0)
- switches all of our javadocs reports to use the non-forking version.

using `mvn -B install -DskipTests && mvn -B site -DskipTests`; times on my local laptop below. I'm sure the impact would be greater in docker for OS X. these single run times has noise I'm sure.

before:
```
hbase busbey$ grep "Total time: " ~/Downloads/HBASE-22033.before.mvn.log 
19:11:32 [INFO] Total time:  05:30 min
19:27:04 [INFO] Total time:  15:29 min
```

after:
```
busbey-mba13:hbase busbey$ grep "Total time: " ~/Downloads/HBASE-22033.after.mvn.log 
18:53:29 [INFO] Total time:  06:22 min
19:02:50 [INFO] Total time:  09:19 min
```

checked using that website generation still works using `bash ./dev-support/jenkins-scripts/generate-hbase-website.sh --local-repo ~/.m2/repository .`