### PR TITLE
HBASE-25002 Create simple pattern matching query for retrieving metri…

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/jmx/JMXJsonServlet.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/jmx/JMXJsonServlet.java
@@ -67,6 +67,21 @@ import org.slf4j.LoggerFactory;
  * </code> will return the cluster id of the namenode mxbean.
  * </p>
  * <p>
+ * If we are not sure on the exact attribute and we want to get all the attributes that match one or
+ * more given pattern then the format is
+ * <code>http://.../jmx?get=MXBeanName::*[RegExp1],*[RegExp2]</code>
+ * </p>
+ * <p>
+ * For example
+ * <code>
+ * <p>
+ * http://../jmx?get=Hadoop:service=HBase,name=RegionServer,sub=Tables::[a-zA-z_0-9]*memStoreSize
+ * </p>
+ * <p>
+ * http://../jmx?get=Hadoop:service=HBase,name=RegionServer,sub=Tables::[a-zA-z_0-9]*memStoreSize,[a-zA-z_0-9]*storeFileSize
+ * </p>
+ * </code>
+ * </p>
  * If the <code>qry</code> or the <code>get</code> parameter is not formatted
  * correctly then a 400 BAD REQUEST http response code will be returned.
  * </p>

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/util/JSONBean.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/util/JSONBean.java
@@ -131,7 +131,7 @@ public class JSONBean {
    */
   private static int write(JsonWriter writer, MBeanServer mBeanServer, ObjectName qry,
       String attribute, boolean description) throws IOException {
-    LOG.debug("Listing beans for " + qry);
+    LOG.debug("Listing beans for {}", qry);
     Set<ObjectName> names = null;
     names = mBeanServer.queryNames(qry, null);
     writer.name("beans").beginArray();
@@ -239,24 +239,13 @@ public class JSONBean {
       } else {
         MBeanAttributeInfo[] attrs = minfo.getAttributes();
         for (int i = 0; i < attrs.length; i++) {
-          if (matchingPattern != null) {
-            writeAttribute(writer, mBeanServer, oname, description, attrs[i], matchingPattern);
-          } else {
-            writeAttribute(writer, mBeanServer, oname, description, attrs[i]);
-          }
-
+          writeAttribute(writer, mBeanServer, oname, description, attrs[i], matchingPattern);
         }
       }
       writer.endObject();
     }
     writer.endArray();
     return 0;
-  }
-
-  private static void writeAttribute(final JsonWriter jg, final MBeanServer mBeanServer,
-      ObjectName oname, final boolean description, final MBeanAttributeInfo attr)
-      throws IOException {
-    writeAttribute(jg, mBeanServer, oname, description, attr, null);
   }
 
   private static void writeAttribute(JsonWriter writer, MBeanServer mBeanServer, ObjectName oname,

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/util/JSONBean.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/util/JSONBean.java
@@ -25,7 +25,6 @@ import java.lang.reflect.Array;
 import java.nio.charset.StandardCharsets;
 import java.util.Iterator;
 import java.util.Set;
-import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 
 import javax.management.AttributeNotFoundException;
@@ -43,13 +42,12 @@ import javax.management.RuntimeMBeanException;
 import javax.management.openmbean.CompositeData;
 import javax.management.openmbean.CompositeType;
 import javax.management.openmbean.TabularData;
-import org.apache.yetus.audience.InterfaceAudience;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
 
 import org.apache.hbase.thirdparty.com.google.gson.Gson;
 import org.apache.hbase.thirdparty.com.google.gson.stream.JsonWriter;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Utility for doing JSON and MBeans.
@@ -239,7 +237,7 @@ public class JSONBean {
       } else {
         MBeanAttributeInfo[] attrs = minfo.getAttributes();
         for (int i = 0; i < attrs.length; i++) {
-          writeAttribute(writer, mBeanServer, oname, description, attrs[i], matchingPattern);
+          writeAttribute(writer, mBeanServer, oname, description, matchingPattern, attrs[i]);
         }
       }
       writer.endObject();
@@ -249,7 +247,7 @@ public class JSONBean {
   }
 
   private static void writeAttribute(JsonWriter writer, MBeanServer mBeanServer, ObjectName oname,
-      boolean description, MBeanAttributeInfo attr, Pattern pattern[]) throws IOException {
+      boolean description, Pattern pattern[], MBeanAttributeInfo attr) throws IOException {
     if (!attr.isReadable()) {
       return;
     }

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/jmx/TestJMXJsonServlet.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/jmx/TestJMXJsonServlet.java
@@ -152,7 +152,8 @@ public class TestJMXJsonServlet extends HttpServerFunctionalTest {
 
   @Test
   public void testPatternMatching() throws Exception {
-    assertReFind("[a-zA-z_]*Table1[a-zA-z_]*memStoreSize", "Namespace_default_table_Table1_metric_memStoreSize");
+    assertReFind("[a-zA-z_]*Table1[a-zA-z_]*memStoreSize",
+      "Namespace_default_table_Table1_metric_memStoreSize");
     assertReFind("[a-zA-z_]*memStoreSize", "Namespace_default_table_Table1_metric_memStoreSize");
   }
 


### PR DESCRIPTION
Supports a pattern for getting a JMX metrics. This is helpful when we have multiple metrics under a the Tables category, then fetching the entire metric under Tables may be very big. So this helps to fetch a certain pattern of metrics alone and returns them as JSON.
The format is
http://../jmx?get=Hadoop:service=HBase,name=RegionServer,sub=Tables::[a-zA-z_0-9]*memStoreSize,[a-zA-z_0-9]*storeFileSize