### PR TITLE
HBASE-24806 Small Updates to Functionality of Shell IRB Workspace

### DIFF
--- a/bin/hirb.rb
+++ b/bin/hirb.rb
@@ -174,16 +174,20 @@ def debug?
   nil
 end
 
+
 # For backwards compatibility, this will export all the HBase shell commands, constants, and
 # instance variables (@hbase and @shell) onto Ruby's top-level receiver object known as "main".
 @shell.export_all(self) if top_level_definitions
 
 # If script2run, try running it.  If we're in interactive mode, will go on to run the shell unless
 # script calls 'exit' or 'exit 0' or 'exit errcode'.
-@shell.eval_io(File.new(script2run)) if script2run
+require 'shell/hbase_loader'
+if script2run
+  ::Shell::Shell.exception_handler(!$fullBackTrace) { @shell.eval_io(Hbase::Loader.file_for_load(script2run), filename = script2run) }
+end
 
 # If we are not running interactively, evaluate standard input
-@shell.eval_io(STDIN) unless interactive
+::Shell::Shell.exception_handler(!$fullBackTrace) { @shell.eval_io(STDIN) } unless interactive
 
 if interactive
   # Output a banner message that tells users where to go for help

--- a/hbase-shell/src/main/ruby/shell/hbase_loader.rb
+++ b/hbase-shell/src/main/ruby/shell/hbase_loader.rb
@@ -1,0 +1,56 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Hbase
+  ##
+  # HBase::Loader serves a similar purpose to IRB::IrbLoader, but with a different separation of
+  # concerns. This loader allows us to directly get the path for a filename in ruby's load path,
+  # and then use that in combination with something like HBase::Shell#eval_io.
+  module Loader
+    ##
+    # Determine the loadable path for a given filename by searching through $LOAD_PATH
+    #
+    # This serves a similar purpose to IRB::IrbLoader#search_file_from_ruby_path, but uses JRuby's
+    # loader, which allows us to find special paths like "uri:classloader" inside of a Jar.
+    #
+    # @param [String] filename
+    # @return [String] path
+    def self.path_for_load(filename)
+      return File.absolute_path(filename) if File.exist? filename
+
+      # Get JRuby's LoadService from the global (singleton) instance of the runtime
+      # (org.jruby.Ruby), which allows us to use JRuby's tools for searching the load path.
+      runtime = org.jruby.Ruby.getGlobalRuntime
+      loader = runtime.getLoadService
+      search_state = loader.findFileForLoad filename
+      raise LoadError, "no such file to load -- #{filename}" if search_state.library.nil?
+
+      search_state.loadName
+    end
+
+    ##
+    # Return a file handle for the given file found in the load path
+    #
+    # @param [String] filename
+    # @return [File] file handle
+    def self.file_for_load(filename)
+      File.new(path_for_load(filename))
+    end
+  end
+end

--- a/hbase-shell/src/test/ruby/shell/shell_test.rb
+++ b/hbase-shell/src/test/ruby/shell/shell_test.rb
@@ -114,6 +114,7 @@ class ShellTest < Test::Unit::TestCase
   #-----------------------------------------------------------------------------
 
   define_test 'Shell::Shell#eval_io should evaluate IO' do
+    StringIO.include HBaseIOExtensions
     # check that at least one of the commands is present while evaluating
     io = StringIO.new <<~EOF
       puts (respond_to? :list)
@@ -123,10 +124,31 @@ class ShellTest < Test::Unit::TestCase
 
     # check that at least one of the HBase constants is present while evaluating
     io = StringIO.new <<~EOF
-      ROWPREFIXFILTER
+      ROWPREFIXFILTER.dump
     EOF
     output = capture_stdout { @shell.eval_io(io) }
     assert_match(/"ROWPREFIXFILTER"/, output)
+  end
+
+  #-----------------------------------------------------------------------------
+
+  define_test 'Shell::Shell#exception_handler should hide traceback' do
+    class TestException < RuntimeError; end
+    hide_traceback = true
+    # When hide_traceback is true, exception_handler should replace exceptions
+    # with SystemExit so that the traceback is not printed.
+    assert_raises(SystemExit) do
+      ::Shell::Shell.exception_handler(true) { raise TestException, 'Custom Exception' }
+    end
+  end
+
+  define_test 'Shell::Shell#exception_handler should show traceback' do
+    class TestException < RuntimeError; end
+    hide_traceback = false
+    # When hide_traceback is false, exception_handler should re-raise Exceptions
+    assert_raises(TestException) do
+      ::Shell::Shell.exception_handler(false) { raise TestException, 'Custom Exception' }
+    end
   end
 
   #-----------------------------------------------------------------------------
@@ -141,7 +163,7 @@ class ShellTest < Test::Unit::TestCase
 
   #-----------------------------------------------------------------------------
 
-  define_test "Shell::Shell interactive mode should not throw" do
+  define_test 'Shell::Shell interactive mode should not throw' do
     # incorrect number of arguments
     @shell.command('create', 'nothrow_table')
     @shell.command('create', 'nothrow_table', 'family_1')

--- a/hbase-shell/src/test/ruby/shell/shell_test.rb
+++ b/hbase-shell/src/test/ruby/shell/shell_test.rb
@@ -134,7 +134,6 @@ class ShellTest < Test::Unit::TestCase
 
   define_test 'Shell::Shell#exception_handler should hide traceback' do
     class TestException < RuntimeError; end
-    hide_traceback = true
     # When hide_traceback is true, exception_handler should replace exceptions
     # with SystemExit so that the traceback is not printed.
     assert_raises(SystemExit) do
@@ -144,7 +143,6 @@ class ShellTest < Test::Unit::TestCase
 
   define_test 'Shell::Shell#exception_handler should show traceback' do
     class TestException < RuntimeError; end
-    hide_traceback = false
     # When hide_traceback is false, exception_handler should re-raise Exceptions
     assert_raises(TestException) do
       ::Shell::Shell.exception_handler(false) { raise TestException, 'Custom Exception' }

--- a/hbase-shell/src/test/ruby/tests_runner.rb
+++ b/hbase-shell/src/test/ruby/tests_runner.rb
@@ -82,9 +82,14 @@ if java.lang.System.get_property('shell.test')
   puts "Only running tests that match #{shell_test_pattern}"
   runner_args << "--testcase=#{shell_test_pattern}"
 end
-# first couple of args are to match the defaults, so we can pass options to limit the tests run
-if !(Test::Unit::AutoRunner.run(false, nil, runner_args))
-  raise "Shell unit tests failed. Check output file for details."
+begin
+  # first couple of args are to match the defaults, so we can pass options to limit the tests run
+  unless Test::Unit::AutoRunner.run(false, nil, runner_args)
+    raise 'Shell unit tests failed. Check output file for details.'
+  end
+rescue SystemExit => e
+  # Unit tests should not raise uncaught SystemExit exceptions. This could cause tests to be ignored.
+  raise 'Caught SystemExit during unit test execution! Check output file for details.'
 end
 
 puts "Done with tests! Shutting down the cluster..."


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/browse/HBASE-24806

## High-Level Overview

1. Create exception handler for shell (to hide tracebacks unless debug is on). The handler just replaces exceptions with SystemExit.
2. Get rid of a recently introduced IRB warning (`can't alias help from irb_help`).
3. Create a new module Hbase::Loader that can find ruby scripts using JRuby's loader. This is better than IRB::Loader because it can find anything that can be found directly with `load`, including files inside a Jar. It is necessary so that our shell can _evaluate_ scripts in the $LOAD_PATH/classpath.
4. Update the test runner to catch SystemExits. This will ensure that our unit tests stay potent and cannot fail unnoticed.

## Changelog

- Move exception handler from Shell::Shell#eval_io to new method,
  Shell::Shell#exception_handler
- Add unit tests for Shell::Shell#exception_handler
- Change Shell::Shell#eval_io to no longer raise SystemExit when any error is
  seen and update unit test
- Update ruby test runner to catch SystemExit and fail to avoid tests that
  cause the test runner to incorrectly exit successfully
- Add Hbase::Loader module to find ruby scripts in the $LOAD_PATH and classpath
  using JRuby's loader.
- In hbase-shell, install IRB commands before exporting HBase commands. The
  HBase commands will override the IRB commands, and no warning will be
  printed.
