### PR TITLE
Backport "HBASE-24583 Normalizer can't actually merge empty regions..." to branch-2

### DIFF
--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TableNameTestRule.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TableNameTestRule.java
@@ -21,7 +21,8 @@ import org.junit.rules.TestWatcher;
 import org.junit.runner.Description;
 
 /**
- * Returns a {@code TableName} based on currently running test method name.
+ * Returns a {@code TableName} based on currently running test method name. Supports
+ *  tests built on the {@link org.junit.runners.Parameterized} runner.
  */
 public class TableNameTestRule extends TestWatcher {
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/MergeNormalizationPlan.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/MergeNormalizationPlan.java
@@ -1,4 +1,4 @@
-/**
+/*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,20 +19,20 @@
 package org.apache.hadoop.hbase.master.normalizer;
 
 import java.io.IOException;
-
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.yetus.audience.InterfaceAudience;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Normalization plan to merge regions (smallest region in the table with its smallest neighbor).
  */
 @InterfaceAudience.Private
 public class MergeNormalizationPlan implements NormalizationPlan {
-  private static final Logger LOG = LoggerFactory.getLogger(MergeNormalizationPlan.class.getName());
 
   private final RegionInfo firstRegion;
   private final RegionInfo secondRegion;
@@ -47,7 +47,6 @@ public class MergeNormalizationPlan implements NormalizationPlan {
    */
   @Override
   public long submit(MasterServices masterServices) throws IOException {
-    LOG.info("Executing merging normalization plan: " + this);
     // Do not use force=true as corner cases can happen, non adjacent regions,
     // merge with a merged child region with no GC done yet, it is going to
     // cause all different issues.
@@ -71,10 +70,35 @@ public class MergeNormalizationPlan implements NormalizationPlan {
 
   @Override
   public String toString() {
-    return "MergeNormalizationPlan{" +
-      "firstRegion=" + firstRegion +
-      ", secondRegion=" + secondRegion +
-      '}';
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+      .append("firstRegion", firstRegion)
+      .append("secondRegion", secondRegion)
+      .toString();
   }
 
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    MergeNormalizationPlan that = (MergeNormalizationPlan) o;
+
+    return new EqualsBuilder()
+      .append(firstRegion, that.firstRegion)
+      .append(secondRegion, that.secondRegion)
+      .isEquals();
+  }
+
+  @Override
+  public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+      .append(firstRegion)
+      .append(secondRegion)
+      .toHashCode();
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
@@ -369,7 +369,8 @@ public class SimpleRegionNormalizer implements RegionNormalizer {
       }
       final long currentSizeMb = getRegionSizeMB(current);
       final long nextSizeMb = getRegionSizeMB(next);
-      if (currentSizeMb + nextSizeMb < avgRegionSizeMb) {
+      // always merge away empty regions when they present themselves.
+      if (currentSizeMb == 0 || nextSizeMb == 0 || currentSizeMb + nextSizeMb < avgRegionSizeMb) {
         plans.add(new MergeNormalizationPlan(current, next));
         candidateIdx++;
       }
@@ -411,7 +412,7 @@ public class SimpleRegionNormalizer implements RegionNormalizer {
       if (regionSize > 2 * avgRegionSize) {
         LOG.info("Table {}, large region {} has size {}, more than twice avg size {}, splitting",
           ctx.getTableName(), hri.getRegionNameAsString(), regionSize, avgRegionSize);
-        plans.add(new SplitNormalizationPlan(hri, null));
+        plans.add(new SplitNormalizationPlan(hri));
       }
     }
     return plans;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SplitNormalizationPlan.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SplitNormalizationPlan.java
@@ -1,4 +1,4 @@
-/**
+/*
  *
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
@@ -19,35 +19,31 @@
 package org.apache.hadoop.hbase.master.normalizer;
 
 import java.io.IOException;
-import java.util.Arrays;
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.commons.lang3.builder.ToStringStyle;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.yetus.audience.InterfaceAudience;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * Normalization plan to split region.
  */
 @InterfaceAudience.Private
 public class SplitNormalizationPlan implements NormalizationPlan {
-  private static final Logger LOG = LoggerFactory.getLogger(SplitNormalizationPlan.class.getName());
 
-  private RegionInfo regionInfo;
-  private byte[] splitPoint;
+  private final RegionInfo regionInfo;
 
-  public SplitNormalizationPlan(RegionInfo regionInfo, byte[] splitPoint) {
+  public SplitNormalizationPlan(RegionInfo regionInfo) {
     this.regionInfo = regionInfo;
-    this.splitPoint = splitPoint;
   }
 
-  /**
-   * {@inheritDoc}
-   */
   @Override
   public long submit(MasterServices masterServices) throws IOException {
-    return masterServices.splitRegion(regionInfo, null, HConstants.NO_NONCE, HConstants.NO_NONCE);
+    return masterServices.splitRegion(regionInfo, null, HConstants.NO_NONCE,
+      HConstants.NO_NONCE);
   }
 
   @Override
@@ -59,24 +55,33 @@ public class SplitNormalizationPlan implements NormalizationPlan {
     return regionInfo;
   }
 
-  public void setRegionInfo(RegionInfo regionInfo) {
-    this.regionInfo = regionInfo;
-  }
-
-  public byte[] getSplitPoint() {
-    return splitPoint;
-  }
-
-  public void setSplitPoint(byte[] splitPoint) {
-    this.splitPoint = splitPoint;
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
+      .append("regionInfo", regionInfo)
+      .toString();
   }
 
   @Override
-  public String toString() {
-    return "SplitNormalizationPlan{" +
-      "regionInfo=" + regionInfo +
-      ", splitPoint=" + Arrays.toString(splitPoint) +
-      '}';
+  public boolean equals(Object o) {
+    if (this == o) {
+      return true;
+    }
+
+    if (o == null || getClass() != o.getClass()) {
+      return false;
+    }
+
+    SplitNormalizationPlan that = (SplitNormalizationPlan) o;
+
+    return new EqualsBuilder()
+      .append(regionInfo, that.regionInfo)
+      .isEquals();
   }
 
+  @Override public int hashCode() {
+    return new HashCodeBuilder(17, 37)
+      .append(regionInfo)
+      .toHashCode();
+  }
 }


### PR DESCRIPTION
when neighbor is larger than average size

* add `testMergeEmptyRegions` to explicitly cover different
  interleaving of 0-sized regions.
* fix bug where merging a 0-size region is skipped due to large
  neighbor.
* remove unused `splitPoint` from `SplitNormalizationPlan`.
* generate `toString`, `hashCode`, and `equals` methods from Apache
  Commons Lang3 template on `SplitNormalizationPlan` and
  `MergeNormalizationPlan`.
* simplify test to use equality matching over `*NormalizationPlan`
  instances as plain pojos.
* test make use of this handy `TableNameTestRule`.
* fix line-length issues in `TestSimpleRegionNormalizer`

Signed-off-by: Wellington Chevreuil <wchevreuil@apache.org>
Signed-off-by: Viraj Jasani <vjasani@apache.org>
Signed-off-by: huaxiangsun <huaxiangsun@apache.org>
Signed-off-by: Aman Poonia <aman.poonia.29@gmail.com>