### PR TITLE
HBASE-25126 Add load balance logic in hbase-client to distribute read…

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetaReplicaLoadBalanceReplicaChooser.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetaReplicaLoadBalanceReplicaChooser.java
@@ -1,0 +1,53 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * There are two modes with meta replica support.
+ *   HighAvailable    - Client sends requests to the primary meta region first, within a
+ *                      configured amount of time, if  there is no response coming back,
+ *                      client sends requests to all replica regions and takes the first
+ *                      response.
+ *
+ *   LoadBalance      - Client sends requests to meta replica regions in a round-robin mode,
+ *                      if results from replica regions are stale, next time, client sends requests for
+ *                      these stable locations to the primary meta region. In this mode, scan
+ *                      requests are load balanced across all replica regions.
+ */
+enum MetaReplicaMode {
+  None,
+  HighAvailable,
+  LoadBalance
+}
+
+/**
+ * A Meta replica chooser decides which meta replica to go for scan requests.
+ */
+@InterfaceAudience.Private
+public interface MetaReplicaLoadBalanceReplicaChooser {
+
+  void updateCacheOnError(final HRegionLocation loc, final int fromMetaReplicaId);
+  int chooseReplicaToGo(final TableName tablename, final byte[] row,
+    final RegionLocateType locateType);
+
+
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetaReplicaLoadBalanceReplicaSimpleChooser.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetaReplicaLoadBalanceReplicaSimpleChooser.java
@@ -1,0 +1,248 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.ScheduledChore;
+import org.apache.hadoop.hbase.Stoppable;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.util.Iterator;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.ConcurrentNavigableMap;
+import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ThreadLocalRandom;
+import static org.apache.hadoop.hbase.HConstants.DEFAULT_META_REPLICA_NUM;
+import static org.apache.hadoop.hbase.HConstants.META_REPLICAS_NUM;
+import static org.apache.hadoop.hbase.client.ConnectionUtils.isEmptyStopRow;
+import static org.apache.hadoop.hbase.util.Bytes.BYTES_COMPARATOR;
+import static org.apache.hadoop.hbase.util.ConcurrentMapUtils.computeIfAbsent;
+
+/**
+ * MetaReplicaLoadBalanceReplicaSimpleChooser implements a simple meta replica load balancing
+ * algorithm. It maintains a stale location cache for each table. Whenever client looks up meta,
+ * it first check if the row is the stale location cache, if yes, this means the the location from
+ * meta replica is stale, it will go to the primary meta to look up update-to-date location;
+ * otherwise, it will randomly pick up a meta replica region for meta lookup. When clients receive
+ * RegionNotServedException from region servers, it will add these region locations to the stale
+ * location cache. The stale cache will be cleaned up periodically by a chore.
+ */
+
+/**
+ * StaleLocationCacheEntry is the entry when a stale location is reported by an client.
+ */
+class StaleLocationCacheEntry {
+  // meta replica id where
+  private int metaReplicaId;
+
+  // timestamp in milliseconds
+  private long timestamp;
+
+  private byte[] endKey;
+
+  StaleLocationCacheEntry(final int metaReplicaId, final byte[] endKey) {
+    this.metaReplicaId = metaReplicaId;
+    this.endKey = endKey;
+    timestamp = System.currentTimeMillis();
+  }
+
+  public byte[] getEndKey() {
+    return this.endKey;
+  }
+
+  public int getMetaReplicaId() {
+    return this.metaReplicaId;
+  }
+  public long getTimestamp() {
+    return this.timestamp;
+  }
+
+  @Override
+  public String toString() {
+    return new ToStringBuilder(this)
+      .append("endKey", endKey)
+      .append("metaReplicaId", metaReplicaId)
+      .append("timestamp", timestamp)
+      .toString();
+  }
+}
+
+/**
+ * A simple implementation of MetaReplicaLoadBalanceReplicaChooser.
+ *
+ * It follows a simple algorithm to choose a meta replica to go:
+ *
+ *  1. If there is no stale location entry for rows it looks up, it will randomly
+ *     pick a meta replica region to do lookup.
+ *  2. If the location from meta replica region is stale, client gets RegionNotServedException
+ *     from region server, in this case, it will create StaleLocationCacheEntry in
+ *     MetaReplicaLoadBalanceReplicaSimpleChooser.
+ *  3. When client tries to do meta lookup, it checks StaleLocationCache first for rows it tries to
+ *     lookup, if entry exists, it will go with primary meta region to do lookup; otherwise, it
+ *     will follow step 1.
+ *  4. A chore will periodically run to clean up cache entries in the StaleLocationCache.
+ */
+class MetaReplicaLoadBalanceReplicaSimpleChooser implements MetaReplicaLoadBalanceReplicaChooser {
+  private static final Logger LOG =
+    LoggerFactory.getLogger(MetaReplicaLoadBalanceReplicaSimpleChooser.class);
+  private final long STALE_CACHE_TIMEOUT_IN_MILLISECONDS = 3000; // 3 seconds
+  private final int STALE_CACHE_CLEAN_CHORE_INTERVAL = 1500; // 1.5 seconds
+
+  private final class StaleTableCache {
+    private final ConcurrentNavigableMap<byte[], StaleLocationCacheEntry> cache =
+      new ConcurrentSkipListMap<>(BYTES_COMPARATOR);
+  }
+
+  private final ConcurrentMap<TableName, StaleTableCache> staleCache;
+  private final int numOfMetaReplicas;
+  private final AsyncConnectionImpl conn;
+
+  MetaReplicaLoadBalanceReplicaSimpleChooser(final AsyncConnectionImpl conn) {
+    staleCache = new ConcurrentHashMap<>();
+    this.numOfMetaReplicas = conn.getConfiguration().getInt(
+      META_REPLICAS_NUM, DEFAULT_META_REPLICA_NUM);
+    this.conn = conn;
+    this.conn.getChoreService().scheduleChore(getCacheCleanupChore(this));
+  }
+
+  /**
+   * When a client runs into RegionNotServingException, it will call this method to
+   * update Chooser's internal state.
+   * @param loc the location which causes exception.
+   * @param fromMetaReplicaId the meta replica id where the location comes from.
+   */
+  public void updateCacheOnError(final HRegionLocation loc, final int fromMetaReplicaId) {
+    StaleTableCache tableCache =
+      computeIfAbsent(staleCache, loc.getRegion().getTable(), StaleTableCache::new);
+    byte[] startKey = loc.getRegion().getStartKey();
+    tableCache.cache.putIfAbsent(startKey,
+      new StaleLocationCacheEntry(fromMetaReplicaId, loc.getRegion().getEndKey()));
+    LOG.debug("Add entry to stale cache for table {} with startKey {}, {}",
+      loc.getRegion().getTable(), startKey, loc.getRegion().getEndKey());
+  }
+
+  /**
+   * When it does a meta lookup, it will call this method to find a meta replica to go.
+   * @param tablename  table name it looks up
+   * @param row   key it looks up.
+   * @param locateType locateType, Only BEFORE and CURRENT will be passed in.
+   * @return meta replica id
+   */
+  public int chooseReplicaToGo(final TableName tablename, final byte[] row,
+    final RegionLocateType locateType) {
+    StaleTableCache tableCache = staleCache.get(tablename);
+    int metaReplicaId = 1 + ThreadLocalRandom.current().nextInt(this.numOfMetaReplicas - 1);
+
+    // If there is no entry in StaleCache, pick a random meta replica id.
+    if (tableCache == null) {
+      return metaReplicaId;
+    }
+
+    Map.Entry<byte[], StaleLocationCacheEntry> entry;
+    boolean isEmptyStopRow = isEmptyStopRow(row);
+    // Only BEFORE and CURRENT are passed in.
+    if (locateType == RegionLocateType.BEFORE) {
+      entry = isEmptyStopRow ? tableCache.cache.lastEntry() : tableCache.cache.lowerEntry(row);
+    } else {
+      entry = tableCache.cache.floorEntry(row);
+    }
+
+    if (entry == null) {
+      return metaReplicaId;
+    }
+
+    // Check if the entry times out.
+    if ((System.currentTimeMillis() - entry.getValue().getTimestamp()) >=
+      STALE_CACHE_TIMEOUT_IN_MILLISECONDS) {
+      LOG.debug("Entry for table {} with startKey {}, {} times out", tablename, entry.getKey(),
+        entry);
+      tableCache.cache.remove(entry.getKey());
+      return metaReplicaId;
+    }
+
+    byte[] endKey =  entry.getValue().getEndKey();
+
+    if (isEmptyStopRow(endKey)) {
+      LOG.debug("Lookup {} goes to primary meta", row);
+      return RegionInfo.DEFAULT_REPLICA_ID;
+    }
+
+    if (locateType == RegionLocateType.BEFORE) {
+      if (!isEmptyStopRow && Bytes.compareTo(endKey, row) >= 0) {
+        LOG.debug("Lookup {} goes to primary meta", row);
+        return RegionInfo.DEFAULT_REPLICA_ID;
+      }
+    } else {
+      if (Bytes.compareTo(row, endKey) < 0) {
+        LOG.debug("Lookup {} goes to primary meta", row);
+        return RegionInfo.DEFAULT_REPLICA_ID;
+      }
+    }
+
+    return metaReplicaId;
+  }
+
+  private void cleanupMetaReplicaStaleCache() {
+    long curTimeInMills = System.currentTimeMillis();
+    for (StaleTableCache tableCache : staleCache.values()) {
+      Iterator<Map.Entry<byte[], StaleLocationCacheEntry>> it =
+        tableCache.cache.entrySet().iterator();
+      while (it.hasNext()) {
+        Map.Entry<byte[], StaleLocationCacheEntry> entry = it.next();
+        if (curTimeInMills - entry.getValue().getTimestamp() >=
+          STALE_CACHE_TIMEOUT_IN_MILLISECONDS) {
+          LOG.debug("clean entry {}, {} from stale cache", entry.getKey(), entry.getValue());
+          it.remove();
+        }
+      }
+    }
+  }
+
+  private static Stoppable createDummyStoppable() {
+    return new Stoppable() {
+      private volatile boolean isStopped = false;
+
+      @Override
+      public void stop(String why) {
+        isStopped = true;
+      }
+
+      @Override
+      public boolean isStopped() {
+        return isStopped;
+      }
+    };
+  }
+
+  public ScheduledChore getCacheCleanupChore(
+    final MetaReplicaLoadBalanceReplicaSimpleChooser simpleChooser) {
+    Stoppable stoppable = createDummyStoppable();
+    return new ScheduledChore("CleanupMetaReplicaStaleCache", stoppable,
+      STALE_CACHE_CLEAN_CHORE_INTERVAL) {
+      @Override
+      protected void chore() {
+        simpleChooser.cleanupMetaReplicaStaleCache();
+      }
+    };
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1128,6 +1128,9 @@ public final class HConstants {
 
   /** Conf key for enabling meta replication */
   public static final String USE_META_REPLICAS = "hbase.meta.replicas.use";
+  public static final String META_REPLICAS_MODE = "hbase.meta.replicas.mode";
+  public static final String META_REPLICAS_MODE_LOADBALANCE_REPILCA_CHOOSER =
+    "hbase.meta.replicas.mode.loadbalance.replica.chooser";
   public static final boolean DEFAULT_USE_META_REPLICAS = false;
   public static final String META_REPLICAS_NUM = "hbase.meta.replica.count";
   public static final int DEFAULT_META_REPLICA_NUM = 1;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/RegionReplicaTestHelper.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/RegionReplicaTestHelper.java
@@ -142,6 +142,21 @@ public final class RegionReplicaTestHelper {
       locator.getRegionLocations(tableName, RegionReplicaUtil.DEFAULT_REPLICA_ID, false)
         .getDefaultRegionLocation().getServerName());
     // should get the new location when reload = true
+    // when meta replica LoadBalance mode is enabled, it may delay a bit.
+    util.waitFor(3000, new ExplainingPredicate<Exception>() {
+      @Override
+      public boolean evaluate() throws Exception {
+        ServerName sn = locator.getRegionLocations(tableName, RegionReplicaUtil.DEFAULT_REPLICA_ID,
+          true).getDefaultRegionLocation().getServerName();
+        return newServerName.equals(sn);
+      }
+
+      @Override
+      public String explainFailure() throws Exception {
+        return "New location does not show up in meta (replica) region";
+      }
+    });
+
     assertEquals(newServerName,
       locator.getRegionLocations(tableName, RegionReplicaUtil.DEFAULT_REPLICA_ID, true)
         .getDefaultRegionLocation().getServerName());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocatorWithMetaReplicaLoadBalance.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocatorWithMetaReplicaLoadBalance.java
@@ -1,0 +1,84 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.testclassification.ClientTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.experimental.categories.Category;
+
+@Category({ MediumTests.class, ClientTests.class })
+public class TestAsyncNonMetaRegionLocatorWithMetaReplicaLoadBalance
+  extends TestAsyncNonMetaRegionLocator {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestAsyncNonMetaRegionLocatorWithMetaReplicaLoadBalance.class);
+
+  private static final int NB_SERVERS = 4;
+  private static int numOfMetaReplica = NB_SERVERS - 1;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.setFloat("hbase.regionserver.logroll.multiplier", 0.0003f);
+    conf.setInt("replication.source.size.capacity", 10240);
+    conf.setLong("replication.source.sleepforretries", 100);
+    conf.setInt("hbase.regionserver.maxlogs", 10);
+    conf.setLong("hbase.master.logcleaner.ttl", 10);
+    conf.setInt("zookeeper.recovery.retry", 1);
+    conf.setInt("zookeeper.recovery.retry.intervalmill", 10);
+    conf.setLong(HConstants.THREAD_WAKE_FREQUENCY, 100);
+    conf.setInt("replication.stats.thread.period.seconds", 5);
+    conf.setBoolean("hbase.tests.use.shortcircuit.reads", false);
+    conf.setInt(HConstants.HBASE_CLIENT_SERVERSIDE_RETRIES_MULTIPLIER, 1);
+    // Enable hbase:meta replication.
+    conf.setBoolean(ServerRegionReplicaUtil.REGION_REPLICA_REPLICATION_CATALOG_CONF_KEY,
+      true);
+    // Set hbase:meta replicas to be 3.
+    conf.setInt(HConstants.META_REPLICAS_NUM, numOfMetaReplica);
+    TEST_UTIL.startMiniCluster(NB_SERVERS);
+    TEST_UTIL.waitFor(30000, () -> TEST_UTIL.getMiniHBaseCluster().getRegions(
+      TableName.META_TABLE_NAME).size() >= numOfMetaReplica);
+
+    TEST_UTIL.getAdmin().balancerSwitch(false, true);
+    ConnectionRegistry registry =
+        ConnectionRegistryFactory.getRegistry(TEST_UTIL.getConfiguration());
+
+    // Enable meta replica LoadBalance mode for this connection.
+    Configuration c = new Configuration(TEST_UTIL.getConfiguration());
+    c.set(HConstants.META_REPLICAS_MODE, "LoadBalance");
+    c.setBoolean(HConstants.USE_META_REPLICAS, true);
+
+    CONN = new AsyncConnectionImpl(c, registry,
+      registry.getClusterId().get(), null, User.getCurrent());
+    LOCATOR = new AsyncNonMetaRegionLocator(CONN);
+    SPLIT_KEYS = new byte[8][];
+    for (int i = 111; i < 999; i += 111) {
+      SPLIT_KEYS[i / 111 - 1] = Bytes.toBytes(String.format("%03d", i));
+    }
+  }
+}


### PR DESCRIPTION
… load over meta replica regions

It adds load balance support. With "hbase.meta.replicas.use" set to true, client support meta replica feature.
The existing mode is called HighAvailable, client sends scan request to the primary meta replica region first,
if response is not back within a configured amount of time, it will send scan requests to all meta replica regions and
take the first response. On top of the existing mode, a new mode LoadBalance is added. In this mode, client first
choose a meta replica region to send scan request. If the response is stale, it will send the scan request to the primary
meta region. In this mode, all meta replica regions serve scan requests.

Two new config knobs are added:

1. hbase.meta.replicas.mode
   Valid value is "HighAvailable" and "LoadBalance".

2. hbase.meta.replicas.mode.loadbalance.replica.chooser
   Implementation class for MetaReplicaChooser. Only org.apache.hadoop.hbase.client.MetaReplicaLoadBalanceReplicaSimpleChooser.class
   is supported for now, which is the default as well.