### PR TITLE
HBASE-24566 Add 2.3.0 to the downloads page

### DIFF
--- a/src/site/xdoc/downloads.xml
+++ b/src/site/xdoc/downloads.xml
@@ -45,6 +45,29 @@ under the License.
     </tr>
     <tr>
       <td style="test-align: left">
+        2.3.0
+      </td>
+      <td style="test-align: left">
+        2020/07/13
+      </td>
+      <td style="test-align: left">
+        <a href="https://downloads.apache.org/hbase/2.3.0/api_compare_2.2.0_to_2.3.0RC3.html">2.2.0 vs 2.3.0</a>
+      </td>
+      <td style="test-align: left">
+        <a href="https://downloads.apache.org/hbase/2.3.0/CHANGES.md">Changes</a>
+      </td>
+      <td style="test-align: left">
+        <a href="https://downloads.apache.org/hbase/2.3.0/RELEASENOTES.md">Release Notes</a>
+      </td>
+      <td style="test-align: left">
+        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.3.0/hbase-2.3.0-src.tar.gz">src</a> (<a href="https://downloads.apache.org/hbase/2.3.0/hbase-2.3.0-src.tar.gz.sha512">sha512</a> <a href="https://downloads.apache.org/hbase/2.3.0/hbase-2.3.0-src.tar.gz.asc">asc</a>) <br />
+        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.3.0/hbase-2.3.0-bin.tar.gz">bin</a> (<a href="https://downloads.apache.org/hbase/2.3.0/hbase-2.3.0-bin.tar.gz.sha512">sha512</a> <a href="https://downloads.apache.org/hbase/2.3.0/hbase-2.3.0-bin.tar.gz.asc">asc</a>) <br />
+        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.3.0/hbase-2.3.0-client-bin.tar.gz">client-bin</a> (<a href="https://downloads.apache.org/hbase/2.3.0/hbase-2.3.0-client-bin.tar.gz.sha512">sha512</a> <a href="https://downloads.apache.org/hbase/2.3.0/hbase-2.3.0-client-bin.tar.gz.asc">asc</a>)
+      </td>
+      <td />
+    </tr>
+    <tr>
+      <td style="test-align: left">
         2.2.5
       </td>
       <td style="test-align: left">


### PR DESCRIPTION
I've copied what I found from the 2.2.5 release. I did change the URLs for everything except the tarballs to point to https://downloads.apache.org. I'm not sure if this is "in policy", so holler.