### PR TITLE
HBASE-25120 Remove the deprecated annotation for MetaTableAccessor.getScanForTableName

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
@@ -319,9 +319,7 @@ public final class MetaTableAccessor {
    * and scan until it hits a new table since that requires parsing the HRI to get the table name.
    * @param tableName bytes of table's name
    * @return configured Scan object
-   * @deprecated This is internal so please remove it when we get a chance.
    */
-  @Deprecated
   public static Scan getScanForTableName(Connection connection, TableName tableName) {
     // Start key is just the table name with delimiters
     byte[] startKey = ClientMetaTableAccessor.getTableStartRowForMeta(tableName, QueryType.REGION);


### PR DESCRIPTION
The comment of `MetaTableAccessor#getScanForTableName` says it is only for internal use but MetaTableAccessor is IA.Private, so it is OK to keep method `getScanForTableName`, which should remove the deprecated annotation for `MetaTableAccessor#getScanForTableName`.