### PR TITLE
Hbase-24764 : Add support of adding base peer configs via hbase-site.xml for all replication peers

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
@@ -18,13 +18,14 @@
 
 package org.apache.hadoop.hbase.replication;
 
+import com.google.common.base.Splitter;
+
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
-import com.google.common.base.Splitter;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.classification.InterfaceAudience;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
@@ -127,7 +127,7 @@ public class ReplicationPeerConfig {
       for (Map.Entry<String,String> entry : basePeerConfigMap.entrySet()) {
         String configName = entry.getKey();
         String configValue = entry.getValue();
-        // Only override if base config does not exist in existing peer configs
+        // Only override if base config does not exist in existing replication peer configs
         if (!receivedPeerConfigMap.containsKey(configName)) {
           receivedPeerConfigMap.put(configName, configValue);
         }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
@@ -119,7 +119,6 @@ public class ReplicationPeerConfig {
    */
   public void addBasePeerConfigsIfNotPresent(Configuration conf) {
     String basePeerConfigs = conf.get(HBASE_REPLICATION_PEER_BASE_CONFIG, "");
-    Map<String,String> receivedPeerConfigMap = this.getConfiguration();
 
     if (basePeerConfigs.length() != 0) {
       Map<String, String> basePeerConfigMap = Splitter.on(';').trimResults().omitEmptyStrings()
@@ -128,8 +127,8 @@ public class ReplicationPeerConfig {
         String configName = entry.getKey();
         String configValue = entry.getValue();
         // Only override if base config does not exist in existing replication peer configs
-        if (!receivedPeerConfigMap.containsKey(configName)) {
-          receivedPeerConfigMap.put(configName, configValue);
+        if (!this.getConfiguration().containsKey(configName)) {
+          this.getConfiguration().put(configName, configValue);
         }
       }
     }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
@@ -24,6 +24,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 
+import com.google.common.base.Splitter;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.classification.InterfaceAudience;
 import org.apache.hadoop.hbase.classification.InterfaceStability;
@@ -42,6 +44,9 @@ public class ReplicationPeerConfig {
   private final Map<String, String> configuration;
   private Map<TableName, ? extends Collection<String>> tableCFsMap = null;
   private long bandwidth = 0;
+
+  public static final String HBASE_REPLICATION_PEER_BASE_CONFIG =
+    "hbase.replication.peer.default.config";
 
   public ReplicationPeerConfig() {
     this.peerData = new TreeMap<byte[], byte[]>(Bytes.BYTES_COMPARATOR);
@@ -97,6 +102,36 @@ public class ReplicationPeerConfig {
   public ReplicationPeerConfig setBandwidth(long bandwidth) {
     this.bandwidth = bandwidth;
     return this;
+  }
+
+  /**
+   * Helper method to add base peer configs from Configuration to ReplicationPeerConfig
+   * if not present in latter.
+   *
+   * This merges the user supplied peer configuration
+   * {@link org.apache.hadoop.hbase.replication.ReplicationPeerConfig} with peer configs
+   * provided as property hbase.replication.peer.base.configs in hbase configuration.
+   * Expected format for this hbase configuration is "k1=v1;k2=v2,v2_1". Original value
+   * of conf is retained if already present in ReplicationPeerConfig.
+   *
+   * @param conf Configuration
+   */
+  public void addBasePeerConfigsIfNotPresent(Configuration conf) {
+    String basePeerConfigs = conf.get(HBASE_REPLICATION_PEER_BASE_CONFIG, "");
+    Map<String,String> receivedPeerConfigMap = this.getConfiguration();
+
+    if (basePeerConfigs.length() != 0) {
+      Map<String, String> basePeerConfigMap = Splitter.on(';').trimResults().omitEmptyStrings()
+        .withKeyValueSeparator("=").split(basePeerConfigs);
+      for (Map.Entry<String,String> entry : basePeerConfigMap.entrySet()) {
+        String configName = entry.getKey();
+        String configValue = entry.getValue();
+        // Only override if base config does not exist in existing peer configs
+        if (!receivedPeerConfigMap.containsKey(configName)) {
+          receivedPeerConfigMap.put(configName, configValue);
+        }
+      }
+    }
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeersZKImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeersZKImpl.java
@@ -123,6 +123,7 @@ public class ReplicationPeersZKImpl extends ReplicationStateZKBase implements Re
 
       checkQueuesDeleted(id);
 
+      peerConfig.addBasePeerConfigsIfNotPresent(this.conf);
       ZKUtil.createWithParents(this.zookeeper, this.peersZNode);
 
       List<ZKUtilOp> listOfOps = new ArrayList<ZKUtil.ZKUtilOp>();
@@ -451,6 +452,9 @@ public class ReplicationPeersZKImpl extends ReplicationStateZKBase implements Re
     }
     ReplicationPeerZKImpl previous =
       ((ConcurrentMap<String, ReplicationPeerZKImpl>) peerClusters).putIfAbsent(peerId, peer);
+    ReplicationPeerConfig peerConfig = peerClusters.get(peerId).getPeerConfig();
+    peerConfig.addBasePeerConfigsIfNotPresent(this.conf);
+    updatePeerConfig(peerId, peerConfig);
     if (previous == null) {
       LOG.info("Added new peer cluster=" + peer.getPeerConfig().getClusterKey());
     } else {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-24764


JIRA Description:

Today, if a user needs to apply some common base peer configs to all the replication peers on the cluster,  the only way is to execute update_peer_config via CLI which requires manual intervention and can be tedious in case of large deployment fleet.

As part of this JIRA, we plan to add the support to have base replication peer configs as part of hbase-site.xml like hbase.replication.peer.base.config="k1=v1;k2=v2.." which can be easily updated and applied as part of a rolling restart. 

Example below:
```
    <property> 
    <name>hbase.replication.peer.base.configs</name>
<value>hbase.replication.source.custom.walentryfilters=x,y,z;hbase.rpc.protection=abc;hbase.xxx.custom_property=123</value>
    </property>
```

This property will be empty by default, but user can override to have base configs in place.

The final peer configuration would be a merge of whatever is currently present or what users override during the peer creation/update (if any) + this newly added base config.

Related Jira: https://issues.apache.org/jira/browse/HBASE-17543.  HBASE-17543 added the support to add the WALEntryFilters to default endpoint via peer configuration. 
By this new Jira we are extending the support to update peer configs via hbase-site.xml and hence WalEntryFilters or any other peer property can be applied just by rolling restart.

master branch PR : https://github.com/apache/hbase/pull/2284