### PR TITLE
HBASE-24481 [REST] Fix wrong response code of get-regions in rest api

### DIFF
--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RegionsResource.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RegionsResource.java
@@ -75,6 +75,9 @@ public class RegionsResource extends ResourceBase {
     servlet.getMetrics().incrementRequests(1);
     try {
       TableName tableName = TableName.valueOf(tableResource.getName());
+      if (!tableResource.exists()) {
+        throw new TableNotFoundException(tableName);
+      }
       TableInfoModel model = new TableInfoModel(tableName.getNameAsString());
 
       List<HRegionLocation> locs;

--- a/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/TestTableResource.java
+++ b/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/TestTableResource.java
@@ -261,5 +261,14 @@ public class TestTableResource {
     checkTableInfo(model);
   }
 
+  @Test
+  public void testTableNotFound() throws IOException {
+    String notExistTable = "notexist";
+    Response response1 = client.get("/" + notExistTable + "/schema", Constants.MIMETYPE_JSON);
+    assertEquals(404, response1.getCode());
+    Response response2 = client.get("/" + notExistTable + "/regions", Constants.MIMETYPE_XML);
+    assertEquals(404, response2.getCode());
+  }
+
 }
 


### PR DESCRIPTION
### What changes were proposed in this pull request?
Fix HBASE-24481
 (Wrong response code of get-regions in rest api: 
for a table which doesn't exist, get-schema will return 404, but get-regions will return 200.)


When you try to get all regions of a table, you should check if the table exists at first.
Currently, `connection.getRegionLocator(tableName)` doesn't check it.

### How was this patch tested?
New ut added.