### PR TITLE
HBASE-19365 Guard against a missing table descriptor which crashes ma…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/AssignmentManager.java
@@ -3220,12 +3220,16 @@ public class AssignmentManager extends ZooKeeperListener {
       // maybe because it crashed.
       PairOfSameType<HRegionInfo> p = MetaTableAccessor.getMergeRegions(result);
       if (p.getFirst() != null && p.getSecond() != null) {
-        int numReplicas = server.getTableDescriptors().get(p.getFirst().
-            getTable()).getRegionReplication();
-        for (HRegionInfo merge : p) {
-          for (int i = 1; i < numReplicas; i++) {
-            replicasToClose.add(RegionReplicaUtil.getRegionInfoForReplica(merge, i));
+        HTableDescriptor desc = server.getTableDescriptors().get(p.getFirst().getTable());
+        if (desc != null) {
+          int numReplicas = desc.getRegionReplication();
+          for (HRegionInfo merge : p) {
+            for (int i = 1; i < numReplicas; i++) {
+              replicasToClose.add(RegionReplicaUtil.getRegionInfoForReplica(merge, i));
+            }
           }
+        } else {
+          LOG.warn("Found no table descriptor on filesystem for " + p.getFirst().getTable());
         }
       }
       RegionLocations rl =  MetaTableAccessor.getRegionLocations(result);


### PR DESCRIPTION
…ster

While we never expect table descriptors to be missing, a corrupt meta
(rogue merge daughters) or corrupt filesystem (missing tabledesc) can result in the master crashing before regions get assigned. We can guard against that happening with a simple null-check.

I didn't try to reproduce this in a unit test, but I was able to reproduce it in a local environment doing the following:
* `create 'usertable', 'family', {SPLITS => (1..n_splits).map{|i| "user#{i}"}}`
* `(0..n_splits).map{|i| put 'usertable', "user#{i}", 'family:q', "#{i}"}`
* Choose two regions in the table and use `merge_region` to merge them together (required!)
* Kill everything (master and regionserver)
* `hdfs dfs -mv /hbase/data/default/usertable/.tabledesc /sidelined-tabledesc`
* Restart HBase
* Observe master crash

After this fix, the master stays up (and hbck can be used normally to generate a new tabledesc and reassign any regions stuck unassigned)
