### PR TITLE
HBASE-25135 Convert the internal seperator while emitting the memstor…

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableSourceImpl.java
@@ -337,7 +337,7 @@ public class MetricsTableSourceImpl implements MetricsTableSource {
       for (Entry<String, Long> entry : metricMap.entrySet()) {
         // append 'store' and its name to the metric
         mrb.addGauge(Interns.info(this.tableNamePrefixPart1 + _COLUMNFAMILY
-            + entry.getKey().split(MetricsTableWrapperAggregate.UNDERSCORE)[1]
+            + entry.getKey().split(MetricsTableWrapperAggregate.HASH)[1]
             + this.tableNamePrefixPart2 + metricName,
           metricDesc), entry.getValue());
       }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableWrapperAggregate.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableWrapperAggregate.java
@@ -28,7 +28,7 @@ import org.apache.yetus.audience.InterfaceAudience;
  */
 @InterfaceAudience.Private
 public interface MetricsTableWrapperAggregate {
-  public String UNDERSCORE = "_";
+  public String HASH = "#";
   /**
    * Get the number of read requests that have been issued against this table
    */

--- a/hbase-hadoop-compat/src/test/java/org/apache/hadoop/hbase/regionserver/MetricsTableWrapperStub.java
+++ b/hbase-hadoop-compat/src/test/java/org/apache/hadoop/hbase/regionserver/MetricsTableWrapperStub.java
@@ -116,14 +116,14 @@ public class MetricsTableWrapperStub implements MetricsTableWrapperAggregate {
   @Override
   public Map<String, Long> getMemstoreOnlyRowReadsCount(String table) {
     Map<String, Long> map = new HashMap<String, Long>();
-    map.put("table_info", 3L);
+    map.put("table#info", 3L);
     return map;
   }
 
   @Override
   public Map<String, Long> getMixedRowReadsCount(String table) {
     Map<String, Long> map = new HashMap<String, Long>();
-    map.put("table_info", 3L);
+    map.put("table#info", 3L);
     return map;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableWrapperAggregateImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableWrapperAggregateImpl.java
@@ -94,7 +94,7 @@ public class MetricsTableWrapperAggregateImpl implements MetricsTableWrapperAggr
                   (long) store.getAvgStoreFileAge().getAsDouble() * store.getStorefilesCount();
             }
             mt.storeCount += 1;
-            tempKey = tbl.getNameAsString() + UNDERSCORE + familyName;
+            tempKey = tbl.getNameAsString() + HASH + familyName;
             Long tempVal = mt.perStoreMemstoreOnlyReadCount.get(tempKey);
             if (tempVal == null) {
               tempVal = 0L;


### PR DESCRIPTION
Change the internal seperate to '#' so that we support families that have '_' in it. 