### PR TITLE
HBASE-25115 HFilePrettyPrinter can't seek to the row which is the first row of a hfile

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -322,16 +322,16 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       // scan over file and read key/value's and check if requested
       HFileScanner scanner = reader.getScanner(false, false, false);
       fileStats = new KeyValueStatsCollector();
-      boolean shouldScanKeysValues = false;
-      if (this.isSeekToRow) {
+      boolean shouldScanKeysValues;
+      if (this.isSeekToRow && !Bytes.equals(row, reader.getFirstRowKey().orElse(null))) {
         // seek to the first kv on this row
-        shouldScanKeysValues =
-          (scanner.seekTo(PrivateCellUtil.createFirstOnRow(this.row)) != -1);
+        shouldScanKeysValues = (scanner.seekTo(PrivateCellUtil.createFirstOnRow(this.row)) != -1);
       } else {
         shouldScanKeysValues = scanner.seekTo();
       }
-      if (shouldScanKeysValues)
+      if (shouldScanKeysValues) {
         scanKeysValues(file, fileStats, scanner, row);
+      }
     }
 
     // print meta data

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFilePrettyPrinter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFilePrettyPrinter.java
@@ -108,4 +108,23 @@ public class TestHFilePrettyPrinter {
     String expectedResult = "Scanning -> " + fileInRootDir + "\n" + "Scanned kv count -> 1000\n";
     assertEquals(expectedResult, result);
   }
+
+  @Test
+  public void testHFilePrettyPrinterSeekFirstRow() throws Exception {
+    Path fileNotInRootDir = UTIL.getDataTestDir("hfile");
+    TestHRegionServerBulkLoad.createHFile(fs, fileNotInRootDir, cf, fam, value, 1000);
+    assertNotEquals("directory used is not an HBase root dir", UTIL.getDefaultRootDirPath(),
+      fileNotInRootDir);
+
+    HFile.Reader reader =
+        HFile.createReader(fs, fileNotInRootDir, CacheConfig.DISABLED, true, conf);
+    String firstRowKey = new String(reader.getFirstRowKey().get());
+
+    System.setOut(ps);
+    new HFilePrettyPrinter(conf)
+        .run(new String[] { "-v", "-w" + firstRowKey, String.valueOf(fileNotInRootDir) });
+    String result = new String(stream.toByteArray());
+    String expectedResult = "Scanning -> " + fileNotInRootDir + "\n" + "Scanned kv count -> 1\n";
+    assertEquals(expectedResult, result);
+  }
 }


### PR DESCRIPTION
If we seek to first row in hfile, the `firstOnRow` with empty famliy( create by `PrivateCellUtil.createFirstOnRow`) is smaller than any row in hfile, So we need to seekTo  the hfile beginning and do the seek