### PR TITLE
HBASE-24603: Make Zookeeper sync() call synchronous (#1945)

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/zookeeper/RecoverableZooKeeper.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/zookeeper/RecoverableZooKeeper.java
@@ -875,7 +875,7 @@ public class RecoverableZooKeeper {
   }
 
   public void sync(String path, AsyncCallback.VoidCallback cb, Object ctx) throws KeeperException {
-    checkZk().sync(path, cb, null);
+    checkZk().sync(path, cb, ctx);
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKAssign.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKAssign.java
@@ -208,7 +208,7 @@ public class ZKAssign {
       region.getRegionName(), serverName, HConstants.EMPTY_BYTE_ARRAY);
     byte [] data = rt.toByteArray();
     String node = getNodeName(zkw, region.getEncodedName());
-    zkw.sync(node);
+    zkw.syncOrTimeout(node);
     int version = ZKUtil.checkExists(zkw, node);
     if (version == -1) {
       return ZKUtil.createAndWatch(zkw, node, data);
@@ -444,7 +444,7 @@ public class ZKAssign {
         "node " + encodedRegionName + " in expected state " + expectedState));
     }
     String node = getNodeName(zkw, encodedRegionName);
-    zkw.sync(node);
+    zkw.syncOrTimeout(node);
     Stat stat = new Stat();
     byte [] bytes = ZKUtil.getDataNoWatch(zkw, node, stat);
     if (bytes == null) {
@@ -645,7 +645,7 @@ public class ZKAssign {
     }
 
     String node = getNodeName(zkw, encoded);
-    zkw.sync(node);
+    zkw.syncOrTimeout(node);
 
     // Read existing data of the node
     Stat stat = new Stat();
@@ -727,7 +727,7 @@ public class ZKAssign {
                                           int expectedVersion) throws KeeperException {
 
     final String encoded = getNodeName(zkw, region.getEncodedName());
-    zkw.sync(encoded);
+    zkw.syncOrTimeout(encoded);
 
     // Read existing data of the node
     Stat stat = new Stat();
@@ -807,7 +807,7 @@ public class ZKAssign {
     }
 
     String node = getNodeName(zkw, encoded);
-    zkw.sync(node);
+    zkw.syncOrTimeout(node);
 
     // Read existing data of the node
     Stat stat = new Stat();

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -244,6 +244,15 @@ public final class HConstants {
   /** Configuration key for ZooKeeper session timeout */
   public static final String ZK_SESSION_TIMEOUT = "zookeeper.session.timeout";
 
+  /** Timeout for the ZK sync() call */
+  public static final String ZK_SYNC_BLOCKING_TIMEOUT_MS = "hbase.zookeeper.sync.timeout.millis";
+  // Choice of the default value is based on the following ZK recommendation (from docs). Keeping it
+  // lower lets the callers fail fast in case of any issues.
+  // "The clients view of the system is guaranteed to be up-to-date within a certain time bound.
+  // (On the order of tens of seconds.) Either system changes will be seen by a client within this
+  // bound, or the client will detect a service outage."
+  public static final long ZK_SYNC_BLOCKING_TIMEOUT_DEFAULT_MS = 30 * 1000;
+
   /** Default value for ZooKeeper session timeout */
   public static final int DEFAULT_ZK_SESSION_TIMEOUT = 180 * 1000;
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/backup/example/HFileArchiveManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/backup/example/HFileArchiveManager.java
@@ -123,7 +123,7 @@ class HFileArchiveManager {
    */
   private void disable(ZooKeeperWatcher zooKeeper, byte[] table) throws KeeperException {
     // ensure the latest state of the archive node is found
-    zooKeeper.sync(archiveZnode);
+    zooKeeper.syncOrTimeout(archiveZnode);
 
     // if the top-level archive node is gone, then we are done
     if (ZKUtil.checkExists(zooKeeper, archiveZnode) < 0) {
@@ -132,7 +132,7 @@ class HFileArchiveManager {
     // delete the table node, from the archive
     String tableNode = this.getTableNode(table);
     // make sure the table is the latest version so the delete takes
-    zooKeeper.sync(tableNode);
+    zooKeeper.syncOrTimeout(tableNode);
 
     LOG.debug("Attempting to delete table node:" + tableNode);
     ZKUtil.deleteNodeRecursively(zooKeeper, tableNode);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/visibility/ZKVisibilityLabelWatcher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/visibility/ZKVisibilityLabelWatcher.java
@@ -109,7 +109,7 @@ public class ZKVisibilityLabelWatcher extends ZooKeeperListener {
   public void nodeDataChanged(String path) {
     if (path.equals(labelZnode) || path.equals(userAuthsZnode)) {
       try {
-        watcher.sync(path);
+        watcher.syncOrTimeout(path);
         byte[] data = ZKUtil.getDataAndWatch(watcher, path);
         if (path.equals(labelZnode)) {
           refreshVisibilityLabelsCache(data);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/Mocking.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/Mocking.java
@@ -71,7 +71,7 @@ public class Mocking {
     String encoded = region.getEncodedName();
 
     String node = ZKAssign.getNodeName(zkw, encoded);
-    zkw.sync(node);
+    zkw.syncOrTimeout(node);
 
     // Read existing data of the node
     byte [] existingBytes = null;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSplitTransactionOnCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSplitTransactionOnCluster.java
@@ -1087,7 +1087,7 @@ public class TestSplitTransactionOnCluster {
       assertTrue("not able to find a splittable region", region != null);
       String node = ZKAssign.getNodeName(regionServer.getZooKeeper(),
           region.getRegionInfo().getEncodedName());
-      regionServer.getZooKeeper().sync(node);
+      regionServer.getZooKeeper().syncOrTimeout(node);
       SplitTransactionImpl st = new SplitTransactionImpl(region, Bytes.toBytes("row2"));
       try {
         st.prepare();
@@ -1318,7 +1318,7 @@ public class TestSplitTransactionOnCluster {
       };
       String node = ZKAssign.getNodeName(regionServer.getZooKeeper(),
           region.getRegionInfo().getEncodedName());
-      regionServer.getZooKeeper().sync(node);
+      regionServer.getZooKeeper().syncOrTimeout(node);
       for (int i = 0; i < 100; i++) {
         // We expect the znode to be deleted by this time. Here the
         // znode could be in OPENED state and the


### PR DESCRIPTION
Writing a test for this is tricky. There is enough coverage for
functional tests. Only concern is performance, but there is enough
logging for it to detect timed out/badly performing sync calls.

Additionally, this patch decouples the ZK event processing into it's
own thread rather than doing it in the EventThread's context. That
avoids deadlocks and stalls of the event thread.

Signed-off-by: Andrew Purtell <apurtell@apache.org>
Signed-off-by: Viraj Jasani <vjasani@apache.org>
(cherry picked from commit 84e246f9b197bfa4307172db5465214771b78d38)
(cherry picked from commit 2379a25f0c4f2bdd3ea91fa5e0ba63f034c8d21c)