### PR TITLE
HBASE-24805 HBaseTestingUtility.getConnection should be threadsafe

### DIFF
--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/HBaseCommonTestingUtility.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/HBaseCommonTestingUtility.java
@@ -69,7 +69,7 @@ public class HBaseCommonTestingUtility {
     Compression.Algorithm.NONE, Compression.Algorithm.GZ
   };
 
-  protected Configuration conf;
+  protected final Configuration conf;
 
   public HBaseCommonTestingUtility() {
     this(null);


### PR DESCRIPTION
This maintains *most* compatibility while changing the handling of the shared connection to threadsafe. Note about compat as comments.