### PR TITLE
HBASE-24579: Failed SASL authentication does not result in an exception on client side

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/HBaseSaslRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/HBaseSaslRpcClient.java
@@ -148,6 +148,18 @@ public class HBaseSaslRpcClient extends AbstractHBaseSaslRpcClient {
           inStream.readFully(saslToken);
         }
       }
+
+      if(isComplete()){
+        try {
+          readStatus(inStream);
+        }
+        catch (Exception e){
+          if(e instanceof RemoteException){
+            LOG.debug("Sasl connection failed: ", e);
+            throw e;
+          }
+        }
+      }
       if (LOG.isDebugEnabled()) {
         LOG.debug("SASL client context established. Negotiated QoP: "
             + saslClient.getNegotiatedProperty(Sasl.QOP));

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/HBaseSaslRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/HBaseSaslRpcClient.java
@@ -149,15 +149,13 @@ public class HBaseSaslRpcClient extends AbstractHBaseSaslRpcClient {
         }
       }
 
-      if(isComplete()){
-        try {
-          readStatus(inStream);
-        }
-        catch (Exception e){
-          if(e instanceof RemoteException){
-            LOG.debug("Sasl connection failed: ", e);
-            throw e;
-          }
+      try {
+        readStatus(inStream);
+      }
+      catch (IOException e){
+        if(e instanceof RemoteException){
+          LOG.debug("Sasl connection failed: ", e);
+          throw e;
         }
       }
       if (LOG.isDebugEnabled()) {


### PR DESCRIPTION
read input stream even if the authentication is completed
add a test