### PR TITLE
HBASE-24628 Region normalizer now respects a rate limit (HMaster chore shutdown NPE ADDENDUM)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1123,7 +1123,9 @@ public class HMaster extends HRegionServer implements MasterServices {
     getChoreService().scheduleChore(clusterStatusChore);
     this.balancerChore = new BalancerChore(this);
     getChoreService().scheduleChore(balancerChore);
-    getChoreService().scheduleChore(regionNormalizerManager.getRegionNormalizerChore());
+    if (regionNormalizerManager != null) {
+      getChoreService().scheduleChore(regionNormalizerManager.getRegionNormalizerChore());
+    }
     this.catalogJanitorChore = new CatalogJanitor(this);
     getChoreService().scheduleChore(catalogJanitorChore);
     this.hbckChore = new HbckChore(this);
@@ -1638,7 +1640,9 @@ public class HMaster extends HRegionServer implements MasterServices {
       choreService.cancelChore(this.mobFileCleanerChore);
       choreService.cancelChore(this.mobFileCompactionChore);
       choreService.cancelChore(this.balancerChore);
-      choreService.cancelChore(getRegionNormalizerManager().getRegionNormalizerChore());
+      if (regionNormalizerManager != null) {
+        choreService.cancelChore(regionNormalizerManager.getRegionNormalizerChore());
+      }
       choreService.cancelChore(this.clusterStatusChore);
       choreService.cancelChore(this.catalogJanitorChore);
       choreService.cancelChore(this.clusterStatusPublisherChore);


### PR DESCRIPTION
I think this variable is null for backup masters. `initializeZKBasedSystemTrackers` only called when a master transitions to active. I don't know why it impacts this test though, as an NPE in the backup master thread should cause the thread to halt.