### PR TITLE
Add a new ReplicationSource for hbase:meta WAL files. The new

### DIFF
--- a/hbase-replication/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerImpl.java
+++ b/hbase-replication/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -49,7 +49,7 @@ public class ReplicationPeerImpl implements ReplicationPeer {
       ReplicationPeerConfig peerConfig) {
     this.conf = conf;
     this.id = id;
-    this.peerState = peerState ? PeerState.ENABLED : PeerState.DISABLED;
+    setPeerState(peerState);
     this.peerConfig = peerConfig;
     this.peerConfigListeners = new ArrayList<>();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1765,7 +1765,7 @@ public class HMaster extends HRegionServer implements MasterServices {
           toPrint = regionsInTransition.subList(0, max);
           truncated = true;
         }
-        LOG.info(prefix + "unning balancer because " + regionsInTransition.size() +
+        LOG.info(prefix + " not running balancer because " + regionsInTransition.size() +
           " region(s) in transition: " + toPrint + (truncated? "(truncated list)": ""));
         if (!force || metaInTransition) return false;
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/EnableTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/EnableTableProcedure.java
@@ -141,9 +141,9 @@ public class EnableTableProcedure
             }
           } else {
             // the replicasFound is less than the regionReplication
-            LOG.info("Number of replicas has increased. Assigning new region replicas." +
+            LOG.info("Number of replicas has increased for {}. Assigning new region replicas." +
                 "The previous replica count was {}. The current replica count is {}.",
-                (currentMaxReplica + 1), configuredReplicaCount);
+              this.tableName, (currentMaxReplica + 1), configuredReplicaCount);
             regionsOfTable = RegionReplicaUtil.addReplicas(regionsOfTable,
               currentMaxReplica + 1, configuredReplicaCount);
           }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -119,10 +119,11 @@ import org.apache.hadoop.hbase.ipc.ServerRpcController;
 import org.apache.hadoop.hbase.log.HBaseMarkers;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.master.LoadBalancer;
-import org.apache.hadoop.hbase.master.RegionState.State;
 import org.apache.hadoop.hbase.master.RegionState;
 import org.apache.hadoop.hbase.master.balancer.BaseLoadBalancer;
 import org.apache.hadoop.hbase.mob.MobFileCache;
+import org.apache.hadoop.hbase.namequeues.NamedQueueRecorder;
+import org.apache.hadoop.hbase.namequeues.SlowLogTableOpsChore;
 import org.apache.hadoop.hbase.procedure.RegionServerProcedureManagerHost;
 import org.apache.hadoop.hbase.procedure2.RSProcedureCallable;
 import org.apache.hadoop.hbase.quotas.FileSystemUtilizationChore;
@@ -139,8 +140,6 @@ import org.apache.hadoop.hbase.regionserver.handler.CloseMetaHandler;
 import org.apache.hadoop.hbase.regionserver.handler.CloseRegionHandler;
 import org.apache.hadoop.hbase.regionserver.handler.RSProcedureHandler;
 import org.apache.hadoop.hbase.regionserver.handler.RegionReplicaFlushHandler;
-import org.apache.hadoop.hbase.namequeues.NamedQueueRecorder;
-import org.apache.hadoop.hbase.namequeues.SlowLogTableOpsChore;
 import org.apache.hadoop.hbase.regionserver.throttle.FlushThroughputControllerFactory;
 import org.apache.hadoop.hbase.regionserver.throttle.ThroughputController;
 import org.apache.hadoop.hbase.replication.regionserver.ReplicationLoad;
@@ -161,7 +160,6 @@ import org.apache.hadoop.hbase.util.CompressionTest;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSTableDescriptors;
 import org.apache.hadoop.hbase.util.FSUtils;
-import org.apache.hadoop.hbase.util.FutureUtils;
 import org.apache.hadoop.hbase.util.JvmPauseMonitor;
 import org.apache.hadoop.hbase.util.NettyEventLoopGroupConfig;
 import org.apache.hadoop.hbase.util.Pair;
@@ -175,7 +173,6 @@ import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
 import org.apache.hadoop.hbase.wal.NettyAsyncFSWALConfigHelper;
 import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.wal.WALFactory;
-import org.apache.hadoop.hbase.wal.WALProvider;
 import org.apache.hadoop.hbase.zookeeper.ClusterStatusTracker;
 import org.apache.hadoop.hbase.zookeeper.MasterAddressTracker;
 import org.apache.hadoop.hbase.zookeeper.MetaTableLocator;
@@ -1919,8 +1916,7 @@ public class HRegionServer extends Thread implements
       throw new IOException("Can not create wal directory " + logDir);
     }
     // Instantiate replication if replication enabled. Pass it the log directories.
-    createNewReplicationInstance(conf, this, this.walFs, logDir, oldLogDir,
-      factory.getWALProvider());
+    createNewReplicationInstance(conf, this, this.walFs, logDir, oldLogDir, factory);
     this.walFactory = factory;
   }
 
@@ -2218,9 +2214,9 @@ public class HRegionServer extends Thread implements
         this.walRoller.addWAL(wal);
       }
       return wal;
-    }catch (FailedCloseWALAfterInitializedErrorException ex) {
+    } catch (FailedCloseWALAfterInitializedErrorException ex) {
       // see HBASE-21751 for details
-      abort("wal can not clean up after init failed", ex);
+      abort("WAL can not clean up after init failed", ex);
       throw ex;
     }
   }
@@ -2229,7 +2225,7 @@ public class HRegionServer extends Thread implements
     return walRoller;
   }
 
-  WALFactory getWalFactory() {
+  public WALFactory getWalFactory() {
     return walFactory;
   }
 
@@ -2445,15 +2441,15 @@ public class HRegionServer extends Thread implements
 
   /**
    * Trigger a flush in the primary region replica if this region is a secondary replica. Does not
-   * block this thread. See RegionReplicaFlushHandler for details.
+   * block this thread. See {@link RegionReplicaFlushHandler} for details.
    */
   private void triggerFlushInPrimaryRegion(final HRegion region) {
     if (ServerRegionReplicaUtil.isDefaultReplica(region.getRegionInfo())) {
       return;
     }
-    if (!ServerRegionReplicaUtil.isRegionReplicaReplicationEnabled(region.conf) ||
-        !ServerRegionReplicaUtil.isRegionReplicaWaitForPrimaryFlushEnabled(
-          region.conf)) {
+    TableName tn = region.getTableDescriptor().getTableName();
+    if (!ServerRegionReplicaUtil.isRegionReplicaReplicationEnabled(region.conf, tn) ||
+        !ServerRegionReplicaUtil.isRegionReplicaWaitForPrimaryFlushEnabled(region.conf)) {
       region.setReadsEnabled(true);
       return;
     }
@@ -2461,10 +2457,13 @@ public class HRegionServer extends Thread implements
     region.setReadsEnabled(false); // disable reads before marking the region as opened.
     // RegionReplicaFlushHandler might reset this.
 
-    // submit it to be handled by one of the handlers so that we do not block OpenRegionHandler
+    // Submit it to be handled by one of the handlers so that we do not block OpenRegionHandler
     if (this.executorService != null) {
       this.executorService.submit(new RegionReplicaFlushHandler(this, clusterConnection,
-          rpcRetryingCallerFactory, rpcControllerFactory, operationTimeout, region));
+        rpcRetryingCallerFactory, rpcControllerFactory, operationTimeout, region));
+    } else {
+      LOG.info("Executor is null; not running flush of primary region replica for {}",
+        region.getRegionInfo());
     }
   }
 
@@ -3050,7 +3049,7 @@ public class HRegionServer extends Thread implements
    * Load the replication executorService objects, if any
    */
   private static void createNewReplicationInstance(Configuration conf, HRegionServer server,
-      FileSystem walFs, Path walDir, Path oldWALDir, WALProvider walProvider) throws IOException {
+      FileSystem walFs, Path walDir, Path oldWALDir, WALFactory walFactory) throws IOException {
     if ((server instanceof HMaster) &&
       (!LoadBalancer.isTablesOnMaster(conf) || LoadBalancer.isSystemTablesOnlyOnMaster(conf))) {
       return;
@@ -3068,19 +3067,19 @@ public class HRegionServer extends Thread implements
     // only one object.
     if (sourceClassname.equals(sinkClassname)) {
       server.replicationSourceHandler = newReplicationInstance(sourceClassname,
-        ReplicationSourceService.class, conf, server, walFs, walDir, oldWALDir, walProvider);
+        ReplicationSourceService.class, conf, server, walFs, walDir, oldWALDir, walFactory);
       server.replicationSinkHandler = (ReplicationSinkService) server.replicationSourceHandler;
     } else {
       server.replicationSourceHandler = newReplicationInstance(sourceClassname,
-        ReplicationSourceService.class, conf, server, walFs, walDir, oldWALDir, walProvider);
+        ReplicationSourceService.class, conf, server, walFs, walDir, oldWALDir, walFactory);
       server.replicationSinkHandler = newReplicationInstance(sinkClassname,
-        ReplicationSinkService.class, conf, server, walFs, walDir, oldWALDir, walProvider);
+        ReplicationSinkService.class, conf, server, walFs, walDir, oldWALDir, walFactory);
     }
   }
 
   private static <T extends ReplicationService> T newReplicationInstance(String classname,
       Class<T> xface, Configuration conf, HRegionServer server, FileSystem walFs, Path logDir,
-      Path oldLogDir, WALProvider walProvider) throws IOException {
+      Path oldLogDir, WALFactory walFactory) throws IOException {
     final Class<? extends T> clazz;
     try {
       ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
@@ -3089,7 +3088,7 @@ public class HRegionServer extends Thread implements
       throw new IOException("Could not find class for " + classname);
     }
     T service = ReflectionUtils.newInstance(clazz, conf);
-    service.initialize(server, walFs, logDir, oldLogDir, walProvider);
+    service.initialize(server, walFs, logDir, oldLogDir, walFactory);
     return service;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/ReplicationService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/ReplicationService.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -22,7 +22,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Server;
 import org.apache.hadoop.hbase.replication.regionserver.ReplicationLoad;
-import org.apache.hadoop.hbase.wal.WALProvider;
+import org.apache.hadoop.hbase.wal.WALFactory;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -32,14 +32,11 @@ import org.apache.yetus.audience.InterfaceAudience;
  */
 @InterfaceAudience.Private
 public interface ReplicationService {
-
   /**
    * Initializes the replication service object.
-   * @param walProvider can be null if not initialized inside a live region server environment, for
-   *          example, {@code ReplicationSyncUp}.
    */
-  void initialize(Server rs, FileSystem fs, Path logdir, Path oldLogDir, WALProvider walProvider)
-      throws IOException;
+  void initialize(Server rs, FileSystem fs, Path logdir, Path oldLogDir, WALFactory walFactory)
+    throws IOException;
 
   /**
    * Start replication services.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
@@ -20,8 +20,11 @@ package org.apache.hadoop.hbase.regionserver.handler;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.executor.EventHandler;
 import org.apache.hadoop.hbase.executor.EventType;
@@ -30,7 +33,10 @@ import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices.PostOpenDeployContext;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices.RegionStateTransitionContext;
+import org.apache.hadoop.hbase.regionserver.wal.WALActionsListener;
 import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
+import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -92,7 +98,7 @@ public class AssignRegionHandler extends EventHandler {
     String regionName = regionInfo.getRegionNameAsString();
     Region onlineRegion = rs.getRegion(encodedName);
     if (onlineRegion != null) {
-      LOG.warn("Received OPEN for the region:{}, which is already online", regionName);
+      LOG.warn("Received OPEN for {} which is already online", regionName);
       // Just follow the old behavior, do we need to call reportRegionStateTransition? Maybe not?
       // For normal case, it could happen that the rpc call to schedule this handler is succeeded,
       // but before returning to master the connection is broken. And when master tries again, we
@@ -104,7 +110,7 @@ public class AssignRegionHandler extends EventHandler {
     if (previous != null) {
       if (previous) {
         // The region is opening and this maybe a retry on the rpc call, it is safe to ignore it.
-        LOG.info("Receiving OPEN for the region:{}, which we are already trying to OPEN" +
+        LOG.info("Receiving OPEN for {} which we are already trying to OPEN" +
           " - ignoring this new request for this region.", regionName);
       } else {
         // The region is closing. This is possible as we will update the region state to CLOSED when
@@ -113,7 +119,7 @@ public class AssignRegionHandler extends EventHandler {
         // closing process.
         long backoff = retryCounter.getBackoffTimeAndIncrementAttempts();
         LOG.info(
-          "Receiving OPEN for the region:{}, which we are trying to close, try again after {}ms",
+          "Receiving OPEN for {} which we are trying to close, try again after {}ms",
           regionName, backoff);
         rs.getExecutorService().delayedSubmit(this, backoff, TimeUnit.MILLISECONDS);
       }
@@ -129,8 +135,15 @@ public class AssignRegionHandler extends EventHandler {
       }
       // pass null for the last parameter, which used to be a CancelableProgressable, as now the
       // opening can not be interrupted by a close request any more.
-      region = HRegion.openHRegion(regionInfo, htd, rs.getWAL(regionInfo), rs.getConfiguration(),
-        rs, null);
+      Configuration conf = rs.getConfiguration();
+      TableName tn = htd.getTableName();
+      if (ServerRegionReplicaUtil.isMetaRegionReplicaReplicationEnabled(conf, tn)) {
+        if (RegionReplicaUtil.isDefaultReplica(this.regionInfo.getReplicaId())) {
+          // Add the hbase:meta replication source on replica zero/default.
+          rs.getReplicationSourceService().getReplicationManager().addHBaseMetaSource();
+        }
+      }
+      region = HRegion.openHRegion(regionInfo, htd, rs.getWAL(regionInfo), conf, rs, null);
     } catch (IOException e) {
       cleanUpAndReportFailure(e);
       return;
@@ -145,11 +158,10 @@ public class AssignRegionHandler extends EventHandler {
     Boolean current = rs.getRegionsInTransitionInRS().remove(regionInfo.getEncodedNameAsBytes());
     if (current == null) {
       // Should NEVER happen, but let's be paranoid.
-      LOG.error("Bad state: we've just opened a region that was NOT in transition. Region={}",
-        regionName);
+      LOG.error("Bad state: we've just opened {} which was NOT in transition", regionName);
     } else if (!current) {
       // Should NEVER happen, but let's be paranoid.
-      LOG.error("Bad state: we've just opened a region that was closing. Region={}", regionName);
+      LOG.error("Bad state: we've just opened {} which was closing", regionName);
     }
   }
 
@@ -168,7 +180,7 @@ public class AssignRegionHandler extends EventHandler {
       long openProcId, TableDescriptor tableDesc, long masterSystemTime) {
     EventType eventType;
     if (regionInfo.isMetaRegion()) {
-      eventType = EventType.M_RS_CLOSE_META;
+      eventType = EventType.M_RS_OPEN_META;
     } else if (regionInfo.getTable().isSystemTable() ||
       (tableDesc != null && tableDesc.getPriority() >= HConstants.ADMIN_QOS)) {
       eventType = EventType.M_RS_OPEN_PRIORITY_REGION;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.executor.EventHandler;
 import org.apache.hadoop.hbase.executor.EventType;
 import org.apache.hadoop.hbase.regionserver.HRegion;
@@ -30,6 +31,7 @@ import org.apache.hadoop.hbase.regionserver.Region;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices.RegionStateTransitionContext;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -84,19 +86,18 @@ public class UnassignRegionHandler extends EventHandler {
         // reportRegionStateTransition, so the HMaster will think the region is online, before we
         // actually open the region, as reportRegionStateTransition is part of the opening process.
         long backoff = retryCounter.getBackoffTimeAndIncrementAttempts();
-        LOG.warn("Received CLOSE for the region: {}, which we are already " +
-          "trying to OPEN. try again after {}ms", encodedName, backoff);
+        LOG.warn("Received CLOSE for {} which we are already " +
+          "trying to OPEN; try again after {}ms", encodedName, backoff);
         rs.getExecutorService().delayedSubmit(this, backoff, TimeUnit.MILLISECONDS);
       } else {
-        LOG.info("Received CLOSE for the region: {}, which we are already trying to CLOSE," +
+        LOG.info("Received CLOSE for {} which we are already trying to CLOSE," +
           " but not completed yet", encodedName);
       }
       return;
     }
     HRegion region = rs.getRegion(encodedName);
     if (region == null) {
-      LOG.debug(
-        "Received CLOSE for a region {} which is not online, and we're not opening/closing.",
+      LOG.debug("Received CLOSE for {} which is not ONLINE and we're not opening/closing.",
         encodedName);
       rs.getRegionsInTransitionInRS().remove(encodedNameBytes, Boolean.FALSE);
       return;
@@ -114,11 +115,20 @@ public class UnassignRegionHandler extends EventHandler {
     if (region.close(abort) == null) {
       // XXX: Is this still possible? The old comment says about split, but now split is done at
       // master side, so...
-      LOG.warn("Can't close region {}, was already closed during close()", regionName);
+      LOG.warn("Can't close for {} which was already closed during close()", regionName);
       rs.getRegionsInTransitionInRS().remove(encodedNameBytes, Boolean.FALSE);
       return;
     }
+
     rs.removeRegion(region, destination);
+    if (ServerRegionReplicaUtil.isMetaRegionReplicaReplicationEnabled(rs.getConfiguration(),
+        region.getTableDescriptor().getTableName())) {
+      if (RegionReplicaUtil.isDefaultReplica(region.getRegionInfo().getReplicaId())) {
+        // If hbase:meta read replicas enabled, remove replication source for hbase:meta Regions.
+        // See assign region handler where we add the replication source on open.
+        rs.getReplicationSourceService().getReplicationManager().removeHBaseMetaSource();
+      }
+    }
     if (!rs.reportRegionStateTransition(
       new RegionStateTransitionContext(TransitionCode.CLOSED, HConstants.NO_SEQNUM, closeProcId,
         -1, region.getRegionInfo()))) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogReader.java
@@ -412,14 +412,14 @@ public class ProtobufLogReader extends ReaderBase {
           + "because originalPosition is negative. last offset={}", this.inputStream.getPos(), eof);
         throw eof;
       }
-      // If stuck at the same place and we got and exception, lets go back at the beginning.
+      // If stuck at the same place and we got an exception, lets go back at the beginning.
       if (inputStream.getPos() == originalPosition) {
         if (resetPosition) {
           LOG.warn("Encountered a malformed edit, seeking to the beginning of the WAL since "
             + "current position and original position match at {}", originalPosition);
           seekOnFs(0);
         } else {
-          LOG.debug("Reached the end of file at position {}", originalPosition);
+          LOG.debug("EOF at position {}", originalPosition);
         }
       } else {
         // Else restore our position to original location in hope that next time through we will

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/HBaseMetaNoQueueStoreReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/HBaseMetaNoQueueStoreReplicationSource.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.replication.regionserver;
+
+import java.util.Collections;
+import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
+import org.apache.hadoop.hbase.wal.WALProvider;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * ReplicationSource that reads hbase:meta WAL files and lets through all WALEdits from these WALs.
+ * It only considers meta WALs -- user-space WALs are filtered out -- and it lets through ALL edits
+ * (default implementation filters OUT hbase:meta edits). Pass the hbase:meta WALProvider, NOT a
+ * user-space WALProvider, else this source will produce no edits. This implementation does NOT
+ * make use of backing storage intentionally; use if do not want to make use of the queue-recovery
+ * feature on server crash.
+ */
+@InterfaceAudience.Private
+class HBaseMetaNoQueueStoreReplicationSource extends ReplicationSource {
+  /**
+   * @param walProvider Pass the hbase:meta WALProvider!
+   */
+  HBaseMetaNoQueueStoreReplicationSource(WALProvider walProvider) {
+    // Filters in hbase:meta WAL files and allows all edits, including 'meta' edits (these are
+    // filtered out in the 'super' class default implementation).
+    super(walProvider, p -> AbstractFSWALProvider.isMetaFile(p), Collections.emptyList());
+  }
+
+  @Override public boolean isQueuePersisted() {
+    // Do NOT persist queues to the replication store when doing hbase:meta replication.
+    return false;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RecoveredReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RecoveredReplicationSource.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -32,6 +32,7 @@ import org.apache.hadoop.hbase.replication.ReplicationQueueStorage;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.Threads;
 import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
+import org.apache.hadoop.hbase.wal.WALProvider;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -42,18 +43,19 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.Private
 public class RecoveredReplicationSource extends ReplicationSource {
-
   private static final Logger LOG = LoggerFactory.getLogger(RecoveredReplicationSource.class);
-
   private String actualPeerId;
+
+  RecoveredReplicationSource(WALProvider walProvider) {
+    super(walProvider);
+  }
 
   @Override
   public void init(Configuration conf, FileSystem fs, ReplicationSourceManager manager,
       ReplicationQueueStorage queueStorage, ReplicationPeer replicationPeer, Server server,
-      String peerClusterZnode, UUID clusterId, WALFileLengthProvider walFileLengthProvider,
-      MetricsSource metrics) throws IOException {
+      String peerClusterZnode, UUID clusterId, MetricsSource metrics) {
     super.init(conf, fs, manager, queueStorage, replicationPeer, server, peerClusterZnode,
-      clusterId, walFileLengthProvider, metrics);
+      clusterId, metrics);
     this.actualPeerId = this.replicationQueueInfo.getPeerId();
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/Replication.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/Replication.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,7 +20,6 @@ package org.apache.hadoop.hbase.replication.regionserver;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -42,7 +41,7 @@ import org.apache.hadoop.hbase.replication.ReplicationStorageFactory;
 import org.apache.hadoop.hbase.replication.ReplicationTracker;
 import org.apache.hadoop.hbase.replication.ReplicationUtils;
 import org.apache.hadoop.hbase.util.Pair;
-import org.apache.hadoop.hbase.wal.WALProvider;
+import org.apache.hadoop.hbase.wal.WALFactory;
 import org.apache.hadoop.hbase.zookeeper.ZKClusterId;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.KeeperException;
@@ -85,7 +84,7 @@ public class Replication implements ReplicationSourceService, ReplicationSinkSer
 
   @Override
   public void initialize(Server server, FileSystem fs, Path logDir, Path oldLogDir,
-      WALProvider walProvider) throws IOException {
+      WALFactory walFactory) throws IOException {
     this.server = server;
     this.conf = this.server.getConfiguration();
     this.isReplicationForBulkLoadDataEnabled =
@@ -123,14 +122,9 @@ public class Replication implements ReplicationSourceService, ReplicationSinkSer
     }
     this.globalMetricsSource = CompatibilitySingletonFactory
         .getInstance(MetricsReplicationSourceFactory.class).getGlobalSource();
-    this.replicationManager = new ReplicationSourceManager(queueStorage, replicationPeers, replicationTracker, conf,
-      this.server, fs, logDir, oldLogDir, clusterId,
-        walProvider != null ? walProvider.getWALFileLengthProvider() : p -> OptionalLong.empty(),
-        globalMetricsSource);
-    if (walProvider != null) {
-      walProvider
-        .addWALActionsListener(new ReplicationSourceWALActionListener(conf, replicationManager));
-    }
+    this.replicationManager = new ReplicationSourceManager(queueStorage, replicationPeers,
+      replicationTracker, conf, this.server, fs, logDir, oldLogDir, clusterId, globalMetricsSource,
+      walFactory);
     this.statsThreadPeriod =
         this.conf.getInt("replication.stats.thread.period.seconds", 5 * 60);
     LOG.debug("Replication stats-in-log period={} seconds",  this.statsThreadPeriod);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceShipper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceShipper.java
@@ -260,8 +260,7 @@ public class ReplicationSourceShipper extends Thread {
     // position and the file will be removed soon in cleanOldLogs.
     if (batch.isEndOfFile() || !batch.getLastWalPath().equals(currentPath) ||
       batch.getLastWalPosition() != currentPosition) {
-      source.getSourceManager().logPositionAndCleanOldLogs(source.getQueueId(),
-        source.isRecovered(), batch);
+      source.getSourceManager().logPositionAndCleanOldLogs(source, batch);
       updated = true;
     }
     // if end of file is true, then we can just skip to the next file in queue.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStream.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStream.java
@@ -174,7 +174,7 @@ class WALEntryStream implements Closeable {
   private void tryAdvanceEntry() throws IOException {
     if (checkReader()) {
       boolean beingWritten = readNextEntryAndRecordReaderPosition();
-      LOG.trace("reading wal file {}. Current open for write: {}", this.currentPath, beingWritten);
+      LOG.trace("Reading WAL {}; currently open for write={}", this.currentPath, beingWritten);
       if (currentEntry == null && !beingWritten) {
         // no more entries in this log file, and the file is already closed, i.e, rolled
         // Before dequeueing, we should always get one more attempt at reading.
@@ -222,7 +222,7 @@ class WALEntryStream implements Closeable {
         if (currentPositionOfReader < stat.getLen()) {
           final long skippedBytes = stat.getLen() - currentPositionOfReader;
           LOG.debug(
-            "Reached the end of WAL file '{}'. It was not closed cleanly," +
+            "Reached the end of WAL {}. It was not closed cleanly," +
               " so we did not parse {} bytes of data. This is normally ok.",
             currentPath, skippedBytes);
           metrics.incrUncleanlyClosedWALs();
@@ -230,7 +230,7 @@ class WALEntryStream implements Closeable {
         }
       } else if (currentPositionOfReader + trailerSize < stat.getLen()) {
         LOG.warn(
-          "Processing end of WAL file '{}'. At position {}, which is too far away from" +
+          "Processing end of WAL {} at position {}, which is too far away from" +
             " reported file length {}. Restarting WAL reading (see HBASE-15983 for details). {}",
           currentPath, currentPositionOfReader, stat.getLen(), getCurrentPathStat());
         setPosition(0);
@@ -241,7 +241,7 @@ class WALEntryStream implements Closeable {
       }
     }
     if (LOG.isTraceEnabled()) {
-      LOG.trace("Reached the end of log " + this.currentPath + ", and the length of the file is " +
+      LOG.trace("Reached the end of " + this.currentPath + " and length of the file is " +
         (stat == null ? "N/A" : stat.getLen()));
     }
     metrics.incrCompletedWAL();
@@ -249,7 +249,7 @@ class WALEntryStream implements Closeable {
   }
 
   private void dequeueCurrentLog() throws IOException {
-    LOG.debug("Reached the end of log {}", currentPath);
+    LOG.debug("EOF, closing {}", currentPath);
     closeReader();
     logQueue.remove();
     setPosition(0);
@@ -264,7 +264,7 @@ class WALEntryStream implements Closeable {
     long readerPos = reader.getPosition();
     OptionalLong fileLength = walFileLengthProvider.getLogFileSizeIfBeingWritten(currentPath);
     if (fileLength.isPresent() && readerPos > fileLength.getAsLong()) {
-      // see HBASE-14004, for AsyncFSWAL which uses fan-out, it is possible that we read uncommitted
+      // See HBASE-14004, for AsyncFSWAL which uses fan-out, it is possible that we read uncommitted
       // data, so we need to make sure that we do not read beyond the committed file length.
       if (LOG.isDebugEnabled()) {
         LOG.debug("The provider tells us the valid length for " + currentPath + " is " +

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ServerRegionReplicaUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ServerRegionReplicaUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,10 +19,14 @@
 package org.apache.hadoop.hbase.util;
 
 import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.ReplicationPeerNotFoundException;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
@@ -32,9 +36,12 @@ import org.apache.hadoop.hbase.io.HFileLink;
 import org.apache.hadoop.hbase.io.Reference;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.replication.ReplicationPeer;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfigListener;
 import org.apache.hadoop.hbase.replication.regionserver.RegionReplicaReplicationEndpoint;
 import org.apache.hadoop.hbase.zookeeper.ZKConfig;
+import org.apache.hadoop.hdfs.util.ByteArrayManager;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +65,15 @@ public class ServerRegionReplicaUtil extends RegionReplicaUtil {
   public static final String REGION_REPLICA_REPLICATION_CONF_KEY
     = "hbase.region.replica.replication.enabled";
   private static final boolean DEFAULT_REGION_REPLICA_REPLICATION = false;
-  private static final String REGION_REPLICA_REPLICATION_PEER = "region_replica_replication";
+  public static final String REGION_REPLICA_REPLICATION_PEER = "region_replica_replication";
+
+  /**
+   * Same as for {@link #REGION_REPLICA_REPLICATION_CONF_KEY} but for hbase:meta.
+   */
+  public static final String META_REGION_REPLICA_REPLICATION_CONF_KEY
+    = "hbase.region.meta.replica.replication.enabled";
+  private static final boolean DEFAULT_META_REGION_REPLICA_REPLICATION = false;
+
 
   /**
    * Enables or disables refreshing store files of secondary region replicas when the memory is
@@ -117,7 +132,6 @@ public class ServerRegionReplicaUtil extends RegionReplicaUtil {
    * files of the primary region, so an HFileLink is used to construct the StoreFileInfo. This
    * way ensures that the secondary will be able to continue reading the store files even if
    * they are moved to archive after compaction
-   * @throws IOException
    */
   public static StoreFileInfo getStoreFileInfo(Configuration conf, FileSystem fs,
       RegionInfo regionInfo, RegionInfo regionInfoForFs, String familyName, Path path)
@@ -154,47 +168,60 @@ public class ServerRegionReplicaUtil extends RegionReplicaUtil {
   }
 
   /**
-   * Create replication peer for replicating to region replicas if needed.
+   * Create replication peer for replicating user-space Region Read Replicas.
    * @param conf configuration to use
-   * @throws IOException
    */
   public static void setupRegionReplicaReplication(Configuration conf) throws IOException {
-    if (!isRegionReplicaReplicationEnabled(conf)) {
+    if (!conf.getBoolean(REGION_REPLICA_REPLICATION_CONF_KEY, DEFAULT_REGION_REPLICA_REPLICATION)) {
       return;
     }
-
+    String peerId = REGION_REPLICA_REPLICATION_PEER;
     try (Connection connection = ConnectionFactory.createConnection(conf);
       Admin admin = connection.getAdmin()) {
       ReplicationPeerConfig peerConfig = null;
       try {
-        peerConfig = admin.getReplicationPeerConfig(REGION_REPLICA_REPLICATION_PEER);
+        peerConfig = admin.getReplicationPeerConfig(peerId);
       } catch (ReplicationPeerNotFoundException e) {
-        LOG.warn(
-          "Region replica replication peer id=" + REGION_REPLICA_REPLICATION_PEER + " not exist",
-          e);
+        LOG.warn("Region replica peer id={} does not exist", peerId, e);
       }
-
       if (peerConfig == null) {
-        LOG.info("Region replica replication peer id=" + REGION_REPLICA_REPLICATION_PEER
-          + " not exist. Creating...");
-        peerConfig = new ReplicationPeerConfig();
-        peerConfig.setClusterKey(ZKConfig.getZooKeeperClusterKey(conf));
-        peerConfig.setReplicationEndpointImpl(RegionReplicaReplicationEndpoint.class.getName());
-        admin.addReplicationPeer(REGION_REPLICA_REPLICATION_PEER, peerConfig);
+        LOG.info("Region Read Replica peerId={} does not exist; creating...", peerId);
+        peerConfig = ReplicationPeerConfig.newBuilder().
+          setClusterKey(ZKConfig.getZooKeeperClusterKey(conf)).
+          setReplicationEndpointImpl(RegionReplicaReplicationEndpoint.class.getName()).build();
+        admin.addReplicationPeer(peerId, peerConfig);
       }
     }
   }
 
-  public static boolean isRegionReplicaReplicationEnabled(Configuration conf) {
-    return conf.getBoolean(REGION_REPLICA_REPLICATION_CONF_KEY,
-      DEFAULT_REGION_REPLICA_REPLICATION);
+  /**
+   * @return True if Region Read Replica is enabled for <code>tn</code>.
+   */
+  public static boolean isRegionReplicaReplicationEnabled(Configuration conf, TableName tn) {
+    return isMetaRegionReplicaReplicationEnabled(conf, tn) ||
+      conf.getBoolean(REGION_REPLICA_REPLICATION_CONF_KEY, DEFAULT_REGION_REPLICA_REPLICATION);
   }
 
+  /**
+   * @return True if hbase:meta Region Read Replica is enabled.
+   */
+  public static boolean isMetaRegionReplicaReplicationEnabled(Configuration conf, TableName tn) {
+    return TableName.isMetaTableName(tn) &&
+      conf.getBoolean(META_REGION_REPLICA_REPLICATION_CONF_KEY,
+        DEFAULT_META_REGION_REPLICA_REPLICATION);
+  }
+
+  /**
+   * @return True if wait for primary to flush is enabled for user-space tables.
+   */
   public static boolean isRegionReplicaWaitForPrimaryFlushEnabled(Configuration conf) {
     return conf.getBoolean(REGION_REPLICA_WAIT_FOR_PRIMARY_FLUSH_CONF_KEY,
       DEFAULT_REGION_REPLICA_WAIT_FOR_PRIMARY_FLUSH);
   }
 
+  /**
+   * @return True if we are to refresh user-space hfiles in Region Read Replicas.
+   */
   public static boolean isRegionReplicaStoreFileRefreshEnabled(Configuration conf) {
     return conf.getBoolean(REGION_REPLICA_STORE_FILE_REFRESH,
       DEFAULT_REGION_REPLICA_STORE_FILE_REFRESH);
@@ -203,13 +230,6 @@ public class ServerRegionReplicaUtil extends RegionReplicaUtil {
   public static double getRegionReplicaStoreFileRefreshMultiplier(Configuration conf) {
     return conf.getDouble(REGION_REPLICA_STORE_FILE_REFRESH_MEMSTORE_MULTIPLIER,
       DEFAULT_REGION_REPLICA_STORE_FILE_REFRESH_MEMSTORE_MULTIPLIER);
-  }
-
-  /**
-   * Return the peer id used for replicating to secondary region replicas
-   */
-  public static String getReplicationPeerId() {
-    return REGION_REPLICA_REPLICATION_PEER;
   }
 
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALFactory.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hbase.wal.WALProvider.Writer;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 /**
@@ -248,8 +247,11 @@ public class WALFactory {
     return provider.getWALs();
   }
 
-  @VisibleForTesting
-  WALProvider getMetaProvider() throws IOException {
+  /**
+   * Called when we lazily create a hbase:meta WAL OR from ReplicationSourceManager ahead of
+   * creating the first hbase:meta WAL so we can register a listener.
+   */
+  public WALProvider getMetaProvider() throws IOException {
     for (;;) {
       WALProvider provider = this.metaProvider.get();
       if (provider != null) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/ReplicationSourceDummy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/ReplicationSourceDummy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -16,12 +16,9 @@
  * limitations under the License.
  */
 package org.apache.hadoop.hbase.replication;
-
-import java.io.IOException;
 import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicBoolean;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -31,9 +28,9 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.replication.regionserver.MetricsSource;
 import org.apache.hadoop.hbase.replication.regionserver.ReplicationSourceInterface;
 import org.apache.hadoop.hbase.replication.regionserver.ReplicationSourceManager;
-import org.apache.hadoop.hbase.replication.regionserver.WALFileLengthProvider;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.wal.WAL.Entry;
+import org.apache.hadoop.hbase.wal.WALProvider;
 
 /**
  * Source that does nothing at all, helpful to test ReplicationSourceManager
@@ -44,18 +41,19 @@ public class ReplicationSourceDummy implements ReplicationSourceInterface {
   String peerClusterId;
   Path currentPath;
   MetricsSource metrics;
-  WALFileLengthProvider walFileLengthProvider;
   AtomicBoolean startup = new AtomicBoolean(false);
 
   @Override
   public void init(Configuration conf, FileSystem fs, ReplicationSourceManager manager,
       ReplicationQueueStorage rq, ReplicationPeer rp, Server server, String peerClusterId,
-      UUID clusterId, WALFileLengthProvider walFileLengthProvider, MetricsSource metrics)
-      throws IOException {
+      UUID clusterId, MetricsSource metrics) {
     this.manager = manager;
     this.peerClusterId = peerClusterId;
     this.metrics = metrics;
-    this.walFileLengthProvider = walFileLengthProvider;
+  }
+
+  @Override public WALProvider getWALProvider() {
+    return null;
   }
 
   @Override
@@ -149,11 +147,6 @@ public class ReplicationSourceDummy implements ReplicationSourceInterface {
 
   @Override
   public void postShipEdits(List<Entry> entries, int batchSize) {
-  }
-
-  @Override
-  public WALFileLengthProvider getWALFileLengthProvider() {
-    return walFileLengthProvider;
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestMetaRegionReplicaReplicationEndpoint.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestMetaRegionReplicaReplicationEndpoint.java
@@ -1,0 +1,373 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.replication.regionserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.ReplicationPeerNotFoundException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.Waiter;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.regionserver.Region;
+import org.apache.hadoop.hbase.regionserver.RegionScanner;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfigBuilder;
+import org.apache.hadoop.hbase.testclassification.FlakeyTests;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
+import org.apache.hadoop.hbase.zookeeper.ZKConfig;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests RegionReplicaReplicationEndpoint class for hbase:meta by setting up region replicas and
+ * verifying async wal replication replays the edits to the secondary region in various scenarios.
+ * @see TestRegionReplicaReplicationEndpoint
+ */
+@Category({FlakeyTests.class, LargeTests.class})
+public class TestMetaRegionReplicaReplicationEndpoint {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestMetaRegionReplicaReplicationEndpoint.class);
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestMetaRegionReplicaReplicationEndpoint.class);
+  private static final int NB_SERVERS = 3;
+  private static final HBaseTestingUtility HTU = new HBaseTestingUtility();
+
+  @Rule
+  public TestName name = new TestName();
+
+  @BeforeClass
+  public static void beforeClass() throws Exception {
+    Configuration conf = HTU.getConfiguration();
+    conf.setFloat("hbase.regionserver.logroll.multiplier", 0.0003f);
+    conf.setInt("replication.source.size.capacity", 10240);
+    conf.setLong("replication.source.sleepforretries", 100);
+    conf.setInt("hbase.regionserver.maxlogs", 10);
+    conf.setLong("hbase.master.logcleaner.ttl", 10);
+    conf.setInt("zookeeper.recovery.retry", 1);
+    conf.setInt("zookeeper.recovery.retry.intervalmill", 10);
+    conf.setLong(HConstants.THREAD_WAKE_FREQUENCY, 100);
+    conf.setInt("replication.stats.thread.period.seconds", 5);
+    conf.setBoolean("hbase.tests.use.shortcircuit.reads", false);
+    conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 5); // less number of retries needed
+    conf.setInt(HConstants.HBASE_CLIENT_SERVERSIDE_RETRIES_MULTIPLIER, 1);
+    // Enable hbase:meta replication.
+    conf.setBoolean(ServerRegionReplicaUtil.META_REGION_REPLICA_REPLICATION_CONF_KEY, true);
+    // Set hbase:meta replicas to be 3.
+    conf.setInt(HConstants.META_REPLICAS_NUM, NB_SERVERS);
+    HTU.startMiniCluster(NB_SERVERS);
+    HTU.waitFor(30000,
+      () -> HTU.getMiniHBaseCluster().getRegions(TableName.META_TABLE_NAME).size() >= NB_SERVERS);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    HTU.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testSpecialMetaReplicationPeerCreated() throws IOException, InterruptedException {
+    MiniHBaseCluster cluster = HTU.getMiniHBaseCluster();
+    HRegionServer hrs = cluster.getRegionServer(cluster.getServerHoldingMeta());
+    assertTrue(isMetaRegionReplicaReplicationSource(hrs));
+    // Now move the hbase:meta and make sure the peer is disabled on original server and enabled on
+    // the new server.
+    HRegionServer hrsOther = null;
+    for (int i = 0; i < cluster.getNumLiveRegionServers(); i++) {
+      hrsOther = cluster.getRegionServer(i);
+      if (hrsOther.getServerName().equals(hrs.getServerName())) {
+        hrsOther = null;
+        continue;
+      }
+      break;
+    }
+    assertNotNull(hrsOther);
+    Region meta = null;
+    for (Region region: hrs.getOnlineRegionsLocalContext()) {
+      if (region.getRegionInfo().isMetaRegion()) {
+        meta = region;
+        break;
+      }
+    }
+    assertNotNull(meta);
+    HTU.moveRegionAndWait(meta.getRegionInfo(), hrsOther.getServerName());
+    assertFalse(isMetaRegionReplicaReplicationSource(hrs));
+    assertTrue(isMetaRegionReplicaReplicationSource(hrsOther));
+  }
+
+  /**
+   * @return Whether the special meta region replica peer is enabled on <code>hrs</code>
+   */
+  private boolean isMetaRegionReplicaReplicationSource(HRegionServer hrs) {
+    boolean on = false;
+    for (ReplicationSourceInterface rsi:
+      hrs.getReplicationSourceService().getReplicationManager().getSources()) {
+      on |= ReplicationSourceManager.META_REGION_REPLICA_REPLICATION_SOURCE.equals(rsi.getPeerId());
+    }
+    return on;
+  }
+
+  /**
+   * Test meta region replica replication. Create some tables and see if replicas pick up the
+   * additions.
+   */
+  @Test
+  public void testHBaseMetaReplicates() throws Exception {
+    HTU.createTable(TableName.valueOf(this.name.getMethodName() + "_0"), HConstants.CATALOG_FAMILY,
+      Arrays.copyOfRange(HBaseTestingUtility.KEYS, 1, HBaseTestingUtility.KEYS.length));
+    verifyReplication(TableName.META_TABLE_NAME, NB_SERVERS, HTU.KEYS);
+  }
+
+  /**
+   * Test meta region replica replication. Create some tables and see if replicas pick up the
+   * additions.
+   */
+  @Test
+  public void testHBaseMetaReplicatesOneRow() throws Exception {
+    HTU.createTable(TableName.valueOf(this.name.getMethodName()), HConstants.CATALOG_FAMILY);
+    verifyReplication(TableName.META_TABLE_NAME, NB_SERVERS,
+      new byte [][] {HTU.getMetaTableRows().get(0)});
+  }
+
+  private void verifyReplication(TableName tableName, int regionReplication, final byte [][] rows) {
+    final Region[] regions = new Region[regionReplication];
+    for (int i = 0; i < NB_SERVERS; i++) {
+      HRegionServer rs = HTU.getMiniHBaseCluster().getRegionServer(i);
+      List<HRegion> onlineRegions = rs.getRegions(tableName);
+      for (HRegion region : onlineRegions) {
+        regions[region.getRegionInfo().getReplicaId()] = region;
+      }
+    }
+
+    for (Region region : regions) {
+      assertNotNull(region);
+    }
+
+    for (int i = 1; i < regionReplication; i++) {
+      final Region region = regions[i];
+      // wait until all the data is replicated to all secondary regions
+      Waiter.waitFor(HTU.getConfiguration(), 90000, 1000, new Waiter.Predicate<Exception>() {
+        @Override
+        public boolean evaluate() throws Exception {
+          LOG.info("Verifying replication for region replica {}", region.getRegionInfo());
+          int count = 0;
+          try (RegionScanner rs = region.getScanner(new Scan())) {
+            List<Cell> cells = new ArrayList<>();
+            while (rs.next(cells)) {
+              cells.clear();
+              count++;
+            }
+            return count == rows.length;
+          } catch(Throwable ex) {
+            LOG.warn("Verification from secondary region is not complete yet", ex);
+            // still wait
+            return false;
+          }
+        }
+      });
+    }
+  }
+
+//  @Test
+//  public void testRegionReplicaReplicationWith2Replicas() throws Exception {
+//    testRegionReplicaReplication(2);
+//  }
+//
+//  @Test
+//  public void testRegionReplicaReplicationWith3Replicas() throws Exception {
+//    testRegionReplicaReplication(3);
+//  }
+//
+//  @Test
+//  public void testRegionReplicaReplicationWith10Replicas() throws Exception {
+//    testRegionReplicaReplication(10);
+//  }
+//
+//  @Test
+//  public void testRegionReplicaReplicationForFlushAndCompaction() throws Exception {
+//    // Tests a table with region replication 3. Writes some data, and causes flushes and
+//    // compactions. Verifies that the data is readable from the replicas. Note that this
+//    // does not test whether the replicas actually pick up flushed files and apply compaction
+//    // to their stores
+//    int regionReplication = 3;
+//    final TableName tableName = TableName.valueOf(name.getMethodName());
+//    HTableDescriptor htd = HTU.createTableDescriptor(tableName);
+//    htd.setRegionReplication(regionReplication);
+//    HTU.getAdmin().createTable(htd);
+//
+//
+//    Connection connection = ConnectionFactory.createConnection(HTU.getConfiguration());
+//    Table table = connection.getTable(tableName);
+//    try {
+//      // load the data to the table
+//
+//      for (int i = 0; i < 6000; i += 1000) {
+//        LOG.info("Writing data from " + i + " to " + (i+1000));
+//        HTU.loadNumericRows(table, HBaseTestingUtility.fam1, i, i+1000);
+//        LOG.info("flushing table");
+//        HTU.flush(tableName);
+//        LOG.info("compacting table");
+//        HTU.compact(tableName, false);
+//      }
+//
+//      verifyReplication(tableName, regionReplication, 0, 1000);
+//    } finally {
+//      table.close();
+//      connection.close();
+//    }
+//  }
+//
+//  @Test
+//  public void testRegionReplicaReplicationIgnoresDisabledTables() throws Exception {
+//    testRegionReplicaReplicationIgnores(false, false);
+//  }
+//
+//  @Test
+//  public void testRegionReplicaReplicationIgnoresDroppedTables() throws Exception {
+//    testRegionReplicaReplicationIgnores(true, false);
+//  }
+//
+//  @Test
+//  public void testRegionReplicaReplicationIgnoresNonReplicatedTables() throws Exception {
+//    testRegionReplicaReplicationIgnores(false, true);
+//  }
+//
+//  public void testRegionReplicaReplicationIgnores(boolean dropTable, boolean disableReplication)
+//      throws Exception {
+//
+//    // tests having edits from a disabled or dropped table is handled correctly by skipping those
+//    // entries and further edits after the edits from dropped/disabled table can be replicated
+//    // without problems.
+//    final TableName tableName = TableName.valueOf(
+//      name.getMethodName() + "_drop_" + dropTable + "_disabledReplication_" + disableReplication);
+//    HTableDescriptor htd = HTU.createTableDescriptor(tableName);
+//    int regionReplication = 3;
+//    htd.setRegionReplication(regionReplication);
+//    HTU.deleteTableIfAny(tableName);
+//
+//    HTU.getAdmin().createTable(htd);
+//    TableName toBeDisabledTable = TableName.valueOf(
+//      dropTable ? "droppedTable" : (disableReplication ? "disableReplication" : "disabledTable"));
+//    HTU.deleteTableIfAny(toBeDisabledTable);
+//    htd = HTU.createTableDescriptor(toBeDisabledTable.toString());
+//    htd.setRegionReplication(regionReplication);
+//    HTU.getAdmin().createTable(htd);
+//
+//    // both tables are created, now pause replication
+//    ReplicationAdmin admin = new ReplicationAdmin(HTU.getConfiguration());
+//    admin.disablePeer(ServerRegionReplicaUtil.REGION_REPLICA_REPLICATION_PEER);
+//
+//    // now that the replication is disabled, write to the table to be dropped, then drop the table.
+//
+//    Connection connection = ConnectionFactory.createConnection(HTU.getConfiguration());
+//    Table table = connection.getTable(tableName);
+//    Table tableToBeDisabled = connection.getTable(toBeDisabledTable);
+//
+//    HTU.loadNumericRows(tableToBeDisabled, HBaseTestingUtility.fam1, 6000, 7000);
+//
+//    AtomicLong skippedEdits = new AtomicLong();
+//    RegionReplicaReplicationEndpoint.RegionReplicaOutputSink sink =
+//        mock(RegionReplicaReplicationEndpoint.RegionReplicaOutputSink.class);
+//    when(sink.getSkippedEditsCounter()).thenReturn(skippedEdits);
+//    FSTableDescriptors fstd =
+//        new FSTableDescriptors(FileSystem.get(HTU.getConfiguration()), HTU.getDefaultRootDirPath());
+//    RegionReplicaReplicationEndpoint.RegionReplicaSinkWriter sinkWriter =
+//        new RegionReplicaReplicationEndpoint.RegionReplicaSinkWriter(sink,
+//            (ClusterConnection) connection, Executors.newSingleThreadExecutor(), Integer.MAX_VALUE,
+//            fstd);
+//    RegionLocator rl = connection.getRegionLocator(toBeDisabledTable);
+//    HRegionLocation hrl = rl.getRegionLocation(HConstants.EMPTY_BYTE_ARRAY);
+//    byte[] encodedRegionName = hrl.getRegionInfo().getEncodedNameAsBytes();
+//
+//    Cell cell = CellBuilderFactory.create(CellBuilderType.DEEP_COPY).setRow(Bytes.toBytes("A"))
+//        .setFamily(HTU.fam1).setValue(Bytes.toBytes("VAL")).setType(Type.Put).build();
+//    Entry entry = new Entry(
+//      new WALKeyImpl(encodedRegionName, toBeDisabledTable, 1),
+//        new WALEdit()
+//            .add(cell));
+//
+//    HTU.getAdmin().disableTable(toBeDisabledTable); // disable the table
+//    if (dropTable) {
+//      HTU.getAdmin().deleteTable(toBeDisabledTable);
+//    } else if (disableReplication) {
+//      htd.setRegionReplication(regionReplication - 2);
+//      HTU.getAdmin().modifyTable(toBeDisabledTable, htd);
+//      HTU.getAdmin().enableTable(toBeDisabledTable);
+//    }
+//    sinkWriter.append(toBeDisabledTable, encodedRegionName,
+//      HConstants.EMPTY_BYTE_ARRAY, Lists.newArrayList(entry, entry));
+//
+//    assertEquals(2, skippedEdits.get());
+//
+//    if (disableReplication) {
+//      // enable replication again so that we can verify replication
+//      HTU.getAdmin().disableTable(toBeDisabledTable); // disable the table
+//      htd.setRegionReplication(regionReplication);
+//      HTU.getAdmin().modifyTable(toBeDisabledTable, htd);
+//      HTU.getAdmin().enableTable(toBeDisabledTable);
+//    }
+//
+//    try {
+//      // load some data to the to-be-dropped table
+//
+//      // load the data to the table
+//      HTU.loadNumericRows(table, HBaseTestingUtility.fam1, 0, 1000);
+//
+//      // now enable the replication
+//      admin.enablePeer(ServerRegionReplicaUtil.REGION_REPLICA_REPLICATION_PEER);
+//
+//      verifyReplication(tableName, regionReplication, 0, 1000);
+//
+//    } finally {
+//      admin.close();
+//      table.close();
+//      rl.close();
+//      tableToBeDisabled.close();
+//      HTU.deleteTableIfAny(toBeDisabledTable);
+//      connection.close();
+//    }
+//  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestRegionReplicaReplicationEndpoint.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestRegionReplicaReplicationEndpoint.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -23,7 +23,6 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.fail;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
-
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -71,7 +70,6 @@ import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 
 /**
@@ -125,8 +123,7 @@ public class TestRegionReplicaReplicationEndpoint {
     // create a table with region replicas. Check whether the replication peer is created
     // and replication started.
     ReplicationAdmin admin = new ReplicationAdmin(HTU.getConfiguration());
-    String peerId = "region_replica_replication";
-
+    String peerId = ServerRegionReplicaUtil.REGION_REPLICA_REPLICATION_PEER;
     ReplicationPeerConfig peerConfig = null;
     try {
       peerConfig = admin.getPeerConfig(peerId);
@@ -245,6 +242,9 @@ public class TestRegionReplicaReplicationEndpoint {
     }
   }
 
+  /**
+   * Used by this test and others.
+   */
   private void verifyReplication(TableName tableName, int regionReplication,
       final int startRow, final int endRow) throws Exception {
     verifyReplication(tableName, regionReplication, startRow, endRow, true);
@@ -406,7 +406,7 @@ public class TestRegionReplicaReplicationEndpoint {
 
     // both tables are created, now pause replication
     ReplicationAdmin admin = new ReplicationAdmin(HTU.getConfiguration());
-    admin.disablePeer(ServerRegionReplicaUtil.getReplicationPeerId());
+    admin.disablePeer(ServerRegionReplicaUtil.REGION_REPLICA_REPLICATION_PEER);
 
     // now that the replication is disabled, write to the table to be dropped, then drop the table.
 
@@ -465,7 +465,7 @@ public class TestRegionReplicaReplicationEndpoint {
       HTU.loadNumericRows(table, HBaseTestingUtility.fam1, 0, 1000);
 
       // now enable the replication
-      admin.enablePeer(ServerRegionReplicaUtil.getReplicationPeerId());
+      admin.enablePeer(ServerRegionReplicaUtil.REGION_REPLICA_REPLICATION_PEER);
 
       verifyReplication(tableName, regionReplication, 0, 1000);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSource.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSource.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import java.io.IOException;
-import java.util.OptionalLong;
 import java.util.UUID;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -115,7 +114,7 @@ public class TestReplicationSource {
    */
   @Test
   public void testDefaultSkipsMetaWAL() throws IOException {
-    ReplicationSource rs = new ReplicationSource();
+    ReplicationSource rs = new ReplicationSource(null);
     Configuration conf = new Configuration(TEST_UTIL.getConfiguration());
     conf.setInt("replication.source.maxretriesmultiplier", 1);
     ReplicationPeer mockPeer = Mockito.mock(ReplicationPeer.class);
@@ -131,7 +130,7 @@ public class TestReplicationSource {
     RegionServerServices rss =
       TEST_UTIL.createMockRegionServerService(ServerName.parseServerName("a.b.c,1,1"));
     rs.init(conf, null, manager, null, mockPeer, rss, queueId, null,
-      p -> OptionalLong.empty(), new MetricsSource(queueId));
+      new MetricsSource(queueId));
     try {
       rs.startup();
       assertTrue(rs.isSourceActive());
@@ -153,7 +152,7 @@ public class TestReplicationSource {
   public void testWALEntryFilter() throws IOException {
     // To get the fully constructed default WALEntryFilter, need to create a ReplicationSource
     // instance and init it.
-    ReplicationSource rs = new ReplicationSource();
+    ReplicationSource rs = new ReplicationSource(null);
     UUID uuid = UUID.randomUUID();
     Configuration conf = new Configuration(TEST_UTIL.getConfiguration());
     ReplicationPeer mockPeer = Mockito.mock(ReplicationPeer.class);
@@ -169,7 +168,7 @@ public class TestReplicationSource {
     RegionServerServices rss =
       TEST_UTIL.createMockRegionServerService(ServerName.parseServerName("a.b.c,1,1"));
     rs.init(conf, null, manager, null, mockPeer, rss, queueId,
-      uuid, p -> OptionalLong.empty(), new MetricsSource(queueId));
+      uuid, new MetricsSource(queueId));
     try {
       rs.startup();
       TEST_UTIL.waitFor(30000, () -> rs.getWalEntryFilter() != null);
@@ -245,7 +244,7 @@ public class TestReplicationSource {
    */
   @Test
   public void testTerminateTimeout() throws Exception {
-    ReplicationSource source = new ReplicationSource();
+    ReplicationSource source = new ReplicationSource(null);
     ReplicationEndpoint
       replicationEndpoint = new DoNothingReplicationEndpoint();
     try {
@@ -257,7 +256,7 @@ public class TestReplicationSource {
       ReplicationSourceManager manager = Mockito.mock(ReplicationSourceManager.class);
       Mockito.when(manager.getTotalBufferUsed()).thenReturn(new AtomicLong());
       source.init(testConf, null, manager, null, mockPeer, null, "testPeer",
-        null, p -> OptionalLong.empty(), null);
+        null, null);
       ExecutorService executor = Executors.newSingleThreadExecutor();
       Future<?> future = executor.submit(
         () -> source.terminate("testing source termination"));

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MetaTableLocator.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MetaTableLocator.java
@@ -221,7 +221,7 @@ public final class MetaTableLocator {
       LOG.warn("Tried to set null ServerName in hbase:meta; skipping -- ServerName required");
       return;
     }
-    LOG.info("Setting hbase:meta (replicaId={}) location in ZooKeeper as {}, state={}", replicaId,
+    LOG.info("Setting hbase:meta replicaId={} location in ZooKeeper as {}, state={}", replicaId,
       serverName, state);
     // Make the MetaRegionServer pb and then get its bytes and save this as
     // the znode content.
@@ -235,9 +235,9 @@ public final class MetaTableLocator {
           zookeeper.getZNodePaths().getZNodeForReplica(replicaId), data);
     } catch(KeeperException.NoNodeException nne) {
       if (replicaId == RegionInfo.DEFAULT_REPLICA_ID) {
-        LOG.debug("META region location doesn't exist, create it");
+        LOG.debug("hbase:meta region location doesn't exist, create it");
       } else {
-        LOG.debug("META region location doesn't exist for replicaId=" + replicaId +
+        LOG.debug("hbase:meta region location doesn't exist for replicaId=" + replicaId +
             ", create it");
       }
       ZKUtil.createAndWatch(zookeeper, zookeeper.getZNodePaths().getZNodeForReplica(replicaId),


### PR DESCRIPTION
ReplicationSource filters in hbase:meta WALs and filters out
user-space WALs. Allows all edits from meta WALs through.
Does not persist replication state to backing store; it is
not needed for in-cluster region replicas (but this patch
only adds this improvment on async WAL region replicas
for hbase:metai table).

Made it explicit that a ReplicationSource feeds from a
WALProvider.

hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
 Fix logging; don't log we've flushed when we haven't.

hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
 Pass WALFactory instead of WALProvider... WALFactory has
 user-space and meta WALProviders. Pass so replication can
 get access to meta WALs. Add spinning up a thread to run
 flush of primary Region if it hbase:meta table.

hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/ReplicationService.java
 Take a WALFactory rather than a WALProvider.

hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
 If we are opening hbase:meta Region and hbase:meta region read replicas
 are enabled, then add hbase:meta WALs as a repliation source.
 Bug fix... We were using a CLOSE executor when opening.

hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
 If closing hbase:meta, then remove replication source if in place.

hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/HBaseMetaNoQueueStoreReplicationSource.java
 Special-case ReplicationSource used by hbase:meta read replicas.
 Configured to suit reading hbase:meta WALs.

hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/Replication.java
 Pass walFactory instead of walProvider. Move adding of listener
 elsewhere to accomodate lazy instantiation of hbase:meta

hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
 Take walProvider on construction and remove the length function from init.
 Clean up some namings; queueId vs peerId vs walGroupId.

hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceFactory.java
 Add being able to create an hbase:meta region read replica ReplicationSource.

hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceInterface.java
 Adds a getWALProvider.

hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceManager.java
 Add key for the hbase:meta region read replica replication source.
 Take WALFactory rather than WALProvider. It has pointers to all

hbase-client/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
 Expose useful util.

hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RegionReplicaReplicationEndpoint.java
 Make it work for the case of lazy onlining of hbase:meta replicas.