### PR TITLE
HBASE-24466 Release scripts in docker mode should be able to use a named volume for maven repo

### DIFF
--- a/dev-support/create-release/do-release.sh
+++ b/dev-support/create-release/do-release.sh
@@ -64,6 +64,15 @@ fi
 GPG_TTY="$(tty)"
 export GPG_TTY
 
+if [[ -n "${REPO}" ]]; then
+  echo "reusing persistent maven repo, testing write access"
+  echo "foo" > "${REPO}/test.file"
+  if [[ -d "${REPO}/org/apache/hbase/" ]]; then
+    echo "reusing persistent maven repo, clearing out our project artifacts."
+    rm -rf "${REPO}/org/apache/hbase/"
+  fi
+fi
+
 if [[ -z "$RELEASE_STEP" ]]; then
   # If doing all stages, leave out 'publish-snapshot'
   RELEASE_STEP="tag_publish-dist_publish-release"

--- a/dev-support/create-release/hbase-rm/Dockerfile
+++ b/dev-support/create-release/hbase-rm/Dockerfile
@@ -53,7 +53,10 @@ ENV YETUS_HOME /opt/apache-yetus-${YETUS_VERSION}
 WORKDIR /opt/hbase-rm/output
 
 ARG UID
-RUN useradd -m -s /bin/bash -p hbase-rm -u $UID hbase-rm
+RUN useradd -m -s /bin/bash -p hbase-rm -u $UID hbase-rm && \
+    mkdir /home/hbase-rm/.m2-repository && \
+    chown -R hbase-rm /home/hbase-rm && \
+    chmod -R 700 /home/hbase-rm
 USER hbase-rm:hbase-rm
 
 ENTRYPOINT [ "/opt/hbase-rm/do-release.sh" ]


### PR DESCRIPTION

* add an option to specify a docker volume to use for the local maven repo
* if we are reusing a maven repo path then remove our package space when we start