### PR TITLE
HBASE-24673 TransitionRegionStateProcedure of non-meta regions should…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
@@ -524,4 +524,13 @@ public interface MasterServices extends Server {
    * Run the ReplicationBarrierChore.
    */
   void runReplicationBarrierCleaner();
+
+  /**
+   * Return {@code true} if {@code ri} is expected to be online and scannable, {@code false}
+   * otherwise.
+   */
+  default boolean isRegionOnline(RegionInfo ri) {
+    final RegionState rs = getAssignmentManager().getRegionStates().getRegionState(ri);
+    return rs.isOpened() && getServerManager().isServerOnline(rs.getServerName());
+  }
 }


### PR DESCRIPTION
… yield when meta is unavailable

One observation from HBASE-24526 is that while meta is unavailable,
other region movement procedures are getting stuck on meta RPCs. Let's
make it so that non-meta transitions check the state of meta before
attempting any RPCs. If meta is known unavailable, release the thread
back to the scheduler.