### PR TITLE
HBASE-24280 ADDENDUM branch on CHANGE_TARGET instead of BRANCH_NAME

### DIFF
--- a/dev-support/jenkins_precommit_github_yetus.sh
+++ b/dev-support/jenkins_precommit_github_yetus.sh
@@ -129,7 +129,7 @@ YETUS_ARGS+=("--skip-dirs=dev-support")
 if [[ -n "${HADOOP_PROFILE}" ]]; then
   # Master has only Hadoop3 support. We don't need to activate any profile.
   # The Jenkinsfile should not attempt to run any Hadoop2 tests.
-  if [[ "${BRANCH_NAME}" =~ branch-2* ]]; then
+  if [[ "${CHANGE_TARGET}" =~ branch-2* ]]; then
     YETUS_ARGS+=("--hadoop-profile=${HADOOP_PROFILE}")
   fi
 fi


### PR DESCRIPTION
Looks like we have two different environments with two sets of environment variables. Yetus talks about that target branch as `BRANCH_NAME`, but GitHub + Jenkins refer to it as `CHANGE_TARGET`, so we need to use that one from the shell script that invokes Yetus.