### PR TITLE
HBASE-24231 Add hadoop 3.2.x in our support matrix

### DIFF
--- a/src/main/asciidoc/_chapters/configuration.adoc
+++ b/src/main/asciidoc/_chapters/configuration.adoc
@@ -312,6 +312,7 @@ link:https://hadoop.apache.org/cve_list.html[CVEs] so we drop the support in new
 |Hadoop-3.0.3+ | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:check-circle[role="green"] | icon:times-circle[role="red"] | icon:times-circle[role="red"]
 |Hadoop-3.1.0 | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:times-circle[role="red"]
 |Hadoop-3.1.1+ | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:check-circle[role="green"] | icon:check-circle[role="green"] | icon:check-circle[role="green"]
+|Hadoop-3.2.x | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:times-circle[role="red"] | icon:check-circle[role="green"] | icon:check-circle[role="green"]
 |===
 
 .Hadoop Pre-2.6.1 and JDK 1.8 Kerberos


### PR DESCRIPTION
Add a line for hadoop-3.2.x. Values are based on the if-statement in
our personality file,

```
  if [[ "${PATCH_BRANCH}" = branch-1* ]]; then
    yetus_info "Setting Hadoop 3 versions to test based on branch-1.x rules."
    hbase_hadoop3_versions=""
  elif [[ "${PATCH_BRANCH}" = branch-2.0 ]] || [[ "${PATCH_BRANCH}" = branch-2.1 ]]; then
    yetus_info "Setting Hadoop 3 versions to test based on branch-2.0/branch-2.1 rules"
    if [[ "${QUICK_HADOOPCHECK}" == "true" ]]; then
      hbase_hadoop3_versions="3.0.3 3.1.2"
    else
      hbase_hadoop3_versions="3.0.3 3.1.1 3.1.2"
    fi
  else
    yetus_info "Setting Hadoop 3 versions to test based on branch-2.2+/master/feature branch rules"
    if [[ "${QUICK_HADOOPCHECK}" == "true" ]]; then
      hbase_hadoop3_versions="3.1.2 3.2.1"
    else
      hbase_hadoop3_versions="3.1.1 3.1.2 3.2.0 3.2.1"
    fi
  fi
```