### PR TITLE
HBASE-24458 release scripts using docker should specify needed disk consistency

### DIFF
--- a/dev-support/create-release/do-release-docker.sh
+++ b/dev-support/create-release/do-release-docker.sh
@@ -181,14 +181,14 @@ if [ -n "${GIT_REPO}" ]; then
     ssh://*|git://*|http://*|https://*|ftp://*|ftps://*) ;;
     # for sure local
     /*)
-      GIT_REPO_MOUNT=(--mount "type=bind,src=${GIT_REPO},dst=/opt/hbase-repo")
+      GIT_REPO_MOUNT=(--mount "type=bind,src=${GIT_REPO},dst=/opt/hbase-repo,consistency=delegated")
       echo "HOST_GIT_REPO=${GIT_REPO}" >> "${ENVFILE}"
       GIT_REPO="/opt/hbase-repo"
       ;;
     # on the host but normally git wouldn't use the local optimization
     file://*)
       echo "[INFO] converted file:// git repo to a local path, which changes git to assume --local."
-      GIT_REPO_MOUNT=(--mount "type=bind,src=${GIT_REPO#file://},dst=/opt/hbase-repo")
+      GIT_REPO_MOUNT=(--mount "type=bind,src=${GIT_REPO#file://},dst=/opt/hbase-repo,consistency=delegated")
       echo "HOST_GIT_REPO=${GIT_REPO}" >> "${ENVFILE}"
       GIT_REPO="/opt/hbase-repo"
       ;;
@@ -217,7 +217,7 @@ if [ -n "${GIT_REPO}" ]; then
       if [ -n "${local_path}" ]; then
         # convert to an absolute path
         GIT_REPO="$(cd "$(dirname "${ORIG_PWD}/${GIT_REPO}")"; pwd)/$(basename "${ORIG_PWD}/${GIT_REPO}")"
-        GIT_REPO_MOUNT=(--mount "type=bind,src=${GIT_REPO},dst=/opt/hbase-repo")
+        GIT_REPO_MOUNT=(--mount "type=bind,src=${GIT_REPO},dst=/opt/hbase-repo,consistency=delegated")
         echo "HOST_GIT_REPO=${GIT_REPO}" >> "${ENVFILE}"
         GIT_REPO="/opt/hbase-repo"
       fi
@@ -229,7 +229,7 @@ fi
 echo "Building $RELEASE_TAG; output will be at $WORKDIR/output"
 cmd=(docker run -ti \
   --env-file "$ENVFILE" \
-  --volume "$WORKDIR:/opt/hbase-rm" \
+  --mount "type=bind,src=${WORKDIR},dst=/opt/hbase-rm,consistency=delegated" \
   "${JAVA_VOL[@]}" \
   "${GIT_REPO_MOUNT[@]}" \
   "hbase-rm:$IMGTAG")


### PR DESCRIPTION
These changes assume that we're running a single release  build at at time and that primarily we only need to see stuff outside of the container when it is done.

docs on delegated consistency:

https://docs.docker.com/storage/bind-mounts/#configure-mount-consistency-for-macos

Before this change (and before HBASE-22033, using my branch with HBASE-23339 in place to build an RC from master):
```
busbey$ grep -E "(Total time:|uilding binary dist)"  output/publish-dist.log
+ echo '2020-05-16T07:35:10Z Building binary dist'
2020-05-16T07:35:10Z Building binary dist
08:46:50 [INFO] Total time:  01:11 h
11:58:02 [INFO] Total time:  03:11 h
16:33:11 [INFO] Total time:  04:34 h
+ echo '2020-05-16T16:35:40Z Done building binary distribution'
2020-05-16T16:35:40Z Done building binary distribution
```

and then the final deploy took a bit over 5 hours.

after this change (now with HBASE-22033 and HBASE-23339) we see a pretty dramatic improvement:

```
busbey$ grep -E "(Total time:|uilding binary dist)"  output/publish-dist.log
+ echo '2020-05-29T22:54:08Z Building binary dist'
2020-05-29T22:54:08Z Building binary dist
23:17:49 [INFO] Total time:  23:34 min
23:37:57 [INFO] Total time:  19:56 min
00:49:06 [INFO] Total time:  01:10 h
+ echo '2020-05-30T00:51:52Z Done building binary distribution'
2020-05-30T00:51:52Z Done building binary distribution
busbey$ grep -E "(Total time:|uilding binary dist)"  output/mvn_deploy_release.log
03:08:57 [INFO] Total time:  47:13 min
```