### PR TITLE
HBASE-25151 warmupRegion frustrates registering WALs on the catalog r…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -1198,11 +1198,11 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
   private void initializeWarmup(final CancelableProgressable reporter) throws IOException {
     MonitoredTask status = TaskMonitor.get().createStatus("Initializing region " + this);
     // Initialize all the HStores
-    status.setStatus("Warming up all the Stores");
+    status.setStatus("Warmup all stores of " + this.getRegionInfo().getRegionNameAsString());
     try {
       initializeStores(reporter, status, true);
     } finally {
-      status.markComplete("Done warming up.");
+      status.markComplete("Warmed up " + this.getRegionInfo().getRegionNameAsString());
     }
   }
 
@@ -8039,14 +8039,9 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
       throws IOException {
 
     Objects.requireNonNull(info, "RegionInfo cannot be null");
-
-    if (LOG.isDebugEnabled()) {
-      LOG.debug("HRegion.Warming up region: " + info);
-    }
-
+    LOG.debug("Warmup {}", info);
     Path rootDir = CommonFSUtils.getRootDir(conf);
     Path tableDir = CommonFSUtils.getTableDir(rootDir, info.getTable());
-
     FileSystem fs = null;
     if (rsServices != null) {
       fs = rsServices.getFileSystem();
@@ -8054,7 +8049,6 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
     if (fs == null) {
       fs = rootDir.getFileSystem(conf);
     }
-
     HRegion r = HRegion.newHRegion(tableDir, wal, fs, conf, info, htd, null);
     r.initializeWarmup(reporter);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -2069,48 +2069,34 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
   }
 
   /**
-   *  Wamrmup a region on this server.
-   *
-   * This method should only be called by Master. It synchrnously opens the region and
+   * Warmup a region on this server.
+   * This method should only be called by Master. It synchronously opens the region and
    * closes the region bringing the most important pages in cache.
-   * <p>
-   *
-   * @param controller the RPC controller
-   * @param request the request
-   * @throws ServiceException
    */
   @Override
   public WarmupRegionResponse warmupRegion(final RpcController controller,
       final WarmupRegionRequest request) throws ServiceException {
-
     final RegionInfo region = ProtobufUtil.toRegionInfo(request.getRegionInfo());
-    TableDescriptor htd;
     WarmupRegionResponse response = WarmupRegionResponse.getDefaultInstance();
-
     try {
       checkOpen();
       String encodedName = region.getEncodedName();
       byte[] encodedNameBytes = region.getEncodedNameAsBytes();
       final HRegion onlineRegion = regionServer.getRegion(encodedName);
-
       if (onlineRegion != null) {
-        LOG.info("Region already online. Skipping warming up " + region);
+        LOG.info("{} is online; skipping warmup", region);
         return response;
       }
-
-      htd = regionServer.tableDescriptors.get(region.getTable());
-
+      TableDescriptor htd = regionServer.tableDescriptors.get(region.getTable());
       if (regionServer.getRegionsInTransitionInRS().containsKey(encodedNameBytes)) {
-        LOG.info("Region is in transition. Skipping warmup " + region);
+        LOG.info("{} is in transition; skipping warmup", region);
         return response;
       }
-
-      LOG.info("Warming up region " + region.getRegionNameAsString());
+      LOG.info("Warmup {}", region.getRegionNameAsString());
       HRegion.warmupHRegion(region, htd, regionServer.getWAL(region),
           regionServer.getConfiguration(), regionServer, null);
-
     } catch (IOException ie) {
-      LOG.error("Failed warming up region " + region.getRegionNameAsString(), ie);
+      LOG.error("Failed warmup of {}", region.getRegionNameAsString(), ie);
       throw new ServiceException(ie);
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
@@ -138,7 +138,8 @@ public class AssignRegionHandler extends EventHandler {
       if (ServerRegionReplicaUtil.isMetaRegionReplicaReplicationEnabled(conf, tn)) {
         if (RegionReplicaUtil.isDefaultReplica(this.regionInfo.getReplicaId())) {
           // Add the hbase:meta replication source on replica zero/default.
-          rs.getReplicationSourceService().getReplicationManager().addCatalogReplicationSource();
+          rs.getReplicationSourceService().getReplicationManager().
+            addCatalogReplicationSource(this.regionInfo);
         }
       }
       region = HRegion.openHRegion(regionInfo, htd, rs.getWAL(regionInfo), conf, rs, null);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
@@ -126,7 +126,8 @@ public class UnassignRegionHandler extends EventHandler {
       if (RegionReplicaUtil.isDefaultReplica(region.getRegionInfo().getReplicaId())) {
         // If hbase:meta read replicas enabled, remove replication source for hbase:meta Regions.
         // See assign region handler where we add the replication source on open.
-        rs.getReplicationSourceService().getReplicationManager().removeCatalogReplicationSource();
+        rs.getReplicationSourceService().getReplicationManager().
+          removeCatalogReplicationSource(region.getRegionInfo());
       }
     }
     if (!rs.reportRegionStateTransition(

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALFactory.java
@@ -289,10 +289,10 @@ public class WALFactory {
   }
 
   /**
-   * @param region the region which we want to get a WAL for it. Could be null.
+   * @param region the region which we want to get a WAL for. Could be null.
    */
   public WAL getWAL(RegionInfo region) throws IOException {
-    // use different WAL for hbase:meta
+    // Use different WAL for hbase:meta. Instantiates the meta WALProvider if not already up.
     if (region != null && region.isMetaRegion() &&
       region.getReplicaId() == RegionInfo.DEFAULT_REPLICA_ID) {
       return getMetaProvider().getWAL(region);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestMetaRegionReplicaReplicationEndpoint.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestMetaRegionReplicaReplicationEndpoint.java
@@ -110,12 +110,13 @@ public class TestMetaRegionReplicaReplicationEndpoint {
    * Assert that the ReplicationSource for hbase:meta gets created when hbase:meta is opened.
    */
   @Test
-  public void testHBaseMetaReplicationSourceCreatedOnOpen()
-    throws IOException, InterruptedException {
+  public void testHBaseMetaReplicationSourceCreatedOnOpen() throws Exception {
     MiniHBaseCluster cluster = HTU.getMiniHBaseCluster();
     HRegionServer hrs = cluster.getRegionServer(cluster.getServerHoldingMeta());
+    // Replicate a row to prove all working.
+    testHBaseMetaReplicatesOneRow(0);
     assertTrue(isMetaRegionReplicaReplicationSource(hrs));
-    // Now move the hbase:meta and make sure the ReplicationSoruce is in both places.
+    // Now move the hbase:meta and make sure the ReplicationSource is in both places.
     HRegionServer hrsOther = null;
     for (int i = 0; i < cluster.getNumLiveRegionServers(); i++) {
       hrsOther = cluster.getRegionServer(i);
@@ -139,6 +140,26 @@ public class TestMetaRegionReplicaReplicationEndpoint {
     // Assert that there is a ReplicationSource in both places now.
     assertTrue(isMetaRegionReplicaReplicationSource(hrs));
     assertTrue(isMetaRegionReplicaReplicationSource(hrsOther));
+    // Replicate to show stuff still works.
+    testHBaseMetaReplicatesOneRow(1);
+    // Now pretend a few hours have gone by... roll the meta WAL in original location... Move the
+    // meta back and retry replication. See if it works.
+    hrs.getWAL(meta.getRegionInfo()).rollWriter(true);
+    testHBaseMetaReplicatesOneRow(2);
+    hrs.getWAL(meta.getRegionInfo()).rollWriter(true);
+    testHBaseMetaReplicatesOneRow(3);
+  }
+
+  /**
+   * Test meta region replica replication. Create some tables and see if replicas pick up the
+   * additions.
+   */
+  private void testHBaseMetaReplicatesOneRow(int i) throws Exception {
+    waitForMetaReplicasToOnline();
+    try (Table table = HTU.createTable(TableName.valueOf(this.name.getMethodName() + "_" + i),
+        HConstants.CATALOG_FAMILY)) {
+      verifyReplication(TableName.META_TABLE_NAME, NB_SERVERS, getMetaCells(table.getName()));
+    }
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSource.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSource.java
@@ -507,9 +507,12 @@ public class TestReplicationSource {
       p -> OptionalLong.empty(), new MetricsSource(queueId));
     try {
       rs.startup();
+      assertTrue(rs.isSourceActive());
       Waiter.waitFor(conf, 1000, () -> FaultyReplicationEndpoint.count > 0);
-      assertFalse(rs.isSourceActive());
+      Waiter.waitFor(conf, 1000, () -> rss.isAborted());
       assertTrue(rss.isAborted());
+      Waiter.waitFor(conf, 1000, () -> !rs.isSourceActive());
+      assertFalse(rs.isSourceActive());
     } finally {
       rs.terminate("Done");
       rss.stop("Done");


### PR DESCRIPTION
…eplicationsource

warmupRegion called by Master on Region move will instatiate
the meta WALProvider as part of its action making it so
it is already created by the time we go to open the
hbsae:meta Region. Accommodate meta walProvider
being already up.

hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
 Pass regionInfo. Needed internally.

hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceManager.java
 Add handling if meta wal provider already instantiated when
 addCatalogReplicationSource runs.

hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestMetaRegionReplicaReplicationEndpoint.java
 Add exercising moving meta around between servers. Test replication
 keeps working.