### PR TITLE
HBASE-24976 Printing the swallowed exception 

### DIFF
--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
@@ -382,13 +382,8 @@ public class RESTServer implements Constants {
       this.infoServer.setAttribute("hbase.conf", conf);
       this.infoServer.start();
     }
-    try {
-      // start server
-      server.start();
-    } catch (Exception e) {
-      LOG.error(HBaseMarkers.FATAL, "Failed to start server", e);
-      throw e;
-    }
+    // start server
+    server.start();
   }
 
   public synchronized void join() throws Exception {
@@ -442,6 +437,7 @@ public class RESTServer implements Constants {
       server.run();
       server.join();
     } catch (Exception e) {
+      LOG.error(HBaseMarkers.FATAL, "Failed to start server", e);
       System.exit(1);
     }
 


### PR DESCRIPTION
When i think i have configurated the secure cluster correctly,  i start the rest server, the log message are:

1.   SLF4J: Class path contains multiple SLF4J bindings.
2.   SLF4J: Found binding in [jar:file:/usr/local/hadoop-2.8.5/share/hadoop/common/lib/slf4j-log4j12- 
     1.7.10.jar!/org/slf4j/impl/StaticLoggerBinder.class]
3.   SLF4J: Found binding in [jar:file:/usr/local/hbase-2.2.1/lib/client-facing-thirdparty/slf4j-log4j12- 
     1.7.25.jar!/org/slf4j/impl/StaticLoggerBinder.class]
4.   SLF4J: See http://www.slf4j.org/codes.html#multiple_bindings for an explanation.
5.   SLF4J: Actual binding is of type [org.slf4j.impl.Log4jLoggerFactory]
6.   2020-09-03 02:10:57,995 INFO  [main] RESTServer: ***** STARTING service 'RESTServer' *****
7.   2020-09-03 02:10:57,998 INFO  [main] util.VersionInfo: HBase 2.2.1
8.   2020-09-03 02:10:57,998 INFO  [main] util.VersionInfo: Source code repository git://hao-OptiPlex- 
      7050/home/hao/open_source/hbase revision=f93aaf770cce81caacbf22174dfee2860dbb4810
9.   2020-09-03 02:10:57,998 INFO  [main] util.VersionInfo: Compiled by hao on 2019年 09月 10日 星期二 14:28:27 CST
10. 2020-09-03 02:10:57,998 INFO  [main] util.VersionInfo: From source with checksum c0f358e344b10713f61037e16fd39f8euse

Apparently RESTServer does't startup successfully, but i can't read any useful feedback message to help me troubleshooting,
 that's awful.  I have to debug the RESTServer and find that one exception containing  root cause is swallowed:

org.apache.hadoop.hbase.rest.RESTServer.main
423       try {
424             server.run();
425             server.join();
426       } catch (Exception e) {
427           System.exit(1);**_// here, exception is not printed_**
428       }

The exception is:
`java.lang.IllegalArgumentException: hbase.rest.keytab.file should be set if security is enabled
        at org.apache.hbase.thirdparty.com.google.common.base.Preconditions.checkArgument(Preconditions.java:142)
        at org.apache.hadoop.hbase.rest.RESTServer.loginServerPrincipal(RESTServer.java:149)
        at org.apache.hadoop.hbase.rest.RESTServer.run(RESTServer.java:237)
        at org.apache.hadoop.hbase.rest.RESTServer.main(RESTServer.java:424)`

We should print the exception!!!!