### PR TITLE
HBASE-24479: Deflake TestCompaction#testStopStartCompaction

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompaction.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompaction.java
@@ -382,7 +382,8 @@ public class TestCompaction {
     assertEquals(0, thread.getLongCompactions().getCompletedTaskCount() +
         thread.getShortCompactions().getCompletedTaskCount());
     // Request a compaction and make sure it is submitted successfully.
-    assertNotNull(thread.requestCompaction(r, store, "test", Store.PRIORITY_USER, new CompactionRequest(), null));
+    assertNotNull(thread.requestCompaction(r, store, "test", Store.PRIORITY_USER,
+        new CompactionRequest(), null));
     // Wait until the compaction finishes.
     Waiter.waitFor(UTIL.getConfiguration(), 5000, new Waiter.Predicate<Exception>() {
       @Override


### PR DESCRIPTION
Polling of active compaction count is racy. Tightened the asserts
to be more reliable.