### PR TITLE
HBASE-24340 PerformanceEvaluation options should not mandate any specific order

### DIFF
--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -2616,29 +2616,18 @@ public class PerformanceEvaluation extends Configured implements Tool {
       final String autoFlush = "--autoFlush=";
       if (cmd.startsWith(autoFlush)) {
         opts.autoFlush = Boolean.parseBoolean(cmd.substring(autoFlush.length()));
-        if (!opts.autoFlush && opts.multiPut > 0) {
-          throw new IllegalArgumentException("autoFlush must be true when multiPut is more than 0");
-        }
         continue;
       }
 
       final String onceCon = "--oneCon=";
       if (cmd.startsWith(onceCon)) {
         opts.oneCon = Boolean.parseBoolean(cmd.substring(onceCon.length()));
-        if (opts.oneCon && opts.connCount > 1) {
-          throw new IllegalArgumentException("oneCon is set to true, "
-              + "connCount should not bigger than 1");
-        }
         continue;
       }
 
       final String connCount = "--connCount=";
       if (cmd.startsWith(connCount)) {
         opts.connCount = Integer.parseInt(cmd.substring(connCount.length()));
-        if (opts.oneCon && opts.connCount > 1) {
-          throw new IllegalArgumentException("oneCon is set to true, "
-              + "connCount should not bigger than 1");
-        }
         continue;
       }
 
@@ -2657,9 +2646,6 @@ public class PerformanceEvaluation extends Configured implements Tool {
       final String multiPut = "--multiPut=";
       if (cmd.startsWith(multiPut)) {
         opts.multiPut = Integer.parseInt(cmd.substring(multiPut.length()));
-        if (!opts.autoFlush && opts.multiPut > 0) {
-          throw new IllegalArgumentException("autoFlush must be true when multiPut is more than 0");
-        }
         continue;
       }
 
@@ -2733,18 +2719,12 @@ public class PerformanceEvaluation extends Configured implements Tool {
       final String valueRandom = "--valueRandom";
       if (cmd.startsWith(valueRandom)) {
         opts.valueRandom = true;
-        if (opts.valueZipf) {
-          throw new IllegalStateException("Either valueZipf or valueRandom but not both");
-        }
         continue;
       }
 
       final String valueZipf = "--valueZipf";
       if (cmd.startsWith(valueZipf)) {
         opts.valueZipf = true;
-        if (opts.valueRandom) {
-          throw new IllegalStateException("Either valueZipf or valueRandom but not both");
-        }
         continue;
       }
 
@@ -2810,6 +2790,8 @@ public class PerformanceEvaluation extends Configured implements Tool {
         continue;
       }
 
+      validateParsedOpts(opts);
+
       if (isCommandClass(cmd)) {
         opts.cmdName = cmd;
         try {
@@ -2829,6 +2811,25 @@ public class PerformanceEvaluation extends Configured implements Tool {
       break;
     }
     return opts;
+  }
+
+  /**
+  * Validates opts after all the opts are parsed, so that caller need not to maintain order of opts
+  */
+  private static void validateParsedOpts(TestOptions opts)  {
+
+    if (!opts.autoFlush && opts.multiPut > 0) {
+      throw new IllegalArgumentException("autoFlush must be true when multiPut is more than 0");
+    }
+
+    if (opts.oneCon && opts.connCount > 1) {
+      throw new IllegalArgumentException("oneCon is set to true, "
+          + "connCount should not bigger than 1");
+    }
+
+    if (opts.valueZipf && opts.valueRandom) {
+      throw new IllegalStateException("Either valueZipf or valueRandom but not both");
+    }
   }
 
   static TestOptions calculateRowsAndSize(final TestOptions opts) {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
@@ -257,9 +257,14 @@ public class TestPerformanceEvaluation {
     } catch (IllegalArgumentException  e) {
       System.out.println(e.getMessage());
     }
-    ((LinkedList<String>) opts).offerFirst(cmdName);
-    ((LinkedList<String>) opts).offerFirst("--multiPut=10");
-    ((LinkedList<String>) opts).offerFirst("--autoFlush=true");
+
+    //Re-create options
+    opts = new LinkedList<>();
+    opts.offer("--autoFlush=true");
+    opts.offer("--multiPut=10");
+    opts.offer(cmdName);
+    opts.offer("64");
+
     options = PerformanceEvaluation.parseOpts(opts);
     assertNotNull(options);
     assertNotNull(options.getCmdName());
@@ -284,6 +289,7 @@ public class TestPerformanceEvaluation {
     assertEquals(10, options.getMultiPut());
 
     // Change the order of AutoFlush and Multiput
+    opts = new LinkedList<>();
     opts.offer(cmdMultiPut);
     opts.offer(cmdAutoFlush);
     opts.offer(cmdName);
@@ -312,8 +318,11 @@ public class TestPerformanceEvaluation {
       System.out.println(e.getMessage());
     }
 
-    ((LinkedList<String>) opts).offerFirst(cmdName);
-    ((LinkedList<String>) opts).offerFirst("--connCount=10");
+    opts = new LinkedList<>();
+    opts.offer("--connCount=10");
+    opts.offer(cmdName);
+    opts.offer("64");
+
     options = PerformanceEvaluation.parseOpts(opts);
     assertNotNull(options);
     assertNotNull(options.getCmdName());
@@ -336,8 +345,12 @@ public class TestPerformanceEvaluation {
     } catch (IllegalStateException  e) {
       System.out.println(e.getMessage());
     }
-    ((LinkedList<String>) opts).offerFirst(cmdName);
-    ((LinkedList<String>) opts).offerFirst("--valueRandom");
+
+    opts = new LinkedList<>();
+    opts.offer("--valueRandom");
+    opts.offer(cmdName);
+    opts.offer("64");
+
     options = PerformanceEvaluation.parseOpts(opts);
 
     assertNotNull(options);

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
@@ -257,6 +257,7 @@ public class TestPerformanceEvaluation {
     } catch (IllegalArgumentException  e) {
       System.out.println(e.getMessage());
     }
+    ((LinkedList<String>) opts).offerFirst(cmdName);
     ((LinkedList<String>) opts).offerFirst("--multiPut=10");
     ((LinkedList<String>) opts).offerFirst("--autoFlush=true");
     options = PerformanceEvaluation.parseOpts(opts);
@@ -264,6 +265,35 @@ public class TestPerformanceEvaluation {
     assertNotNull(options.getCmdName());
     assertEquals(cmdName, options.getCmdName());
     assertEquals(10, options.getMultiPut());
+  }
+
+  @Test
+  public void testParseOptsMultiPutsAndAutoFlushOrder() {
+    Queue<String> opts = new LinkedList<>();
+    String cmdName = "sequentialWrite";
+    String cmdMultiPut = "--multiPut=10";
+    String cmdAutoFlush = "--autoFlush=true";
+    opts.offer(cmdAutoFlush);
+    opts.offer(cmdMultiPut);
+    opts.offer(cmdName);
+    opts.offer("64");
+    PerformanceEvaluation.TestOptions options = null;
+    options = PerformanceEvaluation.parseOpts(opts);
+    assertNotNull(options);
+    assertEquals(true, options.autoFlush);
+    assertEquals(10, options.getMultiPut());
+
+    // Change the order of AutoFlush and Multiput
+    opts.offer(cmdMultiPut);
+    opts.offer(cmdAutoFlush);
+    opts.offer(cmdName);
+    opts.offer("64");
+
+    options = null;
+    options = PerformanceEvaluation.parseOpts(opts);
+    assertNotNull(options);
+    assertEquals(10, options.getMultiPut());
+    assertEquals(true, options.autoFlush);
   }
 
   @Test
@@ -281,6 +311,8 @@ public class TestPerformanceEvaluation {
     } catch (IllegalArgumentException  e) {
       System.out.println(e.getMessage());
     }
+
+    ((LinkedList<String>) opts).offerFirst(cmdName);
     ((LinkedList<String>) opts).offerFirst("--connCount=10");
     options = PerformanceEvaluation.parseOpts(opts);
     assertNotNull(options);
@@ -288,4 +320,30 @@ public class TestPerformanceEvaluation {
     assertEquals(cmdName, options.getCmdName());
     assertEquals(10, options.getConnCount());
   }
+
+  @Test
+  public void testParseOptsValueRandom() {
+    Queue<String> opts = new LinkedList<>();
+    String cmdName = "sequentialWrite";
+    opts.offer("--valueRandom");
+    opts.offer("--valueZipf");
+    opts.offer(cmdName);
+    opts.offer("64");
+    PerformanceEvaluation.TestOptions options = null;
+    try {
+      options = PerformanceEvaluation.parseOpts(opts);
+      fail("should fail");
+    } catch (IllegalStateException  e) {
+      System.out.println(e.getMessage());
+    }
+    ((LinkedList<String>) opts).offerFirst(cmdName);
+    ((LinkedList<String>) opts).offerFirst("--valueRandom");
+    options = PerformanceEvaluation.parseOpts(opts);
+
+    assertNotNull(options);
+    assertNotNull(options.getCmdName());
+    assertEquals(cmdName, options.getCmdName());
+    assertEquals(true, options.valueRandom);
+  }
+
 }


### PR DESCRIPTION
PE options validations were happening while options are getting evaluated. And hence order of options were necessary to make the validations pass. With this patch, moved validations of all such interdependent options to a private method. Added (2) and updated (2) few unit tests to validate the change. 