### PR TITLE
HBASE-25119: Fix property name added as part of HBASE-24764 in branch-1

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
@@ -47,7 +47,7 @@ public class ReplicationPeerConfig {
   private long bandwidth = 0;
 
   public static final String HBASE_REPLICATION_PEER_BASE_CONFIG =
-    "hbase.replication.peer.default.config";
+    "hbase.replication.peer.base.config";
 
   public ReplicationPeerConfig() {
     this.peerData = new TreeMap<byte[], byte[]>(Bytes.BYTES_COMPARATOR);


### PR DESCRIPTION
A new property was added as part of this https://issues.apache.org/jira/browse/HBASE-24764. 

Master branch has the name as "hbase.replication.peer.base.config"

while branch-1 has the name as "hbase.replication.peer.default.config"

As part of this Jira fix the name in branch-1 to be consistent. 