### PR TITLE
Backport: HBASE-24705 MetaFixer#fixHoles() does not include the case for read r…

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionReplicaUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionReplicaUtil.java
@@ -147,14 +147,13 @@ public class RegionReplicaUtil {
   /**
    * Create any replicas for the regions (the default replicas that was already created is passed to
    * the method)
-   * @param tableDescriptor descriptor to use
    * @param regions existing regions
    * @param oldReplicaCount existing replica count
    * @param newReplicaCount updated replica count due to modify table
    * @return the combined list of default and non-default replicas
    */
-  public static List<RegionInfo> addReplicas(final TableDescriptor tableDescriptor,
-      final List<RegionInfo> regions, int oldReplicaCount, int newReplicaCount) {
+  public static List<RegionInfo> addReplicas(final List<RegionInfo> regions, int oldReplicaCount,
+    int newReplicaCount) {
     if ((newReplicaCount - 1) <= 0) {
       return regions;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/CreateTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/CreateTableProcedure.java
@@ -349,7 +349,7 @@ public class CreateTableProcedure
 
     // Add replicas if needed
     // we need to create regions with replicaIds starting from 1
-    List<RegionInfo> newRegions = RegionReplicaUtil.addReplicas(tableDescriptor, regions, 1,
+    List<RegionInfo> newRegions = RegionReplicaUtil.addReplicas(regions, 1,
       tableDescriptor.getRegionReplication());
 
     // Add regions to META

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/EnableTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/EnableTableProcedure.java
@@ -144,7 +144,7 @@ public class EnableTableProcedure
             LOG.info("Number of replicas has increased. Assigning new region replicas." +
                 "The previous replica count was {}. The current replica count is {}.",
                 (currentMaxReplica + 1), configuredReplicaCount);
-            regionsOfTable = RegionReplicaUtil.addReplicas(tableDescriptor, regionsOfTable,
+            regionsOfTable = RegionReplicaUtil.addReplicas(regionsOfTable,
               currentMaxReplica + 1, configuredReplicaCount);
           }
           // Assign all the table regions. (including region replicas if added).

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
@@ -1601,6 +1601,19 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
   }
 
   /**
+   * Create a table with multiple regions.
+   * @param tableName
+   * @param replicaCount replica count.
+   * @param families
+   * @return A Table instance for the created table.
+   * @throws IOException
+   */
+  public Table createMultiRegionTable(TableName tableName, int replicaCount, byte[][] families)
+    throws IOException {
+    return createTable(tableName, families, KEYS_FOR_HBA_CREATE_TABLE, replicaCount);
+  }
+
+  /**
    * Create a table.
    * @param tableName
    * @param families


### PR DESCRIPTION
…eplicas (i.e, replica regions are not created) (#2062)

Signed-off-by: Viraj Jasani <vjasani@apache.org>