### PR TITLE
HBASE-25198 Remove deprecated RpcSchedulerFactory#create

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/FifoRpcSchedulerFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/FifoRpcSchedulerFactory.java
@@ -38,10 +38,4 @@ public class FifoRpcSchedulerFactory implements RpcSchedulerFactory {
       HConstants.DEFAULT_REGION_SERVER_HANDLER_COUNT);
     return new FifoRpcScheduler(conf, handlerCount);
   }
-
-  @Deprecated
-  @Override
-  public RpcScheduler create(Configuration conf, PriorityFunction priority) {
-    return create(conf, priority, null);
-  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RpcSchedulerFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RpcSchedulerFactory.java
@@ -35,11 +35,4 @@ public interface RpcSchedulerFactory {
    * Constructs a {@link org.apache.hadoop.hbase.ipc.RpcScheduler}.
    */
   RpcScheduler create(Configuration conf, PriorityFunction priority, Abortable server);
-
-  /**
-   * @deprecated since 1.0.0.
-   * @see <a href="https://issues.apache.org/jira/browse/HBASE-12028">HBASE-12028</a>
-   */
-  @Deprecated
-  RpcScheduler create(Configuration conf, PriorityFunction priority);
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SimpleRpcSchedulerFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SimpleRpcSchedulerFactory.java
@@ -32,16 +32,6 @@ import org.apache.hadoop.hbase.ipc.SimpleRpcScheduler;
 @InterfaceAudience.LimitedPrivate({HBaseInterfaceAudience.COPROC, HBaseInterfaceAudience.PHOENIX})
 @InterfaceStability.Evolving
 public class SimpleRpcSchedulerFactory implements RpcSchedulerFactory {
-  /**
-   * @deprecated since 1.0.0.
-   * @see <a href="https://issues.apache.org/jira/browse/HBASE-12028">HBASE-12028</a>
-   */
-  @Override
-  @Deprecated
-  public RpcScheduler create(Configuration conf, PriorityFunction priority) {
-	  return create(conf, priority, null);
-  }
-
   @Override
   public RpcScheduler create(Configuration conf, PriorityFunction priority, Abortable server) {
     int handlerCount = conf.getInt(HConstants.REGION_SERVER_HANDLER_COUNT,


### PR DESCRIPTION
Remove the deprecated RpcSchedulerFactory#create(Configuration,
PriorityFunction) method from the interface and in all implementing
classes.