### PR TITLE
HBASE-24765: Dynamic master discovery

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MasterAddressRefresher.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MasterAddressRefresher.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import java.io.Closeable;
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
+import org.apache.hbase.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.ClientMetaService;
+
+/**
+ * Thread safe utility that keeps master end points used by {@link MasterRegistry} up to date. This
+ * uses the RPC {@link ClientMetaService#getMasters} to fetch the latest list of registered masters.
+ * By default the refresh happens periodically (configured via
+ * {@link #PERIODIC_REFRESH_INTERVAL_SECS}). The refresh can also be triggered on demand via
+ * {@link #refreshNow()}. To prevent a flood of on-demand refreshes we expect that any attempts two
+ * should be spaced at least {@link #MIN_SECS_BETWEEN_REFRESHES} seconds apart.
+ */
+@InterfaceAudience.Private
+public class MasterAddressRefresher implements Closeable {
+  private static final Logger LOG = LoggerFactory.getLogger(MasterAddressRefresher.class);
+  public static final String PERIODIC_REFRESH_INTERVAL_SECS =
+      "hbase.client.master_registry.refresh_interval_secs";
+  private static final int PERIODIC_REFRESH_INTERVAL_SECS_DEFAULT = 300;
+  public static final String MIN_SECS_BETWEEN_REFRESHES =
+      "hbase.client.master_registry.min_secs_between_refreshes";
+  private static final int MIN_SECS_BETWEEN_REFRESHES_DEFAULT = 60;
+
+  private final ExecutorService pool;
+  private final MasterRegistry registry;
+  private final long periodicRefreshMs;
+  private final long timeBetweenRefreshesMs;
+  private final Object refreshMasters = new Object();
+
+  @Override
+  public void close() {
+    pool.shutdownNow();
+  }
+
+  /**
+   * Thread that refreshes the master end points until it is interrupted via {@link #close()}.
+   * Multiple callers attempting to refresh at the same time synchronize on {@link #refreshMasters}.
+   */
+  private class RefreshThread implements Runnable {
+    @Override
+    public void run() {
+      long lastRpcTs = 0;
+      while (!Thread.interrupted()) {
+        try {
+          // Spurious wake ups are okay, worst case we make an extra RPC call to refresh. We won't
+          // have duplicate refreshes because once the thread is past the wait(), notify()s are
+          // ignored until the thread is back to the waiting state.
+          synchronized (refreshMasters) {
+            refreshMasters.wait(periodicRefreshMs);
+          }
+          long currentTs = EnvironmentEdgeManager.currentTime();
+          if (lastRpcTs != 0 && currentTs - lastRpcTs <= timeBetweenRefreshesMs) {
+            continue;
+          }
+          lastRpcTs = currentTs;
+          LOG.debug("Attempting to refresh master address end points.");
+          Set<ServerName> newMasters = new HashSet<>(registry.getMasters().get());
+          registry.populateMasterStubs(newMasters);
+          LOG.debug("Finished refreshing master end points. {}", newMasters);
+        } catch (InterruptedException e) {
+          LOG.debug("Interrupted during wait, aborting refresh-masters-thread.", e);
+          break;
+        } catch (ExecutionException | IOException e) {
+          LOG.debug("Error populating latest list of masters.", e);
+        }
+      }
+      LOG.info("Master end point refresher loop exited.");
+    }
+  }
+
+  MasterAddressRefresher(Configuration conf, MasterRegistry registry) {
+    pool = Executors.newSingleThreadExecutor(new ThreadFactoryBuilder()
+        .setNameFormat("master-registry-refresh-end-points").setDaemon(true).build());
+    periodicRefreshMs = TimeUnit.SECONDS.toMillis(conf.getLong(PERIODIC_REFRESH_INTERVAL_SECS,
+        PERIODIC_REFRESH_INTERVAL_SECS_DEFAULT));
+    timeBetweenRefreshesMs = TimeUnit.SECONDS.toMillis(conf.getLong(MIN_SECS_BETWEEN_REFRESHES,
+        MIN_SECS_BETWEEN_REFRESHES_DEFAULT));
+    Preconditions.checkArgument(periodicRefreshMs > 0);
+    Preconditions.checkArgument(timeBetweenRefreshesMs < periodicRefreshMs);
+    this.registry = registry;
+    pool.submit(new RefreshThread());
+  }
+
+  /**
+   * Notifies the refresher thread to refresh the configuration. This does not guarantee a refresh.
+   * See class comment for details.
+   */
+  void refreshNow() {
+    synchronized (refreshMasters) {
+      refreshMasters.notify();
+    }
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MasterRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MasterRegistry.java
@@ -33,11 +33,13 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Predicate;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.exceptions.ClientExceptionsUtil;
 import org.apache.hadoop.hbase.exceptions.MasterRegistryFetchException;
 import org.apache.hadoop.hbase.ipc.HBaseRpcController;
 import org.apache.hadoop.hbase.ipc.RpcClient;
@@ -57,10 +59,11 @@ import org.apache.hbase.thirdparty.com.google.protobuf.RpcCallback;
 
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.ClientMetaService;
-import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetActiveMasterRequest;
-import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetActiveMasterResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetClusterIdRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetClusterIdResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetMastersRequest;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetMastersResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetMastersResponseEntry;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetMetaRegionLocationsRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.GetMetaRegionLocationsResponse;
 
@@ -89,11 +92,14 @@ public class MasterRegistry implements ConnectionRegistry {
   private final int hedgedReadFanOut;
 
   // Configured list of masters to probe the meta information from.
-  private final ImmutableMap<ServerName, ClientMetaService.Interface> masterAddr2Stub;
+  private volatile ImmutableMap<ServerName, ClientMetaService.Interface> masterAddr2Stub;
 
   // RPC client used to talk to the masters.
   private final RpcClient rpcClient;
   private final RpcControllerFactory rpcControllerFactory;
+  private final int rpcTimeoutMs;
+
+  protected final MasterAddressRefresher masterAddressRefresher;
 
   /**
    * Parses the list of master addresses from the provided configuration. Supported format is comma
@@ -115,20 +121,27 @@ public class MasterRegistry implements ConnectionRegistry {
   MasterRegistry(Configuration conf) throws IOException {
     this.hedgedReadFanOut = Math.max(1, conf.getInt(MASTER_REGISTRY_HEDGED_REQS_FANOUT_KEY,
       MASTER_REGISTRY_HEDGED_REQS_FANOUT_DEFAULT));
-    int rpcTimeoutMs = (int) Math.min(Integer.MAX_VALUE,
+    rpcTimeoutMs = (int) Math.min(Integer.MAX_VALUE,
       conf.getLong(HConstants.HBASE_RPC_TIMEOUT_KEY, HConstants.DEFAULT_HBASE_RPC_TIMEOUT));
     // XXX: we pass cluster id as null here since we do not have a cluster id yet, we have to fetch
     // this through the master registry...
     // This is a problem as we will use the cluster id to determine the authentication method
     rpcClient = RpcClientFactory.createClient(conf, null);
     rpcControllerFactory = RpcControllerFactory.instantiate(conf);
-    Set<ServerName> masterAddrs = parseMasterAddrs(conf);
+    // Generate the seed list of master stubs. Subsequent RPCs try to keep a live list of masters
+    // by fetching the end points from this list.
+    populateMasterStubs(parseMasterAddrs(conf));
+    masterAddressRefresher = new MasterAddressRefresher(conf, this);
+  }
+
+  void populateMasterStubs(Set<ServerName> masters) throws IOException {
+    Preconditions.checkNotNull(masters);
     ImmutableMap.Builder<ServerName, ClientMetaService.Interface> builder =
-      ImmutableMap.builderWithExpectedSize(masterAddrs.size());
+        ImmutableMap.builderWithExpectedSize(masters.size());
     User user = User.getCurrent();
-    for (ServerName masterAddr : masterAddrs) {
+    for (ServerName masterAddr : masters) {
       builder.put(masterAddr,
-        ClientMetaService.newStub(rpcClient.createRpcChannel(masterAddr, user, rpcTimeoutMs)));
+          ClientMetaService.newStub(rpcClient.createRpcChannel(masterAddr, user, rpcTimeoutMs)));
     }
     masterAddr2Stub = builder.build();
   }
@@ -169,7 +182,13 @@ public class MasterRegistry implements ConnectionRegistry {
     CompletableFuture<T> future = new CompletableFuture<>();
     callable.call(controller, stub, resp -> {
       if (controller.failed()) {
-        future.completeExceptionally(controller.getFailed());
+        IOException failureReason = controller.getFailed();
+        future.completeExceptionally(failureReason);
+        if (ClientExceptionsUtil.isConnectionException(failureReason)) {
+          // RPC has failed, trigger a refresh of master end points. We can have some spurious
+          // refreshes, but that is okay since the RPC is not expensive and not in a hot path.
+          masterAddressRefresher.refreshNow();
+        }
       } else {
         future.complete(resp);
       }
@@ -188,8 +207,9 @@ public class MasterRegistry implements ConnectionRegistry {
    * been tried and all of them are failed, we will fail the future.
    */
   private <T extends Message> void groupCall(CompletableFuture<T> future,
-    List<ClientMetaService.Interface> masterStubs, int startIndexInclusive, Callable<T> callable,
-    Predicate<T> isValidResp, String debug, ConcurrentLinkedQueue<Throwable> errors) {
+      Set<ServerName> masterServers, List<ClientMetaService.Interface> masterStubs,
+      int startIndexInclusive, Callable<T> callable, Predicate<T> isValidResp, String debug,
+      ConcurrentLinkedQueue<Throwable> errors) {
     int endIndexExclusive = Math.min(startIndexInclusive + hedgedReadFanOut, masterStubs.size());
     AtomicInteger remaining = new AtomicInteger(endIndexExclusive - startIndexInclusive);
     for (int i = startIndexInclusive; i < endIndexExclusive; i++) {
@@ -210,10 +230,10 @@ public class MasterRegistry implements ConnectionRegistry {
               RetriesExhaustedException ex = new RetriesExhaustedException("masters",
                 masterStubs.size(), new ArrayList<>(errors));
               future.completeExceptionally(
-                new MasterRegistryFetchException(masterAddr2Stub.keySet(), ex));
+                new MasterRegistryFetchException(masterServers, ex));
             } else {
-              groupCall(future, masterStubs, endIndexExclusive, callable, isValidResp, debug,
-                errors);
+              groupCall(future, masterServers, masterStubs, endIndexExclusive, callable,
+                  isValidResp, debug, errors);
             }
           }
         } else {
@@ -226,17 +246,20 @@ public class MasterRegistry implements ConnectionRegistry {
 
   private <T extends Message> CompletableFuture<T> call(Callable<T> callable,
     Predicate<T> isValidResp, String debug) {
-    List<ClientMetaService.Interface> masterStubs = new ArrayList<>(masterAddr2Stub.values());
+    ImmutableMap<ServerName, ClientMetaService.Interface> masterAddr2StubRef = masterAddr2Stub;
+    Set<ServerName> masterServers = masterAddr2StubRef.keySet();
+    List<ClientMetaService.Interface> masterStubs = new ArrayList<>(masterAddr2StubRef.values());
     Collections.shuffle(masterStubs, ThreadLocalRandom.current());
     CompletableFuture<T> future = new CompletableFuture<>();
-    groupCall(future, masterStubs, 0, callable, isValidResp, debug, new ConcurrentLinkedQueue<>());
+    groupCall(future, masterServers, masterStubs, 0, callable, isValidResp, debug,
+        new ConcurrentLinkedQueue<>());
     return future;
   }
 
   /**
    * Simple helper to transform the result of getMetaRegionLocations() rpc.
    */
-  private RegionLocations transformMetaRegionLocations(GetMetaRegionLocationsResponse resp) {
+  private static RegionLocations transformMetaRegionLocations(GetMetaRegionLocationsResponse resp) {
     List<HRegionLocation> regionLocations = new ArrayList<>();
     resp.getMetaLocationsList()
       .forEach(location -> regionLocations.add(ProtobufUtil.toRegionLocation(location)));
@@ -247,7 +270,7 @@ public class MasterRegistry implements ConnectionRegistry {
   public CompletableFuture<RegionLocations> getMetaRegionLocations() {
     return this.<GetMetaRegionLocationsResponse> call((c, s, d) -> s.getMetaRegionLocations(c,
       GetMetaRegionLocationsRequest.getDefaultInstance(), d), r -> r.getMetaLocationsCount() != 0,
-      "getMetaLocationsCount").thenApply(this::transformMetaRegionLocations);
+      "getMetaLocationsCount").thenApply(MasterRegistry::transformMetaRegionLocations);
   }
 
   @Override
@@ -259,17 +282,54 @@ public class MasterRegistry implements ConnectionRegistry {
       .thenApply(GetClusterIdResponse::getClusterId);
   }
 
-  private ServerName transformServerName(GetActiveMasterResponse resp) {
-    return ProtobufUtil.toServerName(resp.getServerName());
+  private static boolean hasActiveMaster(GetMastersResponse resp) {
+    List<GetMastersResponseEntry> activeMasters =
+        resp.getMasterServersList().stream().filter(GetMastersResponseEntry::getIsActive).collect(
+        Collectors.toList());
+    return activeMasters.size() == 1;
+  }
+
+  private static ServerName filterActiveMaster(GetMastersResponse resp) throws IOException {
+    List<GetMastersResponseEntry> activeMasters =
+        resp.getMasterServersList().stream().filter(GetMastersResponseEntry::getIsActive).collect(
+            Collectors.toList());
+    if (activeMasters.size() != 1) {
+      throw new IOException(String.format("Incorrect number of active masters encountered." +
+          " Expected: 1 found: %d. Content: %s", activeMasters.size(), activeMasters));
+    }
+    return ProtobufUtil.toServerName(activeMasters.get(0).getServerName());
   }
 
   @Override
   public CompletableFuture<ServerName> getActiveMaster() {
+    CompletableFuture<ServerName> future = new CompletableFuture<>();
+    addListener(call((c, s, d) -> s.getMasters(c, GetMastersRequest.getDefaultInstance(), d),
+      MasterRegistry::hasActiveMaster, "getMasters()"), (resp, ex) -> {
+        if (ex != null) {
+          future.completeExceptionally(ex);
+        }
+        ServerName result = null;
+        try {
+          result = filterActiveMaster((GetMastersResponse)resp);
+        } catch (IOException e) {
+          future.completeExceptionally(e);
+        }
+        future.complete(result);
+      });
+    return future;
+  }
+
+  private static List<ServerName> transformServerNames(GetMastersResponse resp) {
+    return resp.getMasterServersList().stream().map(s -> ProtobufUtil.toServerName(
+        s.getServerName())).collect(Collectors.toList());
+  }
+
+  CompletableFuture<List<ServerName>> getMasters() {
+    System.out.println("getMasters()");
     return this
-      .<GetActiveMasterResponse> call(
-        (c, s, d) -> s.getActiveMaster(c, GetActiveMasterRequest.getDefaultInstance(), d),
-        GetActiveMasterResponse::hasServerName, "getActiveMaster()")
-      .thenApply(this::transformServerName);
+        .<GetMastersResponse> call((c, s, d) -> s.getMasters(
+            c, GetMastersRequest.getDefaultInstance(), d), r -> r.getMasterServersCount() != 0,
+            "getMasters()").thenApply(MasterRegistry::transformServerNames);
   }
 
   @VisibleForTesting
@@ -279,6 +339,9 @@ public class MasterRegistry implements ConnectionRegistry {
 
   @Override
   public void close() {
+    if (masterAddressRefresher != null) {
+      masterAddressRefresher.close();
+    }
     if (rpcClient != null) {
       rpcClient.close();
     }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestMetricsConnection.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestMetricsConnection.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.codahale.metrics.RatioGauge;
 import com.codahale.metrics.RatioGauge.Ratio;
@@ -116,6 +117,11 @@ public class TestMetricsConnection {
               .setRegion(region)
               .build(),
           MetricsConnection.newCallStats());
+    }
+    for (String method: new String[]{"Get", "Scan", "Mutate"}) {
+      final String metricKey = "rpcCount_" + ClientService.getDescriptor().getName() + "_" + method;
+      final long metricVal = METRICS.rpcCounters.get(metricKey).getCount();
+      assertTrue("metric: " + metricKey + " val: " + metricVal, metricVal >= loop);
     }
     for (MetricsConnection.CallTracker t : new MetricsConnection.CallTracker[] {
       METRICS.getTracker, METRICS.scanTracker, METRICS.multiTracker, METRICS.appendTracker,

--- a/hbase-protocol-shaded/src/main/protobuf/Master.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/Master.proto
@@ -1220,6 +1220,17 @@ message GetActiveMasterResponse {
   optional ServerName server_name = 1;
 }
 
+/** Request and response to get the current list of all registers master servers */
+message GetMastersRequest {
+}
+message GetMastersResponseEntry {
+  required ServerName server_name = 1;
+  required bool is_active = 2;
+}
+message GetMastersResponse {
+  repeated GetMastersResponseEntry master_servers = 1;
+}
+
 /** Request and response to get the current list of meta region locations */
 message GetMetaRegionLocationsRequest {
 }
@@ -1229,7 +1240,8 @@ message GetMetaRegionLocationsResponse {
 }
 
 /**
- * Implements all the RPCs needed by clients to look up cluster meta information needed for connection establishment.
+ * Implements all the RPCs needed by clients to look up cluster meta information needed for
+ * connection establishment.
  */
 service ClientMetaService {
   /**
@@ -1238,9 +1250,15 @@ service ClientMetaService {
   rpc GetClusterId(GetClusterIdRequest) returns(GetClusterIdResponse);
 
   /**
-   * Get active master server name for this cluster.
+   * Get active master server name for this cluster. Retained for out of sync client and master
+   * rolling upgrades. Newer clients switched to GetMasters RPC request.
    */
   rpc GetActiveMaster(GetActiveMasterRequest) returns(GetActiveMasterResponse);
+
+  /**
+   * Get registered list of master servers in this cluster.
+   */
+  rpc GetMasters(GetMastersRequest) returns(GetMastersResponse);
 
   /**
    * Get current meta replicas' region locations.

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMasterAddressRefresher.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMasterAddressRefresher.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.Waiter;
+import org.apache.hadoop.hbase.testclassification.ClientTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.apache.hbase.thirdparty.com.google.common.util.concurrent.Uninterruptibles;
+
+@Category({ClientTests.class, SmallTests.class})
+public class TestMasterAddressRefresher {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestMasterAddressRefresher.class);
+
+  private class DummyMasterRegistry extends MasterRegistry {
+
+    private final AtomicInteger getMastersCallCounter = new AtomicInteger(0);
+    private final List<Long> callTimeStamps = new ArrayList<>();
+
+    DummyMasterRegistry(Configuration conf) throws IOException {
+      super(conf);
+    }
+
+    @Override
+    CompletableFuture<List<ServerName>> getMasters() {
+      getMastersCallCounter.incrementAndGet();
+      callTimeStamps.add(EnvironmentEdgeManager.currentTime());
+      return CompletableFuture.completedFuture(new ArrayList<>());
+    }
+
+    public int getMastersCount() {
+      return getMastersCallCounter.get();
+    }
+
+    public List<Long> getCallTimeStamps() {
+      return callTimeStamps;
+    }
+  }
+
+  @Test
+  public void testPeriodicMasterEndPointRefresh() throws IOException {
+    Configuration conf = HBaseConfiguration.create();
+    // Refresh every 1 second.
+    conf.setLong(MasterAddressRefresher.PERIODIC_REFRESH_INTERVAL_SECS, 1);
+    conf.setLong(MasterAddressRefresher.MIN_SECS_BETWEEN_REFRESHES, 0);
+    try (DummyMasterRegistry registry = new DummyMasterRegistry(conf)) {
+      // Wait for > 3 seconds to see that at least 3 getMasters() RPCs have been made.
+      Waiter.waitFor(
+          conf, 5000, (Waiter.Predicate<Exception>) () -> registry.getMastersCount() > 3);
+    }
+  }
+
+  @Test
+  public void testDurationBetweenRefreshes() throws IOException {
+    Configuration conf = HBaseConfiguration.create();
+    // Disable periodic refresh
+    conf.setLong(MasterAddressRefresher.PERIODIC_REFRESH_INTERVAL_SECS, Integer.MAX_VALUE);
+    // A minimum duration of 1s between refreshes
+    conf.setLong(MasterAddressRefresher.MIN_SECS_BETWEEN_REFRESHES, 1);
+    try (DummyMasterRegistry registry = new DummyMasterRegistry(conf)) {
+      // Issue a ton of manual refreshes.
+      for (int i = 0; i < 10000; i++) {
+        registry.masterAddressRefresher.refreshNow();
+        Uninterruptibles.sleepUninterruptibly(1, TimeUnit.MILLISECONDS);
+      }
+      // Overall wait time is 10000 ms, so the number of requests should be <=10
+      List<Long> callTimeStamps = registry.getCallTimeStamps();
+      // Actual calls to getMasters() should be much lower than the refresh count.
+      Assert.assertTrue(
+          String.valueOf(registry.getMastersCount()), registry.getMastersCount() <= 20);
+      Assert.assertTrue(callTimeStamps.size() > 0);
+      // Verify that the delta between subsequent RPCs is at least 1sec as configured.
+      for (int i = 1; i < callTimeStamps.size() - 1; i++) {
+        long delta = callTimeStamps.get(i) - callTimeStamps.get(i - 1);
+        // Few ms cushion to account for any env jitter.
+        Assert.assertTrue(callTimeStamps.toString(), delta > 990);
+      }
+    }
+
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMasterRegistry.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMasterRegistry.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.HConstants.META_REPLICAS_NUM;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -26,6 +28,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
@@ -33,6 +36,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.StartMiniClusterOption;
+import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
@@ -41,6 +45,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 
 @Category({ MediumTests.class, ClientTests.class })
 public class TestMasterRegistry {
@@ -124,6 +129,53 @@ public class TestMasterRegistry {
         Collections.sort(actualMetaLocations);
         assertEquals(actualMetaLocations, metaLocations);
       }
+    }
+  }
+
+  /**
+   * Tests that the list of masters configured in the MasterRegistry is dynamically refreshed in the
+   * event of errors.
+   */
+  @Test
+  public void testDynamicMasterConfigurationRefresh() throws Exception {
+    Configuration conf = new Configuration(TEST_UTIL.getConfiguration());
+    String currentMasterAddrs = Preconditions.checkNotNull(conf.get(HConstants.MASTER_ADDRS_KEY));
+    HMaster activeMaster = TEST_UTIL.getHBaseCluster().getMaster();
+    String clusterId = activeMaster.getClusterId();
+    // Add a non-working master
+    ServerName badServer = ServerName.valueOf("localhost", 1234, -1);
+    conf.set(HConstants.MASTER_ADDRS_KEY, badServer.toShortString() + "," + currentMasterAddrs);
+    // Set the hedging fan out so that all masters are queried.
+    conf.setInt(MasterRegistry.MASTER_REGISTRY_HEDGED_REQS_FANOUT_KEY, 4);
+    // Do not limit the number of refreshes during the test run.
+    conf.setLong(MasterAddressRefresher.MIN_SECS_BETWEEN_REFRESHES, 0);
+    try (MasterRegistry registry = new MasterRegistry(conf)) {
+      final Set<ServerName> masters = registry.getParsedMasterServers();
+      assertTrue(masters.contains(badServer));
+      // Make a registry RPC, this should trigger a refresh since one of the hedged RPC fails.
+      assertEquals(registry.getClusterId().get(), clusterId);
+      // Wait for new set of masters to be populated.
+      TEST_UTIL.waitFor(5000,
+          (Waiter.Predicate<Exception>) () -> !registry.getParsedMasterServers().equals(masters));
+      // new set of masters should not include the bad server
+      final Set<ServerName> newMasters = registry.getParsedMasterServers();
+      // Bad one should be out.
+      assertEquals(3, newMasters.size());
+      assertFalse(newMasters.contains(badServer));
+      // Kill the active master
+      activeMaster.stopMaster();
+      TEST_UTIL.waitFor(10000,
+        () -> TEST_UTIL.getMiniHBaseCluster().getLiveMasterThreads().size() == 2);
+      TEST_UTIL.getMiniHBaseCluster().waitForActiveAndReadyMaster(10000);
+      // Wait until the killed master de-registered. This should also trigger another refresh.
+      TEST_UTIL.waitFor(10000, () -> registry.getMasters().get().size() == 2);
+      TEST_UTIL.waitFor(20000, () -> registry.getParsedMasterServers().size() == 2);
+      final Set<ServerName> newMasters2 = registry.getParsedMasterServers();
+      assertEquals(2, newMasters2.size());
+      assertFalse(newMasters2.contains(activeMaster.getServerName()));
+    } finally {
+      // Reset the state, add a killed master.
+      TEST_UTIL.getMiniHBaseCluster().startMaster();
     }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/AlwaysStandByHMaster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/AlwaysStandByHMaster.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.master;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Server;
 import org.apache.hadoop.hbase.ServerName;
@@ -46,7 +47,8 @@ public class AlwaysStandByHMaster extends HMaster {
     private static final Logger LOG =
         LoggerFactory.getLogger(AlwaysStandByMasterManager.class);
 
-    AlwaysStandByMasterManager(ZKWatcher watcher, ServerName sn, Server master) {
+    AlwaysStandByMasterManager(ZKWatcher watcher, ServerName sn, Server master)
+        throws InterruptedIOException {
       super(watcher, sn, master);
     }
 
@@ -94,8 +96,8 @@ public class AlwaysStandByHMaster extends HMaster {
     super(conf);
   }
 
-  protected ActiveMasterManager createActiveMasterManager(
-      ZKWatcher zk, ServerName sn, org.apache.hadoop.hbase.Server server) {
+  protected ActiveMasterManager createActiveMasterManager(ZKWatcher zk, ServerName sn,
+      org.apache.hadoop.hbase.Server server) throws InterruptedIOException {
     return new AlwaysStandByMasterManager(zk, sn, server);
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestActiveMasterManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestActiveMasterManager.java
@@ -23,6 +23,9 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.io.InterruptedIOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.concurrent.Semaphore;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
@@ -42,6 +45,7 @@ import org.apache.hadoop.hbase.zookeeper.MasterAddressTracker;
 import org.apache.hadoop.hbase.zookeeper.ZKListener;
 import org.apache.hadoop.hbase.zookeeper.ZKUtil;
 import org.apache.hadoop.hbase.zookeeper.ZKWatcher;
+import org.apache.hadoop.hbase.zookeeper.ZNodePaths;
 import org.apache.zookeeper.KeeperException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -76,43 +80,45 @@ public class TestActiveMasterManager {
   }
 
   @Test public void testRestartMaster() throws IOException, KeeperException {
-    ZKWatcher zk = new ZKWatcher(TEST_UTIL.getConfiguration(),
-      "testActiveMasterManagerFromZK", null, true);
-    try {
-      ZKUtil.deleteNode(zk, zk.getZNodePaths().masterAddressZNode);
-      ZKUtil.deleteNode(zk, zk.getZNodePaths().clusterStateZNode);
-    } catch(KeeperException.NoNodeException nne) {}
+    try (ZKWatcher zk = new ZKWatcher(TEST_UTIL.getConfiguration(),
+      "testActiveMasterManagerFromZK", null, true)) {
+      try {
+        ZKUtil.deleteNode(zk, zk.getZNodePaths().masterAddressZNode);
+        ZKUtil.deleteNode(zk, zk.getZNodePaths().clusterStateZNode);
+      } catch (KeeperException.NoNodeException nne) {
+      }
 
-    // Create the master node with a dummy address
-    ServerName master = ServerName.valueOf("localhost", 1, System.currentTimeMillis());
-    // Should not have a master yet
-    DummyMaster dummyMaster = new DummyMaster(zk,master);
-    ClusterStatusTracker clusterStatusTracker =
-      dummyMaster.getClusterStatusTracker();
-    ActiveMasterManager activeMasterManager =
-      dummyMaster.getActiveMasterManager();
-    assertFalse(activeMasterManager.clusterHasActiveMaster.get());
-    assertFalse(activeMasterManager.getActiveMasterServerName().isPresent());
+      // Create the master node with a dummy address
+      ServerName master = ServerName.valueOf("localhost", 1, System.currentTimeMillis());
+      // Should not have a master yet
+      DummyMaster dummyMaster = new DummyMaster(zk, master);
+      ClusterStatusTracker clusterStatusTracker =
+          dummyMaster.getClusterStatusTracker();
+      ActiveMasterManager activeMasterManager =
+          dummyMaster.getActiveMasterManager();
+      assertFalse(activeMasterManager.clusterHasActiveMaster.get());
+      assertFalse(activeMasterManager.getActiveMasterServerName().isPresent());
 
-    // First test becoming the active master uninterrupted
-    MonitoredTask status = Mockito.mock(MonitoredTask.class);
-    clusterStatusTracker.setClusterUp();
+      // First test becoming the active master uninterrupted
+      MonitoredTask status = Mockito.mock(MonitoredTask.class);
+      clusterStatusTracker.setClusterUp();
 
-    activeMasterManager.blockUntilBecomingActiveMaster(100, status);
-    assertTrue(activeMasterManager.clusterHasActiveMaster.get());
-    assertMaster(zk, master);
-    assertMaster(zk, activeMasterManager.getActiveMasterServerName().get());
+      activeMasterManager.blockUntilBecomingActiveMaster(100, status);
+      assertTrue(activeMasterManager.clusterHasActiveMaster.get());
+      assertMaster(zk, master);
+      assertMaster(zk, activeMasterManager.getActiveMasterServerName().get());
 
-    // Now pretend master restart
-    DummyMaster secondDummyMaster = new DummyMaster(zk,master);
-    ActiveMasterManager secondActiveMasterManager =
-      secondDummyMaster.getActiveMasterManager();
-    assertFalse(secondActiveMasterManager.clusterHasActiveMaster.get());
-    activeMasterManager.blockUntilBecomingActiveMaster(100, status);
-    assertTrue(activeMasterManager.clusterHasActiveMaster.get());
-    assertMaster(zk, master);
-    assertMaster(zk, activeMasterManager.getActiveMasterServerName().get());
-    assertMaster(zk, secondActiveMasterManager.getActiveMasterServerName().get());
+      // Now pretend master restart
+      DummyMaster secondDummyMaster = new DummyMaster(zk, master);
+      ActiveMasterManager secondActiveMasterManager =
+          secondDummyMaster.getActiveMasterManager();
+      assertFalse(secondActiveMasterManager.clusterHasActiveMaster.get());
+      activeMasterManager.blockUntilBecomingActiveMaster(100, status);
+      assertTrue(activeMasterManager.clusterHasActiveMaster.get());
+      assertMaster(zk, master);
+      assertMaster(zk, activeMasterManager.getActiveMasterServerName().get());
+      assertMaster(zk, secondActiveMasterManager.getActiveMasterServerName().get());
+    }
   }
 
   /**
@@ -122,87 +128,122 @@ public class TestActiveMasterManager {
    */
   @Test
   public void testActiveMasterManagerFromZK() throws Exception {
-    ZKWatcher zk = new ZKWatcher(TEST_UTIL.getConfiguration(),
-      "testActiveMasterManagerFromZK", null, true);
-    try {
+    try (ZKWatcher zk = new ZKWatcher(TEST_UTIL.getConfiguration(),
+      "testActiveMasterManagerFromZK", null, true)) {
+      try {
+        ZKUtil.deleteNode(zk, zk.getZNodePaths().masterAddressZNode);
+        ZKUtil.deleteNode(zk, zk.getZNodePaths().clusterStateZNode);
+      } catch (KeeperException.NoNodeException nne) {
+      }
+
+      // Create the master node with a dummy address
+      ServerName firstMasterAddress =
+          ServerName.valueOf("localhost", 1, System.currentTimeMillis());
+      ServerName secondMasterAddress =
+          ServerName.valueOf("localhost", 2, System.currentTimeMillis());
+
+      // Should not have a master yet
+      DummyMaster ms1 = new DummyMaster(zk, firstMasterAddress);
+      ActiveMasterManager activeMasterManager =
+          ms1.getActiveMasterManager();
+      assertFalse(activeMasterManager.clusterHasActiveMaster.get());
+      assertFalse(activeMasterManager.getActiveMasterServerName().isPresent());
+
+      // First test becoming the active master uninterrupted
+      ClusterStatusTracker clusterStatusTracker =
+          ms1.getClusterStatusTracker();
+      clusterStatusTracker.setClusterUp();
+      activeMasterManager.blockUntilBecomingActiveMaster(100,
+          Mockito.mock(MonitoredTask.class));
+      assertTrue(activeMasterManager.clusterHasActiveMaster.get());
+      assertMaster(zk, firstMasterAddress);
+      assertMaster(zk, activeMasterManager.getActiveMasterServerName().get());
+
+      // New manager will now try to become the active master in another thread
+      WaitToBeMasterThread t = new WaitToBeMasterThread(zk, secondMasterAddress);
+      t.start();
+      // Wait for this guy to figure out there is another active master
+      // Wait for 1 second at most
+      int sleeps = 0;
+      while (!t.manager.clusterHasActiveMaster.get() && sleeps < 100) {
+        Thread.sleep(10);
+        sleeps++;
+      }
+
+      // Both should see that there is an active master
+      assertTrue(activeMasterManager.clusterHasActiveMaster.get());
+      assertTrue(t.manager.clusterHasActiveMaster.get());
+      // But secondary one should not be the active master
+      assertFalse(t.isActiveMaster);
+      // Verify the active master ServerName is populated in standby master.
+      assertEquals(firstMasterAddress, t.manager.getActiveMasterServerName().get());
+
+      // Close the first server and delete it's master node
+      ms1.stop("stopping first server");
+
+      // Use a listener to capture when the node is actually deleted
+      NodeDeletionListener listener = new NodeDeletionListener(zk,
+          zk.getZNodePaths().masterAddressZNode);
+      zk.registerListener(listener);
+
+      LOG.info("Deleting master node");
       ZKUtil.deleteNode(zk, zk.getZNodePaths().masterAddressZNode);
-      ZKUtil.deleteNode(zk, zk.getZNodePaths().clusterStateZNode);
-    } catch(KeeperException.NoNodeException nne) {}
 
-    // Create the master node with a dummy address
-    ServerName firstMasterAddress =
-        ServerName.valueOf("localhost", 1, System.currentTimeMillis());
-    ServerName secondMasterAddress =
-        ServerName.valueOf("localhost", 2, System.currentTimeMillis());
+      // Wait for the node to be deleted
+      LOG.info("Waiting for active master manager to be notified");
+      listener.waitForDeletion();
+      LOG.info("Master node deleted");
 
-    // Should not have a master yet
-    DummyMaster ms1 = new DummyMaster(zk,firstMasterAddress);
-    ActiveMasterManager activeMasterManager =
-      ms1.getActiveMasterManager();
-    assertFalse(activeMasterManager.clusterHasActiveMaster.get());
-    assertFalse(activeMasterManager.getActiveMasterServerName().isPresent());
+      // Now we expect the secondary manager to have and be the active master
+      // Wait for 1 second at most
+      sleeps = 0;
+      while (!t.isActiveMaster && sleeps < 100) {
+        Thread.sleep(10);
+        sleeps++;
+      }
+      LOG.debug("Slept " + sleeps + " times");
 
-    // First test becoming the active master uninterrupted
-    ClusterStatusTracker clusterStatusTracker =
-      ms1.getClusterStatusTracker();
-    clusterStatusTracker.setClusterUp();
-    activeMasterManager.blockUntilBecomingActiveMaster(100,
-        Mockito.mock(MonitoredTask.class));
-    assertTrue(activeMasterManager.clusterHasActiveMaster.get());
-    assertMaster(zk, firstMasterAddress);
-    assertMaster(zk, activeMasterManager.getActiveMasterServerName().get());
+      assertTrue(t.manager.clusterHasActiveMaster.get());
+      assertTrue(t.isActiveMaster);
+      assertEquals(secondMasterAddress, t.manager.getActiveMasterServerName().get());
 
-    // New manager will now try to become the active master in another thread
-    WaitToBeMasterThread t = new WaitToBeMasterThread(zk, secondMasterAddress);
-    t.start();
-    // Wait for this guy to figure out there is another active master
-    // Wait for 1 second at most
-    int sleeps = 0;
-    while(!t.manager.clusterHasActiveMaster.get() && sleeps < 100) {
-      Thread.sleep(10);
-      sleeps++;
+      LOG.info("Deleting master node");
+
+      ZKUtil.deleteNode(zk, zk.getZNodePaths().masterAddressZNode);
     }
+  }
 
-    // Both should see that there is an active master
-    assertTrue(activeMasterManager.clusterHasActiveMaster.get());
-    assertTrue(t.manager.clusterHasActiveMaster.get());
-    // But secondary one should not be the active master
-    assertFalse(t.isActiveMaster);
-    // Verify the active master ServerName is populated in standby master.
-    assertEquals(firstMasterAddress, t.manager.getActiveMasterServerName().get());
-
-    // Close the first server and delete it's master node
-    ms1.stop("stopping first server");
-
-    // Use a listener to capture when the node is actually deleted
-    NodeDeletionListener listener = new NodeDeletionListener(zk,
-            zk.getZNodePaths().masterAddressZNode);
-    zk.registerListener(listener);
-
-    LOG.info("Deleting master node");
-    ZKUtil.deleteNode(zk, zk.getZNodePaths().masterAddressZNode);
-
-    // Wait for the node to be deleted
-    LOG.info("Waiting for active master manager to be notified");
-    listener.waitForDeletion();
-    LOG.info("Master node deleted");
-
-    // Now we expect the secondary manager to have and be the active master
-    // Wait for 1 second at most
-    sleeps = 0;
-    while(!t.isActiveMaster && sleeps < 100) {
-      Thread.sleep(10);
-      sleeps++;
+  @Test
+  public void testBackupMasterUpdates() throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (ZKWatcher zk = new ZKWatcher(conf, "testBackupMasterUpdates", null, true)) {
+      ServerName sn1 = ServerName.valueOf("localhost", 1, -1);
+      DummyMaster master1 = new DummyMaster(zk, sn1);
+      ActiveMasterManager activeMasterManager = master1.getActiveMasterManager();
+      activeMasterManager.blockUntilBecomingActiveMaster(100,
+          Mockito.mock(MonitoredTask.class));
+      assertEquals(sn1, activeMasterManager.getActiveMasterServerName().get());
+      assertEquals(0, activeMasterManager.getBackupMasters().size());
+      // Add backup masters
+      List<String> backupZNodes = new ArrayList<>();
+      for (int i = 1; i <= 10; i++) {
+        ServerName backupSn = ServerName.valueOf("localhost", 1000 + i, -1);
+        String backupZn = ZNodePaths.joinZNode(
+            zk.getZNodePaths().backupMasterAddressesZNode, backupSn.toString());
+        backupZNodes.add(backupZn);
+        MasterAddressTracker.setMasterAddress(zk, backupZn, backupSn, 1234);
+        TEST_UTIL.waitFor(10000,
+          () -> activeMasterManager.getBackupMasters().size() == backupZNodes.size());
+      }
+      // Remove backup masters
+      int numBackups = backupZNodes.size();
+      for (String backupZNode: backupZNodes) {
+        ZKUtil.deleteNode(zk, backupZNode);
+        final int currentBackups = --numBackups;
+        TEST_UTIL.waitFor(10000,
+          () -> activeMasterManager.getBackupMasters().size() == currentBackups);
+      }
     }
-    LOG.debug("Slept " + sleeps + " times");
-
-    assertTrue(t.manager.clusterHasActiveMaster.get());
-    assertTrue(t.isActiveMaster);
-    assertEquals(secondMasterAddress, t.manager.getActiveMasterServerName().get());
-
-    LOG.info("Deleting master node");
-
-    ZKUtil.deleteNode(zk, zk.getZNodePaths().masterAddressZNode);
   }
 
   /**
@@ -212,12 +253,11 @@ public class TestActiveMasterManager {
    * @throws KeeperException unexpected Zookeeper exception
    * @throws IOException if an IO problem is encountered
    */
-  private void assertMaster(ZKWatcher zk,
-      ServerName expectedAddress)
-  throws KeeperException, IOException {
+  private void assertMaster(ZKWatcher zk, ServerName expectedAddress) throws
+      KeeperException, IOException {
     ServerName readAddress = MasterAddressTracker.getMasterAddress(zk);
     assertNotNull(readAddress);
-    assertTrue(expectedAddress.equals(readAddress));
+    assertEquals(expectedAddress, readAddress);
   }
 
   public static class WaitToBeMasterThread extends Thread {
@@ -226,7 +266,7 @@ public class TestActiveMasterManager {
     DummyMaster dummyMaster;
     boolean isActiveMaster;
 
-    public WaitToBeMasterThread(ZKWatcher zk, ServerName address) {
+    public WaitToBeMasterThread(ZKWatcher zk, ServerName address) throws InterruptedIOException {
       this.dummyMaster = new DummyMaster(zk,address);
       this.manager = this.dummyMaster.getActiveMasterManager();
       isActiveMaster = false;
@@ -274,7 +314,7 @@ public class TestActiveMasterManager {
     private ClusterStatusTracker clusterStatusTracker;
     private ActiveMasterManager activeMasterManager;
 
-    public DummyMaster(ZKWatcher zk, ServerName master) {
+    public DummyMaster(ZKWatcher zk, ServerName master) throws InterruptedIOException {
       this.clusterStatusTracker =
         new ClusterStatusTracker(zk, this);
       clusterStatusTracker.start();


### PR DESCRIPTION
This patch adds the ability to discover newly added masters
dynamically on the master registry side. The trigger for the
re-fetch is either periodic (5 mins) or any registry RPC failure.
Master server information is cached in masters to avoid repeated
ZK lookups.

Updates the client side connection metrics to maintain a counter
per RPC type so that clients have visibility into counts grouped
by RPC method name.

I didn't add the method to ZK registry interface since there
is a design discussion going on in splittable meta doc. We can
add it later if needed.

Signed-off-by: Nick Dimiduk <ndimiduk@apache.org>
Signed-off-by: Viraj Jasani <vjasani@apache.org>
Signed-off-by: Duo Zhang <zhangduo@apache.org>
(cherry picked from commit 275a38e1533eafa1d4bd1d50c13bcecd9a397ea8)