### PR TITLE
HBASE-24996 Support CheckAndMutate in Region.batchMutate()

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RowMutations.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RowMutations.java
@@ -29,7 +29,6 @@ import org.apache.hbase.thirdparty.org.apache.commons.collections4.CollectionUti
 
 /**
  * Performs multiple mutations atomically on a single row.
- * Currently {@link Put} and {@link Delete} are supported.
  *
  * The mutations are performed in the order in which they
  * were added.
@@ -75,8 +74,6 @@ public class RowMutations implements Row {
   }
 
   /**
-   * Currently only supports {@link Put} and {@link Delete} mutations.
-   *
    * @param mutation The data to send.
    * @throws IOException if the row of added mutation doesn't match the original row
    */
@@ -85,15 +82,13 @@ public class RowMutations implements Row {
   }
 
   /**
-   * Currently only supports {@link Put} and {@link Delete} mutations.
-   *
    * @param mutations The data to send.
    * @throws IOException if the row of added mutation doesn't match the original row
    */
   public RowMutations add(List<? extends Mutation> mutations) throws IOException {
     for (Mutation mutation : mutations) {
       if (!Bytes.equals(row, mutation.getRow())) {
-        throw new WrongRowIOException("The row in the recently added Put/Delete <" +
+        throw new WrongRowIOException("The row in the recently added Mutation <" +
           Bytes.toStringBinary(mutation.getRow()) + "> doesn't match the original one <" +
           Bytes.toStringBinary(this.row) + ">");
       }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CompositeFamilyCellMap.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CompositeFamilyCellMap.java
@@ -1,0 +1,314 @@
+/**
+ *
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.util;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.NavigableSet;
+import java.util.Set;
+import java.util.TreeMap;
+import java.util.TreeSet;
+import java.util.stream.Collectors;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Composite read-only familyCellMap
+ */
+@InterfaceAudience.Private
+public class CompositeFamilyCellMap implements NavigableMap<byte[], List<Cell>> {
+
+  private static class CompositeFamilyCellMapEntry implements Entry<byte[], List<Cell>> {
+    private final byte[] key;
+    private final List<Cell> value;
+
+    public CompositeFamilyCellMapEntry(byte[] key, List<Cell> value) {
+      this.key = key;
+      this.value = value;
+    }
+
+    @Override
+    public byte[] getKey() {
+      return key;
+    }
+
+    @Override
+    public List<Cell> getValue() {
+      return value;
+    }
+
+    @Override
+    public List<Cell> setValue(List<Cell> value) {
+      throw new UnsupportedOperationException("read-only");
+    }
+  }
+
+  private final List<NavigableMap<byte[], List<Cell>>> familyCellMapList = new ArrayList<>();
+
+  public CompositeFamilyCellMap() {
+  }
+
+  public CompositeFamilyCellMap(List<NavigableMap<byte[], List<Cell>>> familyCellMapList) {
+    for (NavigableMap<byte[], List<Cell>> familyCellMap : familyCellMapList) {
+      addFamilyCellMap(familyCellMap);
+    }
+  }
+
+  public void addFamilyCellMap(NavigableMap<byte[], List<Cell>> familyCellMap) {
+    familyCellMapList.add(familyCellMap);
+  }
+
+  @Override
+  public Entry<byte[], List<Cell>> lowerEntry(byte[] key) {
+    byte[] lowerKey = lowerKey(key);
+    return new CompositeFamilyCellMapEntry(lowerKey, get(lowerKey));
+  }
+
+  @Override
+  public byte[] lowerKey(byte[] key) {
+    return navigableKeySet().lower(key);
+  }
+
+  @Override
+  public Entry<byte[], List<Cell>> floorEntry(byte[] key) {
+    byte[] floorKey = floorKey(key);
+    return new CompositeFamilyCellMapEntry(floorKey, get(floorKey));
+  }
+
+  @Override
+  public byte[] floorKey(byte[] key) {
+    return navigableKeySet().floor(key);
+  }
+
+  @Override
+  public Entry<byte[], List<Cell>> ceilingEntry(byte[] key) {
+    byte[] ceilingKey = ceilingKey(key);
+    return new CompositeFamilyCellMapEntry(ceilingKey, get(ceilingKey));
+  }
+
+  @Override
+  public byte[] ceilingKey(byte[] key) {
+    return navigableKeySet().ceiling(key);
+  }
+
+  @Override
+  public Entry<byte[], List<Cell>> higherEntry(byte[] key) {
+    byte[] higherKey = higherKey(key);
+    return new CompositeFamilyCellMapEntry(higherKey, get(higherKey));
+  }
+
+  @Override
+  public byte[] higherKey(byte[] key) {
+    return navigableKeySet().higher(key);
+  }
+
+  @Override
+  public Entry<byte[], List<Cell>> firstEntry() {
+    byte[] firstKey = firstKey();
+    return new CompositeFamilyCellMapEntry(firstKey, get(firstKey));
+  }
+
+  @Override
+  public Entry<byte[], List<Cell>> lastEntry() {
+    byte[] lastKey = lastKey();
+    return new CompositeFamilyCellMapEntry(lastKey, get(lastKey));
+  }
+
+  @Override
+  public Entry<byte[], List<Cell>> pollFirstEntry() {
+    throw new UnsupportedOperationException("read-only");
+  }
+
+  @Override
+  public Entry<byte[], List<Cell>> pollLastEntry() {
+    throw new UnsupportedOperationException("read-only");
+  }
+
+  @Override
+  public NavigableMap<byte[], List<Cell>> descendingMap() {
+    NavigableMap<byte[], List<Cell>> ret = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    for (byte[] key : descendingKeySet()) {
+      ret.put(key, get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public NavigableSet<byte[]> navigableKeySet() {
+    NavigableSet<byte[]> keySet = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+    for (NavigableMap<byte[], List<Cell>> familyMap : familyCellMapList) {
+      keySet.addAll(familyMap.keySet());
+    }
+    return keySet;
+  }
+
+  @Override
+  public NavigableSet<byte[]> descendingKeySet() {
+    return navigableKeySet().descendingSet();
+  }
+
+  @Override
+  public NavigableMap<byte[], List<Cell>> subMap(byte[] fromKey, boolean fromInclusive,
+    byte[] toKey, boolean toInclusive) {
+    NavigableMap<byte[], List<Cell>> ret = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    for (byte[] key : navigableKeySet().subSet(fromKey, fromInclusive, toKey, toInclusive)) {
+      ret.put(key, get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public NavigableMap<byte[], List<Cell>> headMap(byte[] toKey, boolean inclusive) {
+    NavigableMap<byte[], List<Cell>> ret = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    for (byte[] key : navigableKeySet().headSet(toKey, inclusive)) {
+      ret.put(key, get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public NavigableMap<byte[], List<Cell>> tailMap(byte[] fromKey, boolean inclusive) {
+    NavigableMap<byte[], List<Cell>> ret = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    for (byte[] key : navigableKeySet().tailSet(fromKey, inclusive)) {
+      ret.put(key, get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public Comparator<? super byte[]> comparator() {
+    return Bytes.BYTES_COMPARATOR;
+  }
+
+  @Override
+  public NavigableMap<byte[], List<Cell>> subMap(byte[] fromKey, byte[] toKey) {
+    NavigableMap<byte[], List<Cell>> ret = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    for (byte[] key : navigableKeySet().subSet(fromKey, toKey)) {
+      ret.put(key, get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public NavigableMap<byte[], List<Cell>> headMap(byte[] toKey) {
+    NavigableMap<byte[], List<Cell>> ret = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    for (byte[] key : navigableKeySet().headSet(toKey)) {
+      ret.put(key, get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public NavigableMap<byte[], List<Cell>> tailMap(byte[] fromKey) {
+    NavigableMap<byte[], List<Cell>> ret = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    for (byte[] key : navigableKeySet().tailSet(fromKey)) {
+      ret.put(key, get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public byte[] firstKey() {
+    return navigableKeySet().first();
+  }
+
+  @Override
+  public byte[] lastKey() {
+    return navigableKeySet().last();
+  }
+
+  @Override
+  public int size() {
+    return familyCellMapList.stream().mapToInt(Map::size).sum();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return familyCellMapList.stream().allMatch(Map::isEmpty);
+  }
+
+  @Override
+  public boolean containsKey(Object key) {
+    return familyCellMapList.stream().anyMatch(familyMap -> familyMap.containsKey(key));
+  }
+
+  @Override
+  public boolean containsValue(Object value) {
+    return familyCellMapList.stream().anyMatch(familyMap -> familyMap.containsValue(value));
+  }
+
+  @Override
+  public List<Cell> get(Object key) {
+    return familyCellMapList.stream()
+      .map(familyMap -> familyMap.getOrDefault(key, Collections.emptyList()))
+      .flatMap(Collection::stream)
+      .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<Cell> put(byte[] key, List<Cell> value) {
+    throw new UnsupportedOperationException("read-only");
+  }
+
+  @Override
+  public List<Cell> remove(Object key) {
+    throw new UnsupportedOperationException("read-only");
+  }
+
+  @Override
+  public void putAll(Map<? extends byte[], ? extends List<Cell>> m) {
+    throw new UnsupportedOperationException("read-only");
+  }
+
+  @Override
+  public void clear() {
+    throw new UnsupportedOperationException("read-only");
+  }
+
+  @Override
+  public Set<byte[]> keySet() {
+    return navigableKeySet();
+  }
+
+  @Override
+  public Collection<List<Cell>> values() {
+    Set<byte[]> keySet = keySet();
+    List<List<Cell>> ret = new ArrayList<>(keySet.size());
+    for (byte[] key : keySet) {
+      ret.add(get(key));
+    }
+    return ret;
+  }
+
+  @Override
+  public Set<Entry<byte[], List<Cell>>> entrySet() {
+    Set<Entry<byte[], List<Cell>>> ret = new TreeSet<>(
+      (o1, o2) -> Bytes.BYTES_COMPARATOR.compare(o1.getKey(), o2.getKey()));
+    for (byte[] key : keySet()) {
+      ret.add(new CompositeFamilyCellMapEntry(key, get(key)));
+    }
+    return ret;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionObserver.java
@@ -441,8 +441,8 @@ public interface RegionObserver {
   /**
    * This will be called for every batch mutation operation happening at the server. This will be
    * called after acquiring the locks on the mutating rows and after applying the proper timestamp
-   * for each Mutation at the server. The batch may contain Put/Delete/Increment/Append. By
-   * setting OperationStatus of Mutations
+   * for each Mutation at the server. The batch may contain
+   * Put/Delete/Increment/Append/CheckAndMutate. By setting OperationStatus of Mutations
    * ({@link MiniBatchOperationInProgress#setOperationStatus(int, OperationStatus)}),
    * {@link RegionObserver} can make Region to skip these Mutations.
    * <p>
@@ -460,7 +460,8 @@ public interface RegionObserver {
    * {@link #postPut(ObserverContext, Put, WALEdit, Durability)}
    * and {@link #postDelete(ObserverContext, Delete, WALEdit, Durability)}
    * and {@link #postIncrement(ObserverContext, Increment, Result)}
-   * and {@link #postAppend(ObserverContext, Append, Result)} is
+   * and {@link #postAppend(ObserverContext, Append, Result)}
+   * and {@link #postCheckAndMutate(ObserverContext, CheckAndMutate, CheckAndMutateResult)} is
    * this hook will be executed before the mvcc transaction completion.
    * <p>
    * Note: Do not retain references to any Cells in Mutations beyond the life of this invocation.
@@ -491,8 +492,8 @@ public interface RegionObserver {
       Operation operation) throws IOException {}
 
   /**
-   * Called after the completion of batch put/delete/increment/append and will be called even if
-   * the batch operation fails.
+   * Called after the completion of batch put/delete/increment/append/checkAndMutate and will be
+   * called even if the batch operation fails.
    * <p>
    * Note: Do not retain references to any Cells in Mutations beyond the life of this invocation.
    * If need a Cell reference for later use, copy the cell and use that.
@@ -919,7 +920,7 @@ public interface RegionObserver {
   /**
    * Called after checkAndMutate
    * <p>
-   * Note: Do not retain references to any Cells in 'delete' beyond the life of this invocation.
+   * Note: Do not retain references to any Cells in actions beyond the life of this invocation.
    * If need a Cell reference for later use, copy the cell and use that.
    * @param c the environment provided by the region server
    * @param checkAndMutate the CheckAndMutate object
@@ -1358,7 +1359,8 @@ public interface RegionObserver {
 
   /**
    * Called after a list of new cells has been created during an increment operation, but before
-   * they are committed to the WAL or memstore.
+   * they are committed to the WAL or memstore. This is also called in case of an increment
+   * operation in checkAndMutate.
    *
    * @param ctx       the environment provided by the region server
    * @param mutation  the current mutation
@@ -1380,7 +1382,8 @@ public interface RegionObserver {
 
   /**
    * Called after a list of new cells has been created during an append operation, but before
-   * they are committed to the WAL or memstore.
+   * they are committed to the WAL or memstore. This is also called in case of an append
+   * operation in checkAndMutate.
    *
    * @param ctx       the environment provided by the region server
    * @param mutation  the current mutation

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MiniBatchOperationInProgress.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MiniBatchOperationInProgress.java
@@ -124,6 +124,7 @@ public class MiniBatchOperationInProgress<T> {
    * in the same batch. These mutations are applied to the WAL and applied to the memstore as well.
    * The timestamp of the cells in the given Mutations MUST be obtained from the original mutation.
    * <b>Note:</b> The durability from CP will be replaced by the durability of corresponding mutation.
+   * <b>Note:</b> Currently only supports Put and Delete operations.
    * @param index the index that corresponds to the original mutation index in the batch
    * @param newOperations the Mutations to add
    */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/OperationStatus.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/OperationStatus.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.regionserver;
 
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.HConstants.OperationStatusCode;
+import org.apache.hadoop.hbase.client.CheckAndMutateResult;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -44,28 +45,38 @@ public class OperationStatus {
   public static final OperationStatus NOT_RUN = new OperationStatus(OperationStatusCode.NOT_RUN);
 
   private final OperationStatusCode code;
+  // For Increment/Append operations
   private final Result result;
+  // For CheckAndMutate operations
+  private final CheckAndMutateResult checkAndMutateResult;
+
   private final String exceptionMsg;
 
   public OperationStatus(OperationStatusCode code) {
-    this(code, null, "");
+    this(code, null, null, "");
   }
 
   public OperationStatus(OperationStatusCode code, Result result) {
-    this(code, result, "");
+    this(code, result, null, "");
+  }
+
+  public OperationStatus(OperationStatusCode code, CheckAndMutateResult checkAndMutateResult) {
+    this(code, null, checkAndMutateResult, "");
   }
 
   public OperationStatus(OperationStatusCode code, String exceptionMsg) {
-    this(code, null, exceptionMsg);
+    this(code, null, null, exceptionMsg);
   }
 
   public OperationStatus(OperationStatusCode code, Exception e) {
-    this(code, null, (e == null) ? "" : e.getClass().getName() + ": " + e.getMessage());
+    this(code, null, null, (e == null) ? "" : e.getClass().getName() + ": " + e.getMessage());
   }
 
-  private OperationStatus(OperationStatusCode code, Result result, String exceptionMsg) {
+  private OperationStatus(OperationStatusCode code, Result result,
+    CheckAndMutateResult checkAndMutateResult, String exceptionMsg) {
     this.code = code;
     this.result = result;
+    this.checkAndMutateResult = checkAndMutateResult;
     this.exceptionMsg = exceptionMsg;
   }
 
@@ -81,6 +92,13 @@ public class OperationStatus {
    */
   public Result getResult() {
     return result;
+  }
+
+  /**
+   * @return checkAndMutateResult
+   */
+  public CheckAndMutateResult getCheckAndMutateResult() {
+    return checkAndMutateResult;
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -629,17 +629,7 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
         return new CheckAndMutateResult(true, null);
       } else {
         CheckAndMutate checkAndMutate = ProtobufUtil.toCheckAndMutate(condition, mutations);
-        CheckAndMutateResult result = null;
-        if (region.getCoprocessorHost() != null) {
-          result = region.getCoprocessorHost().preCheckAndMutate(checkAndMutate);
-        }
-        if (result == null) {
-          result = region.checkAndMutate(checkAndMutate);
-          if (region.getCoprocessorHost() != null) {
-            result = region.getCoprocessorHost().postCheckAndMutate(checkAndMutate, result);
-          }
-        }
-        return result;
+        return region.checkAndMutate(checkAndMutate);
       }
     } finally {
       // Currently, the checkAndMutate isn't supported by batch so it won't mess up the cell scanner
@@ -3062,17 +3052,7 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
     checkCellSizeLimit(region, (Mutation) checkAndMutate.getAction());
     spaceQuota.getPolicyEnforcement(region).check((Mutation) checkAndMutate.getAction());
     quota.addMutation((Mutation) checkAndMutate.getAction());
-
-    CheckAndMutateResult result = null;
-    if (region.getCoprocessorHost() != null) {
-      result = region.getCoprocessorHost().preCheckAndMutate(checkAndMutate);
-    }
-    if (result == null) {
-      result = region.checkAndMutate(checkAndMutate);
-      if (region.getCoprocessorHost() != null) {
-        result = region.getCoprocessorHost().postCheckAndMutate(checkAndMutate, result);
-      }
-    }
+    CheckAndMutateResult result = region.checkAndMutate(checkAndMutate);
     MetricsRegionServer metricsRegionServer = regionServer.getMetrics();
     if (metricsRegionServer != null) {
       long after = EnvironmentEdgeManager.currentTime();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/Region.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/Region.java
@@ -291,16 +291,16 @@ public interface Region extends ConfigurationObserver {
 
   /**
    * Perform a batch of mutations.
-   * <p>
-   * Note this supports only Put, Delete, Increment and Append mutations and will ignore other
-   * types passed.
+   *
+   * Please do not operate on a same column of a single row in a batch, we will not consider the
+   * previous operation in the same batch when performing the operations in the batch.
+   *
    * @param mutations the list of mutations
    * @return an array of OperationStatus which internally contains the
    *         OperationStatusCode and the exceptionMessage if any.
    * @throws IOException
    */
-  OperationStatus[] batchMutate(Mutation[] mutations)
-      throws IOException;
+  OperationStatus[] batchMutate(Mutation[] mutations) throws IOException;
 
   /**
    * Atomically checks if a row/family/qualifier value matches the expected value and if it does,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CollectionBackedScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CollectionBackedScanner.java
@@ -113,6 +113,7 @@ public class CollectionBackedScanner extends NonReversedNonLazyKeyValueScanner {
         return true;
       }
     }
+    current = null;
     return false;
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/coprocessor/SimpleRegionObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/coprocessor/SimpleRegionObserver.java
@@ -777,12 +777,24 @@ public class SimpleRegionObserver implements RegionCoprocessor, RegionObserver {
     return ctPreBatchMutate.get() > 0;
   }
 
+  public int getPreBatchMutate() {
+    return ctPreBatchMutate.get();
+  }
+
   public boolean hadPostBatchMutate() {
     return ctPostBatchMutate.get() > 0;
   }
 
+  public int getPostBatchMutate() {
+    return ctPostBatchMutate.get();
+  }
+
   public boolean hadPostBatchMutateIndispensably() {
     return ctPostBatchMutateIndispensably.get() > 0;
+  }
+
+  public int getPostBatchMutateIndispensably() {
+    return ctPostBatchMutateIndispensably.get();
   }
 
   public boolean hadPostStartRegionOperation() {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
@@ -59,6 +59,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -2382,6 +2383,7 @@ public class TestHRegion {
     CheckAndMutateResult res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, emptyVal).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // Putting data in key
     put = new Put(row1);
@@ -2391,17 +2393,20 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, emptyVal).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // not empty anymore
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, emptyVal).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     Delete delete = new Delete(row1);
     delete.addColumn(fam1, qf1);
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, emptyVal).build(delete));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     put = new Put(row1);
     put.addColumn(fam1, qf1, val2);
@@ -2409,6 +2414,7 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, val1).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // checkAndDelete with correct value
     delete = new Delete(row1);
@@ -2417,11 +2423,13 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, val2).build(delete));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     delete = new Delete(row1);
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, emptyVal).build(delete));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // checkAndPut looking for a null value
     put = new Put(row1);
@@ -2430,6 +2438,7 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1).ifNotExists(fam1, qf1)
       .build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
   }
 
   @Test
@@ -2453,6 +2462,7 @@ public class TestHRegion {
     CheckAndMutateResult res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, val2).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // checkAndDelete with wrong value
     Delete delete = new Delete(row1);
@@ -2460,6 +2470,7 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, val2).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // Putting data in key
     put = new Put(row1);
@@ -2470,6 +2481,7 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, Bytes.toBytes(bd2)).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // checkAndDelete with wrong value
     delete = new Delete(row1);
@@ -2477,6 +2489,7 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.EQUAL, Bytes.toBytes(bd2)).build(delete));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
   }
 
   @Test
@@ -2546,11 +2559,13 @@ public class TestHRegion {
     CheckAndMutateResult res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.LESS, val3).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.LESS: original = val3, compare with val4, fail
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.LESS, val4).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.LESS: original = val3, compare with val2,
     // succeed (now value = val2)
@@ -2559,17 +2574,20 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.LESS, val2).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.LESS_OR_EQUAL: original = val2, compare with val3, fail
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.LESS_OR_EQUAL, val3).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.LESS_OR_EQUAL: original = val2, compare with val2,
     // succeed (value still = val2)
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.LESS_OR_EQUAL, val2).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.LESS_OR_EQUAL: original = val2, compare with val1,
     // succeed (now value = val3)
@@ -2578,16 +2596,19 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.LESS_OR_EQUAL, val1).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.GREATER: original = val3, compare with val3, fail
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.GREATER, val3).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.GREATER: original = val3, compare with val2, fail
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.GREATER, val2).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.GREATER: original = val3, compare with val4,
     // succeed (now value = val2)
@@ -2596,22 +2617,26 @@ public class TestHRegion {
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.GREATER, val4).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.GREATER_OR_EQUAL: original = val2, compare with val1, fail
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.GREATER_OR_EQUAL, val1).build(put));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.GREATER_OR_EQUAL: original = val2, compare with val2,
     // succeed (value still = val2)
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.GREATER_OR_EQUAL, val2).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     // Test CompareOp.GREATER_OR_EQUAL: original = val2, compare with val3, succeed
     res = region.checkAndMutate(CheckAndMutate.newBuilder(row1)
       .ifMatches(fam1, qf1, CompareOperator.GREATER_OR_EQUAL, val3).build(put));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
   }
 
   @Test
@@ -2751,6 +2776,7 @@ public class TestHRegion {
           Bytes.toBytes("b"))))
       .build(new Put(row).addColumn(FAMILY, Bytes.toBytes("D"), Bytes.toBytes("d"))));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     Result result = region.get(new Get(row).addColumn(FAMILY, Bytes.toBytes("D")));
     assertEquals("d", Bytes.toString(result.getValue(FAMILY, Bytes.toBytes("D"))));
@@ -2764,6 +2790,7 @@ public class TestHRegion {
           Bytes.toBytes("c"))))
       .build(new Put(row).addColumn(FAMILY, Bytes.toBytes("E"), Bytes.toBytes("e"))));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     assertTrue(region.get(new Get(row).addColumn(FAMILY, Bytes.toBytes("E"))).isEmpty());
 
@@ -2776,6 +2803,7 @@ public class TestHRegion {
           Bytes.toBytes("b"))))
       .build(new Delete(row).addColumns(FAMILY, Bytes.toBytes("D"))));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     assertTrue(region.get(new Get(row).addColumn(FAMILY, Bytes.toBytes("D"))).isEmpty());
 
@@ -2791,6 +2819,7 @@ public class TestHRegion {
           .addColumn(FAMILY, Bytes.toBytes("E"), Bytes.toBytes("e")))
         .add((Mutation) new Delete(row).addColumns(FAMILY, Bytes.toBytes("A")))));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     result = region.get(new Get(row).addColumn(FAMILY, Bytes.toBytes("E")));
     assertEquals("e", Bytes.toString(result.getValue(FAMILY, Bytes.toBytes("E"))));
@@ -2815,6 +2844,7 @@ public class TestHRegion {
       .timeRange(TimeRange.between(0, 101))
       .build(new Put(row).addColumn(FAMILY, Bytes.toBytes("B"), Bytes.toBytes("b"))));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     Result result = region.get(new Get(row).addColumn(FAMILY, Bytes.toBytes("B")));
     assertEquals("b", Bytes.toString(result.getValue(FAMILY, Bytes.toBytes("B"))));
@@ -2826,6 +2856,7 @@ public class TestHRegion {
       .timeRange(TimeRange.between(0, 100))
       .build(new Put(row).addColumn(FAMILY, Bytes.toBytes("C"), Bytes.toBytes("c"))));
     assertFalse(res.isSuccess());
+    assertNull(res.getResult());
 
     assertTrue(region.get(new Get(row).addColumn(FAMILY, Bytes.toBytes("C"))).isEmpty());
 
@@ -2839,6 +2870,7 @@ public class TestHRegion {
           .addColumn(FAMILY, Bytes.toBytes("D"), Bytes.toBytes("d")))
         .add((Mutation) new Delete(row).addColumns(FAMILY, Bytes.toBytes("A")))));
     assertTrue(res.isSuccess());
+    assertNull(res.getResult());
 
     result = region.get(new Get(row).addColumn(FAMILY, Bytes.toBytes("D")));
     assertEquals("d", Bytes.toString(result.getValue(FAMILY, Bytes.toBytes("D"))));
@@ -2965,6 +2997,64 @@ public class TestHRegion {
 
     result = region.get(new Get(row).addColumn(FAMILY, Bytes.toBytes("B")));
     assertEquals("bbb", Bytes.toString(result.getValue(FAMILY, Bytes.toBytes("B"))));
+  }
+
+  @Test
+  public void testCheckAndIncrementAndAppend() throws Throwable {
+    // Setting up region
+    this.region = initHRegion(tableName, method, CONF, fam1);
+
+    // CheckAndMutate with Increment and Append
+    CheckAndMutate checkAndMutate = CheckAndMutate.newBuilder(row)
+      .ifNotExists(fam1, qual)
+      .build(new RowMutations(row)
+        .add((Mutation) new Increment(row).addColumn(fam1, qual1, 1L))
+        .add((Mutation) new Append(row).addColumn(fam1, qual2, Bytes.toBytes("a")))
+      );
+
+    CheckAndMutateResult result = region.checkAndMutate(checkAndMutate);
+    assertTrue(result.isSuccess());
+    assertEquals(1L, Bytes.toLong(result.getResult().getValue(fam1, qual1)));
+    assertEquals("a", Bytes.toString(result.getResult().getValue(fam1, qual2)));
+
+    Result r = region.get(new Get(row));
+    assertEquals(1L, Bytes.toLong(r.getValue(fam1, qual1)));
+    assertEquals("a", Bytes.toString(r.getValue(fam1, qual2)));
+
+    // Set return results to false
+    checkAndMutate = CheckAndMutate.newBuilder(row)
+      .ifNotExists(fam1, qual)
+      .build(new RowMutations(row)
+        .add((Mutation) new Increment(row).addColumn(fam1, qual1, 1L).setReturnResults(false))
+        .add((Mutation) new Append(row).addColumn(fam1, qual2, Bytes.toBytes("a"))
+          .setReturnResults(false))
+      );
+
+    result = region.checkAndMutate(checkAndMutate);
+    assertTrue(result.isSuccess());
+    assertNull(result.getResult().getValue(fam1, qual1));
+    assertNull(result.getResult().getValue(fam1, qual2));
+
+    r = region.get(new Get(row));
+    assertEquals(2L, Bytes.toLong(r.getValue(fam1, qual1)));
+    assertEquals("aa", Bytes.toString(r.getValue(fam1, qual2)));
+
+    checkAndMutate = CheckAndMutate.newBuilder(row)
+      .ifNotExists(fam1, qual)
+      .build(new RowMutations(row)
+        .add((Mutation) new Increment(row).addColumn(fam1, qual1, 1L))
+        .add((Mutation) new Append(row).addColumn(fam1, qual2, Bytes.toBytes("a"))
+          .setReturnResults(false))
+      );
+
+    result = region.checkAndMutate(checkAndMutate);
+    assertTrue(result.isSuccess());
+    assertEquals(3L, Bytes.toLong(result.getResult().getValue(fam1, qual1)));
+    assertNull(result.getResult().getValue(fam1, qual2));
+
+    r = region.get(new Get(row));
+    assertEquals(3L, Bytes.toLong(r.getValue(fam1, qual1)));
+    assertEquals("aaa", Bytes.toString(r.getValue(fam1, qual2)));
   }
 
   // ////////////////////////////////////////////////////////////////////////////
@@ -6964,6 +7054,164 @@ public class TestHRegion {
 
     assertTrue(Bytes.equals(c.getValueArray(), c.getValueOffset(), c.getValueLength(),
       qual2, 0, qual2.length));
+  }
+
+  @Test
+  public void testBatchMutate() throws Exception {
+    final byte[] row = Bytes.toBytes("row");
+    final byte[] q1 = Bytes.toBytes("q1");
+    final byte[] q2 = Bytes.toBytes("q2");
+    final byte[] q3 = Bytes.toBytes("q3");
+    final byte[] q4 = Bytes.toBytes("q4");
+    final byte[] q5 = Bytes.toBytes("q5");
+    final String v1 = "v1";
+    final String v2 = "v2";
+
+    region = initHRegion(tableName, method, CONF, fam1);
+
+    // Initial values
+    region.batchMutate(new Mutation[] {
+      new Put(row).addColumn(fam1, q2, Bytes.toBytes("toBeDeleted")),
+      new Put(row).addColumn(fam1, q3, Bytes.toBytes(5L)),
+      new Put(row).addColumn(fam1, q4, Bytes.toBytes("a")),
+    });
+
+    // Do batch mutate
+    OperationStatus[] statuses = region.batchMutate(new Mutation[] {
+      new Put(row).addColumn(fam1, q1, Bytes.toBytes(v1)),
+      new Delete(row).addColumns(fam1, q2),
+      new Increment(row).addColumn(fam1, q3, 1),
+      new Append(row).addColumn(fam1, q4, Bytes.toBytes("b")),
+      CheckAndMutate.newBuilder(row).ifNotExists(fam1, q5)
+        .build(new Put(row).addColumn(fam1, q5, Bytes.toBytes(v2)))
+    });
+    assertEquals(6L, Bytes.toLong(statuses[2].getResult().getValue(fam1, q3)));
+    assertEquals("ab", Bytes.toString(statuses[3].getResult().getValue(fam1, q4)));
+    assertTrue(statuses[4].getCheckAndMutateResult().isSuccess());
+
+    // Verify the value
+    Result result = region.get(new Get(row));
+    assertEquals(v1, Bytes.toString(result.getValue(fam1, q1)));
+    assertNull(result.getValue(fam1, q2));
+    assertEquals(6L, Bytes.toLong(result.getValue(fam1, q3)));
+    assertEquals("ab", Bytes.toString(result.getValue(fam1, q4)));
+    assertEquals(v2, Bytes.toString(result.getValue(fam1, q5)));
+  }
+
+  @Test
+  public void testBatchMutateInParallel() throws Exception {
+    final int numReaderThreads = 100;
+    final CountDownLatch latch = new CountDownLatch(numReaderThreads);
+
+    final byte[] row = Bytes.toBytes("row");
+    final byte[] q1 = Bytes.toBytes("q1");
+    final byte[] q2 = Bytes.toBytes("q2");
+    final byte[] q3 = Bytes.toBytes("q3");
+    final byte[] q4 = Bytes.toBytes("q4");
+    final byte[] q5 = Bytes.toBytes("q5");
+    final String v1 = "v1";
+    final String v2 = "v2";
+    final String v3 = "v3";
+
+    // We need to ensure the timestamp of the delete operation is more than the previous one
+    final AtomicLong deleteTimestamp = new AtomicLong();
+
+    region = initHRegion(tableName, method, CONF, fam1);
+
+    // Initial values
+    region.batchMutate(new Mutation[] {
+      new Put(row).addColumn(fam1, q1, Bytes.toBytes(v1))
+        .addColumn(fam1, q2, deleteTimestamp.getAndIncrement(), Bytes.toBytes(v2))
+        .addColumn(fam1, q3, Bytes.toBytes(1L))
+        .addColumn(fam1, q4, Bytes.toBytes("a"))
+        .addColumn(fam1, q5, Bytes.toBytes(v3))
+    });
+
+    final AtomicReference<AssertionError> assertionError = new AtomicReference<>();
+
+    // Writer thread
+    Thread writerThread = new Thread(() -> {
+      try {
+        while (true) {
+          // If all the reader threads finish, then stop the writer thread
+          if (latch.await(0, TimeUnit.MILLISECONDS)) {
+            return;
+          }
+
+          // Execute the mutations. This should be done atomically
+          region.batchMutate(new Mutation[] {
+            new Put(row).addColumn(fam1, q1, Bytes.toBytes(v2)),
+            new Delete(row).addColumns(fam1, q2, deleteTimestamp.getAndIncrement()),
+            new Increment(row).addColumn(fam1, q3, 1L),
+            new Append(row).addColumn(fam1, q4, Bytes.toBytes("b")),
+            CheckAndMutate.newBuilder(row).ifEquals(fam1, q5, Bytes.toBytes(v3)).build(
+              new Put(row).addColumn(fam1, q5, Bytes.toBytes(v1))) });
+
+          // We need to ensure the timestamps of the Increment/Append/CheckAndPut operations are
+          // more than the previous ones
+          Result result = region.get(new Get(row)
+            .addColumn(fam1, q3).addColumn(fam1, q4).addColumn(fam1, q5));
+          long tsIncrement = result.getColumnLatestCell(fam1, q3).getTimestamp();
+          long tsAppend = result.getColumnLatestCell(fam1, q4).getTimestamp();
+          long tsCheckAndPut = result.getColumnLatestCell(fam1, q5).getTimestamp();
+
+          // Put the initial values
+          region.batchMutate(new Mutation[] {
+            new Put(row).addColumn(fam1, q1, Bytes.toBytes(v1))
+              .addColumn(fam1, q2, deleteTimestamp.getAndIncrement(), Bytes.toBytes(v2))
+              .addColumn(fam1, q3, tsIncrement + 1, Bytes.toBytes(1L))
+              .addColumn(fam1, q4, tsAppend + 1, Bytes.toBytes("a"))
+              .addColumn(fam1, q5, tsCheckAndPut + 1, Bytes.toBytes(v3))
+          });
+        }
+      } catch (Exception e) {
+        e.printStackTrace();
+        assertionError.set(new AssertionError(e.getMessage()));
+      }
+    });
+    writerThread.start();
+
+    // Reader threads
+    for (int i = 0; i < numReaderThreads; i++) {
+      new Thread(() -> {
+        try {
+          for (int j = 0; j < 10000; j++) {
+            // Verify the values
+            Result result = region.get(new Get(row));
+
+            // The values should be equals to either the initial values or the values after
+            // executing the mutations
+            String q1Value = Bytes.toString(result.getValue(fam1, q1));
+            if (v1.equals(q1Value)) {
+              assertEquals(v2, Bytes.toString(result.getValue(fam1, q2)));
+              assertEquals(1L, Bytes.toLong(result.getValue(fam1, q3)));
+              assertEquals("a", Bytes.toString(result.getValue(fam1, q4)));
+              assertEquals(v3, Bytes.toString(result.getValue(fam1, q5)));
+            } else if (v2.equals(q1Value)) {
+              assertNull(Bytes.toString(result.getValue(fam1, q2)));
+              assertEquals(2L, Bytes.toLong(result.getValue(fam1, q3)));
+              assertEquals("ab", Bytes.toString(result.getValue(fam1, q4)));
+              assertEquals(v1, Bytes.toString(result.getValue(fam1, q5)));
+            } else {
+              fail("the qualifier " + q1 + " should be " + v1 + " or " + v2 + ", but " + q1Value);
+            }
+          }
+        } catch (Exception e) {
+          e.printStackTrace();
+          assertionError.set(new AssertionError(e.getMessage()));
+        } catch (AssertionError e) {
+          assertionError.set(e);
+        }
+
+        latch.countDown();
+      }).start();
+    }
+
+    writerThread.join();
+
+    if (assertionError.get() != null) {
+      throw assertionError.get();
+    }
   }
 
   @Test


### PR DESCRIPTION
- After this change, Region.batchMutate() will support CheckAndMutate operations and we will be able to perform Put/Delete/Increment/Append/CheckAndMutate operations atomically.
- When CheckAndMutate operations are executed, the following coprocessor methods of RegionObserver will be no longer called. However, postIncrementBeforeWAL/postAppendBeforeWAL will be still called.
  - prePut
  - postPut
  - preDelete
  - postDelete
  - preIncrement
  - preIncrementAfterRowLock
  - postIncrement
  - preAppend
  - preAppendAfterRowLock
  - postAppend
- Also, the following coprocessor methods of RegionObserver will be called when CheckAndMutate operations are performed:
  - preBatchMutate()
  - postBatchMutate()
  - postBatchMutateIndispensably()