### PR TITLE
HBASE-20819 Use TableDescriptor to replace HTableDescriptor in hbase-shell module

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptorBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptorBuilder.java
@@ -396,6 +396,11 @@ public class TableDescriptorBuilder {
     return this;
   }
 
+  public TableDescriptorBuilder removeValue(final String key) {
+    desc.removeValue(key);
+    return this;
+  }
+
   public TableDescriptorBuilder removeValue(Bytes key) {
     desc.removeValue(key);
     return this;
@@ -734,6 +739,17 @@ public class TableDescriptorBuilder {
       } else {
         return new Bytes(f.apply(t));
       }
+    }
+
+    /**
+     * Remove metadata represented by the key from the {@link #values} map
+     *
+     * @param key Key whose key and value we're to remove from TableDescriptor
+     * parameters.
+     * @return the modifyable TD
+     */
+    public ModifyableTableDescriptor removeValue(final String key) {
+      return setValue(key, (String) null);
     }
 
     /**

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -713,13 +713,13 @@ module Hbase
                 if tdb.build.getValue(key).nil?
                   raise ArgumentError, "Could not find attribute: #{key}"
                 end
-                tdb.setValue(key, nil)
+                tdb.removeValue(key)
               end
             else
               if tdb.build.getValue(name).nil?
                 raise ArgumentError, "Could not find attribute: #{name}"
               end
-              tdb.setValue(name, nil)
+              tdb.removeValue(name)
             end
             hasTableUpdate = true
           # Unset table configuration
@@ -730,13 +730,13 @@ module Hbase
                 if tdb.build.getValue(key).nil?
                   raise ArgumentError, "Could not find configuration: #{key}"
                 end
-                tdb.setValue(key, nil)
+                tdb.removeValue(key)
               end
             else
               if tdb.build.getValue(name).nil?
                 raise ArgumentError, "Could not find configuration: #{name}"
               end
-              tdb.setValue(name, nil)
+              tdb.removeValue(name)
             end
             hasTableUpdate = true
           # Unknown method

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -765,8 +765,8 @@ module Hbase
           v = String.new(value)
           v.strip!
           # TODO: We should not require user to config the coprocessor with our inner format.
-	  # This is a roundabout approach, but will be replaced shortly since
-	  # the setCoprocessorWithSpec method is marked for deprecation.
+          # This is a roundabout approach, but will be replaced shortly since
+          # the setCoprocessorWithSpec method is marked for deprecation.
           coprocessor_descriptors = tdb.build.setCoprocessorWithSpec(v).getCoprocessorDescriptors
           tdb.setCoprocessors(coprocessor_descriptors)
           valid_coproc_keys << key

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -444,7 +444,7 @@ module Hbase
         if arg.is_a?(String) || arg.key?(NAME)
           # If the arg is a string, default action is to add a column to the table.
           # If arg has a name, it must also be a column descriptor.
-          descriptor = hcd(arg, tdb)
+          descriptor = cfd(arg, tdb)
           # Warn if duplicate columns are added
           if tdb.build.hasColumnFamily(descriptor.getName)
             puts "Family '" + descriptor.getNameAsString + "' already exists, the old one will be replaced"
@@ -684,7 +684,7 @@ module Hbase
         # 1) Column family spec. Distinguished by having a NAME and no METHOD.
         method = arg.delete(METHOD)
         if method.nil? && arg.key?(NAME)
-          descriptor = hcd(arg, tdb)
+          descriptor = cfd(arg, tdb)
           column_name = descriptor.getNameAsString
 
           # If column already exist, then try to alter it. Create otherwise.
@@ -977,16 +977,15 @@ module Hbase
 
     #----------------------------------------------------------------------------------------------
     # Return a new ColumnFamilyDescriptor made of passed args
-    def hcd(arg, tdb)
+    def cfd(arg, tdb)
       # String arg, single parameter constructor
-
       return ColumnFamilyDescriptorBuilder.of(arg) if arg.is_a?(String)
 
       raise(ArgumentError, "Column family #{arg} must have a name") unless name = arg.delete(NAME)
 
-      cfd = tdb.build.getColumnFamily(name.to_java_bytes)
-      unless cfd.nil?
-        cfdb = ColumnFamilyDescriptorBuilder.newBuilder(cfd)
+      descriptor = tdb.build.getColumnFamily(name.to_java_bytes)
+      unless descriptor.nil?
+        cfdb = ColumnFamilyDescriptorBuilder.newBuilder(descriptor)
       end
       # create it if it's a new family
       cfdb ||= ColumnFamilyDescriptorBuilder.newBuilder(name.to_java_bytes)

--- a/hbase-shell/src/main/ruby/hbase/security.rb
+++ b/hbase-shell/src/main/ruby/hbase/security.rb
@@ -66,10 +66,10 @@ module Hbase
             raise(ArgumentError, "Can't find a table: #{table_name}") unless exists?(table_name)
 
             tableName = org.apache.hadoop.hbase.TableName.valueOf(table_name)
-            htd = org.apache.hadoop.hbase.HTableDescriptor.new(@admin.getDescriptor(tableName))
+            td = @admin.getDescriptor(tableName)
 
             unless family.nil?
-              raise(ArgumentError, "Can't find a family: #{family}") unless htd.hasFamily(family.to_java_bytes)
+              raise(ArgumentError, "Can't find a family: #{family}") unless td.hasColumnFamily(family.to_java_bytes)
             end
 
             fambytes = family.to_java_bytes unless family.nil?
@@ -111,10 +111,10 @@ module Hbase
             raise(ArgumentError, "Can't find a table: #{table_name}") unless exists?(table_name)
 
             tableName = org.apache.hadoop.hbase.TableName.valueOf(table_name)
-            htd = org.apache.hadoop.hbase.HTableDescriptor.new(@admin.getDescriptor(tableName))
+            td = @admin.getDescriptor(tableName)
 
             unless family.nil?
-              raise(ArgumentError, "Can't find a family: #{family}") unless htd.hasFamily(family.to_java_bytes)
+              raise(ArgumentError, "Can't find a family: #{family}") unless td.hasColumnFamily(family.to_java_bytes)
             end
 
             fambytes = family.to_java_bytes unless family.nil?

--- a/hbase-shell/src/main/ruby/hbase_constants.rb
+++ b/hbase-shell/src/main/ruby/hbase_constants.rb
@@ -39,7 +39,7 @@ module HBaseConstants
   NAME = org.apache.hadoop.hbase.HConstants::NAME
   VERSIONS = org.apache.hadoop.hbase.HConstants::VERSIONS
   IN_MEMORY = org.apache.hadoop.hbase.HConstants::IN_MEMORY
-  IN_MEMORY_COMPACTION = org.apache.hadoop.hbase.HColumnDescriptor::IN_MEMORY_COMPACTION
+  IN_MEMORY_COMPACTION = org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder::IN_MEMORY_COMPACTION
   METADATA = org.apache.hadoop.hbase.HConstants::METADATA
   STOPROW = 'STOPROW'.freeze
   STARTROW = 'STARTROW'.freeze
@@ -109,8 +109,8 @@ module HBaseConstants
     end
   end
 
-  promote_constants(org.apache.hadoop.hbase.HColumnDescriptor.constants)
-  promote_constants(org.apache.hadoop.hbase.HTableDescriptor.constants)
+  promote_constants(org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder.constants)
+  promote_constants(org.apache.hadoop.hbase.client.TableDescriptorBuilder.constants)
 end
 
 # Include classes definition

--- a/hbase-shell/src/main/ruby/hbase_constants.rb
+++ b/hbase-shell/src/main/ruby/hbase_constants.rb
@@ -98,6 +98,9 @@ module HBaseConstants
   FORMATTER_CLASS = 'FORMATTER_CLASS'.freeze
   POLICY = 'POLICY'.freeze
   REGIONSERVER = 'REGIONSERVER'.freeze
+  REPLICATION_SCOPE_BYTES = org.apache.hadoop.hbase.ColumnFamilyDescriptor::REPLICATION_SCOPE_BYTES
+  FOREVER = org.apache.hadoop.hbase.HConstants::FOREVER
+  IS_ROOT = 'IS_ROOT'.freeze
 
   # Load constants from hbase java API
   def self.promote_constants(constants)

--- a/hbase-shell/src/main/ruby/hbase_constants.rb
+++ b/hbase-shell/src/main/ruby/hbase_constants.rb
@@ -98,7 +98,7 @@ module HBaseConstants
   FORMATTER_CLASS = 'FORMATTER_CLASS'.freeze
   POLICY = 'POLICY'.freeze
   REGIONSERVER = 'REGIONSERVER'.freeze
-  REPLICATION_SCOPE_BYTES = org.apache.hadoop.hbase.ColumnFamilyDescriptor::REPLICATION_SCOPE_BYTES
+  REPLICATION_SCOPE_BYTES = org.apache.hadoop.hbase.client.ColumnFamilyDescriptor::REPLICATION_SCOPE_BYTES
   FOREVER = org.apache.hadoop.hbase.HConstants::FOREVER
   IS_ROOT = 'IS_ROOT'.freeze
 

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -808,6 +808,27 @@ module Hbase
       assert_no_match(eval("/" + key_2 + "/"), admin.describe(@test_name))
     end
 
+
+    define_test "alter should raise error trying to remove nonexistent attributes" do
+      drop_test_table(@test_name)
+      create_test_table(@test_name)
+
+      key_1 = "TestAttr1"
+      key_2 = "TestAttr2"
+      assert_no_match(eval("/" + key_1 + "/"), admin.describe(@test_name))
+      assert_no_match(eval("/" + key_2 + "/"), admin.describe(@test_name))
+
+      # first, try removing just one nonexistent attribute
+      assert_raise(ArgumentError) do
+        command(:alter, @test_name, 'METHOD' => 'table_att_unset', 'NAME' => key_1)
+      end
+
+      # second, try removing multiple nonexistent attributes
+      assert_raise(ArgumentError) do
+        command(:alter, @test_name, 'METHOD' => 'table_att_unset', 'NAME' => [ key_1, key_2 ])
+      end
+    end
+
     define_test "alter should be able to remove a table configuration" do
       drop_test_table(@test_name)
       create_test_table(@test_name)
@@ -836,6 +857,26 @@ module Hbase
       command(:alter, @test_name, 'METHOD' => 'table_conf_unset', 'NAME' => [ key_1, key_2 ])
       assert_no_match(eval("/" + key_1 + "/"), admin.describe(@test_name))
       assert_no_match(eval("/" + key_2 + "/"), admin.describe(@test_name))
+    end
+
+    define_test "alter should raise error trying to remove nonexistent configurations" do
+      drop_test_table(@test_name)
+      create_test_table(@test_name)
+
+      key_1 = "TestConf1"
+      key_2 = "TestConf2"
+      assert_no_match(eval("/" + key_1 + "/"), admin.describe(@test_name))
+      assert_no_match(eval("/" + key_2 + "/"), admin.describe(@test_name))
+
+      # first, try removing just one nonexistent configuration
+      assert_raise(ArgumentError) do
+        command(:alter, @test_name, 'METHOD' => 'table_conf_unset', 'NAME' => key_1)
+      end
+
+      # second, try removing multiple nonexistent configurations
+      assert_raise(ArgumentError) do
+        command(:alter, @test_name, 'METHOD' => 'table_conf_unset', 'NAME' => [ key_1, key_2 ])
+      end
     end
 
     define_test "get_table should get a real table" do


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/browse/HBASE-20819

- Based on an old patch from Ha, Xiaolin (patch is still attached to Jira), updated for the current master branch
- In the hbase-shell module, replace all usages of HTableDescriptor with TableDescriptorBuilder
- Add unit tests for removing nonexistent attributes and configurations in the shell (This was previously untested and touches some of the code changes in this PR)
- Added new overload for TableDescriptorBuilder.removeValue that takes a String argument.