### PR TITLE
HBASE-20598 - Upgrade to JRuby 9.2

### DIFF
--- a/hbase-shell/src/main/ruby/jar-bootstrap.rb
+++ b/hbase-shell/src/main/ruby/jar-bootstrap.rb
@@ -207,8 +207,16 @@ if interactive
       $0 = File.basename(ap_path, '.rb') if ap_path
 
       IRB.setup(ap_path)
+      IRB.conf[:PROMPT][:CUSTOM] = {
+        :PROMPT_I => "%N:%03n> ",
+        :PROMPT_S => "%N:%03n%l ",
+        :PROMPT_C => "%N:%03n* ",
+        :RETURN => "=> %s\n"
+      }
+
       @CONF[:IRB_NAME] = 'hbase'
       @CONF[:AP_NAME] = 'hbase'
+      @CONF[:PROMPT_MODE] = :CUSTOM
       @CONF[:BACK_TRACE_LIMIT] = 0 unless $fullBackTrace
 
       hirb = if @CONF[:SCRIPT]

--- a/hbase-shell/src/main/ruby/jar-bootstrap.rb
+++ b/hbase-shell/src/main/ruby/jar-bootstrap.rb
@@ -208,9 +208,9 @@ if interactive
 
       IRB.setup(ap_path)
       IRB.conf[:PROMPT][:CUSTOM] = {
-        :PROMPT_I => "%N:%03n> ",
-        :PROMPT_S => "%N:%03n%l ",
-        :PROMPT_C => "%N:%03n* ",
+        :PROMPT_I => "%N:%03n:%i> ",
+        :PROMPT_S => "%N:%03n:%i%l ",
+        :PROMPT_C => "%N:%03n:%i* ",
         :RETURN => "=> %s\n"
       }
 

--- a/pom.xml
+++ b/pom.xml
@@ -1633,7 +1633,7 @@
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <jettison.version>1.3.8</jettison.version>
     <!--Make sure these joni/jcodings are compatible with the versions used by jruby-->
-    <joni.version>2.1.40</joni.version>
+    <joni.version>2.1.31</joni.version>
     <jcodings.version>1.0.55</jcodings.version>
     <spy.version>2.12.2</spy.version>
     <bouncycastle.version>1.60</bouncycastle.version>

--- a/pom.xml
+++ b/pom.xml
@@ -1617,7 +1617,7 @@
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
     <glassfish.jsp.version>2.3.2</glassfish.jsp.version>
     <glassfish.el.version>3.0.1-b08</glassfish.el.version>
-    <jruby.version>9.1.17.0</jruby.version>
+    <jruby.version>9.2.13.0</jruby.version>
     <junit.version>4.13</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
     <htrace.version>4.2.0-incubating</htrace.version>
@@ -1633,8 +1633,8 @@
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <jettison.version>1.3.8</jettison.version>
     <!--Make sure these joni/jcodings are compatible with the versions used by jruby-->
-    <joni.version>2.1.11</joni.version>
-    <jcodings.version>1.0.18</jcodings.version>
+    <joni.version>2.1.40</joni.version>
+    <jcodings.version>1.0.55</jcodings.version>
     <spy.version>2.12.2</spy.version>
     <bouncycastle.version>1.60</bouncycastle.version>
     <kerby.version>1.0.1</kerby.version>


### PR DESCRIPTION
After upgrade, prompt changed (mainly what it prints as session name, used to be "main" now the hbase object instance name). We decided to change prompt to"%N:%03n>", %N being Irb.conf[:IRB_NAME] (hbase) and %03n the line number.

Add to docs:
For changelog please check https://www.jruby.org/news

Main changes:
JRuby 9.2.0 minor release:
- Ruby 2.5 language and stdlib support
- 225 issues fixed

JRuby versions up to 9.2.13.0 had various bugfixes, security fixes, performance improvements (memory reduction, runtime generations), IO improvements, basic support for java11,

Main gems changes:
- 9.2.11.0: Gems and gem paths packaged inside jar files will properly load now. This 9.2.10.0 regression was caused by a change in RubyGems 3 that exposed a bug in JRuby
- 9.2.10.0: RubyGems has been updated to version 3.0.6.

No change in license