### PR TITLE
HBASE-24601: Change default Hfile storage policy from HOT to NONE for HDFS

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -139,8 +139,8 @@ public class HStore implements Store, HeapSize, StoreConfigInformation,
       "hbase.server.compactchecker.interval.multiplier";
   public static final String BLOCKING_STOREFILES_KEY = "hbase.hstore.blockingStoreFiles";
   public static final String BLOCK_STORAGE_POLICY_KEY = "hbase.hstore.block.storage.policy";
-  // keep in accordance with HDFS default storage policy
-  public static final String DEFAULT_BLOCK_STORAGE_POLICY = "HOT";
+  // "NONE" is not a valid storage policy and means we defer the policy to HDFS
+  public static final String DEFAULT_BLOCK_STORAGE_POLICY = "NONE";
   public static final int DEFAULT_COMPACTCHECKER_INTERVAL_MULTIPLIER = 1000;
   public static final int DEFAULT_BLOCKING_STOREFILE_COUNT = 16;
 


### PR DESCRIPTION
Details Link: [HBASE-24601](https://issues.apache.org/jira/browse/HBASE-24601)