### PR TITLE
Should not use XXXService.Interface.class.getSimpleName as stub key prefix in AsyncConnectionImpl

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
@@ -254,7 +254,7 @@ class AsyncConnectionImpl implements AsyncConnection {
 
   ClientService.Interface getRegionServerStub(ServerName serverName) throws IOException {
     return ConcurrentMapUtils.computeIfAbsentEx(rsStubs,
-      getStubKey(ClientService.Interface.class.getSimpleName(), serverName, hostnameCanChange),
+      getStubKey(ClientService.getDescriptor().getName(), serverName, hostnameCanChange),
       () -> createRegionServerStub(serverName));
   }
 
@@ -268,7 +268,7 @@ class AsyncConnectionImpl implements AsyncConnection {
 
   AdminService.Interface getAdminStub(ServerName serverName) throws IOException {
     return ConcurrentMapUtils.computeIfAbsentEx(adminSubs,
-      getStubKey(AdminService.Interface.class.getSimpleName(), serverName, hostnameCanChange),
+      getStubKey(AdminService.getDescriptor().getName(), serverName, hostnameCanChange),
       () -> createAdminServerStub(serverName));
   }
 


### PR DESCRIPTION
It will just return "Interface" for all services. This is not a bug for AsyncConnectionImpl as we have different maps for ClientService and AdminService, but it is still a bit confusing to developers.

I suggest either we just use empty string and add a comment to say that the service name is not important here, or change to use XXXService.class.getSimpleName() or XXXService.getDescriptor().getName(), so it is less confusing to developers.