### PR TITLE
Turn off cost function if multiplier <=0

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -204,19 +204,19 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     regionReplicaRackCostFunction = new RegionReplicaRackCostFunction(conf);
 
     costFunctions = new ArrayList<>();
-    costFunctions.add(new RegionCountSkewCostFunction(conf));
-    costFunctions.add(new PrimaryRegionCountSkewCostFunction(conf));
-    costFunctions.add(new MoveCostFunction(conf));
-    costFunctions.add(localityCost);
-    costFunctions.add(rackLocalityCost);
-    costFunctions.add(new TableSkewCostFunction(conf));
-    costFunctions.add(regionReplicaHostCostFunction);
-    costFunctions.add(regionReplicaRackCostFunction);
-    costFunctions.add(regionLoadFunctions[0]);
-    costFunctions.add(regionLoadFunctions[1]);
-    costFunctions.add(regionLoadFunctions[2]);
-    costFunctions.add(regionLoadFunctions[3]);
-    loadCustomCostFunctions(conf);
+
+    addCostFunction(new RegionCountSkewCostFunction(conf));
+    addCostFunction(new PrimaryRegionCountSkewCostFunction(conf));
+    addCostFunction(new MoveCostFunction(conf));
+    addCostFunction(localityCost);
+    addCostFunction(rackLocalityCost);
+    addCostFunction(new TableSkewCostFunction(conf));
+    addCostFunction(regionReplicaHostCostFunction);
+    addCostFunction(regionReplicaRackCostFunction);
+    addCostFunction(regionLoadFunctions[0]);
+    addCostFunction(regionLoadFunctions[1]);
+    addCostFunction(regionLoadFunctions[2]);
+    addCostFunction(regionLoadFunctions[3]);
 
     curFunctionCosts = new Double[costFunctions.size()];
     tempFunctionCosts = new Double[costFunctions.size()];
@@ -596,6 +596,14 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     }
   }
 
+  private void addCostFunction(CostFunction costFunction) {
+    if (costFunction.getMultiplier() <= 0) {
+      LOG.info("exclude cost function {}", costFunction.getClass().getSimpleName());
+    } else {
+      costFunctions.add(costFunction);
+    }
+  }
+  
   /**
    * Get the names of the cost functions
    */


### PR DESCRIPTION
StochastoicBalancer takes a long time to generate a plan for larger clusters. We want to make the cost functions optional.