### PR TITLE
HBASE-22146 SpaceQuotaViolationPolicy Disable is not working in Names…

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaTableUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaTableUtil.java
@@ -629,6 +629,34 @@ public class QuotaTableUtil {
   }
 
   /**
+   * Remove table usage snapshots (u:p columns) for the namespace passed
+   * @param connection connection to re-use
+   * @param namespace the namespace to fetch the list of table usage snapshots
+   */
+  static void deleteTableUsageSnapshotsForNamespace(Connection connection, String namespace)
+    throws IOException {
+    Scan s = new Scan();
+    //Get rows for all tables in namespace
+    s.setRowPrefixFilter(Bytes.toBytes("t." + namespace));
+    //Scan for table usage column (u:p) in quota table
+    s.addColumn(QUOTA_FAMILY_USAGE,QUOTA_QUALIFIER_POLICY);
+    //Scan for table quota column (q:s) if table has a space quota defined
+    s.addColumn(QUOTA_FAMILY_INFO,QUOTA_QUALIFIER_SETTINGS);
+    try (Table quotaTable = connection.getTable(QUOTA_TABLE_NAME);
+         ResultScanner rs = quotaTable.getScanner(s)) {
+      for (Result r : rs) {
+        byte[] data = r.getValue(QUOTA_FAMILY_INFO, QUOTA_QUALIFIER_SETTINGS);
+        //if table does not have a table space quota defined, delete table usage column (u:p)
+        if (data == null) {
+          Delete delete = new Delete(r.getRow());
+          delete.addColumns(QUOTA_FAMILY_USAGE,QUOTA_QUALIFIER_POLICY);
+          quotaTable.delete(delete);
+        }
+      }
+    }
+  }
+
+  /**
    * Fetches the computed size of all snapshots against tables in a namespace for space quotas.
    */
   static long getNamespaceSnapshotSize(

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaTableUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaTableUtil.java
@@ -637,7 +637,7 @@ public class QuotaTableUtil {
     throws IOException {
     Scan s = new Scan();
     //Get rows for all tables in namespace
-    s.setRowPrefixFilter(Bytes.toBytes("t." + namespace));
+    s.setRowPrefixFilter(Bytes.add(QUOTA_TABLE_ROW_KEY_PREFIX, Bytes.toBytes(namespace + TableName.NAMESPACE_DELIM)));
     //Scan for table usage column (u:p) in quota table
     s.addColumn(QUOTA_FAMILY_USAGE,QUOTA_QUALIFIER_POLICY);
     //Scan for table quota column (q:s) if table has a space quota defined

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/namespace/NamespaceAuditor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/namespace/NamespaceAuditor.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.namespace;
 
 import java.io.IOException;
+import java.util.Set;
 
 import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.MetaTableAccessor;
@@ -141,6 +142,10 @@ public class NamespaceAuditor {
 
   public void deleteNamespace(String namespace) throws IOException {
     stateManager.deleteNamespace(namespace);
+    Set<TableName> tableNameSet = getState(namespace).getTables();
+    for (TableName tableName: tableNameSet) {
+      removeFromNamespaceUsage(tableName);
+    }
   }
 
   public void removeFromNamespaceUsage(TableName tableName)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/namespace/NamespaceAuditor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/namespace/NamespaceAuditor.java
@@ -142,10 +142,6 @@ public class NamespaceAuditor {
 
   public void deleteNamespace(String namespace) throws IOException {
     stateManager.deleteNamespace(namespace);
-    Set<TableName> tableNameSet = getState(namespace).getTables();
-    for (TableName tableName: tableNameSet) {
-      removeFromNamespaceUsage(tableName);
-    }
   }
 
   public void removeFromNamespaceUsage(TableName tableName)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/namespace/NamespaceAuditor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/namespace/NamespaceAuditor.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hbase.namespace;
 
 import java.io.IOException;
-import java.util.Set;
 
 import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.MetaTableAccessor;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
@@ -267,6 +267,14 @@ public class QuotaUtil extends QuotaTableUtil {
       delete.addColumns(QUOTA_FAMILY_INFO, qualifier);
     }
     doDelete(connection, delete);
+    if (isNamespaceRowKey(rowKey)) {
+      TableName[] tableArray = connection.getAdmin().listTableNamesByNamespace(getNamespaceFromRowKey(rowKey));
+      for (TableName tableName: tableArray) {
+        if (QuotaUtil.getTableQuota(connection, tableName) == null) {
+          deleteTableQuota(connection,tableName);
+        }
+      }
+    }
   }
 
   public static Map<String, UserQuotaState> fetchUserQuotas(final Connection connection,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
@@ -270,6 +270,7 @@ public class QuotaUtil extends QuotaTableUtil {
       String ns = getNamespaceFromRowKey(rowKey);
       Quotas namespaceQuota = getNamespaceQuota(connection,ns);
       if (namespaceQuota != null && namespaceQuota.hasSpace()) {
+        // When deleting namespace space quota, also delete table usage(u:p) snapshots
         deleteTableUsageSnapshotsForNamespace(connection, ns);
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
@@ -265,6 +265,7 @@ public class QuotaUtil extends QuotaTableUtil {
       final byte[] qualifier) throws IOException {
     Delete delete = new Delete(rowKey);
     if (qualifier != null) {
+      //Check if delete qualifier is for persisted space quota snapshot usage column family
       if (Arrays.equals(qualifier,QUOTA_QUALIFIER_POLICY)) {
         delete.addColumns(QUOTA_FAMILY_USAGE, qualifier);
       } else

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotDisabledException;
 import org.apache.hadoop.hbase.TableNotEnabledException;
 import org.apache.hadoop.hbase.TableNotFoundException;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Delete;
@@ -264,17 +265,33 @@ public class QuotaUtil extends QuotaTableUtil {
       final byte[] qualifier) throws IOException {
     Delete delete = new Delete(rowKey);
     if (qualifier != null) {
-      delete.addColumns(QUOTA_FAMILY_INFO, qualifier);
+      if (Arrays.equals(qualifier,QUOTA_QUALIFIER_POLICY)) {
+        delete.addColumns(QUOTA_FAMILY_USAGE, qualifier);
+      } else
+        delete.addColumns(QUOTA_FAMILY_INFO, qualifier);
     }
-    doDelete(connection, delete);
     if (isNamespaceRowKey(rowKey)) {
-      TableName[] tableArray = connection.getAdmin().listTableNamesByNamespace(getNamespaceFromRowKey(rowKey));
-      for (TableName tableName: tableArray) {
-        if (QuotaUtil.getTableQuota(connection, tableName) == null) {
-          deleteTableQuota(connection,tableName);
+      //Check namespace is not deleted before you get info about quota and list of tables in namespace
+      NamespaceDescriptor[] descs = connection.getAdmin().listNamespaceDescriptors();
+      String ns = getNamespaceFromRowKey(rowKey);
+      int index = 0;
+      while (index < descs.length) {
+        if (ns.equals(descs[index].getName())) {
+          Quotas namespaceQuota = getNamespaceQuota(connection,ns);
+          if (namespaceQuota != null && namespaceQuota.hasSpace()) {
+            TableName[] tableArray = connection.getAdmin().listTableNamesByNamespace(ns);
+            for (TableName tableName : tableArray) {
+              deleteQuotas(connection, getTableRowKey(tableName), QUOTA_QUALIFIER_POLICY);
+            }
+          }
+          //Exit the while loop by moving to last index
+          index = descs.length;
+        } else {
+          index++;
         }
       }
     }
+    doDelete(connection, delete);
   }
 
   public static Map<String, UserQuotaState> fetchUserQuotas(final Connection connection,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/SpaceQuotaHelperForTests.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/SpaceQuotaHelperForTests.java
@@ -283,6 +283,19 @@ public class SpaceQuotaHelperForTests {
   }
 
   /**
+   * Verifies that table usage snapshot exists for the table
+   */
+  void verifyTableUsageSnapshotForSpaceQuotaExist(TableName tn) throws Exception {
+    boolean sawUsageSnapshot = false;
+    try (Table quotaTable = testUtil.getConnection().getTable(QuotaTableUtil.QUOTA_TABLE_NAME)) {
+      Scan s = QuotaTableUtil.makeQuotaSnapshotScanForTable(tn);
+      ResultScanner rs = quotaTable.getScanner(s);
+      sawUsageSnapshot = (rs.next() != null);
+    }
+    assertTrue("Expected to succeed in getting table usage snapshots for space quota", sawUsageSnapshot);
+  }
+
+  /**
    * Sets the given quota (policy & limit) on the passed table.
    */
   void setQuotaLimit(final TableName tn, SpaceViolationPolicy policy, long sizeInMBs)
@@ -454,7 +467,13 @@ public class SpaceQuotaHelperForTests {
   }
 
   NamespaceDescriptor createNamespace() throws Exception {
-    NamespaceDescriptor nd = NamespaceDescriptor.create("ns" + counter.getAndIncrement()).build();
+    return createNamespace(null);
+  }
+
+  NamespaceDescriptor createNamespace(String namespace) throws Exception {
+    if (namespace == null || namespace.trim().isEmpty())
+      namespace = "ns" + counter.getAndIncrement();
+    NamespaceDescriptor nd = NamespaceDescriptor.create(namespace).build();
     testUtil.getAdmin().createNamespace(nd);
     return nd;
   }


### PR DESCRIPTION
HBASE-22146 SpaceQuotaViolationPolicy Disable is not working in Namespace level 

When a namespace space quota is deleted, the namespace quota (q:s) row from hbase:quota table is removed, however the related u:p rows from tables in the namespace still stay. Removing the u:p rows for tables in the namespace to fix this issue.