### PR TITLE
HBASE-24343 Document how to configure the http request log

### DIFF
--- a/conf/log4j.properties
+++ b/conf/log4j.properties
@@ -126,3 +126,14 @@ log4j.logger.org.apache.hadoop.metrics2.impl.MetricsSystemImpl=WARN
 # Disable request log by default, you can enable this by changing the appender
 log4j.category.http.requests=INFO,NullAppender
 log4j.additivity.http.requests=false
+# Replace the above with this configuration if you want an http access.log
+#log4j.appender.accessRFA=org.apache.log4j.RollingFileAppender
+#log4j.appender.accessRFA.File=/var/log/hbase/access.log
+#log4j.appender.accessRFA.layout=org.apache.log4j.PatternLayout
+#log4j.appender.accessRFA.layout.ConversionPattern=%m%n
+#log4j.appender.accessRFA.MaxFileSize=200MB
+#log4j.appender.accessRFA.MaxBackupIndex=10
+# route http.requests to the accessRFA appender
+#log4j.logger.http.requests=INFO,accessRFA
+# disable http.requests.* entries going up to the root logger
+#log4j.additivity.http.requests=false


### PR DESCRIPTION
We don't have a section in the book on configuring logging, so I left it as comments in `conf/log4j.properties`.