### PR TITLE
HBASE-24438 Don't update TaskMonitor when deserializing ServerCrashProcedure

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ServerCrashProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ServerCrashProcedure.java
@@ -424,7 +424,6 @@ public class ServerCrashProcedure
         this.regionsOnCrashedServer.add(ProtobufUtil.toRegionInfo(ri));
       }
     }
-    updateProgress(false);
   }
 
   @Override


### PR DESCRIPTION
The ServerCrashProcedure could have been completed by previously active
HBase Master which results in a stale ServerCrashProcedure task in TaskMonitor.
The TaskMonitor should only reflect the procedure in case the procedure has actually
been started/resumed which is done when ServerCrashProcedure.executeFromState is called.