### PR TITLE
HBASE-24763 Remove 2.1 Documentation direct link from website

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -125,14 +125,6 @@
         <item name="User API" href="1.4/apidocs/index.html" target="_blank" />
         <item name="Developer API" href="1.4/devapidocs/index.html" target="_blank" />
       </item>
-      <item name="2.1 Documentation">
-        <item name="Ref Guide" href="2.1/book.html" target="_blank" />
-        <item name="Reference Guide (PDF)" href="2.1/apache_hbase_reference_guide.pdf" target="_blank" />
-        <item name="User API" href="2.1/apidocs/index.html" target="_blank" />
-        <item name="User API (Test)" href="2.1/testapidocs/index.html" target="_blank" />
-        <item name="Developer API" href="2.1/devapidocs/index.html" target="_blank" />
-        <item name="Developer API (Test)" href="2.1/testdevapidocs/index.html" target="_blank" />
-      </item>
       <item name="2.2 Documentation">
         <item name="Ref Guide" href="2.2/book.html" target="_blank" />
         <item name="Reference Guide (PDF)" href="2.2/apache_hbase_reference_guide.pdf" target="_blank" />


### PR DESCRIPTION
2.1 is EOM so the 2.1 Documentation link can be removed.
The content is still available under https://hbase.apache.org/2.1