### PR TITLE
HBASE-24720: Meta replicas not cleaned when disabled

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterMetaBootstrap.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterMetaBootstrap.java
@@ -56,10 +56,6 @@ class MasterMetaBootstrap {
       throws IOException, InterruptedException, KeeperException {
     int numReplicas = master.getConfiguration().getInt(HConstants.META_REPLICAS_NUM,
            HConstants.DEFAULT_META_REPLICA_NUM);
-    if (numReplicas <= 1) {
-      // No replicaas to assign. Return.
-      return;
-    }
     final AssignmentManager assignmentManager = master.getAssignmentManager();
     if (!assignmentManager.isMetaLoaded()) {
       throw new IllegalStateException("hbase:meta must be initialized first before we can " +

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hbase.YouAreDeadException;
 import org.apache.hadoop.hbase.client.AsyncClusterConnection;
 import org.apache.hadoop.hbase.client.AsyncRegionServerAdmin;
 import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.ipc.RemoteWithExtrasException;
 import org.apache.hadoop.hbase.master.assignment.RegionStates;
 import org.apache.hadoop.hbase.monitoring.MonitoredTask;
 import org.apache.hadoop.hbase.procedure2.Procedure;
@@ -715,7 +716,10 @@ public class ServerManager {
           return;
         }
       } catch (IOException ioe) {
-        if (ioe instanceof NotServingRegionException) {
+        if (ioe instanceof NotServingRegionException ||
+          (ioe instanceof RemoteWithExtrasException &&
+            ((RemoteWithExtrasException)ioe).unwrapRemoteException()
+              instanceof NotServingRegionException)) {
           // no need to retry again
           return;
         }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMetaWithReplicasBasic.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMetaWithReplicasBasic.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hbase.client;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
-
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HConstants;
@@ -40,7 +40,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
-import java.util.List;
 
 @Category({ MiscTests.class, MediumTests.class })
 public class TestMetaWithReplicasBasic extends MetaWithReplicasTestBase {
@@ -87,7 +86,7 @@ public class TestMetaWithReplicasBasic extends MetaWithReplicasTestBase {
   public void testReplicaCleanup() throws Exception {
     ZKWatcher zkw = TEST_UTIL.getZooKeeperWatcher();
     List<String> metaReplicaZnodes = zkw.getMetaReplicaNodes();
-    assertEquals(metaReplicaZnodes.size(), 3);
+    assertEquals(3, metaReplicaZnodes.size());
 
     final HMaster master = TEST_UTIL.getMiniHBaseCluster().getMaster();
     master.stop("Restarting");
@@ -101,7 +100,7 @@ public class TestMetaWithReplicasBasic extends MetaWithReplicasTestBase {
     TEST_UTIL.waitFor(30000, () -> newMaster.getMasterQuotaManager() != null);
     zkw = TEST_UTIL.getZooKeeperWatcher();
     metaReplicaZnodes = zkw.getMetaReplicaNodes();
-    assertEquals(metaReplicaZnodes.size(), 1);
+    assertEquals(1, metaReplicaZnodes.size());
 
   }
   @Test


### PR DESCRIPTION
- make sure to always clean up excess meta replicas not just when their number get decreased
- make sure NotServingRegionException is handled properly even when wrapped
- add test