### PR TITLE
HBASE-24567 Create release should url-encode all characters when building git uri

### DIFF
--- a/dev-support/create-release/release-util.sh
+++ b/dev-support/create-release/release-util.sh
@@ -412,8 +412,8 @@ function git_clone_overwrite {
     echo "[INFO] clone will be of the gitbox repo for ${PROJECT}."
     if [ -n "${ASF_USERNAME}" ] && [ -n "${ASF_PASSWORD}" ]; then
       # Ugly!
-      encoded_username=$(python -c "import urllib; print urllib.quote('''$ASF_USERNAME''')")
-      encoded_password=$(python -c "import urllib; print urllib.quote('''$ASF_PASSWORD''')")
+      encoded_username=$(python -c "import urllib; print urllib.quote('''$ASF_USERNAME''', '')")
+      encoded_password=$(python -c "import urllib; print urllib.quote('''$ASF_PASSWORD''', '')")
       GIT_REPO="https://$encoded_username:$encoded_password@${asf_repo}"
     else
       GIT_REPO="https://${asf_repo}"


### PR DESCRIPTION
By default, `urllib.quote` will skipp over `/` characters, which are valid for use in passwords.