### PR TITLE
HBASE-24632 Enable procedure-based log splitting as default in hbase3…

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1447,9 +1447,18 @@ public final class HConstants {
   public static final String HBASE_CLIENT_FAST_FAIL_INTERCEPTOR_IMPL =
     "hbase.client.fast.fail.interceptor.impl";
 
+  /**
+   * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+   *   distributed WAL splitter; see SplitWALManager.
+   */
+  @Deprecated
   public static final String HBASE_SPLIT_WAL_COORDINATED_BY_ZK = "hbase.split.wal.zk.coordinated";
 
-  public static final boolean DEFAULT_HBASE_SPLIT_COORDINATED_BY_ZK = true;
+  /**
+   * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0.
+   */
+  @Deprecated
+  public static final boolean DEFAULT_HBASE_SPLIT_COORDINATED_BY_ZK = false;
 
   public static final String HBASE_SPLIT_WAL_MAX_SPLITTER = "hbase.regionserver.wal.max.splitters";
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/SplitLogCounters.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/SplitLogCounters.java
@@ -25,9 +25,14 @@ import org.apache.yetus.audience.InterfaceAudience;
 /**
  * Counters kept by the distributed WAL split log process.
  * Used by master and regionserver packages.
+ * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+ *   distributed WAL splitter, see SplitWALManager
  */
+@Deprecated
 @InterfaceAudience.Private
 public class SplitLogCounters {
+  private SplitLogCounters() {}
+
   //Spnager counters
   public final static LongAdder tot_mgr_log_split_batch_start = new LongAdder();
   public final static LongAdder tot_mgr_log_split_batch_success = new LongAdder();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/SplitLogTask.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/SplitLogTask.java
@@ -31,7 +31,10 @@ import org.apache.hadoop.hbase.util.Bytes;
  * Encapsulates protobuf serialization/deserialization so we don't leak generated pb outside of
  * this class.  Used by regionserver and master packages.
  * <p>Immutable
+ * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+ *   distributed WAL splitter, see SplitWALManager
  */
+@Deprecated
 @InterfaceAudience.Private
 public class SplitLogTask {
   private final ServerName originServer;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coordination/SplitLogManagerCoordination.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coordination/SplitLogManagerCoordination.java
@@ -40,8 +40,11 @@ import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesti
  * Methods required for task life circle: <BR>
  * {@link #checkTaskStillAvailable(String)} Check that task is still there <BR>
  * {@link #checkTasks()} check for unassigned tasks and resubmit them
+ * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+ *   distributed WAL splitter, see SplitWALManager
  */
 @InterfaceAudience.Private
+@Deprecated
 public interface SplitLogManagerCoordination {
   /**
    * Detail class that shares data between coordination and split log manager

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coordination/SplitLogWorkerCoordination.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coordination/SplitLogWorkerCoordination.java
@@ -1,5 +1,4 @@
- /**
-  *
+ /*
   * Licensed to the Apache Software Foundation (ASF) under one
   * or more contributor license agreements.  See the NOTICE file
   * distributed with this work for additional information
@@ -18,16 +17,14 @@
   */
 package org.apache.hadoop.hbase.coordination;
 import java.util.concurrent.atomic.LongAdder;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.SplitLogTask;
-import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices;
 import org.apache.hadoop.hbase.regionserver.SplitLogWorker;
 import org.apache.hadoop.hbase.regionserver.SplitLogWorker.TaskExecutor;
-
+import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 /**
@@ -44,7 +41,10 @@ import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesti
  * <p>
  * Important methods for WALSplitterHandler: <BR>
  * splitting task has completed.
+ * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+ *   distributed WAL splitter, see SplitWALManager
  */
+@Deprecated
 @InterfaceAudience.Private
 public interface SplitLogWorkerCoordination {
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coordination/ZkCoordinatedStateManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coordination/ZkCoordinatedStateManager.java
@@ -25,7 +25,10 @@ import org.apache.yetus.audience.InterfaceAudience;
 
 /**
  * ZooKeeper-based implementation of {@link org.apache.hadoop.hbase.CoordinatedStateManager}.
+ * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+ *   distributed WAL splitter (see SplitWALManager) which doesn't use this zk-based coordinator.
  */
+@Deprecated
 @InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.CONFIG)
 public class ZkCoordinatedStateManager implements CoordinatedStateManager {
   protected ZKWatcher watcher;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
@@ -159,6 +159,9 @@ public class MetricsMasterWrapperImpl implements MetricsMasterWrapper {
 
   @Override
   public Map<String,Entry<Long,Long>> getTableSpaceUtilization() {
+    if (master == null) {
+      return Collections.emptyMap();
+    }
     QuotaObserverChore quotaChore = master.getQuotaObserverChore();
     if (quotaChore == null) {
       return Collections.emptyMap();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitLogManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitLogManager.java
@@ -86,7 +86,10 @@ import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesti
  * again. If a task is resubmitted then there is a risk that old "delete task"
  * can delete the re-submission.
  * @see SplitWALManager for an alternate implementation based on Procedures.
+ * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+ *   distributed WAL splitter, see SplitWALManager.
  */
+@Deprecated
 @InterfaceAudience.Private
 public class SplitLogManager {
   private static final Logger LOG = LoggerFactory.getLogger(SplitLogManager.class);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ServerCrashProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ServerCrashProcedure.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,10 +16,8 @@
  * limitations under the License.
  */
 package org.apache.hadoop.hbase.master.procedure;
-
 import static org.apache.hadoop.hbase.HConstants.DEFAULT_HBASE_SPLIT_COORDINATED_BY_ZK;
 import static org.apache.hadoop.hbase.HConstants.HBASE_SPLIT_WAL_COORDINATED_BY_ZK;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -47,7 +45,6 @@ import org.apache.hadoop.hbase.procedure2.StateMachineProcedure;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos.ServerCrashState;
@@ -154,8 +151,8 @@ public class ServerCrashProcedure
           break;
         case SERVER_CRASH_SPLIT_META_LOGS:
           if (env.getMasterConfiguration().getBoolean(HBASE_SPLIT_WAL_COORDINATED_BY_ZK,
-            DEFAULT_HBASE_SPLIT_COORDINATED_BY_ZK)) {
-            splitMetaLogs(env);
+              DEFAULT_HBASE_SPLIT_COORDINATED_BY_ZK)) {
+            zkCoordinatedSplitMetaLogs(env);
             setNextState(ServerCrashState.SERVER_CRASH_ASSIGN_META);
           } else {
             am.getRegionStates().metaLogSplitting(serverName);
@@ -164,8 +161,7 @@ public class ServerCrashProcedure
           }
           break;
         case SERVER_CRASH_DELETE_SPLIT_META_WALS_DIR:
-          if(isSplittingDone(env, true)){
-            cleanupSplitDir(env);
+          if (isSplittingDone(env, true)) {
             setNextState(ServerCrashState.SERVER_CRASH_ASSIGN_META);
             am.getRegionStates().metaLogSplit(serverName);
           } else {
@@ -195,7 +191,7 @@ public class ServerCrashProcedure
         case SERVER_CRASH_SPLIT_LOGS:
           if (env.getMasterConfiguration().getBoolean(HBASE_SPLIT_WAL_COORDINATED_BY_ZK,
             DEFAULT_HBASE_SPLIT_COORDINATED_BY_ZK)) {
-            splitLogs(env);
+            zkCoordinatedSplitLogs(env);
             setNextState(ServerCrashState.SERVER_CRASH_ASSIGN);
           } else {
             am.getRegionStates().logSplitting(this.serverName);
@@ -256,19 +252,27 @@ public class ServerCrashProcedure
   private void cleanupSplitDir(MasterProcedureEnv env) {
     SplitWALManager splitWALManager = env.getMasterServices().getSplitWALManager();
     try {
+      if (!this.carryingMeta) {
+        // If we are NOT carrying hbase:meta, check if any left-over hbase:meta WAL files from an
+        // old hbase:meta tenancy on this server; clean these up if any before trying to remove the
+        // WAL directory of this server or we will fail. See archiveMetaLog comment for more details
+        // on this condition.
+        env.getMasterServices().getMasterWalManager().archiveMetaLog(this.serverName);
+      }
       splitWALManager.deleteWALDir(serverName);
     } catch (IOException e) {
-      LOG.warn("Remove WAL directory of server {} failed, ignore...", serverName, e);
+      LOG.warn("Remove WAL directory for {} failed, ignore...{}", serverName, e.getMessage());
     }
   }
 
   private boolean isSplittingDone(MasterProcedureEnv env, boolean splitMeta) {
-    LOG.debug("check if splitting WALs of {} done? isMeta: {}", serverName, splitMeta);
     SplitWALManager splitWALManager = env.getMasterServices().getSplitWALManager();
     try {
-      return splitWALManager.getWALsToSplit(serverName, splitMeta).size() == 0;
+      int wals = splitWALManager.getWALsToSplit(serverName, splitMeta).size();
+      LOG.debug("Check if {} WAL splitting is done? wals={}, meta={}", serverName, wals, splitMeta);
+      return wals == 0;
     } catch (IOException e) {
-      LOG.warn("get filelist of serverName {} failed, retry...", serverName, e);
+      LOG.warn("Get WALs of {} failed, retry...", serverName, e);
       return false;
     }
   }
@@ -293,7 +297,12 @@ public class ServerCrashProcedure
     return hri.isMetaRegion() && RegionReplicaUtil.isDefaultReplica(hri);
   }
 
-  private void splitMetaLogs(MasterProcedureEnv env) throws IOException {
+  /**
+   * Split hbase:meta logs using 'classic' zk-based coordination.
+   * Superceded by procedure-based WAL splitting.
+   * @see #createSplittingWalProcedures(MasterProcedureEnv, boolean)
+   */
+  private void zkCoordinatedSplitMetaLogs(MasterProcedureEnv env) throws IOException {
     LOG.debug("Splitting meta WALs {}", this);
     MasterWalManager mwm = env.getMasterServices().getMasterWalManager();
     AssignmentManager am = env.getMasterServices().getAssignmentManager();
@@ -303,7 +312,12 @@ public class ServerCrashProcedure
     LOG.debug("Done splitting meta WALs {}", this);
   }
 
-  private void splitLogs(final MasterProcedureEnv env) throws IOException {
+  /**
+   * Split logs using 'classic' zk-based coordination.
+   * Superceded by procedure-based WAL splitting.
+   * @see #createSplittingWalProcedures(MasterProcedureEnv, boolean)
+   */
+  private void zkCoordinatedSplitLogs(final MasterProcedureEnv env) throws IOException {
     LOG.debug("Splitting WALs {}", this);
     MasterWalManager mwm = env.getMasterServices().getMasterWalManager();
     AssignmentManager am = env.getMasterServices().getAssignmentManager();
@@ -333,14 +347,12 @@ public class ServerCrashProcedure
       currentRunningState = getCurrentState();
     }
     int childrenLatch = getChildrenLatch();
-    status.setStatus(msg + " current State " + currentRunningState
-        + (childrenLatch > 0 ? "; remaining num of running child procedures = " + childrenLatch
-            : ""));
+    status.setStatus(msg + " current State " + currentRunningState + (childrenLatch > 0?
+      "; remaining num of running child procedures = " + childrenLatch: ""));
   }
 
   @Override
-  protected void rollbackState(MasterProcedureEnv env, ServerCrashState state)
-  throws IOException {
+  protected void rollbackState(MasterProcedureEnv env, ServerCrashState state) throws IOException {
     // Can't rollback.
     throw new UnsupportedOperationException("unhandled state=" + state);
   }
@@ -424,7 +436,8 @@ public class ServerCrashProcedure
     int size = state.getRegionsOnCrashedServerCount();
     if (size > 0) {
       this.regionsOnCrashedServer = new ArrayList<>(size);
-      for (org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.RegionInfo ri: state.getRegionsOnCrashedServerList()) {
+      for (org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.RegionInfo ri:
+          state.getRegionsOnCrashedServerList()) {
         this.regionsOnCrashedServer.add(ProtobufUtil.toRegionInfo(ri));
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SplitWALRemoteProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SplitWALRemoteProcedure.java
@@ -96,7 +96,7 @@ public class SplitWALRemoteProcedure extends ServerRemoteProcedure
   protected void complete(MasterProcedureEnv env, Throwable error) {
     if (error == null) {
       try {
-        env.getMasterServices().getSplitWALManager().deleteSplitWAL(walPath);
+        env.getMasterServices().getSplitWALManager().archive(walPath);
       } catch (IOException e) {
         LOG.warn("Failed split of {}; ignore...", walPath, e);
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SplitLogWorker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SplitLogWorker.java
@@ -66,7 +66,10 @@ import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesti
  * the absence of a global lock there is a unavoidable race here - a worker might have just finished
  * its task when it is stripped of its ownership. Here we rely on the idempotency of the log
  * splitting task for correctness
+ * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+ *   distributed WAL splitter, see SplitWALRemoteProcedure
  */
+@Deprecated
 @InterfaceAudience.Private
 public class SplitLogWorker implements Runnable {
 
@@ -181,8 +184,8 @@ public class SplitLogWorker implements Runnable {
       SplitLogWorkerCoordination splitLogWorkerCoordination =
           server.getCoordinatedStateManager() == null ? null
               : server.getCoordinatedStateManager().getSplitLogWorkerCoordination();
-      if (!WALSplitter.splitLogFile(walDir, fs.getFileStatus(new Path(walDir, filename)), fs, conf, p,
-        sequenceIdChecker, splitLogWorkerCoordination, factory, server)) {
+      if (!WALSplitter.splitLogFile(walDir, fs.getFileStatus(new Path(walDir, filename)), fs, conf,
+        p, sequenceIdChecker, splitLogWorkerCoordination, factory, server)) {
         return Status.PREEMPTED;
       }
     } catch (InterruptedIOException iioe) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/WALSplitterHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/WALSplitterHandler.java
@@ -38,7 +38,10 @@ import org.apache.hadoop.hbase.util.CancelableProgressable;
 /**
  * Handles log splitting a wal
  * Used by the zk-based distributed log splitting. Created by ZKSplitLogWorkerCoordination.
- */
+ * @deprecated since 2.4.0 and in 3.0.0, to be removed in 4.0.0, replaced by procedure-based
+  *   distributed WAL splitter, see SplitWALManager
+  */
+@Deprecated
 @InterfaceAudience.Private
 public class WALSplitterHandler extends EventHandler {
   private static final Logger LOG = LoggerFactory.getLogger(WALSplitterHandler.class);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALSplitter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALSplitter.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.wal;
 
-import static org.apache.hadoop.hbase.wal.WALSplitUtil.finishSplitLogFile;
 import java.io.EOFException;
 import java.io.FileNotFoundException;
 import java.io.IOException;
@@ -30,6 +29,7 @@ import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicReference;
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
@@ -53,7 +53,6 @@ import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.RecoverLeaseFSUtils;
 import org.apache.hadoop.hbase.wal.WAL.Entry;
 import org.apache.hadoop.hbase.wal.WAL.Reader;
-import org.apache.hadoop.hbase.zookeeper.ZKSplitLog;
 import org.apache.hadoop.ipc.RemoteException;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
@@ -63,24 +62,26 @@ import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 import org.apache.hbase.thirdparty.com.google.protobuf.TextFormat;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ClusterStatusProtos.RegionStoreSequenceIds;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ClusterStatusProtos.StoreSequenceId;
+import javax.validation.constraints.Null;
 
 /**
  * Split RegionServer WAL files. Splits the WAL into new files,
  * one per region, to be picked up on Region reopen. Deletes the split WAL when finished.
- * See {@link #split(Path, Path, Path, FileSystem, Configuration, WALFactory)} or
- * {@link #splitLogFile(Path, FileStatus, FileSystem, Configuration, CancelableProgressable,
- *   LastSequenceId, SplitLogWorkerCoordination, WALFactory, RegionServerServices)} for
- *   entry-point.
+ * Create an instance and call {@link #splitWAL(FileStatus, CancelableProgressable)} per file or
+ * use static helper methods.
  */
 @InterfaceAudience.Private
 public class WALSplitter {
   private static final Logger LOG = LoggerFactory.getLogger(WALSplitter.class);
+  public static final String SPLIT_SKIP_ERRORS_KEY = "hbase.hlog.split.skip.errors";
 
-  /** By default we retry errors in splitting, rather than skipping. */
+  /**
+   * By default we retry errors in splitting, rather than skipping.
+   */
   public static final boolean SPLIT_SKIP_ERRORS_DEFAULT = false;
 
   // Parameters for split process
-  protected final Path walDir;
+  protected final Path walRootDir;
   protected final FileSystem walFS;
   protected final Configuration conf;
   final Path rootDir;
@@ -99,8 +100,6 @@ public class WALSplitter {
   private SplitLogWorkerCoordination splitLogWorkerCoordination;
 
   private final WALFactory walFactory;
-
-  private MonitoredTask status;
 
   // For checking the latest flushed sequence id
   protected final LastSequenceId sequenceIdChecker;
@@ -132,17 +131,28 @@ public class WALSplitter {
 
   public final static String SPLIT_WAL_BUFFER_SIZE = "hbase.regionserver.hlog.splitlog.buffersize";
   public final static String SPLIT_WAL_WRITER_THREADS =
-      "hbase.regionserver.hlog.splitlog.writer.threads";
+    "hbase.regionserver.hlog.splitlog.writer.threads";
+
+  private final int numWriterThreads;
+  private final long bufferSize;
+  private final boolean splitWriterCreationBounded;
+  private final boolean hfile;
+  private final boolean skipErrors;
+
+  WALSplitter(final WALFactory factory, Configuration conf, Path walRootDir,
+      FileSystem walFS, Path rootDir, FileSystem rootFS) {
+    this(factory, conf, walRootDir, walFS, rootDir, rootFS, null, null, null);
+  }
 
   @VisibleForTesting
-  WALSplitter(final WALFactory factory, Configuration conf, Path walDir, FileSystem walFS,
-      Path rootDir, FileSystem rootFS, LastSequenceId idChecker,
+  WALSplitter(final WALFactory factory, Configuration conf, Path walRootDir,
+      FileSystem walFS, Path rootDir, FileSystem rootFS, LastSequenceId idChecker,
       SplitLogWorkerCoordination splitLogWorkerCoordination, RegionServerServices rsServices) {
     this.conf = HBaseConfiguration.create(conf);
     String codecClassName =
-        conf.get(WALCellCodec.WAL_CELL_CODEC_CLASS_KEY, WALCellCodec.class.getName());
+      conf.get(WALCellCodec.WAL_CELL_CODEC_CLASS_KEY, WALCellCodec.class.getName());
     this.conf.set(HConstants.RPC_CODEC_CONF_KEY, codecClassName);
-    this.walDir = walDir;
+    this.walRootDir = walRootDir;
     this.walFS = walFS;
     this.rootDir = rootDir;
     this.rootFS = rootFS;
@@ -150,32 +160,17 @@ public class WALSplitter {
     this.splitLogWorkerCoordination = splitLogWorkerCoordination;
     this.rsServices = rsServices;
     this.walFactory = factory;
-    PipelineController controller = new PipelineController();
     this.tmpDirName =
       conf.get(HConstants.TEMPORARY_FS_DIRECTORY_KEY, HConstants.DEFAULT_TEMPORARY_HDFS_DIRECTORY);
-
-
     // if we limit the number of writers opened for sinking recovered edits
-    boolean splitWriterCreationBounded = conf.getBoolean(SPLIT_WRITER_CREATION_BOUNDED, false);
-    boolean splitToHFile = conf.getBoolean(WAL_SPLIT_TO_HFILE, DEFAULT_WAL_SPLIT_TO_HFILE);
-    long bufferSize = this.conf.getLong(SPLIT_WAL_BUFFER_SIZE, 128 * 1024 * 1024);
-    int numWriterThreads = this.conf.getInt(SPLIT_WAL_WRITER_THREADS, 3);
-
-    if (splitToHFile) {
-      entryBuffers = new BoundedEntryBuffers(controller, bufferSize);
-      outputSink =
-          new BoundedRecoveredHFilesOutputSink(this, controller, entryBuffers, numWriterThreads);
-    } else if (splitWriterCreationBounded) {
-      entryBuffers = new BoundedEntryBuffers(controller, bufferSize);
-      outputSink =
-          new BoundedRecoveredEditsOutputSink(this, controller, entryBuffers, numWriterThreads);
-    } else {
-      entryBuffers = new EntryBuffers(controller, bufferSize);
-      outputSink = new RecoveredEditsOutputSink(this, controller, entryBuffers, numWriterThreads);
-    }
+    this.splitWriterCreationBounded = conf.getBoolean(SPLIT_WRITER_CREATION_BOUNDED, false);
+    this.bufferSize = this.conf.getLong(SPLIT_WAL_BUFFER_SIZE, 128 * 1024 * 1024);
+    this.numWriterThreads = this.conf.getInt(SPLIT_WAL_WRITER_THREADS, 3);
+    this.hfile = conf.getBoolean(WAL_SPLIT_TO_HFILE, DEFAULT_WAL_SPLIT_TO_HFILE);
+    this.skipErrors = conf.getBoolean(SPLIT_SKIP_ERRORS_KEY, SPLIT_SKIP_ERRORS_DEFAULT);
   }
 
-  WALFactory getWalFactory(){
+  WALFactory getWalFactory() {
     return this.walFactory;
   }
 
@@ -193,6 +188,9 @@ public class WALSplitter {
 
   /**
    * Splits a WAL file.
+   * Used by old {@link org.apache.hadoop.hbase.regionserver.SplitLogWorker} and tests.
+   * Not used by new procedure-based WAL splitter.
+   *
    * @return false if it is interrupted by the progress-able.
    */
   public static boolean splitLogFile(Path walDir, FileStatus logfile, FileSystem walFS,
@@ -201,9 +199,12 @@ public class WALSplitter {
       RegionServerServices rsServices) throws IOException {
     Path rootDir = CommonFSUtils.getRootDir(conf);
     FileSystem rootFS = rootDir.getFileSystem(conf);
-    WALSplitter s = new WALSplitter(factory, conf, walDir, walFS, rootDir, rootFS, idChecker,
-        splitLogWorkerCoordination, rsServices);
-    return s.splitLogFile(logfile, reporter);
+    WALSplitter splitter = new WALSplitter(factory, conf, walDir, walFS, rootDir, rootFS, idChecker,
+      splitLogWorkerCoordination, rsServices);
+    // splitWAL returns a data structure with whether split is finished and if the file is corrupt.
+    // We don't need to propagate corruption flag here because it is propagated by the
+    // SplitLogWorkerCoordination.
+    return splitter.splitWAL(logfile, reporter).isFinished();
   }
 
   /**
@@ -214,85 +215,123 @@ public class WALSplitter {
    * @return List of output files created by the split.
    */
   @VisibleForTesting
-  public static List<Path> split(Path walDir, Path logDir, Path oldLogDir, FileSystem walFS,
+  public static List<Path> split(Path walRootDir, Path walsDir, Path archiveDir, FileSystem walFS,
       Configuration conf, final WALFactory factory) throws IOException {
     Path rootDir = CommonFSUtils.getRootDir(conf);
     FileSystem rootFS = rootDir.getFileSystem(conf);
-    final FileStatus[] logfiles =
-        SplitLogManager.getFileList(conf, Collections.singletonList(logDir), null);
+    WALSplitter splitter = new WALSplitter(factory, conf, walRootDir, walFS, rootDir, rootFS);
+    final FileStatus[] wals =
+      SplitLogManager.getFileList(conf, Collections.singletonList(walsDir), null);
     List<Path> splits = new ArrayList<>();
-    if (ArrayUtils.isNotEmpty(logfiles)) {
-      for (FileStatus logfile : logfiles) {
-        WALSplitter s =
-            new WALSplitter(factory, conf, walDir, walFS, rootDir, rootFS, null, null, null);
-        if (s.splitLogFile(logfile, null)) {
-          finishSplitLogFile(walDir, oldLogDir, logfile.getPath(), conf);
-          if (s.outputSink.splits != null) {
-            splits.addAll(s.outputSink.splits);
+    if (ArrayUtils.isNotEmpty(wals)) {
+      for (FileStatus wal: wals) {
+        SplitWALResult splitWALResult = splitter.splitWAL(wal, null);
+        if (splitWALResult.isFinished()) {
+          WALSplitUtil.archive(wal.getPath(), splitWALResult.isCorrupt(), archiveDir, walFS, conf);
+          if (splitter.outputSink.splits != null) {
+            splits.addAll(splitter.outputSink.splits);
           }
         }
       }
     }
-    if (!walFS.delete(logDir, true)) {
-      throw new IOException("Unable to delete src dir: " + logDir);
+    if (!walFS.delete(walsDir, true)) {
+      throw new IOException("Unable to delete src dir " + walsDir);
     }
     return splits;
   }
 
   /**
-   * WAL splitting implementation, splits one log file.
-   * @param logfile should be an actual log file.
+   * Data structure returned as result by #splitWAL(FileStatus, CancelableProgressable).
+   * Test {@link #isFinished()} to see if we are done with the WAL and {@link #isCorrupt()} for if
+   * the WAL is corrupt.
+   */
+  static final class SplitWALResult {
+    private final boolean finished;
+    private final boolean corrupt;
+
+    private SplitWALResult(boolean finished, boolean corrupt) {
+      this.finished = finished;
+      this.corrupt = corrupt;
+    }
+
+    public boolean isFinished() {
+      return finished;
+    }
+
+    public boolean isCorrupt() {
+      return corrupt;
+    }
+  }
+
+  /**
+   * Setup the output sinks and entry buffers ahead of splitting WAL.
+   */
+  private void createOutputSinkAndEntryBuffers() {
+    PipelineController controller = new PipelineController();
+    if (this.hfile) {
+      this.entryBuffers = new BoundedEntryBuffers(controller, this.bufferSize);
+      this.outputSink = new BoundedRecoveredHFilesOutputSink(this, controller,
+        this.entryBuffers, this.numWriterThreads);
+    } else if (this.splitWriterCreationBounded) {
+      this.entryBuffers = new BoundedEntryBuffers(controller, this.bufferSize);
+      this.outputSink = new BoundedRecoveredEditsOutputSink(this, controller,
+        this.entryBuffers, this.numWriterThreads);
+    } else {
+      this.entryBuffers = new EntryBuffers(controller, this.bufferSize);
+      this.outputSink = new RecoveredEditsOutputSink(this, controller,
+        this.entryBuffers, this.numWriterThreads);
+    }
+  }
+
+  /**
+   * WAL splitting implementation, splits one WAL file.
+   * @param walStatus should be for an actual WAL file.
    */
   @VisibleForTesting
-  boolean splitLogFile(FileStatus logfile, CancelableProgressable reporter) throws IOException {
-    Preconditions.checkState(status == null);
-    Preconditions.checkArgument(logfile.isFile(),
-        "passed in file status is for something other than a regular file.");
-    boolean isCorrupted = false;
-    boolean skipErrors = conf.getBoolean("hbase.hlog.split.skip.errors",
-      SPLIT_SKIP_ERRORS_DEFAULT);
+  SplitWALResult splitWAL(FileStatus walStatus, CancelableProgressable cancel) throws IOException {
+    Path wal = walStatus.getPath();
+    Preconditions.checkArgument(walStatus.isFile(), "Not a regular file " + wal.toString());
+    boolean corrupt = false;
     int interval = conf.getInt("hbase.splitlog.report.interval.loglines", 1024);
-    Path logPath = logfile.getPath();
     boolean outputSinkStarted = false;
-    boolean progressFailed = false;
+    boolean cancelled = false;
     int editsCount = 0;
     int editsSkipped = 0;
-
-    status = TaskMonitor.get().createStatus(
-          "Splitting log file " + logfile.getPath() + "into a temporary staging area.");
+    MonitoredTask status =
+      TaskMonitor.get().createStatus("Splitting " + wal + " to temporary staging area.");
     status.enableStatusJournal(true);
-    Reader logFileReader = null;
-    this.fileBeingSplit = logfile;
+    Reader walReader = null;
+    this.fileBeingSplit = walStatus;
     long startTS = EnvironmentEdgeManager.currentTime();
+    long length = walStatus.getLen();
+    String lengthStr = StringUtils.humanSize(length);
+    createOutputSinkAndEntryBuffers();
     try {
-      long logLength = logfile.getLen();
-      LOG.info("Splitting WAL={}, size={} ({} bytes)", logPath, StringUtils.humanSize(logLength),
-          logLength);
-      status.setStatus("Opening log file " + logPath);
-      if (reporter != null && !reporter.progress()) {
-        progressFailed = true;
-        return false;
+      String logStr = "Splitting " + wal + ", size=" + lengthStr + " (" + length + "bytes)";
+      LOG.info(logStr);
+      status.setStatus(logStr);
+      if (cancel != null && !cancel.progress()) {
+        cancelled = true;
+        return new SplitWALResult(false, corrupt);
       }
-      logFileReader = getReader(logfile, skipErrors, reporter);
-      if (logFileReader == null) {
-        LOG.warn("Nothing to split in WAL={}", logPath);
-        return true;
+      walReader = getReader(walStatus, this.skipErrors, cancel);
+      if (walReader == null) {
+        LOG.warn("Nothing in {}; empty?", wal);
+        return new SplitWALResult(true, corrupt);
       }
-      long openCost = EnvironmentEdgeManager.currentTime() - startTS;
-      LOG.info("Open WAL={} cost {} ms", logPath, openCost);
+      LOG.info("Open {} took {}ms", wal, EnvironmentEdgeManager.currentTime() - startTS);
       int numOpenedFilesBeforeReporting = conf.getInt("hbase.splitlog.report.openedfiles", 3);
       int numOpenedFilesLastCheck = 0;
-      outputSink.setReporter(reporter);
+      outputSink.setReporter(cancel);
       outputSink.setStatus(status);
       outputSink.startWriterThreads();
       outputSinkStarted = true;
       Entry entry;
-      Long lastFlushedSequenceId = -1L;
       startTS = EnvironmentEdgeManager.currentTime();
-      while ((entry = getNextLogLine(logFileReader, logPath, skipErrors)) != null) {
+      while ((entry = getNextLogLine(walReader, wal, this.skipErrors)) != null) {
         byte[] region = entry.getKey().getEncodedRegionName();
         String encodedRegionNameAsStr = Bytes.toString(region);
-        lastFlushedSequenceId = lastFlushedSequenceIds.get(encodedRegionNameAsStr);
+        Long lastFlushedSequenceId = lastFlushedSequenceIds.get(encodedRegionNameAsStr);
         if (lastFlushedSequenceId == null) {
           if (!(isRegionDirPresentUnderRoot(entry.getKey().getTableName(),
               encodedRegionNameAsStr))) {
@@ -301,8 +340,7 @@ public class WALSplitter {
             // region. Setting lastFlushedSequenceId as Long.MAX_VALUE so that all edits
             // will get skipped by the seqId check below.
             // See more details at https://issues.apache.org/jira/browse/HBASE-24189
-            LOG.info("{} no longer available in the FS. Skipping all edits for this region.",
-                encodedRegionNameAsStr);
+            LOG.info("{} no longer in filesystem; skipping all edits.", encodedRegionNameAsStr);
             lastFlushedSequenceId = Long.MAX_VALUE;
           } else {
             if (sequenceIdChecker != null) {
@@ -315,7 +353,7 @@ public class WALSplitter {
               regionMaxSeqIdInStores.put(encodedRegionNameAsStr, maxSeqIdInStores);
               lastFlushedSequenceId = ids.getLastFlushedSequenceId();
               if (LOG.isDebugEnabled()) {
-                LOG.debug("DLS Last flushed sequenceid for " + encodedRegionNameAsStr + ": "
+                LOG.debug("Last flushed sequenceid for " + encodedRegionNameAsStr + ": "
                     + TextFormat.shortDebugString(ids));
               }
             }
@@ -344,9 +382,9 @@ public class WALSplitter {
           String countsStr = (editsCount - (editsSkipped + outputSink.getTotalSkippedEdits()))
               + " edits, skipped " + editsSkipped + " edits.";
           status.setStatus("Split " + countsStr);
-          if (reporter != null && !reporter.progress()) {
-            progressFailed = true;
-            return false;
+          if (cancel != null && !cancel.progress()) {
+            cancelled = true;
+            return new SplitWALResult(false, corrupt);
           }
         }
       }
@@ -355,68 +393,64 @@ public class WALSplitter {
       iie.initCause(ie);
       throw iie;
     } catch (CorruptedLogFileException e) {
-      LOG.warn("Could not parse, corrupted WAL={}", logPath, e);
-      if (splitLogWorkerCoordination != null) {
+      LOG.warn("Could not parse, corrupt WAL={}", wal, e);
+      // If splitLogWorkerCoordination, then its old-school zk-coordinated splitting so update
+      // zk. Otherwise, it is the newer procedure-based WAL split which has no zk component.
+      if (this.splitLogWorkerCoordination != null) {
         // Some tests pass in a csm of null.
-        splitLogWorkerCoordination.markCorrupted(walDir, logfile.getPath().getName(), walFS);
-      } else {
-        // for tests only
-        ZKSplitLog.markCorrupted(walDir, logfile.getPath().getName(), walFS);
+        splitLogWorkerCoordination.markCorrupted(walRootDir, wal.getName(), walFS);
       }
-      isCorrupted = true;
+      corrupt = true;
     } catch (IOException e) {
       e = e instanceof RemoteException ? ((RemoteException) e).unwrapRemoteException() : e;
       throw e;
     } finally {
-      final String log = "Finishing writing output logs and closing down";
+      final String log = "Finishing writing output for " + wal + " so closing down";
       LOG.debug(log);
       status.setStatus(log);
       try {
-        if (null != logFileReader) {
-          logFileReader.close();
+        if (null != walReader) {
+          walReader.close();
         }
       } catch (IOException exception) {
-        LOG.warn("Could not close WAL reader", exception);
+        LOG.warn("Could not close {} reader", wal, exception);
       }
       try {
         if (outputSinkStarted) {
-          // Set progress_failed to true as the immediate following statement will reset its value
-          // when close() throws exception, progress_failed has the right value
-          progressFailed = true;
-          progressFailed = outputSink.close() == null;
+          // Set cancelled to true as the immediate following statement will reset its value.
+          // If close() throws an exception, cancelled will have the right value
+          cancelled = true;
+          cancelled = outputSink.close() == null;
         }
       } finally {
         long processCost = EnvironmentEdgeManager.currentTime() - startTS;
         // See if length got updated post lease recovery
         String msg = "Processed " + editsCount + " edits across " +
-            outputSink.getNumberOfRecoveredRegions() + " regions cost " + processCost +
-            " ms; edits skipped=" + editsSkipped + "; WAL=" + logPath + ", size=" +
-            StringUtils.humanSize(logfile.getLen()) + ", length=" + logfile.getLen() +
-            ", corrupted=" + isCorrupted + ", progress failed=" + progressFailed;
+          outputSink.getNumberOfRecoveredRegions() + " Regions in " + processCost +
+          " ms; skipped=" + editsSkipped + "; WAL=" + wal + ", size=" + lengthStr +
+          ", length=" + length + ", corrupted=" + corrupt + ", cancelled=" + cancelled;
         LOG.info(msg);
         status.markComplete(msg);
         if (LOG.isDebugEnabled()) {
-          LOG.debug("WAL split completed for {} , Journal Log: {}", logPath,
-            status.prettyPrintJournal());
+          LOG.debug("Completed split of {}, journal: {}", wal, status.prettyPrintJournal());
         }
       }
     }
-    return !progressFailed;
+    return new SplitWALResult(!cancelled, corrupt);
   }
 
-  private boolean isRegionDirPresentUnderRoot(TableName tableName, String regionName)
-      throws IOException {
-    Path regionDirPath = CommonFSUtils.getRegionDir(this.rootDir, tableName, regionName);
-    return this.rootFS.exists(regionDirPath);
+  private boolean isRegionDirPresentUnderRoot(TableName tn, String region) throws IOException {
+    return this.rootFS.exists(CommonFSUtils.getRegionDir(this.rootDir, tn, region));
   }
 
   /**
    * Create a new {@link Reader} for reading logs to split.
+   * @return Returns null if file has length zero or file can't be found.
    */
-  private Reader getReader(FileStatus file, boolean skipErrors, CancelableProgressable reporter)
+  protected Reader getReader(FileStatus walStatus, boolean skipErrors, CancelableProgressable cancel)
       throws IOException, CorruptedLogFileException {
-    Path path = file.getPath();
-    long length = file.getLen();
+    Path path = walStatus.getPath();
+    long length = walStatus.getLen();
     Reader in;
 
     // Check for possibly empty file. With appends, currently Hadoop reports a
@@ -427,9 +461,9 @@ public class WALSplitter {
     }
 
     try {
-      RecoverLeaseFSUtils.recoverFileLease(walFS, path, conf, reporter);
+      RecoverLeaseFSUtils.recoverFileLease(walFS, path, conf, cancel);
       try {
-        in = getReader(path, reporter);
+        in = getReader(path, cancel);
       } catch (EOFException e) {
         if (length <= 0) {
           // TODO should we ignore an empty, not-last log file if skip.errors
@@ -451,8 +485,8 @@ public class WALSplitter {
       if (!skipErrors || e instanceof InterruptedIOException) {
         throw e; // Don't mark the file corrupted if interrupted, or not skipErrors
       }
-      throw new CorruptedLogFileException("skipErrors=true Could not open wal "
-        + path + " ignoring", e);
+      throw new CorruptedLogFileException("skipErrors=true; could not open " + path +
+        ", skipping", e);
     }
     return in;
   }
@@ -463,14 +497,14 @@ public class WALSplitter {
       return in.next();
     } catch (EOFException eof) {
       // truncated files are expected if a RS crashes (see HBASE-2643)
-      LOG.info("EOF from wal {}. Continuing.", path);
+      LOG.info("EOF from {}; continuing.", path);
       return null;
     } catch (IOException e) {
       // If the IOE resulted from bad file format,
       // then this problem is idempotent and retrying won't help
       if (e.getCause() != null && (e.getCause() instanceof ParseException
           || e.getCause() instanceof org.apache.hadoop.fs.ChecksumException)) {
-        LOG.warn("Parse exception from wal {}. Continuing", path, e);
+        LOG.warn("Parse exception from {}; continuing", path, e);
         return null;
       }
       if (!skipErrors) {
@@ -493,7 +527,7 @@ public class WALSplitter {
    * Create a new {@link Reader} for reading logs to split.
    * @return new Reader instance, caller should close
    */
-  protected Reader getReader(Path curLogFile, CancelableProgressable reporter) throws IOException {
+  private Reader getReader(Path curLogFile, CancelableProgressable reporter) throws IOException {
     return walFactory.createReader(walFS, curLogFile, reporter);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/AbstractTestDLS.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/AbstractTestDLS.java
@@ -1,5 +1,4 @@
 /*
- *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,17 +19,9 @@ package org.apache.hadoop.hbase.master;
 
 import static org.apache.hadoop.hbase.HConstants.HBASE_SPLIT_WAL_MAX_SPLITTER;
 import static org.apache.hadoop.hbase.SplitLogCounters.tot_mgr_wait_for_zk_delete;
-import static org.apache.hadoop.hbase.SplitLogCounters.tot_wkr_final_transition_failed;
-import static org.apache.hadoop.hbase.SplitLogCounters.tot_wkr_preempt_task;
-import static org.apache.hadoop.hbase.SplitLogCounters.tot_wkr_task_acquired;
-import static org.apache.hadoop.hbase.SplitLogCounters.tot_wkr_task_done;
-import static org.apache.hadoop.hbase.SplitLogCounters.tot_wkr_task_err;
-import static org.apache.hadoop.hbase.SplitLogCounters.tot_wkr_task_resigned;
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -43,18 +34,14 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.MiniHBaseCluster;
-import org.apache.hadoop.hbase.NamespaceDescriptor;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.SplitLogCounters;
 import org.apache.hadoop.hbase.StartMiniClusterOption;
@@ -67,7 +54,6 @@ import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.coordination.ZKSplitLogManagerCoordination;
 import org.apache.hadoop.hbase.ipc.ServerNotRunningYetException;
-import org.apache.hadoop.hbase.master.SplitLogManager.TaskBatch;
 import org.apache.hadoop.hbase.master.assignment.RegionStates;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.regionserver.MultiVersionConcurrencyControl;
@@ -77,12 +63,10 @@ import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.JVMClusterUtil.MasterThread;
 import org.apache.hadoop.hbase.util.JVMClusterUtil.RegionServerThread;
 import org.apache.hadoop.hbase.util.Threads;
-import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
 import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.wal.WALEdit;
 import org.apache.hadoop.hbase.wal.WALFactory;
 import org.apache.hadoop.hbase.wal.WALKeyImpl;
-import org.apache.hadoop.hbase.wal.WALSplitUtil;
 import org.apache.hadoop.hbase.zookeeper.ZKUtil;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -93,7 +77,6 @@ import org.junit.Test;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 
 /**
@@ -177,83 +160,6 @@ public abstract class AbstractTestDLS {
   }
 
   @Test
-  public void testRecoveredEdits() throws Exception {
-    conf.setLong("hbase.regionserver.hlog.blocksize", 30 * 1024); // create more than one wal
-    startCluster(NUM_RS);
-
-    int numLogLines = 10000;
-    SplitLogManager slm = master.getMasterWalManager().getSplitLogManager();
-    // turn off load balancing to prevent regions from moving around otherwise
-    // they will consume recovered.edits
-    master.balanceSwitch(false);
-    FileSystem fs = master.getMasterFileSystem().getFileSystem();
-
-    List<RegionServerThread> rsts = cluster.getLiveRegionServerThreads();
-
-    Path rootdir = CommonFSUtils.getRootDir(conf);
-
-    int numRegions = 50;
-    try (Table t = installTable(numRegions)) {
-      List<RegionInfo> regions = null;
-      HRegionServer hrs = null;
-      for (int i = 0; i < NUM_RS; i++) {
-        hrs = rsts.get(i).getRegionServer();
-        regions = ProtobufUtil.getOnlineRegions(hrs.getRSRpcServices());
-        // At least one RS will have >= to average number of regions.
-        if (regions.size() >= numRegions / NUM_RS) {
-          break;
-        }
-      }
-      Path logDir = new Path(rootdir,
-          AbstractFSWALProvider.getWALDirectoryName(hrs.getServerName().toString()));
-
-      LOG.info("#regions = " + regions.size());
-      Iterator<RegionInfo> it = regions.iterator();
-      while (it.hasNext()) {
-        RegionInfo region = it.next();
-        if (region.getTable().getNamespaceAsString()
-            .equals(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR)) {
-          it.remove();
-        }
-      }
-
-      makeWAL(hrs, regions, numLogLines, 100);
-
-      slm.splitLogDistributed(logDir);
-
-      int count = 0;
-      for (RegionInfo hri : regions) {
-        @SuppressWarnings("deprecation")
-        Path editsdir = WALSplitUtil
-            .getRegionDirRecoveredEditsDir(CommonFSUtils.getWALRegionDir(conf,
-                tableName, hri.getEncodedName()));
-        LOG.debug("Checking edits dir " + editsdir);
-        FileStatus[] files = fs.listStatus(editsdir, new PathFilter() {
-          @Override
-          public boolean accept(Path p) {
-            if (WALSplitUtil.isSequenceIdFile(p)) {
-              return false;
-            }
-            return true;
-          }
-        });
-        LOG.info("Files {}", Arrays.stream(files).map(f -> f.getPath().toString()).
-          collect(Collectors.joining(",")));
-        assertTrue("Edits dir should have more than a one file", files.length > 1);
-        for (int i = 0; i < files.length; i++) {
-          int c = countWAL(files[i].getPath(), fs, conf);
-          count += c;
-        }
-        LOG.info(count + " edits in " + files.length + " recovered edits files.");
-      }
-
-      // check that the log file is moved
-      assertFalse(fs.exists(logDir));
-      assertEquals(numLogLines, count);
-    }
-  }
-
-  @Test
   public void testMasterStartsUpWithLogSplittingWork() throws Exception {
     conf.setInt(ServerManager.WAIT_ON_REGIONSERVERS_MINTOSTART, NUM_RS - 1);
     startCluster(NUM_RS);
@@ -303,71 +209,6 @@ public abstract class AbstractTestDLS {
     }
   }
 
-  /**
-   * The original intention of this test was to force an abort of a region server and to make sure
-   * that the failure path in the region servers is properly evaluated. But it is difficult to
-   * ensure that the region server doesn't finish the log splitting before it aborts. Also now,
-   * there is this code path where the master will preempt the region server when master detects
-   * that the region server has aborted.
-   * @throws Exception
-   */
-  // Was marked flaky before Distributed Log Replay cleanup.
-  @Test
-  public void testWorkerAbort() throws Exception {
-    LOG.info("testWorkerAbort");
-    startCluster(3);
-    int numLogLines = 10000;
-    SplitLogManager slm = master.getMasterWalManager().getSplitLogManager();
-    FileSystem fs = master.getMasterFileSystem().getFileSystem();
-
-    List<RegionServerThread> rsts = cluster.getLiveRegionServerThreads();
-    HRegionServer hrs = findRSToKill(false);
-    Path rootdir = CommonFSUtils.getRootDir(conf);
-    final Path logDir = new Path(rootdir,
-        AbstractFSWALProvider.getWALDirectoryName(hrs.getServerName().toString()));
-
-    try (Table t = installTable(40)) {
-      makeWAL(hrs, ProtobufUtil.getOnlineRegions(hrs.getRSRpcServices()), numLogLines, 100);
-
-      new Thread() {
-        @Override
-        public void run() {
-          try {
-            waitForCounter(tot_wkr_task_acquired, 0, 1, 1000);
-          } catch (InterruptedException e) {
-          }
-          for (RegionServerThread rst : rsts) {
-            rst.getRegionServer().abort("testing");
-            break;
-          }
-        }
-      }.start();
-      FileStatus[] logfiles = fs.listStatus(logDir);
-      TaskBatch batch = new TaskBatch();
-      slm.enqueueSplitTask(logfiles[0].getPath().toString(), batch);
-      // waitForCounter but for one of the 2 counters
-      long curt = System.currentTimeMillis();
-      long waitTime = 80000;
-      long endt = curt + waitTime;
-      while (curt < endt) {
-        if ((tot_wkr_task_resigned.sum() + tot_wkr_task_err.sum() +
-            tot_wkr_final_transition_failed.sum() + tot_wkr_task_done.sum() +
-            tot_wkr_preempt_task.sum()) == 0) {
-          Thread.sleep(100);
-          curt = System.currentTimeMillis();
-        } else {
-          assertTrue(1 <= (tot_wkr_task_resigned.sum() + tot_wkr_task_err.sum() +
-              tot_wkr_final_transition_failed.sum() + tot_wkr_task_done.sum() +
-              tot_wkr_preempt_task.sum()));
-          return;
-        }
-      }
-      fail("none of the following counters went up in " + waitTime + " milliseconds - " +
-          "tot_wkr_task_resigned, tot_wkr_task_err, " +
-          "tot_wkr_final_transition_failed, tot_wkr_task_done, " + "tot_wkr_preempt_task");
-    }
-  }
-
   @Test
   public void testThreeRSAbort() throws Exception {
     LOG.info("testThreeRSAbort");
@@ -411,6 +252,11 @@ public abstract class AbstractTestDLS {
 
   @Test
   public void testDelayedDeleteOnFailure() throws Exception {
+    if (!this.conf.getBoolean(HConstants.HBASE_SPLIT_WAL_COORDINATED_BY_ZK,
+        HConstants.DEFAULT_HBASE_SPLIT_COORDINATED_BY_ZK)) {
+      // This test depends on zk coordination....
+     return;
+    }
     LOG.info("testDelayedDeleteOnFailure");
     startCluster(1);
     final SplitLogManager slm = master.getMasterWalManager().getSplitLogManager();
@@ -504,8 +350,9 @@ public abstract class AbstractTestDLS {
     NavigableSet<String> regions = HBaseTestingUtility.getAllOnlineRegions(cluster);
     LOG.debug("Verifying only catalog region is assigned\n");
     if (regions.size() != 1) {
-      for (String oregion : regions)
+      for (String oregion : regions) {
         LOG.debug("Region still online: " + oregion);
+      }
     }
     assertEquals(1 + existingRegions, regions.size());
     LOG.debug("Enabling table\n");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCleanupMetaWAL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCleanupMetaWAL.java
@@ -77,7 +77,7 @@ public class TestCleanupMetaWAL {
     Path walPath = new Path(fs.getWALRootDir(), HConstants.HREGION_LOGDIR_NAME);
     for (FileStatus status : CommonFSUtils.listStatus(fs.getFileSystem(), walPath)) {
       if (status.getPath().toString().contains(SPLITTING_EXT)) {
-        fail("Should not have splitting wal dir here:" + status);
+        fail("Splitting WAL dir should have been cleaned up: " + status);
       }
     }
   }

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MetaTableLocator.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MetaTableLocator.java
@@ -221,8 +221,8 @@ public final class MetaTableLocator {
       LOG.warn("Tried to set null ServerName in hbase:meta; skipping -- ServerName required");
       return;
     }
-    LOG.info("Setting hbase:meta (replicaId={}) location in ZooKeeper as {}", replicaId,
-      serverName);
+    LOG.info("Setting hbase:meta (replicaId={}) location in ZooKeeper as {}, state={}", replicaId,
+      serverName, state);
     // Make the MetaRegionServer pb and then get its bytes and save this as
     // the znode content.
     MetaRegionServer pbrsr = MetaRegionServer.newBuilder()

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKSplitLog.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKSplitLog.java
@@ -32,7 +32,10 @@ import org.slf4j.LoggerFactory;
 /**
  * Common methods and attributes used by SplitLogManager and SplitLogWorker running distributed
  * splitting of WAL logs.
+ * @deprecated  since 2.4.0 and 3.0.0 replaced by procedure-based WAL splitting; see
+ *    SplitWALManager.
  */
+@Deprecated
 @InterfaceAudience.Private
 public final class ZKSplitLog {
   private static final Logger LOG = LoggerFactory.getLogger(ZKSplitLog.class);


### PR DESCRIPTION
… Add deprecation of 'classic' zk-based WAL splitter.

Also fix three bugs:

 * We were trying to delete non-empty directory; weren't doing
 accounting for meta WALs where meta had moved off the server
 (successfully)
 * We were deleting split WALs rather than archiving them.
 * We were not handling corrupt files.

Deprecations and removal of tests of old system.