### PR TITLE
[HBASE-24893] [branch-1] Fix failing TestLogLevel unit test on ci-hadoop

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
@@ -470,7 +470,7 @@ public class TestLogLevel {
     Throwable t = throwable;
     while (t != null) {
       String msg = t.toString();
-      if (msg != null && msg.contains(substr)) {
+      if (msg != null && msg.toLowerCase().contains(substr.toLowerCase())) {
         return;
       }
       t = t.getCause();


### PR DESCRIPTION
This PR introduces changes to fix the failing `TestLogLevel` unit tests.

Post making this change I looked into the branch-2 tests on ci-hadoop and found that the same test was passing for the same profile ie [JDK 8 + Hadoop 2]. So I delved into the code-base for this test in branch-2 and found that a similar fix had already been done to branch-2 as part of `HBASE-23829`. Here is the link to the PR introducing similar code change in branch-2 - https://github.com/apache/hbase/pull/1296/files#diff-88475ac51af9e041c429e33afc3e8ca0

This PR basically cherrypicks the changes in the TestLogLevel class as introduced in https://github.com/apache/hbase/pull/1296