### PR TITLE
HBASE-25144 Add Hadoop-3.3.0 to precommit check list

### DIFF
--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -619,9 +619,9 @@ function hadoopcheck_rebuild
   else
     yetus_info "Setting Hadoop 3 versions to test based on branch-2.2+/master/feature branch rules"
     if [[ "${QUICK_HADOOPCHECK}" == "true" ]]; then
-      hbase_hadoop3_versions="3.1.2 3.2.1"
+      hbase_hadoop3_versions="3.1.2 3.2.1 3.3.0"
     else
-      hbase_hadoop3_versions="3.1.1 3.1.2 3.2.0 3.2.1"
+      hbase_hadoop3_versions="3.1.1 3.1.2 3.2.0 3.2.1 3.3.0"
     fi
   fi
 


### PR DESCRIPTION
Now that Hadoop 3.3.0 is released, let's figure out where it goes in
our testing matrix. Start by adding it to precommit checks.