### PR TITLE
HBASE-24722 Update commands with unintentional return values (#2058)

### DIFF
--- a/hbase-shell/src/main/ruby/shell/commands/balance_switch.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/balance_switch.rb
@@ -31,7 +31,7 @@ EOF
       end
 
       def command(enableDisable)
-        prev_state = admin.balance_switch(enableDisable) ? 'true' : 'false'
+        prev_state = !!admin.balance_switch(enableDisable)
         formatter.row(["Previous balancer state : #{prev_state}"])
         prev_state
       end

--- a/hbase-shell/src/main/ruby/shell/commands/balancer.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/balancer.rb
@@ -44,7 +44,9 @@ EOF
         elsif !force.nil?
           raise ArgumentError, "Invalid argument #{force}."
         end
-        formatter.row([admin.balancer(force_balancer) ? 'true' : 'false'])
+        did_balancer_run = !!admin.balancer(force_balancer)
+        formatter.row([did_balancer_run.to_s])
+        did_balancer_run
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/catalogjanitor_enabled.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/catalogjanitor_enabled.rb
@@ -29,7 +29,9 @@ EOF
       end
 
       def command
-        formatter.row([admin.catalogjanitor_enabled ? 'true' : 'false'])
+        current_state = !!admin.catalogjanitor_enabled
+        formatter.row([current_state.to_s])
+        current_state
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/catalogjanitor_switch.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/catalogjanitor_switch.rb
@@ -30,7 +30,9 @@ EOF
       end
 
       def command(enableDisable)
-        formatter.row([admin.catalogjanitor_switch(enableDisable) ? 'true' : 'false'])
+        previous_state = !!admin.catalogjanitor_switch(enableDisable)
+        formatter.row([previous_state.to_s])
+        previous_state
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/cleaner_chore_enabled.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/cleaner_chore_enabled.rb
@@ -29,7 +29,9 @@ EOF
       end
 
       def command
-        formatter.row([admin.cleaner_chore_enabled ? 'true' : 'false'])
+        current_state = !!admin.cleaner_chore_enabled
+        formatter.row([current_state.to_s])
+        current_state
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/cleaner_chore_switch.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/cleaner_chore_switch.rb
@@ -30,7 +30,9 @@ EOF
       end
 
       def command(enableDisable)
-        formatter.row([admin.cleaner_chore_switch(enableDisable) ? 'true' : 'false'])
+        previous_state = !!admin.cleaner_chore_switch(enableDisable)
+        formatter.row([previous_state.to_s])
+        previous_state
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/clear_block_cache.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/clear_block_cache.rb
@@ -33,6 +33,7 @@ EOF
 
       def command(table_name)
         formatter.row([admin.clear_block_cache(table_name)])
+        nil
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/clear_deadservers.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/clear_deadservers.rb
@@ -22,7 +22,9 @@ module Shell
     class ClearDeadservers < Command
       def help
         <<-EOF
-          Clear the dead region servers that are never used.
+          Clear the dead region servers that are never used. Returns an array containing any
+          deadservers that could not be cleared.
+
           Examples:
           Clear all dead region servers:
           hbase> clear_deadservers
@@ -35,18 +37,20 @@ module Shell
       end
 
       # rubocop:disable Metrics/AbcSize
-      # rubocop:disable Metrics/MethodLength
       def command(*dead_servers)
         servers = admin.clear_deadservers(dead_servers)
         if servers.size <= 0
           formatter.row(['true'])
+          []
         else
           formatter.row(['Some dead server clear failed'])
           formatter.row(['SERVERNAME'])
-          servers.each do |server|
-            formatter.row([server.toString])
+          server_names = servers.map { |server| server.toString }
+          server_names.each do |server|
+            formatter.row([server])
           end
           formatter.footer(servers.size)
+          server_names
         end
       end
       # rubocop:enable Metrics/AbcSize

--- a/hbase-shell/src/main/ruby/shell/commands/disable_exceed_throttle_quota.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/disable_exceed_throttle_quota.rb
@@ -31,7 +31,7 @@ Examples:
       end
 
       def command
-        prev_state = quotas_admin.switch_exceed_throttle_quota(false) ? 'true' : 'false'
+        prev_state = !!quotas_admin.switch_exceed_throttle_quota(false)
         formatter.row(["Previous exceed throttle quota enabled : #{prev_state}"])
         prev_state
       end

--- a/hbase-shell/src/main/ruby/shell/commands/disable_rpc_throttle.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/disable_rpc_throttle.rb
@@ -31,7 +31,7 @@ Examples:
       end
 
       def command
-        prev_state = quotas_admin.switch_rpc_throttle(false) ? 'true' : 'false'
+        prev_state = !!quotas_admin.switch_rpc_throttle(false)
         formatter.row(["Previous rpc throttle state : #{prev_state}"])
         prev_state
       end

--- a/hbase-shell/src/main/ruby/shell/commands/enable_exceed_throttle_quota.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/enable_exceed_throttle_quota.rb
@@ -41,7 +41,7 @@ Examples:
       end
 
       def command
-        prev_state = quotas_admin.switch_exceed_throttle_quota(true) ? 'true' : 'false'
+        prev_state = !!quotas_admin.switch_exceed_throttle_quota(true)
         formatter.row(["Previous exceed throttle quota enabled : #{prev_state}"])
         prev_state
       end

--- a/hbase-shell/src/main/ruby/shell/commands/enable_rpc_throttle.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/enable_rpc_throttle.rb
@@ -31,7 +31,7 @@ Examples:
       end
 
       def command
-        prev_state = quotas_admin.switch_rpc_throttle(true) ? 'true' : 'false'
+        prev_state = !!quotas_admin.switch_rpc_throttle(true)
         formatter.row(["Previous rpc throttle state : #{prev_state}"])
         prev_state
       end

--- a/hbase-shell/src/main/ruby/shell/commands/is_disabled.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/is_disabled.rb
@@ -29,8 +29,10 @@ EOF
       end
 
       def command(table)
-        formatter.row([admin.disabled?(table) ? 'true' : 'false'])
-    end
+        disabled = !!admin.disabled?(table)
+        formatter.row([disabled.to_s])
+        disabled
+      end
     end
   end
 end

--- a/hbase-shell/src/main/ruby/shell/commands/normalize.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/normalize.rb
@@ -33,7 +33,9 @@ EOF
       end
 
       def command
-        formatter.row([admin.normalize ? 'true' : 'false'])
+        did_normalize_run = !!admin.normalize
+        formatter.row([did_normalize_run.to_s])
+        did_normalize_run
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/normalizer_enabled.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/normalizer_enabled.rb
@@ -30,7 +30,9 @@ EOF
       end
 
       def command
-        formatter.row([admin.normalizer_enabled?.to_s])
+        current_state = admin.normalizer_enabled?
+        formatter.row([current_state.to_s])
+        current_state
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/normalizer_switch.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/normalizer_switch.rb
@@ -32,7 +32,9 @@ EOF
       end
 
       def command(enableDisable)
-        formatter.row([admin.normalizer_switch(enableDisable) ? 'true' : 'false'])
+        previous_state = !!admin.normalizer_switch(enableDisable)
+        formatter.row([previous_state.to_s])
+        previous_state
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/snapshot_cleanup_switch.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/snapshot_cleanup_switch.rb
@@ -34,7 +34,7 @@ Examples:
       end
 
       def command(enable_disable)
-        prev_state = admin.snapshot_cleanup_switch(enable_disable) ? 'true' : 'false'
+        prev_state = !!admin.snapshot_cleanup_switch(enable_disable)
         formatter.row(["Previous snapshot cleanup state : #{prev_state}"])
         prev_state
       end

--- a/hbase-shell/src/main/ruby/shell/commands/splitormerge_enabled.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/splitormerge_enabled.rb
@@ -30,9 +30,9 @@ EOF
       end
 
       def command(switch_type)
-        formatter.row(
-          [admin.splitormerge_enabled(switch_type) ? 'true' : 'false']
-        )
+        current_state = !!admin.splitormerge_enabled(switch_type)
+        formatter.row([current_state.to_s])
+        current_state
       end
     end
   end

--- a/hbase-shell/src/main/ruby/shell/commands/splitormerge_switch.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/splitormerge_switch.rb
@@ -32,9 +32,11 @@ EOF
       end
 
       def command(switch_type, enabled)
+        previous_state = !!admin.splitormerge_switch(switch_type, enabled)
         formatter.row(
-          [admin.splitormerge_switch(switch_type, enabled) ? 'true' : 'false']
+          [previous_state.to_s]
         )
+        previous_state
       end
     end
   end

--- a/hbase-shell/src/test/ruby/hbase/quotas_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/quotas_test.rb
@@ -245,11 +245,15 @@ module Hbase
     end
 
     define_test 'switch rpc throttle' do
-      output = capture_stdout { command(:disable_rpc_throttle) }
+      result = nil
+      output = capture_stdout { result = command(:disable_rpc_throttle) }
       assert(output.include?('Previous rpc throttle state : true'))
+      assert(result == true)
 
-      output = capture_stdout { command(:enable_rpc_throttle) }
+      result = nil
+      output = capture_stdout { result = command(:enable_rpc_throttle) }
       assert(output.include?('Previous rpc throttle state : false'))
+      assert(result == false)
     end
 
     define_test 'can set and remove region server quota' do
@@ -275,11 +279,17 @@ module Hbase
 
     define_test 'switch exceed throttle quota' do
       command(:set_quota, TYPE => THROTTLE, REGIONSERVER => 'all', LIMIT => '1CU/sec')
-      output = capture_stdout { command(:enable_exceed_throttle_quota) }
-      assert(output.include?('Previous exceed throttle quota enabled : false'))
 
-      output = capture_stdout { command(:disable_exceed_throttle_quota) }
+      result = nil
+      output = capture_stdout { result = command(:enable_exceed_throttle_quota) }
+      assert(output.include?('Previous exceed throttle quota enabled : false'))
+      assert(result == false)
+
+      result = nil
+      output = capture_stdout { result = command(:disable_exceed_throttle_quota) }
       assert(output.include?('Previous exceed throttle quota enabled : true'))
+      assert(result == true)
+
       command(:set_quota, TYPE => THROTTLE, REGIONSERVER => 'all', LIMIT => NONE)
     end
 


### PR DESCRIPTION
- Prior to this commit, there were 13 commands that unintentionally return the
  number of lines they print (usually one). This commit ensures that they
  return the value documented by the help text, or nil if there is not a simple
  logical value to return.
- Fixes 6 hbase-shell commands that return String rather than TrueClass or
  FalseClass
- Use double-bang to cast truthy values to TrueClass and FalseClass so that
  ruby's to_s can reliably print true or false without using ternary operators
- Updates tests for is_disabled, is_enabled, disable_rpc_throttle,
  enable_rpc_throttle, disable_exceed_throttle_quota,
  enable_exceed_throttle_quota, clear_deadservers, snapshot_cleanup_switch,
  snapshot_cleanup_enabled, and balancer to check return values
- Adds new tests for balance_switch, balancer_enabled, normalizer_switch,
  normalizer_enabled, catalog_janitor_switch, catalogjanitor_enabled,
  cleaner_chore_switch, cleaner_chore_enabled, splitormerge_switch, and
  splitormerge_enabled

signed-off-by: stack <stack@apache.org>