### PR TITLE
HBASE-25193: Add support for row prefix and type in the WAL Pretty Printer

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/procedure2/store/region/WALProcedurePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/procedure2/store/region/WALProcedurePrettyPrinter.java
@@ -105,7 +105,7 @@ public class WALProcedurePrettyPrinter extends AbstractHBaseTool {
           if (!Bytes.equals(PROC_FAMILY, 0, PROC_FAMILY.length, cell.getFamilyArray(),
             cell.getFamilyOffset(), cell.getFamilyLength())) {
             // We could have cells other than procedure edits, for example, a flush marker
-            WALPrettyPrinter.printCell(out, op, false);
+            WALPrettyPrinter.printCell(out, op, false, false);
             continue;
           }
           long procId = Bytes.toLong(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALPrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALPrettyPrinter.java
@@ -346,7 +346,7 @@ public class WALPrettyPrinter {
           }
           for (int i = 0; i < actions.size(); i++) {
             Map<String, Object> op = actions.get(i);
-            printCell(out, op, outputOnlyRowKey, outputValues);
+            printCell(out, op, outputValues, outputOnlyRowKey);
           }
         }
         if (!outputOnlyRowKey) {
@@ -363,7 +363,7 @@ public class WALPrettyPrinter {
   }
 
   public static void printCell(PrintStream out, Map<String, Object> op,
-    boolean outputOnlyRowKey, boolean outputValues) {
+    boolean outputValues, boolean outputOnlyRowKey) {
     String rowDetails = "row=" + op.get("row");
     if (outputOnlyRowKey) {
       out.println(rowDetails);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALPrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/WALPrettyPrinter.java
@@ -47,6 +47,7 @@ import org.apache.yetus.audience.InterfaceStability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hbase.thirdparty.com.google.common.base.Strings;
 import org.apache.hbase.thirdparty.com.google.gson.Gson;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLineParser;
@@ -85,7 +86,7 @@ public class WALPrettyPrinter {
   // List of tables for filter
   private final Set<String> tableSet;
   private String region;
-  private String row;
+  private String rowPrefix;
   private boolean outputOnlyRowKey;
   // enable in order to output a single list of transactions from several files
   private boolean persistentOutput;
@@ -106,7 +107,7 @@ public class WALPrettyPrinter {
     sequence = -1;
     tableSet = new HashSet<>();
     region = null;
-    row = null;
+    rowPrefix = null;
     outputOnlyRowKey = false;
     persistentOutput = false;
     firstTxn = true;
@@ -171,14 +172,14 @@ public class WALPrettyPrinter {
   }
 
   /**
-   * sets the row key by which output will be filtered
+   * sets the rowPrefix key prefix by which output will be filtered
    *
-   * @param row
-   *          when not null, serves as a filter; only log entries from this row
-   *          will be printed
+   * @param rowPrefix
+   *          when not null, serves as a filter; only log entries with rows
+   *          having this prefix will be printed
    */
-  public void setRowFilter(String row) {
-    this.row = row;
+  public void setRowPrefixFilter(String rowPrefix) {
+    this.rowPrefix = rowPrefix;
   }
 
   /**
@@ -301,15 +302,12 @@ public class WALPrettyPrinter {
         List<Map<String, Object>> actions = new ArrayList<>();
         for (Cell cell : edit.getCells()) {
           // add atomic operation to txn
-          Map<String, Object> op = new HashMap<>(toStringMap(cell, outputOnlyRowKey));
-          if (outputValues) {
-            op.put("value", Bytes.toStringBinary(CellUtil.cloneValue(cell)));
+          Map<String, Object> op =
+            new HashMap<>(toStringMap(cell, outputOnlyRowKey, rowPrefix, outputValues));
+          if (op.isEmpty()) {
+            continue;
           }
-          // check row output filter
-          if (row == null || ((String) op.get("row")).equals(row)) {
-            actions.add(op);
-          }
-          op.put("total_size_sum", cell.heapSize());
+          actions.add(op);
         }
         if (actions.isEmpty()) {
           continue;
@@ -330,7 +328,7 @@ public class WALPrettyPrinter {
               txn.get("sequence"), txn.get("table"), txn.get("region"), new Date(writeTime)));
           for (int i = 0; i < actions.size(); i++) {
             Map<String, Object> op = actions.get(i);
-            printCell(out, op, outputValues);
+            printCell(out, op, outputOnlyRowKey, outputValues);
           }
         }
         out.println("edit heap size: " + entry.getEdit().heapSize());
@@ -344,9 +342,16 @@ public class WALPrettyPrinter {
     }
   }
 
-  public static void printCell(PrintStream out, Map<String, Object> op, boolean outputValues) {
-    out.println("row=" + op.get("row") + ", type=" + op.get("type") + ", column=" +
-      op.get("family") + ":" + op.get("qualifier"));
+  public static void printCell(PrintStream out, Map<String, Object> op,
+    boolean outputOnlyRowKey, boolean outputValues) {
+    String rowDetails = "row=" + op.get("row");
+    if (outputOnlyRowKey) {
+      out.println(rowDetails);
+      return;
+    }
+
+    rowDetails += ", column=" + op.get("family") + ":" + op.get("qualifier");
+    out.println(rowDetails);
     if (op.get("tag") != null) {
       out.println("    tag: " + op.get("tag"));
     }
@@ -356,11 +361,18 @@ public class WALPrettyPrinter {
     out.println("cell total size sum: " + op.get("total_size_sum"));
   }
 
-  public static Map<String, Object> toStringMap(Cell cell, boolean printRowKeyOnly) {
+  public static Map<String, Object> toStringMap(Cell cell,
+    boolean printRowKeyOnly, String rowPrefix, boolean outputValues) {
     Map<String, Object> stringMap = new HashMap<>();
-    stringMap.put("row",
-      Bytes.toStringBinary(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength()));
+    String rowKey = Bytes.toStringBinary(cell.getRowArray(),
+      cell.getRowOffset(), cell.getRowLength());
+    // If the row prefix is provided and the current row doesn't satisfy
+    // the prefix requirement return empty map
+    if (!Strings.isNullOrEmpty(rowPrefix) && !rowKey.startsWith(rowPrefix)) {
+      return stringMap;
+    }
 
+    stringMap.put("row", rowKey);
     if (printRowKeyOnly) {
       return stringMap;
     }
@@ -372,6 +384,7 @@ public class WALPrettyPrinter {
         cell.getQualifierLength()));
     stringMap.put("timestamp", cell.getTimestamp());
     stringMap.put("vlen", cell.getValueLength());
+    stringMap.put("total_size_sum", cell.heapSize());
     if (cell.getTagsLength() > 0) {
       List<String> tagsString = new ArrayList<>();
       Iterator<Tag> tagsIterator = PrivateCellUtil.tagsIterator(cell);
@@ -382,11 +395,14 @@ public class WALPrettyPrinter {
       }
       stringMap.put("tag", tagsString);
     }
+    if (outputValues) {
+      stringMap.put("value", Bytes.toStringBinary(CellUtil.cloneValue(cell)));
+    }
     return stringMap;
   }
 
   public static Map<String, Object> toStringMap(Cell cell) {
-    return toStringMap(cell, false);
+    return toStringMap(cell, false, null, false);
   }
 
   public static void main(String[] args) throws IOException {
@@ -416,7 +432,7 @@ public class WALPrettyPrinter {
         "Sequence to filter by. Pass sequence number.");
     options.addOption("k", "outputOnlyRowKey", false,
       "Print only row keys");
-    options.addOption("w", "row", true, "Row to filter by. Pass row name.");
+    options.addOption("w", "row", true, "Row key prefix to filter by");
     options.addOption("g", "goto", true, "Position to seek to in the file");
 
     WALPrettyPrinter printer = new WALPrettyPrinter();
@@ -450,7 +466,7 @@ public class WALPrettyPrinter {
         printer.setSequenceFilter(Long.parseLong(cmd.getOptionValue("s")));
       }
       if (cmd.hasOption("w")) {
-        printer.setRowFilter(cmd.getOptionValue("w"));
+        printer.setRowPrefixFilter(cmd.getOptionValue("w"));
       }
       if (cmd.hasOption("g")) {
         printer.setPosition(Long.parseLong(cmd.getOptionValue("g")));


### PR DESCRIPTION
Currently, the WAL Pretty Printer has an option to filter the keys with an exact match of row. However, it is super useful sometimes to have a row key prefix instead of an exact match.

The prefix can act as a full match filter as well due to the nature of the prefix.

Secondly, we are not having the cell type in the WAL Pretty Printer in any of the branches.
Lastly, the option rowkey only options prints additional stuff as well.