### PR TITLE
HBASE-24380 : Provide WAL splitting journal logging

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredEditsOutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredEditsOutputSink.java
@@ -58,7 +58,7 @@ class BoundedRecoveredEditsOutputSink extends AbstractRecoveredEditsOutputSink {
   }
 
   @Override
-  public void append(EntryBuffers.RegionEntryBuffer buffer, MonitoredTask status)
+  public void append(EntryBuffers.RegionEntryBuffer buffer)
       throws IOException {
     List<WAL.Entry> entries = buffer.entryBuffer;
     if (entries.isEmpty()) {
@@ -68,7 +68,7 @@ class BoundedRecoveredEditsOutputSink extends AbstractRecoveredEditsOutputSink {
     // The key point is create a new writer, write edits then close writer.
     RecoveredEditsWriter writer =
       createRecoveredEditsWriter(buffer.tableName, buffer.encodedRegionName,
-        entries.get(0).getKey().getSequenceId(), status);
+        entries.get(0).getKey().getSequenceId(), this.status);
     if (writer != null) {
       openingWritersNum.incrementAndGet();
       writer.writeRegionEntries(entries);
@@ -85,7 +85,7 @@ class BoundedRecoveredEditsOutputSink extends AbstractRecoveredEditsOutputSink {
   }
 
   @Override
-  public List<Path> close(MonitoredTask status) throws IOException {
+  public List<Path> close() throws IOException {
     boolean isSuccessful = true;
     try {
       isSuccessful = finishWriterThreads();
@@ -104,7 +104,7 @@ class BoundedRecoveredEditsOutputSink extends AbstractRecoveredEditsOutputSink {
   private boolean writeRemainingEntryBuffers(MonitoredTask status) throws IOException {
     for (EntryBuffers.RegionEntryBuffer buffer : entryBuffers.buffers.values()) {
       closeCompletionService.submit(() -> {
-        append(buffer, status);
+        append(buffer);
         return null;
       });
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredEditsOutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredEditsOutputSink.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Future;
 import java.util.concurrent.atomic.AtomicInteger;
 
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.monitoring.MonitoredTask;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.io.MultipleIOException;
 import org.apache.yetus.audience.InterfaceAudience;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredHFilesOutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredHFilesOutputSink.java
@@ -41,7 +41,6 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
-import org.apache.hadoop.hbase.monitoring.MonitoredTask;
 import org.apache.hadoop.hbase.regionserver.CellSet;
 import org.apache.hadoop.hbase.regionserver.HStore;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredHFilesOutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredHFilesOutputSink.java
@@ -129,7 +129,7 @@ public class BoundedRecoveredHFilesOutputSink extends OutputSink {
     try {
       isSuccessful = finishWriterThreads();
     } finally {
-      isSuccessful &= writeRemainingEntryBuffers(status);
+      isSuccessful &= writeRemainingEntryBuffers();
     }
     return isSuccessful ? splits : null;
   }
@@ -137,10 +137,9 @@ public class BoundedRecoveredHFilesOutputSink extends OutputSink {
   /**
    * Write out the remaining RegionEntryBuffers and close the writers.
    *
-   * @param status MonitoredTask instance to capture WAL splitting
    * @return true when there is no error.
    */
-  private boolean writeRemainingEntryBuffers(MonitoredTask status) throws IOException {
+  private boolean writeRemainingEntryBuffers() throws IOException {
     for (EntryBuffers.RegionEntryBuffer buffer : entryBuffers.buffers.values()) {
       closeCompletionService.submit(() -> {
         append(buffer);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredHFilesOutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredHFilesOutputSink.java
@@ -77,7 +77,7 @@ public class BoundedRecoveredHFilesOutputSink extends OutputSink {
   }
 
   @Override
-  void append(RegionEntryBuffer buffer, MonitoredTask status) throws IOException {
+  void append(RegionEntryBuffer buffer) throws IOException {
     Map<String, CellSet> familyCells = new HashMap<>();
     Map<String, Long> familySeqIds = new HashMap<>();
     boolean isMetaTable = buffer.tableName.equals(META_TABLE_NAME);
@@ -124,7 +124,7 @@ public class BoundedRecoveredHFilesOutputSink extends OutputSink {
   }
 
   @Override
-  public List<Path> close(MonitoredTask status) throws IOException {
+  public List<Path> close() throws IOException {
     boolean isSuccessful = true;
     try {
       isSuccessful = finishWriterThreads();
@@ -143,7 +143,7 @@ public class BoundedRecoveredHFilesOutputSink extends OutputSink {
   private boolean writeRemainingEntryBuffers(MonitoredTask status) throws IOException {
     for (EntryBuffers.RegionEntryBuffer buffer : entryBuffers.buffers.values()) {
       closeCompletionService.submit(() -> {
-        append(buffer, status);
+        append(buffer);
         return null;
       });
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/OutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/OutputSink.java
@@ -59,7 +59,7 @@ abstract class OutputSink {
 
   protected final List<Path> splits = new ArrayList<>();
 
-  private MonitoredTask status = null;
+  protected MonitoredTask status = null;
 
   /**
    * Used when close this output sink.
@@ -138,13 +138,11 @@ abstract class OutputSink {
 
   /**
    * @param buffer A buffer of some number of edits for a given region.
-   * @param status MonitoredTask instance to capture WAL splitting
    * @throws IOException For any IO errors
    */
-  abstract void append(EntryBuffers.RegionEntryBuffer buffer, MonitoredTask status)
-    throws IOException;
+  abstract void append(EntryBuffers.RegionEntryBuffer buffer) throws IOException;
 
-  abstract List<Path> close(MonitoredTask status) throws IOException;
+  abstract List<Path> close() throws IOException;
 
   /**
    * @return a map from encoded region ID to the number of edits written out for that region.
@@ -220,7 +218,7 @@ abstract class OutputSink {
     }
 
     private void writeBuffer(EntryBuffers.RegionEntryBuffer buffer) throws IOException {
-      outputSink.append(buffer, status);
+      outputSink.append(buffer);
     }
 
     private void finish() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/OutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/OutputSink.java
@@ -123,7 +123,9 @@ abstract class OutputSink {
     controller.checkForErrors();
     final String msg = this.writerThreads.size() + " split writer threads finished";
     LOG.info(msg);
-    status.setStatus(msg);
+    if (status != null) {
+      status.setStatus(msg);
+    }
     return (!progressFailed);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/RecoveredEditsOutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/RecoveredEditsOutputSink.java
@@ -53,7 +53,7 @@ class RecoveredEditsOutputSink extends AbstractRecoveredEditsOutputSink {
   }
 
   @Override
-  public void append(EntryBuffers.RegionEntryBuffer buffer, MonitoredTask status)
+  public void append(EntryBuffers.RegionEntryBuffer buffer)
       throws IOException {
     List<WAL.Entry> entries = buffer.entryBuffer;
     if (entries.isEmpty()) {
@@ -88,7 +88,7 @@ class RecoveredEditsOutputSink extends AbstractRecoveredEditsOutputSink {
   }
 
   @Override
-  public List<Path> close(MonitoredTask status) throws IOException {
+  public List<Path> close() throws IOException {
     boolean isSuccessful = true;
     try {
       isSuccessful = finishWriterThreads();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALSplitter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALSplitter.java
@@ -364,7 +364,7 @@ public class WALSplitter {
           // Set progress_failed to true as the immediate following statement will reset its value
           // when close() throws exception, progress_failed has the right value
           progressFailed = true;
-          progressFailed = outputSink.close(status) == null;
+          progressFailed = outputSink.close() == null;
         }
       } finally {
         long processCost = EnvironmentEdgeManager.currentTime() - startTS;


### PR DESCRIPTION
Sample output:
```
Journal Log: null at 1591291865775
Opening log file hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/WALs/testsplitlogfilemultipleregions,16010,1591291865558/wal.dat.0 at 1591291865776
Finishing writing output logs and closing down at 1591291865801
Creating recovered edits writer path=hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/data/default/t1/ccc/recovered.edits/0000000000000000002-wal.dat.0.temp at 1591291866091
Creating recovered edits writer path=hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/data/default/t1/bbb/recovered.edits/0000000000000000001-wal.dat.0.temp at 1591291866091
3 split writer threads finished at 1591291866118
Closed recovered edits writer path=hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/data/default/t1/ccc/recovered.edits/0000000000000000002-wal.dat.0.temp (wrote 10 edits, skipped 0 edits in 25 ms) at 1591291866137
Closed recovered edits writer path=hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/data/default/t1/bbb/recovered.edits/0000000000000000001-wal.dat.0.temp (wrote 10 edits, skipped 0 edits in 25 ms) at 1591291866137
Rename recovered edits hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/data/default/t1/ccc/recovered.edits/0000000000000000002-wal.dat.0.temp to hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/data/default/t1/ccc/recovered.edits/0000000000000000020 at 1591291866139
Rename recovered edits hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/data/default/t1/bbb/recovered.edits/0000000000000000001-wal.dat.0.temp to hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/data/default/t1/bbb/recovered.edits/0000000000000000019 at 1591291866139
Processed 20 edits across 2 regions cost 354 ms; edits skipped=7; WAL=hdfs://localhost:64541/user/vjasani/test-data/9cad028f-1b56-2eeb-fec5-c83773b30f41/WALs/testsplitlogfilemultipleregions,16010,1591291865558/wal.dat.0, size=2.3 K, length=2322, corrupted=false, progress failed=false at 1591291866139
```