### PR TITLE
HBASE-24767 Change default to false for HBASE-15519 per-user metrics

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsUserAggregateFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsUserAggregateFactory.java
@@ -28,7 +28,7 @@ public class MetricsUserAggregateFactory {
   }
 
   public static final String METRIC_USER_ENABLED_CONF = "hbase.regionserver.user.metrics.enabled";
-  public static final boolean DEFAULT_METRIC_USER_ENABLED_CONF = true;
+  public static final boolean DEFAULT_METRIC_USER_ENABLED_CONF = false;
 
   public static MetricsUserAggregate getMetricsUserAggregate(Configuration conf) {
     if (conf.getBoolean(METRIC_USER_ENABLED_CONF, DEFAULT_METRIC_USER_ENABLED_CONF)) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientClusterMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientClusterMetrics.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.filter.FilterAllFilter;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.regionserver.MetricsUserAggregateFactory;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
@@ -251,6 +252,11 @@ public class TestClientClusterMetrics {
 
   @Test public void testUserMetrics() throws Exception {
     Configuration conf = UTIL.getConfiguration();
+    // If metrics for users is not enabled, this test doesn't  make sense.
+    if (!conf.getBoolean(MetricsUserAggregateFactory.METRIC_USER_ENABLED_CONF,
+        MetricsUserAggregateFactory.DEFAULT_METRIC_USER_ENABLED_CONF)) {
+      return;
+    }
     User userFoo = User.createUserForTesting(conf, "FOO_USER_METRIC_TEST", new String[0]);
     User userBar = User.createUserForTesting(conf, "BAR_USER_METRIC_TEST", new String[0]);
     User userTest = User.createUserForTesting(conf, "TEST_USER_METRIC_TEST", new String[0]);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsUserAggregate.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsUserAggregate.java
@@ -47,7 +47,7 @@ public class TestMetricsUserAggregate {
 
   private MetricsRegionServerWrapperStub wrapper;
   private MetricsRegionServer rsm;
-  private MetricsUserAggregateImpl userAgg;
+  private MetricsUserAggregate userAgg;
   private TableName tableName = TableName.valueOf("testUserAggregateMetrics");
 
   @BeforeClass
@@ -60,7 +60,7 @@ public class TestMetricsUserAggregate {
     wrapper = new MetricsRegionServerWrapperStub();
     Configuration conf = HBaseConfiguration.create();
     rsm = new MetricsRegionServer(wrapper,conf , null);
-    userAgg = (MetricsUserAggregateImpl)rsm.getMetricsUserAggregate();
+    userAgg = (MetricsUserAggregate)rsm.getMetricsUserAggregate();
   }
 
   private void doOperations() {
@@ -90,6 +90,11 @@ public class TestMetricsUserAggregate {
   @Test
   public void testPerUserOperations() {
     Configuration conf = HBaseConfiguration.create();
+    // If metrics for users is not enabled, this test doesn't  make sense.
+    if (!conf.getBoolean(MetricsUserAggregateFactory.METRIC_USER_ENABLED_CONF,
+      MetricsUserAggregateFactory.DEFAULT_METRIC_USER_ENABLED_CONF)) {
+      return;
+    }
     User userFoo = User.createUserForTesting(conf, "FOO", new String[0]);
     User userBar = User.createUserForTesting(conf, "BAR", new String[0]);
 
@@ -128,6 +133,11 @@ public class TestMetricsUserAggregate {
 
   @Test public void testLossyCountingOfUserMetrics() {
     Configuration conf = HBaseConfiguration.create();
+    // If metrics for users is not enabled, this test doesn't  make sense.
+    if (!conf.getBoolean(MetricsUserAggregateFactory.METRIC_USER_ENABLED_CONF,
+      MetricsUserAggregateFactory.DEFAULT_METRIC_USER_ENABLED_CONF)) {
+      return;
+    }
     int noOfUsers = 10000;
     for (int i = 1; i <= noOfUsers; i++) {
       User.createUserForTesting(conf, "FOO" + i, new String[0]).getUGI()


### PR DESCRIPTION
Set hbase.regionserver.user.metrics.enabled default to false; i.e. off.