### PR TITLE
HBASE-24631 Loosen Dockerfile pinned package versions of the "debian-revision"

### DIFF
--- a/dev-support/Dockerfile
+++ b/dev-support/Dockerfile
@@ -26,10 +26,10 @@ COPY . /hbase/dev-support
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y update \
     && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --no-install-recommends \
-      curl=7.58.0-2ubuntu3.8 \
-      python2.7=2.7.17-1~18.04ubuntu1 \
-      python-pip=9.0.1-2.3~ubuntu1.18.04.1 \
-      python-setuptools=39.0.1-2 \
+      curl='7.58.0-*' \
+      python2.7='2.7.17-*' \
+      python-pip='9.0.1-*' \
+      python-setuptools='39.0.1-*' \
     && apt-get clean \
     && rm -rf /var/lib/apt/lists/*
 RUN pip install -r /hbase/dev-support/python-requirements.txt

--- a/dev-support/create-release/hbase-rm/Dockerfile
+++ b/dev-support/create-release/hbase-rm/Dockerfile
@@ -27,17 +27,17 @@ FROM ubuntu:18.04
 # the most current package versions (instead of potentially using old versions cached by docker).
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq -y update \
   && DEBIAN_FRONTEND=noninteractive apt-get -qq -y install --no-install-recommends \
-    curl=7.58.0-2ubuntu3.8 \
-    git=1:2.17.1-1ubuntu0.7 \
-    gnupg=2.2.4-1ubuntu1.2 \
-    libcurl4-openssl-dev=7.58.0-2ubuntu3.8 \
-    libxml2-dev=2.9.4+dfsg1-6.1ubuntu1.3 \
-    lsof=4.89+dfsg-0.1 \
-    maven=3.6.0-1~18.04.1 \
-    openjdk-8-jdk=8u252-b09-1~18.04 \
-    python-pip=9.0.1-2.3~ubuntu1.18.04.1 \
-    subversion=1.9.7-4ubuntu1 \
-    wget=1.19.4-1ubuntu2.2 \
+    curl='7.58.0-*' \
+    git='1:2.17.1-*' \
+    gnupg='2.2.4-*' \
+    libcurl4-openssl-dev='7.58.0-*' \
+    libxml2-dev='2.9.4+dfsg1-*' \
+    lsof='4.89+dfsg-*' \
+    maven='3.6.0-*' \
+    openjdk-8-jdk='8u252-b09-*' \
+    python-pip='9.0.1-*' \
+    subversion='1.9.7-*' \
+    wget='1.19.4-*' \
   && apt-get clean \
   && rm -rf /var/lib/apt/lists/* \
   && update-alternatives --set java /usr/lib/jvm/java-8-openjdk-amd64/jre/bin/java \

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -27,8 +27,8 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update && \
   DEBIAN_FRONTEND=noninteractive apt-get -qq install --no-install-recommends -y \
     ca-certificates=20180409 \
-    curl=7.58.0-2ubuntu3.8 \
-    locales=2.27-3ubuntu1 \
+    curl='7.58.0-*' \
+    locales='2.27-*' \
 ##
 # install dependencies from system packages.
 # be careful not to install any system packages (i.e., findbugs) that will
@@ -36,23 +36,23 @@ RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update && \
 #
 # bring the base image into conformance with the expectations imposed by
 # Yetus and our personality file of what a build environment looks like.
-    bash=4.4.18-2ubuntu1.2 \
+    bash='4.4.18-*' \
     build-essential=12.4ubuntu1 \
-    diffutils=1:3.6-1 \
-    git=1:2.17.1-1ubuntu0.7 \
-    rsync=3.1.2-2.1ubuntu1 \
-    tar=1.29b-2ubuntu0.1 \
-    wget=1.19.4-1ubuntu2.2 \
+    diffutils='1:3.6-*' \
+    git='1:2.17.1-*' \
+    rsync='3.1.2-*' \
+    tar='1.29b-*' \
+    wget='1.19.4-*' \
 # install the dependencies required in order to enable the sundry precommit
 # checks/features provided by Yetus plugins.
-    bats=0.4.0-1.1 \
-    libperl-critic-perl=1.130-1 \
-    python3=3.6.7-1~18.04 \
-    python3-pip=9.0.1-2.3~ubuntu1.18.04.1 \
-    python3-setuptools=39.0.1-2 \
+    bats='0.4.0-*' \
+    libperl-critic-perl='1.130-*' \
+    python3='3.6.7-*' \
+    python3-pip='9.0.1-*' \
+    python3-setuptools='39.0.1-*' \
     ruby=1:2.5.1 \
     ruby-dev=1:2.5.1 \
-    shellcheck=0.4.6-1 \
+    shellcheck='0.4.6-*' \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*

--- a/dev-support/hbase_docker/Dockerfile
+++ b/dev-support/hbase_docker/Dockerfile
@@ -20,9 +20,9 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update && \
   DEBIAN_FRONTEND=noninteractive apt-get -qq install --no-install-recommends -y \
     ca-certificates=20180409 \
-    curl=7.58.0-2ubuntu3.8 \
-    git=1:2.17.1-1ubuntu0.7 \
-    locales=2.27-3ubuntu1 \
+    curl='7.58.0-*' \
+    git='1:2.17.1-*' \
+    locales='2.27-*' \
     && \
     apt-get clean && \
     rm -rf /var/lib/apt/lists/*


### PR DESCRIPTION
After a bit of research into [0] and [1], and a bit of experimentation, it seems we can use a partial wild-card expression for these version strings. Let's try this for now. If it works out, we should expand this usage to all the version package numbers, pinning them to their epic:upstream-version components.

[0]: http://manpages.ubuntu.com/manpages/xenial/en/man5/deb-version.5.html
[1]: http://manpages.ubuntu.com/manpages/xenial/man8/apt-get.8.html