### PR TITLE
HBASE-24651 release script utils should set local user when GPG_KEY is defined.

### DIFF
--- a/dev-support/create-release/do-release.sh
+++ b/dev-support/create-release/do-release.sh
@@ -67,7 +67,6 @@ if [ "$RUNNING_IN_DOCKER" = "1" ]; then
   if [ -d "output" ]; then
     cd output
   fi
-  GPG_ARGS=("${GPG_ARGS[@]}" --local-user "${GPG_KEY}")
   echo "GPG Version: $("${GPG}" "${GPG_ARGS[@]}" --version)"
   # Inside docker, need to import the GPG key stored in the current directory.
   if ! $GPG "${GPG_ARGS[@]}" --import "$SELF/gpg.key.public" ; then
@@ -85,7 +84,6 @@ if [ "$RUNNING_IN_DOCKER" = "1" ]; then
 else
   # Outside docker, need to ask for information about the release.
   get_release_info
-  GPG_ARGS=("${GPG_ARGS[@]}" --local-user "${GPG_KEY}")
 fi
 
 GPG_TTY="$(tty)"

--- a/dev-support/create-release/release-util.sh
+++ b/dev-support/create-release/release-util.sh
@@ -20,6 +20,9 @@ DRY_RUN=${DRY_RUN:-1} #default to dry run
 DEBUG=${DEBUG:-0}
 GPG=${GPG:-gpg}
 GPG_ARGS=(--no-autostart --batch)
+if [ -n "${GPG_KEY}" ]; then
+  GPG_ARGS=("${GPG_ARGS[@]}" --local-user "${GPG_KEY}")
+fi
 # Maven Profiles for publishing snapshots and release to Maven Central and Dist
 PUBLISH_PROFILES=("-P" "apache-release,release")
 
@@ -256,6 +259,7 @@ EOF
     echo "Exiting."
     exit 1
   fi
+  GPG_ARGS=("${GPG_ARGS[@]}" --local-user "${GPG_KEY}")
 
   if ! is_dry_run; then
     if [ -z "$ASF_PASSWORD" ]; then


### PR DESCRIPTION
If the release manager has multiple private keys defined and wants to use one for running a release that isn't configured to be the default then currently the release scripts will use the selected gpg key when doing the test signing but will fall back to using whatever is configured as the default when signing the source and binary tarballs.

this PR changes when we define the local user arg for gpg so that it is defined whenever we have GPG_KEY defined. tested both using `do-release-docker.sh` and directly with `do-release.sh`.