### PR TITLE
HBASE-25193: Add support for row prefix and type in the WAL Pretty Printer

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/HLogPrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/HLogPrettyPrinter.java
@@ -68,7 +68,7 @@ public class HLogPrettyPrinter extends WALPrettyPrinter {
    * Basic constructor that simply initializes values to reasonable defaults.
    */
   public HLogPrettyPrinter() {
-    this(false, false, -1l, null, null, null, null, false, System.out);
+    this(false, false, -1L, null, null, null, null, false, System.out);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/HLogPrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/HLogPrettyPrinter.java
@@ -68,7 +68,7 @@ public class HLogPrettyPrinter extends WALPrettyPrinter {
    * Basic constructor that simply initializes values to reasonable defaults.
    */
   public HLogPrettyPrinter() {
-    this(false, false, -1l, null, null, null, false, System.out);
+    this(false, false, -1l, null, null, null, null, false, System.out);
   }
 
   /**
@@ -92,6 +92,9 @@ public class HLogPrettyPrinter extends WALPrettyPrinter {
    * @param row
    *          when not null, serves as a filter; only log entries from this row
    *          will be printed
+   * @param rowPrefix
+   *          when not null, serves as a filter; only log entries with row key
+   *          having this prefix will be printed
    * @param persistentOutput
    *          keeps a single list running for multiple files. if enabled, the
    *          endPersistentOutput() method must be used!
@@ -100,10 +103,10 @@ public class HLogPrettyPrinter extends WALPrettyPrinter {
    *          PrettyPrinter's output.
    */
   public HLogPrettyPrinter(boolean outputValues, boolean outputJSON,
-      long sequence, String table, String region, String row, boolean persistentOutput,
-      PrintStream out) {
-    super(outputValues, outputJSON, sequence, Collections.singleton(table), region, row,
-      false, persistentOutput, out);
+      long sequence, String table, String region, String row, String rowPrefix,
+      boolean persistentOutput, PrintStream out) {
+    super(outputValues, outputJSON, sequence, Collections.singleton(table), region,
+      row, rowPrefix,false, persistentOutput, out);
   }
 
   public static void main(String[] args) throws IOException {


### PR DESCRIPTION
Currently, the WAL Pretty Printer has an option to filter the keys with an exact match of row. However, it is super useful sometimes to have a row key prefix instead of an exact match.

The prefix can act as a full match filter as well due to the nature of the prefix.

Additionally, we are not having the cell type in the WAL Pretty Printer in any of the branches.