### PR TITLE
HBASE-20904 : Prometheus /metrics http endpoint for monitoring

### DIFF
--- a/hbase-http/pom.xml
+++ b/hbase-http/pom.xml
@@ -156,6 +156,10 @@
       <type>test-jar</type>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-metrics-api</artifactId>
+    </dependency>
     <!-- resource bundle only needed at build time -->
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/hbase-http/pom.xml
+++ b/hbase-http/pom.xml
@@ -160,6 +160,11 @@
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-metrics-api</artifactId>
     </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-metrics</artifactId>
+      <scope>test</scope>
+    </dependency>
     <!-- resource bundle only needed at build time -->
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusHadoop2Servlet.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusHadoop2Servlet.java
@@ -1,0 +1,45 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.http.prom;
+
+import org.apache.hadoop.hbase.http.HttpServer;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.yetus.audience.InterfaceAudience;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@InterfaceAudience.Private public class PrometheusHadoop2Servlet extends HttpServlet {
+
+  public PrometheusMetricsSink getPrometheusSink() {
+    return
+      (PrometheusMetricsSink) getServletContext().getAttribute(
+        HttpServer.PROMETHEUS_SINK);
+  }
+
+  @Override
+  protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+    throws ServletException, IOException {
+    DefaultMetricsSystem.instance().publishMetricsNow();
+    getPrometheusSink().writeMetrics(resp.getWriter());
+    resp.getWriter().flush();
+  }
+}

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusMetricsSink.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusMetricsSink.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.http.prom;
+
+import org.apache.commons.configuration2.SubsetConfiguration;
+import org.apache.hadoop.metrics2.AbstractMetric;
+import org.apache.hadoop.metrics2.MetricType;
+import org.apache.hadoop.metrics2.MetricsRecord;
+import org.apache.hadoop.metrics2.MetricsSink;
+import org.apache.hadoop.metrics2.MetricsTag;
+
+import java.io.IOException;
+import java.io.Writer;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.regex.Pattern;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Metrics sink for prometheus exporter.
+ * <p>
+ * Stores the metric data in-memory and return with it on request.
+ */
+@InterfaceAudience.Private public class PrometheusMetricsSink implements MetricsSink {
+
+  /**
+   * Cached output lines for each metrics.
+   */
+  private Map<String, String> metricLines = new HashMap<>();
+
+  private static final Pattern SPLIT_PATTERN =
+    Pattern.compile("(?<!(^|[A-Z_]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])");
+
+  public PrometheusMetricsSink() {
+  }
+
+  @Override
+  public void putMetrics(MetricsRecord metricsRecord) {
+    for (AbstractMetric metrics : metricsRecord.metrics()) {
+      if (metrics.type() == MetricType.COUNTER
+        || metrics.type() == MetricType.GAUGE) {
+
+        String key = PrometheusUtils.toPrometheusName(
+          metricsRecord.name(), metrics.name());
+
+        StringBuilder builder = new StringBuilder();
+        builder.append("# TYPE " + key + " " +
+          metrics.type().toString().toLowerCase() + "\n");
+        builder.append(key + "{");
+        String sep = "";
+
+        //add tags
+        for (MetricsTag tag : metricsRecord.tags()) {
+          String tagName = tag.name().toLowerCase();
+
+          //ignore specific tag which includes sub-hierarchy
+          if (!tagName.equals("numopenconnectionsperuser")) {
+            builder.append(
+              sep + tagName + "=\"" + tag.value() + "\"");
+            sep = ",";
+          }
+        }
+        builder.append("} ");
+        builder.append(metrics.value());
+        metricLines.put(key, builder.toString());
+
+      }
+    }
+  }
+
+  @Override
+  public void flush() {
+
+  }
+
+  @Override
+  public void init(SubsetConfiguration subsetConfiguration) {
+
+  }
+
+  public void writeMetrics(Writer writer) throws IOException {
+    for (String line : metricLines.values()) {
+      writer.write(line + "\n");
+    }
+  }
+}

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusServlet.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusServlet.java
@@ -21,6 +21,7 @@ package org.apache.hadoop.hbase.http.prom;
 import static org.apache.hadoop.hbase.http.prom.PrometheusUtils.toPrometheusName;
 import java.io.IOException;
 import java.io.PrintWriter;
+import java.util.Collection;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -41,7 +42,8 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@InterfaceAudience.Private public class PrometheusServlet extends HttpServlet {
+@InterfaceAudience.Private
+public class PrometheusServlet extends HttpServlet {
 
   //Strings used to create metrics names.
   String NUM_OPS_METRIC_NAME = "_num_ops";
@@ -63,80 +65,84 @@ import org.slf4j.LoggerFactory;
     throws IOException {
 
     final PrintWriter op = resp.getWriter();
-    final List<Pair<String, Number>> expandedMetrics = new LinkedList<>();
 
-    MetricRegistries.global().getMetricRegistries()
-      .forEach(mr -> snapshotAllMetrics(mr, expandedMetrics));
-    expandedMetrics.forEach(
-      p -> op.append(p.getFirst()).append(" ").append(p.getSecond().toString()).append('\n'));
+    writeMetrics(MetricRegistries.global().getMetricRegistries(), op);
   }
 
-  public void snapshotAllMetrics(MetricRegistry metricRegistry,
-    List<Pair<String, Number>> builder) {
+  public void writeMetrics(Collection<MetricRegistry> metricRegistries, PrintWriter pw) {
+    final List<Pair<String, Number>> metrics = new LinkedList<>();
+    metricRegistries.forEach(mr -> snapshotAllMetrics(mr, metrics));
+    metrics.forEach(p -> pw.append(p.getFirst()).append(" ").println(p.getSecond()));
+    pw.flush();
+  }
+
+  private void snapshotAllMetrics(MetricRegistry metricRegistry,
+    List<Pair<String, Number>> metricList) {
     Map<String, Metric> metrics = metricRegistry.getMetrics();
 
     for (Map.Entry<String, Metric> e : metrics.entrySet()) {
 
-      String name = toPrometheusName(metricRegistry.getMetricRegistryInfo().getMetricsName(), e.getKey());
+      String name =
+        toPrometheusName(metricRegistry.getMetricRegistryInfo().getMetricsName(), e.getKey());
       Metric metric = e.getValue();
 
       if (metric instanceof Gauge) {
-        addGauge(name, (Gauge<Number>) metric, builder);
+        addGauge(name, (Gauge<Number>) metric, metricList);
       } else if (metric instanceof Counter) {
-        addCounter(name, (Counter) metric, builder);
+        addCounter(name, (Counter) metric, metricList);
       } else if (metric instanceof Histogram) {
-        addHistogram(name, (Histogram) metric, builder);
+        addHistogram(name, (Histogram) metric, metricList);
       } else if (metric instanceof Meter) {
-        addMeter(name, (Meter) metric, builder);
+        addMeter(name, (Meter) metric, metricList);
       } else if (metric instanceof Timer) {
-        addTimer(name, (Timer) metric, builder);
+        addTimer(name, (Timer) metric, metricList);
       } else {
         LOG.info("Ignoring unknown Metric class " + metric.getClass().getName());
       }
     }
   }
 
-  private void addGauge(String name, Gauge<Number> gauge, List<Pair<String, Number>> builder) {
-    builder.add(new Pair<>(name, gauge.getValue()));
+  private void addGauge(String name, Gauge<Number> gauge, List<Pair<String, Number>> metricList) {
+    metricList.add(new Pair<>(name, gauge.getValue()));
   }
 
-  private void addCounter(String name, Counter counter, List<Pair<String, Number>> builder) {
-    builder.add(new Pair<>(name, counter.getCount()));
+  private void addCounter(String name, Counter counter, List<Pair<String, Number>> metricList) {
+    metricList.add(new Pair<>(name, counter.getCount()));
   }
 
-  private void addHistogram(String name, Histogram histogram, List<Pair<String, Number>> builder) {
+  private void addHistogram(String name, Histogram histogram, List<Pair<String, Number>> metricList) {
     Snapshot snapshot = histogram.snapshot();
 
-    builder.add(new Pair<>(name + NUM_OPS_METRIC_NAME, histogram.getCount()));
-    builder.add(new Pair<>(name + MIN_METRIC_NAME, snapshot.getMin()));
-    builder.add(new Pair<>(name + MAX_METRIC_NAME, snapshot.getMax()));
-    builder.add(new Pair<>(name + MEAN_METRIC_NAME, snapshot.getMean()));
-    builder
+    metricList.add(new Pair<>(name + NUM_OPS_METRIC_NAME, histogram.getCount()));
+    metricList.add(new Pair<>(name + MIN_METRIC_NAME, snapshot.getMin()));
+    metricList.add(new Pair<>(name + MAX_METRIC_NAME, snapshot.getMax()));
+    metricList.add(new Pair<>(name + MEAN_METRIC_NAME, snapshot.getMean()));
+    metricList
       .add(new Pair<>(name + TWENTY_FIFTH_PERCENTILE_METRIC_NAME, snapshot.get25thPercentile()));
-    builder.add(new Pair<>(name + MEDIAN_METRIC_NAME, snapshot.getMedian()));
-    builder
+    metricList.add(new Pair<>(name + MEDIAN_METRIC_NAME, snapshot.getMedian()));
+    metricList
       .add(new Pair<>(name + SEVENTY_FIFTH_PERCENTILE_METRIC_NAME, snapshot.get75thPercentile()));
-    builder.add(new Pair<>(name + NINETIETH_PERCENTILE_METRIC_NAME, snapshot.get90thPercentile()));
-    builder
+    metricList.add(new Pair<>(name + NINETIETH_PERCENTILE_METRIC_NAME, snapshot.get90thPercentile()));
+    metricList
       .add(new Pair<>(name + NINETY_FIFTH_PERCENTILE_METRIC_NAME, snapshot.get95thPercentile()));
-    builder
+    metricList
       .add(new Pair<>(name + NINETY_EIGHTH_PERCENTILE_METRIC_NAME, snapshot.get98thPercentile()));
-    builder
+    metricList
       .add(new Pair<>(name + NINETY_NINETH_PERCENTILE_METRIC_NAME, snapshot.get99thPercentile()));
-    builder.add(new Pair<>(name + NINETY_NINE_POINT_NINETH_PERCENTILE_METRIC_NAME,
+    metricList.add(new Pair<>(name + NINETY_NINE_POINT_NINETH_PERCENTILE_METRIC_NAME,
       snapshot.get999thPercentile()));
   }
 
-  private void addMeter(String name, Meter meter, List<Pair<String, Number>> builder) {
-    builder.add(new Pair<>(name + "_count", meter.getCount()));
-    builder.add(new Pair<>(name + "_mean_rate", meter.getMeanRate()));
-    builder.add(new Pair<>(name + "_1min_rate", meter.getOneMinuteRate()));
-    builder.add(new Pair<>(name + "_5min_rate", meter.getFiveMinuteRate()));
-    builder.add(new Pair<>(name + "_15min_rate", meter.getFifteenMinuteRate()));
+  private void addMeter(String name, Meter meter, List<Pair<String, Number>> metricList) {
+    metricList.add(new Pair<>(name + "_count", meter.getCount()));
+    metricList.add(new Pair<>(name + "_mean_rate", meter.getMeanRate()));
+    metricList.add(new Pair<>(name + "_1min_rate", meter.getOneMinuteRate()));
+    metricList.add(new Pair<>(name + "_5min_rate", meter.getFiveMinuteRate()));
+    metricList.add(new Pair<>(name + "_15min_rate", meter.getFifteenMinuteRate()));
   }
 
-  private void addTimer(String name, Timer timer, List<Pair<String, Number>> builder) {
-    addMeter(name, timer.getMeter(), builder);
-    addHistogram(name, timer.getHistogram(), builder);
+  private void addTimer(String name, Timer timer, List<Pair<String, Number>> metricList) {
+    addMeter(name, timer.getMeter(), metricList);
+    addHistogram(name, timer.getHistogram(), metricList);
   }
 }

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusServlet.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusServlet.java
@@ -1,0 +1,142 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.http.prom;
+
+import static org.apache.hadoop.hbase.http.prom.PrometheusUtils.toPrometheusName;
+import java.io.IOException;
+import java.io.PrintWriter;
+import java.util.LinkedList;
+import java.util.List;
+import java.util.Map;
+import javax.servlet.http.HttpServlet;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.hadoop.hbase.metrics.Counter;
+import org.apache.hadoop.hbase.metrics.Gauge;
+import org.apache.hadoop.hbase.metrics.Histogram;
+import org.apache.hadoop.hbase.metrics.Meter;
+import org.apache.hadoop.hbase.metrics.Metric;
+import org.apache.hadoop.hbase.metrics.MetricRegistries;
+import org.apache.hadoop.hbase.metrics.MetricRegistry;
+import org.apache.hadoop.hbase.metrics.Snapshot;
+import org.apache.hadoop.hbase.metrics.Timer;
+import org.apache.hadoop.hbase.util.Pair;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InterfaceAudience.Private public class PrometheusServlet extends HttpServlet {
+
+  //Strings used to create metrics names.
+  String NUM_OPS_METRIC_NAME = "_num_ops";
+  String MIN_METRIC_NAME = "_min";
+  String MAX_METRIC_NAME = "_max";
+  String MEAN_METRIC_NAME = "_mean";
+  String MEDIAN_METRIC_NAME = "_median";
+  String TWENTY_FIFTH_PERCENTILE_METRIC_NAME = "_25th_percentile";
+  String SEVENTY_FIFTH_PERCENTILE_METRIC_NAME = "_75th_percentile";
+  String NINETIETH_PERCENTILE_METRIC_NAME = "_90th_percentile";
+  String NINETY_FIFTH_PERCENTILE_METRIC_NAME = "_95th_percentile";
+  String NINETY_EIGHTH_PERCENTILE_METRIC_NAME = "_98th_percentile";
+  String NINETY_NINETH_PERCENTILE_METRIC_NAME = "_99th_percentile";
+  String NINETY_NINE_POINT_NINETH_PERCENTILE_METRIC_NAME = "_99.9th_percentile";
+
+  Logger LOG = LoggerFactory.getLogger(PrometheusServlet.class);
+
+  @Override protected void doGet(HttpServletRequest req, HttpServletResponse resp)
+    throws IOException {
+
+    final PrintWriter op = resp.getWriter();
+    final List<Pair<String, Number>> expandedMetrics = new LinkedList<>();
+
+    MetricRegistries.global().getMetricRegistries()
+      .forEach(mr -> snapshotAllMetrics(mr, expandedMetrics));
+    expandedMetrics.forEach(
+      p -> op.append(p.getFirst()).append(" ").append(p.getSecond().toString()).append('\n'));
+  }
+
+  public void snapshotAllMetrics(MetricRegistry metricRegistry,
+    List<Pair<String, Number>> builder) {
+    Map<String, Metric> metrics = metricRegistry.getMetrics();
+
+    for (Map.Entry<String, Metric> e : metrics.entrySet()) {
+
+      String name = toPrometheusName(metricRegistry.getMetricRegistryInfo().getMetricsName(), e.getKey());
+      Metric metric = e.getValue();
+
+      if (metric instanceof Gauge) {
+        addGauge(name, (Gauge<Number>) metric, builder);
+      } else if (metric instanceof Counter) {
+        addCounter(name, (Counter) metric, builder);
+      } else if (metric instanceof Histogram) {
+        addHistogram(name, (Histogram) metric, builder);
+      } else if (metric instanceof Meter) {
+        addMeter(name, (Meter) metric, builder);
+      } else if (metric instanceof Timer) {
+        addTimer(name, (Timer) metric, builder);
+      } else {
+        LOG.info("Ignoring unknown Metric class " + metric.getClass().getName());
+      }
+    }
+  }
+
+  private void addGauge(String name, Gauge<Number> gauge, List<Pair<String, Number>> builder) {
+    builder.add(new Pair<>(name, gauge.getValue()));
+  }
+
+  private void addCounter(String name, Counter counter, List<Pair<String, Number>> builder) {
+    builder.add(new Pair<>(name, counter.getCount()));
+  }
+
+  private void addHistogram(String name, Histogram histogram, List<Pair<String, Number>> builder) {
+    Snapshot snapshot = histogram.snapshot();
+
+    builder.add(new Pair<>(name + NUM_OPS_METRIC_NAME, histogram.getCount()));
+    builder.add(new Pair<>(name + MIN_METRIC_NAME, snapshot.getMin()));
+    builder.add(new Pair<>(name + MAX_METRIC_NAME, snapshot.getMax()));
+    builder.add(new Pair<>(name + MEAN_METRIC_NAME, snapshot.getMean()));
+    builder
+      .add(new Pair<>(name + TWENTY_FIFTH_PERCENTILE_METRIC_NAME, snapshot.get25thPercentile()));
+    builder.add(new Pair<>(name + MEDIAN_METRIC_NAME, snapshot.getMedian()));
+    builder
+      .add(new Pair<>(name + SEVENTY_FIFTH_PERCENTILE_METRIC_NAME, snapshot.get75thPercentile()));
+    builder.add(new Pair<>(name + NINETIETH_PERCENTILE_METRIC_NAME, snapshot.get90thPercentile()));
+    builder
+      .add(new Pair<>(name + NINETY_FIFTH_PERCENTILE_METRIC_NAME, snapshot.get95thPercentile()));
+    builder
+      .add(new Pair<>(name + NINETY_EIGHTH_PERCENTILE_METRIC_NAME, snapshot.get98thPercentile()));
+    builder
+      .add(new Pair<>(name + NINETY_NINETH_PERCENTILE_METRIC_NAME, snapshot.get99thPercentile()));
+    builder.add(new Pair<>(name + NINETY_NINE_POINT_NINETH_PERCENTILE_METRIC_NAME,
+      snapshot.get999thPercentile()));
+  }
+
+  private void addMeter(String name, Meter meter, List<Pair<String, Number>> builder) {
+    builder.add(new Pair<>(name + "_count", meter.getCount()));
+    builder.add(new Pair<>(name + "_mean_rate", meter.getMeanRate()));
+    builder.add(new Pair<>(name + "_1min_rate", meter.getOneMinuteRate()));
+    builder.add(new Pair<>(name + "_5min_rate", meter.getFiveMinuteRate()));
+    builder.add(new Pair<>(name + "_15min_rate", meter.getFifteenMinuteRate()));
+  }
+
+  private void addTimer(String name, Timer timer, List<Pair<String, Number>> builder) {
+    addMeter(name, timer.getMeter(), builder);
+    addHistogram(name, timer.getHistogram(), builder);
+  }
+}

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusUtils.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusUtils.java
@@ -23,7 +23,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import java.util.regex.Pattern;
 
 @InterfaceAudience.Private
-class PrometheusUtils {
+public class PrometheusUtils {
 
   private static final Pattern SPLIT_PATTERN =
     Pattern.compile("(?<!(^|[A-Z_]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])");
@@ -32,7 +32,12 @@ class PrometheusUtils {
     String baseName = StringUtils.capitalize(recordName) + StringUtils.capitalize(metricName);
     baseName = baseName.replace('-', '_');
     String[] parts = SPLIT_PATTERN.split(baseName);
-    return String.join("_", parts).toLowerCase();
+    return String
+            .join("_", parts)
+            .toLowerCase()
+            .replace('.', '_')
+            .replace('-', '_')
+            .replaceAll("(_)+", "_");
   }
 
 }

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusUtils.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prom/PrometheusUtils.java
@@ -1,0 +1,38 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.http.prom;
+
+import org.apache.commons.lang3.StringUtils;
+import org.apache.yetus.audience.InterfaceAudience;
+import java.util.regex.Pattern;
+
+@InterfaceAudience.Private
+class PrometheusUtils {
+
+  private static final Pattern SPLIT_PATTERN =
+    Pattern.compile("(?<!(^|[A-Z_]))(?=[A-Z])|(?<!^)(?=[A-Z][a-z])");
+
+  public static String toPrometheusName(String recordName, String metricName) {
+    String baseName = StringUtils.capitalize(recordName) + StringUtils.capitalize(metricName);
+    baseName = baseName.replace('-', '_');
+    String[] parts = SPLIT_PATTERN.split(baseName);
+    return String.join("_", parts).toLowerCase();
+  }
+
+}

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestPrometheus2Servlet.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestPrometheus2Servlet.java
@@ -1,0 +1,102 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.IOException;
+import java.io.OutputStreamWriter;
+
+import org.apache.hadoop.hbase.http.prom.PrometheusMetricsSink;
+import org.apache.hadoop.hbase.http.prom.PrometheusUtils;
+import org.apache.hadoop.metrics2.MetricsSystem;
+import org.apache.hadoop.metrics2.annotation.Metric;
+import org.apache.hadoop.metrics2.annotation.Metrics;
+import org.apache.hadoop.metrics2.lib.DefaultMetricsSystem;
+import org.apache.hadoop.metrics2.lib.MutableCounterLong;
+
+import org.junit.Assert;
+import org.junit.Test;
+
+import static java.nio.charset.StandardCharsets.UTF_8;
+import static org.apache.hadoop.hbase.http.prom.PrometheusUtils.toPrometheusName;
+
+/**
+ * Test prometheus Sink.
+ */
+public class TestPrometheus2Servlet {
+
+  @Test
+  public void testPublish() throws IOException {
+    //GIVEN
+    MetricsSystem metrics = DefaultMetricsSystem.instance();
+
+    metrics.init("test");
+    PrometheusMetricsSink sink = new PrometheusMetricsSink();
+    metrics.register("Prometheus", "Prometheus", sink);
+    TestMetrics testMetrics = metrics.register("TestMetrics", "Testing metrics", new TestMetrics());
+
+    metrics.start();
+    testMetrics.numBucketCreateFails.incr();
+    metrics.publishMetricsNow();
+    ByteArrayOutputStream stream = new ByteArrayOutputStream();
+    OutputStreamWriter writer = new OutputStreamWriter(stream, UTF_8);
+
+    //WHEN
+    sink.writeMetrics(writer);
+    writer.flush();
+
+    //THEN
+    String writtenMetrics = stream.toString(UTF_8.name());
+    System.out.println(writtenMetrics);
+    Assert.assertTrue("The expected metric line is missing from prometheus metrics output",
+      writtenMetrics.contains("test_metrics_num_bucket_create_fails{context=\"dfs\""));
+
+    metrics.stop();
+    metrics.shutdown();
+  }
+
+  @Test
+  public void testNamingCamelCase() {
+    PrometheusMetricsSink sink = new PrometheusMetricsSink();
+
+    Assert.assertEquals("rpc_time_some_metrics", toPrometheusName("RpcTime", "SomeMetrics"));
+
+    Assert.assertEquals("om_rpc_time_om_info_keys", toPrometheusName("OMRpcTime", "OMInfoKeys"));
+
+    Assert.assertEquals("rpc_time_small", toPrometheusName("RpcTime", "small"));
+  }
+
+  @Test
+  public void testNamingPipeline() {
+    PrometheusMetricsSink sink = new PrometheusMetricsSink();
+
+    String recordName = "SCMPipelineMetrics";
+    String metricName = "NumBlocksAllocated-" + "RATIS-THREE-47659e3d-40c9-43b3-9792-4982fc279aba";
+    Assert.assertEquals("scm_pipeline_metrics_" + "num_blocks_allocated_"
+        + "ratis_three_47659e3d_40c9_43b3_9792_4982fc279aba",
+      toPrometheusName(recordName, metricName));
+  }
+
+  /**
+   * Example metric pojo.
+   */
+  @Metrics(about = "Test Metrics", context = "dfs")
+  private static class TestMetrics {
+
+    @Metric
+    private MutableCounterLong numBucketCreateFails;
+  }
+}

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestPrometheusServlet.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestPrometheusServlet.java
@@ -1,0 +1,141 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.http;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintWriter;
+import org.apache.hadoop.hbase.http.prom.PrometheusServlet;
+import org.apache.hadoop.hbase.metrics.Counter;
+import org.apache.hadoop.hbase.metrics.Histogram;
+import org.apache.hadoop.hbase.metrics.Meter;
+import org.apache.hadoop.hbase.metrics.MetricRegistries;
+import org.apache.hadoop.hbase.metrics.MetricRegistry;
+import org.apache.hadoop.hbase.metrics.MetricRegistryInfo;
+import org.apache.hadoop.hbase.metrics.Timer;
+import org.apache.hadoop.hbase.testclassification.MiscTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ SmallTests.class, MiscTests.class })
+public class TestPrometheusServlet {
+
+  PrometheusServlet ps;
+  MetricRegistry mr;
+
+  @Before
+  public void setup() {
+    ps = new PrometheusServlet();
+    MetricRegistryInfo mri = new MetricRegistryInfo(
+      "metricGroup",
+      "dummy metric for tests",
+      "",
+      "mctxt",
+      false);
+    mr = MetricRegistries.global().create(mri);
+  }
+
+  @Test
+  public void testPrometheusServlet() {
+
+    //Counters
+    Counter c1 = mr.counter("c1");
+    c1.increment();
+    test(ps, "metric_group_c1 1\n");
+    mr.remove("c1");
+
+    //Meters
+    Meter m1 = mr.meter("m1");
+    m1.mark(0);
+    test(ps, "metric_group_m1_count 0\n" + "metric_group_m1_mean_rate 0.0\n"
+      + "metric_group_m1_1min_rate 0.0\n" + "metric_group_m1_5min_rate 0.0\n"
+      + "metric_group_m1_15min_rate 0.0\n");
+    mr.remove("m1");
+
+    //Timers (don't update the timer)
+    Timer t1 = mr.timer("t1");
+    test(ps,
+      "metric_group_t1_count 0\n"
+      + "metric_group_t1_mean_rate 0.0\n"
+      + "metric_group_t1_1min_rate 0.0\n"
+      + "metric_group_t1_5min_rate 0.0\n"
+      + "metric_group_t1_15min_rate 0.0\n"
+      + "metric_group_t1_num_ops 0\n"
+      + "metric_group_t1_min 0\n"
+      + "metric_group_t1_max 0\n"
+      + "metric_group_t1_mean 0\n"
+      + "metric_group_t1_25th_percentile 0\n"
+      + "metric_group_t1_median 0\n"
+      + "metric_group_t1_75th_percentile 0\n"
+      + "metric_group_t1_90th_percentile 0\n"
+      + "metric_group_t1_95th_percentile 0\n"
+      + "metric_group_t1_98th_percentile 0\n"
+      + "metric_group_t1_99th_percentile 0\n"
+      + "metric_group_t1_99.9th_percentile 0\n");
+    mr.remove("t1");
+
+    //Histograms
+    Histogram h1 = mr.histogram("h1");
+    h1.update(0);
+    test(ps,
+      "metric_group_h1_num_ops 1\n"
+      + "metric_group_h1_min 0\n"
+      + "metric_group_h1_max 0\n"
+      + "metric_group_h1_mean 0\n"
+      + "metric_group_h1_25th_percentile 0\n"
+      + "metric_group_h1_median 0\n"
+      + "metric_group_h1_75th_percentile 0\n"
+      + "metric_group_h1_90th_percentile 0\n"
+      + "metric_group_h1_95th_percentile 0\n"
+      + "metric_group_h1_98th_percentile 0\n"
+      + "metric_group_h1_99th_percentile 0\n"
+      + "metric_group_h1_99.9th_percentile 0\n");
+    mr.remove("h1");
+
+  }
+
+  @Test
+  public void testStrings() {
+    testWithCounter(ps, "my.counter", "metric_group_my_counter 0\n");
+
+    testWithCounter(ps, "my-counter", "metric_group_my_counter 0\n");
+
+    testWithCounter(ps, "myCounter",  "metric_group_my_counter 0\n");
+
+    testWithCounter(ps, "my_Counter", "metric_group_my_counter 0\n");
+
+    testWithCounter(ps, "my__Counter","metric_group_my_counter 0\n");
+  }
+
+  private void testWithCounter(PrometheusServlet ps, String metricName, String expected) {
+    mr.counter(metricName);
+    test(ps, expected);
+    mr.remove(metricName);
+  }
+
+  private void test(PrometheusServlet ps, String expected) {
+    ByteArrayOutputStream bos = new ByteArrayOutputStream();
+    PrintWriter pw = new PrintWriter(bos);
+    ps.writeMetrics(MetricRegistries.global().getMetricRegistries(), pw);
+    String out = bos.toString();
+    assert out.equals(expected) : String.format("Expected [%s] but result is [%s]", expected, out);
+  }
+
+}


### PR DESCRIPTION
Since all the metricsources have not moved to new metrics API, I added two servlets.

a. /prom (PrometheusServlet) uses the new metrics API.
b. /prom2 (PrometheusHadoop2Servlet) uses the old hadoop2 metrics API

PrometheusHadoop2Servlet can be thrown out once all the metricsources start using the new API.

Side note
1. Most of the servlet code for /prom2 code is cloned from HADOOP-16398 