### PR TITLE
HBASE-24776 [hbtop] Support Batch mode

### DIFF
--- a/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/HBTop.java
+++ b/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/HBTop.java
@@ -17,11 +17,17 @@
  */
 package org.apache.hadoop.hbase.hbtop;
 
+import java.util.ArrayList;
+import java.util.List;
 import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.hbtop.field.Field;
+import org.apache.hadoop.hbase.hbtop.field.FieldInfo;
 import org.apache.hadoop.hbase.hbtop.mode.Mode;
 import org.apache.hadoop.hbase.hbtop.screen.Screen;
 import org.apache.hadoop.util.Tool;
@@ -56,36 +62,19 @@ public class HBTop extends Configured implements Tool {
   public int run(String[] args) throws Exception {
     long initialRefreshDelay = 3 * 1000;
     Mode initialMode = Mode.REGION;
+    List<Field> initialFields = null;
+    Field initialSortField = null;
+    Boolean initialAscendingSort = null;
+    List<RecordFilter> initialFilters = null;
+    long numberOfIterations = Long.MAX_VALUE;
+    boolean batchMode = false;
     try {
-      // Command line options
-      Options opts = new Options();
-      opts.addOption("h", "help", false,
-        "Print usage; for help while the tool is running press 'h'");
-      opts.addOption("d", "delay", true,
-        "The refresh delay (in seconds); default is 3 seconds");
-      opts.addOption("m", "mode", true,
-        "The mode; n (Namespace)|t (Table)|r (Region)|s (RegionServer)"
-          + ", default is r (Region)");
-
+      Options opts = getOptions();
       CommandLine commandLine = new DefaultParser().parse(opts, args);
 
       if (commandLine.hasOption("help")) {
         printUsage(opts);
         return 0;
-      }
-
-      if (commandLine.hasOption("delay")) {
-        int delay = 0;
-        try {
-          delay = Integer.parseInt(commandLine.getOptionValue("delay"));
-        } catch (NumberFormatException ignored) {
-        }
-
-        if (delay < 1) {
-          LOGGER.warn("Delay set too low or invalid, using default");
-        } else {
-          initialRefreshDelay = delay * 1000L;
-        }
       }
 
       if (commandLine.hasOption("mode")) {
@@ -107,21 +96,146 @@ public class HBTop extends Configured implements Tool {
             initialMode = Mode.REGION_SERVER;
             break;
 
+          case "u":
+            initialMode = Mode.USER;
+            break;
+
+          case "c":
+            initialMode = Mode.CLIENT;
+            break;
+
           default:
             LOGGER.warn("Mode set invalid, using default");
             break;
         }
+      }
+
+      if (commandLine.hasOption("outputFieldNames")) {
+        initialMode.getFieldInfos().forEach(f -> System.out.println(f.getField().getHeader()));
+        return 0;
+      }
+
+      if (commandLine.hasOption("delay")) {
+        int delay = 0;
+        try {
+          delay = Integer.parseInt(commandLine.getOptionValue("delay"));
+        } catch (NumberFormatException ignored) {
+        }
+
+        if (delay < 1) {
+          LOGGER.warn("Delay set too low or invalid, using default");
+        } else {
+          initialRefreshDelay = delay * 1000L;
+        }
+      }
+
+      if (commandLine.hasOption("numberOfIterations")) {
+        try {
+          numberOfIterations = Long.parseLong(commandLine.getOptionValue("numberOfIterations"));
+        } catch (NumberFormatException ignored) {
+          LOGGER.warn("The number of iterations set invalid, ignoring");
+        }
+      }
+
+      if (commandLine.hasOption("sortField")) {
+        String sortField = commandLine.getOptionValue("sortField");
+
+        String field;
+        boolean ascendingSort;
+        if (sortField.startsWith("+")) {
+          field = sortField.substring(1);
+          ascendingSort = false;
+        } else if (sortField.startsWith("-")) {
+          field = sortField.substring(1);
+          ascendingSort = true;
+        } else {
+          field = sortField;
+          ascendingSort = false;
+        }
+
+        Optional<FieldInfo> fieldInfo = initialMode.getFieldInfos().stream()
+          .filter(f -> f.getField().getHeader().equals(field)).findFirst();
+        if (fieldInfo.isPresent()) {
+          initialSortField = fieldInfo.get().getField();
+          initialAscendingSort = ascendingSort;
+        } else {
+          LOGGER.warn("The specified sort field " + field + " is not found, using default");
+        }
+      }
+
+      if (commandLine.hasOption("fields")) {
+        String[] fields = commandLine.getOptionValue("fields").split(",");
+        initialFields = new ArrayList<>();
+        for (String field : fields) {
+          Optional<FieldInfo> fieldInfo = initialMode.getFieldInfos().stream()
+            .filter(f -> f.getField().getHeader().equals(field)).findFirst();
+          if (fieldInfo.isPresent()) {
+            initialFields.add(fieldInfo.get().getField());
+          } else {
+            LOGGER.warn("The specified field " + field + " is not found, ignoring");
+          }
+        }
+      }
+
+      if (commandLine.hasOption("filters")) {
+        String[] filters = commandLine.getOptionValue("filters").split(",");
+        List<Field> fields = initialMode.getFieldInfos().stream().map(FieldInfo::getField)
+          .collect(Collectors.toList());
+        for (String filter : filters) {
+          RecordFilter f = RecordFilter.parse(filter, fields, false);
+          if (f != null) {
+            if (initialFilters == null) {
+              initialFilters = new ArrayList<>();
+            }
+            initialFilters.add(f);
+          } else {
+            LOGGER.warn("The specified filter " + filter + " is invalid, ignoring");
+          }
+        }
+      }
+
+      if (commandLine.hasOption("batchMode")) {
+        batchMode = true;
       }
     } catch (Exception e) {
       LOGGER.error("Unable to parse options", e);
       return 1;
     }
 
-    try (Screen screen = new Screen(getConf(), initialRefreshDelay, initialMode)) {
+    try (Screen screen = new Screen(getConf(), initialRefreshDelay, initialMode, initialFields,
+      initialSortField, initialAscendingSort, initialFilters, numberOfIterations, batchMode)) {
       screen.run();
     }
 
     return 0;
+  }
+
+  private Options getOptions() {
+    Options opts = new Options();
+    opts.addOption("h", "help", false,
+      "Print usage; for help while the tool is running press 'h'");
+    opts.addOption("d", "delay", true,
+      "The refresh delay (in seconds); default is 3 seconds");
+    opts.addOption("m", "mode", true,
+      "The mode; n (Namespace)|t (Table)|r (Region)|s (RegionServer)|u (User)"
+        + "|c (Client), default is r");
+    opts.addOption("n", "numberOfIterations", true,
+      "The number of iterations");
+    opts.addOption("s", "sortField", true,
+      "The initial sort field. You can prepend a `+' or `-' to the field name to also override"
+        + " the sort direction. A leading `+' will force sorting high to low, whereas a `-' will"
+        + " ensure a low to high ordering");
+    opts.addOption("O", "outputFieldNames", false,
+      "Print each of the available field names on a separate line, then quit");
+    opts.addOption("f", "fields", true,
+      "Show only the given fields. Specify comma separated fields to show multiple fields");
+    opts.addOption("i", "filters", true,
+      "The initial filters. Specify comma separated filters to set multiple filters");
+    opts.addOption("b", "batchMode", false,
+      "Starts hbtop in Batch mode, which could be useful for sending output from hbtop to other"
+        + " programs or to a file. In this mode, hbtop will not accept input and runs until the"
+        + " iterations limit you've set with the `-n' command-line option or until killed");
+    return opts;
   }
 
   private void printUsage(Options opts) {

--- a/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/screen/AbstractScreenView.java
+++ b/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/screen/AbstractScreenView.java
@@ -75,6 +75,7 @@ public abstract class AbstractScreenView implements ScreenView {
     return terminal.getTerminalPrinter(startRow);
   }
 
+  @Nullable
   protected TerminalSize getTerminalSize() {
     return terminal.getSize();
   }

--- a/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/screen/top/TopScreenModel.java
+++ b/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/screen/top/TopScreenModel.java
@@ -19,13 +19,13 @@ package org.apache.hadoop.hbase.hbtop.screen.top;
 
 import static org.apache.commons.lang3.time.DateFormatUtils.ISO_8601_EXTENDED_TIME_FORMAT;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import java.util.Objects;
 import java.util.stream.Collectors;
-
 import org.apache.hadoop.hbase.ClusterMetrics;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.hbtop.Record;
@@ -64,28 +64,55 @@ public class TopScreenModel {
 
   private boolean ascendingSort;
 
-  public TopScreenModel(Admin admin, Mode initialMode) {
+  public TopScreenModel(Admin admin, Mode initialMode, @Nullable List<Field> initialFields,
+    @Nullable Field initialSortField, @Nullable Boolean initialAscendingSort,
+    @Nullable List<RecordFilter> initialFilters) {
     this.admin = Objects.requireNonNull(admin);
-    switchMode(Objects.requireNonNull(initialMode), null, false);
+    switchMode(Objects.requireNonNull(initialMode), initialSortField, false, initialFields,
+      initialAscendingSort, initialFilters);
   }
 
-  public void switchMode(Mode nextMode, List<RecordFilter> initialFilters,
-    boolean keepSortFieldAndSortOrderIfPossible) {
+  public void switchMode(Mode nextMode, boolean keepSortFieldAndSortOrderIfPossible,
+    List<RecordFilter> initialFilters) {
+    switchMode(nextMode, null, keepSortFieldAndSortOrderIfPossible, null, null, initialFilters);
+  }
 
+  public void switchMode(Mode nextMode, Field initialSortField,
+    boolean keepSortFieldAndSortOrderIfPossible, @Nullable List<Field> initialFields,
+    @Nullable Boolean initialAscendingSort, @Nullable List<RecordFilter> initialFilters) {
     currentMode = nextMode;
     fieldInfos = Collections.unmodifiableList(new ArrayList<>(currentMode.getFieldInfos()));
-    fields = Collections.unmodifiableList(currentMode.getFieldInfos().stream()
-      .map(FieldInfo::getField).collect(Collectors.toList()));
+
+    if (initialFields != null) {
+      List<Field> tmp = new ArrayList<>(initialFields);
+      tmp.addAll(currentMode.getFieldInfos().stream().map(FieldInfo::getField)
+        .filter(f -> !initialFields.contains(f))
+        .collect(Collectors.toList()));
+      fields = Collections.unmodifiableList(tmp);
+    } else {
+      fields = Collections.unmodifiableList(currentMode.getFieldInfos().stream()
+        .map(FieldInfo::getField).collect(Collectors.toList()));
+    }
 
     if (keepSortFieldAndSortOrderIfPossible) {
       boolean match = fields.stream().anyMatch(f -> f == currentSortField);
       if (!match) {
+        if (initialSortField != null && initialAscendingSort != null) {
+          currentSortField = initialSortField;
+          ascendingSort = initialAscendingSort;
+        } else {
+          currentSortField = nextMode.getDefaultSortField();
+          ascendingSort = false;
+        }
+      }
+    } else {
+      if (initialSortField != null && initialAscendingSort != null) {
+        currentSortField = initialSortField;
+        ascendingSort = initialAscendingSort;
+      } else {
         currentSortField = nextMode.getDefaultSortField();
         ascendingSort = false;
       }
-    } else {
-      currentSortField = nextMode.getDefaultSortField();
-      ascendingSort = false;
     }
 
     clearFilters();
@@ -173,7 +200,7 @@ public class TopScreenModel {
     if (drillDownInfo == null) {
       return false;
     }
-    switchMode(drillDownInfo.getNextMode(), drillDownInfo.getInitialFilters(), true);
+    switchMode(drillDownInfo.getNextMode(), true, drillDownInfo.getInitialFilters());
     return true;
   }
 

--- a/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/terminal/impl/batch/BatchTerminal.java
+++ b/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/terminal/impl/batch/BatchTerminal.java
@@ -1,0 +1,80 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.hbtop.terminal.impl.batch;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.apache.hadoop.hbase.hbtop.terminal.CursorPosition;
+import org.apache.hadoop.hbase.hbtop.terminal.KeyPress;
+import org.apache.hadoop.hbase.hbtop.terminal.Terminal;
+import org.apache.hadoop.hbase.hbtop.terminal.TerminalPrinter;
+import org.apache.hadoop.hbase.hbtop.terminal.TerminalSize;
+
+public class BatchTerminal implements Terminal {
+
+  private static final TerminalPrinter TERMINAL_PRINTER = new BatchTerminalPrinter();
+
+  @Override
+  public void clear() {
+  }
+
+  @Override
+  public void refresh() {
+    // Add a new line
+    TERMINAL_PRINTER.endOfLine();
+  }
+
+  @Nullable
+  @Override
+  public TerminalSize getSize() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public TerminalSize doResizeIfNecessary() {
+    return null;
+  }
+
+  @Nullable
+  @Override
+  public KeyPress pollKeyPress() {
+    return null;
+  }
+
+  @Override
+  public CursorPosition getCursorPosition() {
+    return null;
+  }
+
+  @Override
+  public void setCursorPosition(int column, int row) {
+  }
+
+  @Override
+  public void hideCursor() {
+  }
+
+  @Override
+  public TerminalPrinter getTerminalPrinter(int startRow) {
+    return TERMINAL_PRINTER;
+  }
+
+  @Override
+  public void close() {
+  }
+}

--- a/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/terminal/impl/batch/BatchTerminalPrinter.java
+++ b/hbase-hbtop/src/main/java/org/apache/hadoop/hbase/hbtop/terminal/impl/batch/BatchTerminalPrinter.java
@@ -15,25 +15,40 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hbase.hbtop.terminal;
+package org.apache.hadoop.hbase.hbtop.terminal.impl.batch;
 
-import edu.umd.cs.findbugs.annotations.Nullable;
-import java.io.Closeable;
-import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.hadoop.hbase.hbtop.terminal.TerminalPrinter;
 
+public class BatchTerminalPrinter implements TerminalPrinter {
 
-/**
- * The terminal interface that is an abstraction of terminal screen.
- */
-@InterfaceAudience.Private
-public interface Terminal extends Closeable {
-  void clear();
-  void refresh();
-  @Nullable TerminalSize getSize();
-  @Nullable TerminalSize doResizeIfNecessary();
-  @Nullable KeyPress pollKeyPress();
-  CursorPosition getCursorPosition();
-  void setCursorPosition(int column, int row);
-  void hideCursor();
-  TerminalPrinter getTerminalPrinter(int startRow);
+  @Override
+  public TerminalPrinter print(String value) {
+    System.out.print(value);
+    return this;
+  }
+
+  @Override
+  public TerminalPrinter startHighlight() {
+    return this;
+  }
+
+  @Override
+  public TerminalPrinter stopHighlight() {
+    return this;
+  }
+
+  @Override
+  public TerminalPrinter startBold() {
+    return this;
+  }
+
+  @Override
+  public TerminalPrinter stopBold() {
+    return this;
+  }
+
+  @Override
+  public void endOfLine() {
+    System.out.println();
+  }
 }

--- a/hbase-hbtop/src/test/java/org/apache/hadoop/hbase/hbtop/screen/top/TestTopScreenModel.java
+++ b/hbase-hbtop/src/test/java/org/apache/hadoop/hbase/hbtop/screen/top/TestTopScreenModel.java
@@ -63,7 +63,7 @@ public class TestTopScreenModel {
   @Before
   public void setup() throws IOException {
     when(admin.getClusterMetrics()).thenReturn(TestUtils.createDummyClusterMetrics());
-    topScreenModel = new TopScreenModel(admin, Mode.REGION);
+    topScreenModel = new TopScreenModel(admin, Mode.REGION, null, null, null, null);
 
     fields = Mode.REGION.getFieldInfos().stream()
       .map(FieldInfo::getField)
@@ -84,17 +84,17 @@ public class TestTopScreenModel {
     TestUtils.assertRecordsInRegionMode(topScreenModel.getRecords());
 
     // Namespace Mode
-    topScreenModel.switchMode(Mode.NAMESPACE, null, false);
+    topScreenModel.switchMode(Mode.NAMESPACE, false, null);
     topScreenModel.refreshMetricsData();
     TestUtils.assertRecordsInNamespaceMode(topScreenModel.getRecords());
 
     // Table Mode
-    topScreenModel.switchMode(Mode.TABLE, null, false);
+    topScreenModel.switchMode(Mode.TABLE, false, null);
     topScreenModel.refreshMetricsData();
     TestUtils.assertRecordsInTableMode(topScreenModel.getRecords());
 
     // Namespace Mode
-    topScreenModel.switchMode(Mode.REGION_SERVER, null, false);
+    topScreenModel.switchMode(Mode.REGION_SERVER, false, null);
     topScreenModel.refreshMetricsData();
     TestUtils.assertRecordsInRegionServerMode(topScreenModel.getRecords());
   }
@@ -168,7 +168,7 @@ public class TestTopScreenModel {
 
   @Test
   public void testSwitchMode() {
-    topScreenModel.switchMode(Mode.TABLE, null, false);
+    topScreenModel.switchMode(Mode.TABLE, false, null);
     assertThat(topScreenModel.getCurrentMode(), is(Mode.TABLE));
 
     // Test for initialFilters
@@ -176,7 +176,7 @@ public class TestTopScreenModel {
       RecordFilter.parse("TABLE==table1", fields, true),
       RecordFilter.parse("TABLE==table2", fields, true));
 
-    topScreenModel.switchMode(Mode.TABLE, initialFilters, false);
+    topScreenModel.switchMode(Mode.TABLE, false, initialFilters);
 
     assertThat(topScreenModel.getFilters().size(), is(initialFilters.size()));
     for (int i = 0; i < topScreenModel.getFilters().size(); i++) {
@@ -186,13 +186,13 @@ public class TestTopScreenModel {
 
     // Test when keepSortFieldAndSortOrderIfPossible is true
     topScreenModel.setSortFieldAndFields(Field.NAMESPACE, fields);
-    topScreenModel.switchMode(Mode.NAMESPACE, null, true);
+    topScreenModel.switchMode(Mode.NAMESPACE, true, null);
     assertThat(topScreenModel.getCurrentSortField(), is(Field.NAMESPACE));
   }
 
   @Test
   public void testDrillDown() {
-    topScreenModel.switchMode(Mode.TABLE, null, false);
+    topScreenModel.switchMode(Mode.TABLE, false, null);
     topScreenModel.setSortFieldAndFields(Field.NAMESPACE, fields);
     topScreenModel.refreshMetricsData();
 

--- a/hbase-hbtop/src/test/java/org/apache/hadoop/hbase/hbtop/screen/top/TestTopScreenPresenter.java
+++ b/hbase-hbtop/src/test/java/org/apache/hadoop/hbase/hbtop/screen/top/TestTopScreenPresenter.java
@@ -95,7 +95,8 @@ public class TestTopScreenPresenter {
     when(topScreenModel.getRecords()).thenReturn(TEST_RECORDS);
     when(topScreenModel.getSummary()).thenReturn(TEST_SUMMARY);
 
-    topScreenPresenter = new TopScreenPresenter(topScreenView, 3000, topScreenModel);
+    topScreenPresenter = new TopScreenPresenter(topScreenView, 3000, topScreenModel,
+      null, Long.MAX_VALUE);
   }
 
   @Test


### PR DESCRIPTION
Added the following command line parameters to hbtop:
| Argument | Description | 
|---|---|
| -n,--numberOfIterations <arg> | The number of iterations |
| -O,--outputFieldNames | Print each of the available field names on a separate line, then quit |
| -f,--fields <arg> | Show only the given fields. Specify comma separated fields to show multiple fields |
| -s,--sortField <arg> | The initial sort field. You can prepend a `+' or `-' to the field name to also override the sort direction. A leading `+' will force sorting high to low, whereas a `-' will ensure a low to high ordering |
| -i,--filters <arg> | The initial filters. Specify comma separated filters to set multiple filters |
| -b,--batchMode | Starts hbtop in Batch mode, which could be useful for sending output from hbtop to other programs or to a file. In this mode, hbtop will not accept input and runs until the iterations limit you've set with the `-n' command-line option or until killed |