### PR TITLE
HBASE-25143 Remove branch-1.3 from precommit and docs

### DIFF
--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -553,14 +553,7 @@ function hadoopcheck_rebuild
 
   # All supported Hadoop versions that we want to test the compilation with
   # See the Hadoop section on prereqs in the HBase Reference Guide
-  if [[ "${PATCH_BRANCH}" = branch-1.3 ]]; then
-    yetus_info "Setting Hadoop 2 versions to test based on branch-1.3 rules."
-    if [[ "${QUICK_HADOOPCHECK}" == "true" ]]; then
-      hbase_hadoop2_versions="2.4.1 2.5.2 2.6.5 2.7.7"
-    else
-      hbase_hadoop2_versions="2.4.0 2.4.1 2.5.0 2.5.1 2.5.2 2.6.1 2.6.2 2.6.3 2.6.4 2.6.5 2.7.1 2.7.2 2.7.3 2.7.4 2.7.5 2.7.6 2.7.7"
-    fi
-  elif [[ "${PATCH_BRANCH}" = branch-1.4 ]]; then
+  if [[ "${PATCH_BRANCH}" = branch-1.4 ]]; then
     yetus_info "Setting Hadoop 2 versions to test based on branch-1.4 rules."
     if [[ "${QUICK_HADOOPCHECK}" == "true" ]]; then
       hbase_hadoop2_versions="2.7.7"

--- a/src/main/asciidoc/_chapters/community.adoc
+++ b/src/main/asciidoc/_chapters/community.adoc
@@ -43,13 +43,18 @@ See link:http://search-hadoop.com/m/asM982C5FkS1[HBase, mail # dev - Thoughts
 [[hbase.fix.version.in.jira]]
 .How to set fix version in JIRA on issue resolve
 
-Here is how link:http://search-hadoop.com/m/azemIi5RCJ1[we agreed] to set versions in JIRA when we resolve an issue.
-If master is going to be 2.0.0, and branch-1 1.4.0 then:
+Here is how link:http://search-hadoop.com/m/azemIi5RCJ1[we agreed] to set versions in JIRA when we
+resolve an issue. If master is going to be 3.0.0, branch-2 will be 2.4.0, and branch-1 will be
+1.7.0 then:
 
-* Commit only to master: Mark with 2.0.0
-* Commit to branch-1 and master: Mark with 2.0.0, and 1.4.0
-* Commit to branch-1.3, branch-1, and master: Mark with 2.0.0, 1.4.0, and 1.3.x
-* Commit site fixes: no version
+* Commit only to master (i.e., backward-incompatible new feature): Mark with 3.0.0
+* Commit only to master and branch-2 (i.e., backward-compatible new feature, applicable only to
+  2.x+): Mark with 3.0.0 and 2.4.0
+* Commit to master, branch-2, and branch-1 (i.e., backward-compatible new feature, applicable
+  everywhere): Mark with 3.0.0, 2.4.0, and 1.7.0
+* Commit to master, branch-2, and branch-2.3, branch-2.2, branch-2, branch-1.4 (i.e., bug fix
+  applicable to all active release lines): Mark with 3.0.0, 2.4.0, 2.3.x, 2.2.x, 1.7.0, and 1.4.x
+* Commit a fix to the website: no version
 
 [[hbase.when.to.close.jira]]
 .Policy on when to set a RESOLVED JIRA as CLOSED


### PR DESCRIPTION
Following the [announcement](0) to EOL branch-1.3, update the precommit
script to not consider this branch any longer, and refresh mentions of
this branch in the doc.

[0]: https://lists.apache.org/thread.html/r9552e9085aaac2a43f8b26b866d34825a84a9be7f19118ac560d14de%40%3Cuser.hbase.apache.org%3E