### PR TITLE
HBASE-25196 Add deprecation documentation to HConstants

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1358,8 +1358,9 @@ public final class HConstants {
 
   /**
    * Drop edits for tables that been deleted from the replication source and target
-   * @deprecated since 3.0.0 (HBASE-24359). Will be removed in 4.0.0.
+   * @deprecated since 3.0.0. Will be removed in 4.0.0.
    *             Moved it into HBaseInterClusterReplicationEndpoint.
+   * @see <a href="https://issues.apache.org/jira/browse/HBASE-24359">HBASE-24359</a>
    */
   @Deprecated
   public static final String REPLICATION_DROP_ON_DELETED_TABLE_KEY =

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1358,7 +1358,8 @@ public final class HConstants {
 
   /**
    * Drop edits for tables that been deleted from the replication source and target
-   * @deprecated moved it into HBaseInterClusterReplicationEndpoint
+   * @deprecated since 3.0.0 (HBASE-24359). Will be removed in 4.0.0.
+   *             Moved it into HBaseInterClusterReplicationEndpoint.
    */
   @Deprecated
   public static final String REPLICATION_DROP_ON_DELETED_TABLE_KEY =


### PR DESCRIPTION
Add the documentation when
HConstants#REPLICATION_DROP_ON_DELETED_TABLE_KEY was deprecated and when
it is expected to be removed.