### PR TITLE
HBASE-24874 Fix hbase-shell access to ModifiableTableDescriptor methods

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptorBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptorBuilder.java
@@ -1628,6 +1628,8 @@ public class TableDescriptorBuilder {
     }
   }
 
+  // This method is mostly intended for internal use. However, it it also relied on by hbase-shell
+  // for backwards compatibility.
   private static Optional<CoprocessorDescriptor> toCoprocessorDescriptor(String spec) {
     Matcher matcher = CP_HTD_ATTR_VALUE_PATTERN.matcher(spec);
     if (matcher.matches()) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptorBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptorBuilder.java
@@ -1628,8 +1628,10 @@ public class TableDescriptorBuilder {
     }
   }
 
-  // This method is mostly intended for internal use. However, it it also relied on by hbase-shell
-  // for backwards compatibility.
+  /**
+   * This method is mostly intended for internal use. However, it it also relied on by hbase-shell
+   * for backwards compatibility.
+   */
   private static Optional<CoprocessorDescriptor> toCoprocessorDescriptor(String spec) {
     Matcher matcher = CP_HTD_ATTR_VALUE_PATTERN.matcher(spec);
     if (matcher.matches()) {

--- a/hbase-shell/src/main/ruby/hbase_constants.rb
+++ b/hbase-shell/src/main/ruby/hbase_constants.rb
@@ -39,12 +39,14 @@ module HBaseConstants
   BATCH = 'BATCH'.freeze
   CACHE = 'CACHE'.freeze
   CACHE_BLOCKS = 'CACHE_BLOCKS'.freeze
+  CLASSNAME = 'CLASSNAME'.freeze
   CLUSTER_KEY = 'CLUSTER_KEY'.freeze
   COLUMN = 'COLUMN'.freeze
   COLUMNS = 'COLUMNS'.freeze
   CONFIG = 'CONFIG'.freeze
   CONFIGURATION = org.apache.hadoop.hbase.HConstants::CONFIGURATION
   CONSISTENCY = 'CONSISTENCY'.freeze
+  COPROCESSOR = 'COPROCESSOR'.freeze
   DATA = 'DATA'.freeze
   ENDPOINT_CLASSNAME = 'ENDPOINT_CLASSNAME'.freeze
   FILTER = 'FILTER'.freeze
@@ -56,6 +58,7 @@ module HBaseConstants
   IN_MEMORY_COMPACTION = org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder::IN_MEMORY_COMPACTION
   ISOLATION_LEVEL = 'ISOLATION_LEVEL'.freeze
   IS_ROOT = 'IS_ROOT'.freeze
+  JAR_PATH = 'JAR_PATH'.freeze
   LIMIT = 'LIMIT'.freeze
   LOCALITY_THRESHOLD = 'LOCALITY_THRESHOLD'.freeze
   MAXLENGTH = 'MAXLENGTH'.freeze
@@ -69,6 +72,8 @@ module HBaseConstants
   NONE = 'NONE'.freeze
   NUMREGIONS = 'NUMREGIONS'.freeze
   POLICY = 'POLICY'.freeze
+  PRIORITY = 'PRIORITY'.freeze
+  PROPERTIES = 'PROPERTIES'.freeze
   RAW = 'RAW'.freeze
   READ_TYPE = 'READ_TYPE'.freeze
   REGIONSERVER = 'REGIONSERVER'.freeze

--- a/hbase-shell/src/main/ruby/shell/commands/alter.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/alter.rb
@@ -56,11 +56,11 @@ for example, to change the max size of a region to 128MB, do:
 You can add a table coprocessor by setting a table coprocessor attribute. Only the CLASSNAME is
 required in the coprocessor specification.
 
-  hbase> alter 't1', 'coprocessor' => {
-           'CLASSNAME' => 'org.apache.hadoop.hbase.coprocessor.SimpleRegionObserver',
-           'JAR_PATH' => 'hdfs:///foo.jar'
-           'PRIORITY' => 12,
-           'PROPERTIES' => {'a' => '17' }
+  hbase> alter 't1', COPROCESSOR => {
+           CLASSNAME => 'org.apache.hadoop.hbase.coprocessor.SimpleRegionObserver',
+           JAR_PATH => 'hdfs:///foo.jar',
+           PRIORITY => 12,
+           PROPERTIES => {'a' => '17' }
          }
 
 Since you can have multiple coprocessors configured for a table, a

--- a/hbase-shell/src/main/ruby/shell/commands/alter.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/alter.rb
@@ -53,19 +53,19 @@ for example, to change the max size of a region to 128MB, do:
 
   hbase> alter 't1', MAX_FILESIZE => '134217728'
 
-You can add a table coprocessor by setting a table coprocessor attribute:
+You can add a table coprocessor by setting a table coprocessor attribute. Only the CLASSNAME is
+required in the coprocessor specification.
 
-  hbase> alter 't1',
-    'coprocessor'=>'hdfs:///foo.jar|com.foo.FooRegionObserver|1001|arg1=1,arg2=2'
+  hbase> alter 't1', 'coprocessor' => {
+           'CLASSNAME' => 'org.apache.hadoop.hbase.coprocessor.SimpleRegionObserver',
+           'JAR_PATH' => 'hdfs:///foo.jar'
+           'PRIORITY' => 12,
+           'PROPERTIES' => {'a' => '17' }
+         }
 
 Since you can have multiple coprocessors configured for a table, a
 sequence number will be automatically appended to the attribute name
-to uniquely identify it.
-
-The coprocessor attribute must match the pattern below in order for
-the framework to understand how to load the coprocessor classes:
-
-  [coprocessor jar file location] | class name | [priority] | [arguments]
+to uniquely identify it. For example, the attribute name might be "coprocessor$1".
 
 You can also set configuration settings specific to this table or column family:
 


### PR DESCRIPTION
Resolves https://issues.apache.org/jira/browse/HBASE-24874

## Changelog

- Fix hbase-shell access in JDK 11 for calls to
  TableDescriptorBuilder.toCoprocessorDescriptor and
  ModifiableTableDescriptor.toStringTableAttributes.
- Allow coprocessors to be specified using a Ruby hash in the hbase-shell alter
  command and replace usage in the help text. The previous String overload of
  the alter command will continue to work and is still covered by a unit test,
  but will no longer be suggested in the alter command help.