### PR TITLE
HBASE-24652 master-status UI, make date type fields sortable

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
@@ -437,8 +437,20 @@ AssignmentManager assignmentManager = master.getAssignmentManager();
                     return $.tablesorter.formatFloat( s.replace(/,/g,'') );
                 }, type: "numeric"
             });
+            $.tablesorter.addParser(
+            {
+                id: "dateTime",
+                is: function (s) {
+                    return /^([a-zA-Z]{3}\s){2}\d{2}\s\d{2}:\d{2}:\d{2}\s[a-zA-Z]{3}\s\d{4}$/.test(s);
+                }, format: function (s) {
+                    var split = s.split(" ");
+                    var time = Date.parse(split[1] + " " + split[2] + " " + split[3] + " " + split[5]);
+                    return $.tablesorter.formatFloat(time);
+                }, type: "numeric"
+            });
             $("#baseStatsTable").tablesorter({
                 headers: {
+                    1: {sorter: 'dateTime'},
                     4: {sorter: 'separator'},
                     5: {sorter: 'separator'}
                 }


### PR DESCRIPTION
Revisit of HBASE-21207, HBASE-22543

date type values such as regionserver list 'Start time' field on master-status page, are not sorted by time.

HBASE-21207, HBASE-22543 missed it. so before this fix, date sorted as String.
first field of it is 'day'. therefore always Friday goes first Wednesday goes last, no matter what date it is.

this fix make date type values sorted by time and date.



