### PR TITLE
HBASE-24756 Backport HBASE-24336 "[Metrics] FSDataInputStream's localBytesRead is wrong" to branch-2.2

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/FSDataInputStreamWrapper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/FSDataInputStreamWrapper.java
@@ -253,7 +253,7 @@ public class FSDataInputStreamWrapper implements Closeable {
         readStatistics.totalBytesRead += hdfsDataInputStream.getReadStatistics().
           getTotalBytesRead();
         readStatistics.totalLocalBytesRead += hdfsDataInputStream.getReadStatistics().
-          getTotalBytesRead();
+          getTotalLocalBytesRead();
         readStatistics.totalShortCircuitBytesRead += hdfsDataInputStream.getReadStatistics().
           getTotalShortCircuitBytesRead();
         readStatistics.totalZeroCopyBytesRead += hdfsDataInputStream.getReadStatistics().


### PR DESCRIPTION
HBASE-24336 is applicable to branch-2.2 also.