### PR TITLE
HBASE-24869 migrate website generation to new asf jenkins

### DIFF
--- a/dev-support/jenkins-scripts/generate-hbase-website.Jenkinsfile
+++ b/dev-support/jenkins-scripts/generate-hbase-website.Jenkinsfile
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one
+// or more contributor license agreements.  See the NOTICE file
+// distributed with this work for additional information
+// regarding copyright ownership.  The ASF licenses this file
+// to you under the Apache License, Version 2.0 (the
+// "License"); you may not use this file except in compliance
+// with the License.  You may obtain a copy of the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing,
+// software distributed under the License is distributed on an
+// "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+// KIND, either express or implied.  See the License for the
+// specific language governing permissions and limitations
+// under the License.
+pipeline {
+  agent {
+    node {
+      label 'git-websites'
+    }
+  }
+  triggers {
+    pollSCM('@daily')
+  }
+  options {
+    buildDiscarder(logRotator(numToKeepStr: '30'))
+    timeout (time: 1, unit: 'HOURS')
+    timestamps()
+    skipDefaultCheckout()
+    disableConcurrentBuilds()
+  }
+  parameters {
+    booleanParam(name: 'DEBUG', defaultValue: false, description: 'Produce a lot more meta-information.')
+    booleanParam(name: 'FORCE_FAIL', defaultValue: false, description: 'force a failure to test notifications.')
+  }
+  stages {
+    stage ('generate hbase website') {
+      tools {
+        maven 'Maven (latest)'
+        // this needs to be set to the jdk that ought to be used to build releases on the branch the Jenkinsfile is stored in.
+        jdk "JDK 1.8 (latest)"
+      }
+      steps {
+        dir('hbase') {
+          checkout scm
+        }
+        sh '''#!/usr/bin/env bash
+          set -e
+          if [ "${DEBUG}" = "true" ]; then
+            set -x
+          fi
+          if [ "${FORCE_FAIL}" = "true" ]; then
+            false
+          fi
+          bash hbase/dev-support/jenkins-scripts/generate-hbase-website.sh --working-dir "${WORKSPACE}" --publish hbase
+'''
+      }
+    }
+  }
+  post {
+    always {
+      // Has to be relative to WORKSPACE.
+      archiveArtifacts artifacts: '*.patch.zip,hbase-*.txt'
+    }
+    failure {
+      mail to: 'dev@hbase.apache.org', replyTo: 'dev@hbase.apache.org', subject: "Failure: HBase Generate Website", body: """
+Build status: ${currentBuild.currentResult}
+
+The HBase website has not been updated to incorporate recent HBase changes.
+
+See ${env.BUILD_URL}console
+"""
+    }
+    cleanup {
+      deleteDir()
+    }
+  }
+}


### PR DESCRIPTION
Equivalent to our existing job on builds.a.o except:

* moves to Jenkins Pipeline so we can configure some things that were done in plugins on the old jenkins
* reduces the timeout from 4 hours to 1 hour. normal build times are ~15-20 minutes.
* alters the message body for failure notifications because we can't set jenkins environment variables from our script.
* adds an optional "force failure" parameter so we can test notifications

tested with a feature branch on ci-hadoop.a.o
* [build 3](https://ci-hadoop.apache.org/job/HBase/job/hbase_generate_website/3/) was able to [publish an update](https://github.com/apache/hbase-site/commit/0b1ad5eab6f29b479dbf5223ffd372682d74ce86), archive the same artifacts, and clean up the workspace
* [build 6](https://ci-hadoop.apache.org/job/HBase/job/hbase_generate_website/6/) was run with force fail set and produced a [reasonable notification email to dev@hbase](https://lists.apache.org/thread.html/r0ba69e2ec439c95f1311b70bd10d466b81b0e8bcda4fc859239e44cd%40%3Cdev.hbase.apache.org%3E).