### PR TITLE
HBASE-25220 Backport HBASE-24246 Miscellaneous hbck2 fixMeta bulk merge fixes: better logging around merges/overlap-fixing, 'HBCK Report' overlap listing, and configuration

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfo.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfo.java
@@ -304,12 +304,11 @@ public interface RegionInfo {
   }
 
   /**
-   * @return Return a String of short, printable names for <code>hris</code>
-   * (usually encoded name) for us logging.
+   * @return Return a String of short, printable names for <code>hris</code> (usually encoded name)
+   *   for us logging.
    */
   static String getShortNameToLog(final List<RegionInfo> ris) {
-    return ris.stream().map(ri -> ri.getShortNameToLog()).
-    collect(Collectors.toList()).toString();
+    return ris.stream().map(RegionInfo::getEncodedName).collect(Collectors.toList()).toString();
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1881,8 +1881,8 @@ public class HMaster extends HRegionServer implements MasterServices {
           " failed because merge switch is off");
     }
 
-    final String mergeRegionsStr = Arrays.stream(regionsToMerge).
-      map(r -> RegionInfo.getShortNameToLog(r)).collect(Collectors.joining(", "));
+    final String mergeRegionsStr = Arrays.stream(regionsToMerge).map(r -> r.getEncodedName()).
+      collect(Collectors.joining(", "));
     return MasterProcedureUtil.submitProcedure(new NonceProcedureRunnable(this, ng, nonce) {
       @Override
       protected void run() throws IOException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetaFixer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetaFixer.java
@@ -52,7 +52,7 @@ import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesti
 class MetaFixer {
   private static final Logger LOG = LoggerFactory.getLogger(MetaFixer.class);
   private static final String MAX_MERGE_COUNT_KEY = "hbase.master.metafixer.max.merge.count";
-  private static final int MAX_MERGE_COUNT_DEFAULT = 10;
+  private static final int MAX_MERGE_COUNT_DEFAULT = 64;
 
   private final MasterServices masterServices;
   /**
@@ -247,6 +247,10 @@ class MetaFixer {
       if (regionInfoWithlargestEndKey != null) {
         if (!isOverlap(regionInfoWithlargestEndKey, pair) ||
             currentMergeSet.size() >= maxMergeCount) {
+          // Log when we cut-off-merge because we hit the configured maximum merge limit.
+          if (currentMergeSet.size() >= maxMergeCount) {
+            LOG.warn("Ran into maximum-at-a-time merges limit={}", maxMergeCount);
+          }
           merges.add(currentMergeSet);
           currentMergeSet = new TreeSet<>();
         }

--- a/hbase-server/src/main/resources/hbase-webapps/master/hbck.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/hbck.jsp
@@ -166,7 +166,8 @@
       <p>
         <span>
           The below are Regions we've lost account of. To be safe, run bulk load of any data found in these Region orphan directories back into the HBase cluster.
-          First make sure <em>hbase:meta</em> is in a healthy state; run <em>hbck2 fixMeta</em> to be sure. Once this is done, per Region below, run a bulk
+          First make sure <em>hbase:meta</em> is in a healthy state, that there are no holes, overlaps or inconsistencies (else bulk load may complain);
+          run <em>hbck2 fixMeta</em>. Once this is done, per Region below, run a bulk
           load -- <em>$ hbase completebulkload REGION_DIR_PATH TABLE_NAME</em> -- and then delete the desiccated directory content (HFiles are removed upon
           successful load; all that is left are empty directories and occasionally a seqid marking file).
         </span>
@@ -223,8 +224,8 @@
             </tr>
             <% for (Pair<RegionInfo, RegionInfo> p : report.getHoles()) { %>
             <tr>
-              <td><%= p.getFirst() %></td>
-              <td><%= p.getSecond() %></td>
+              <td><span title="<%= p.getFirst() %>"><%= p.getFirst().getEncodedName() %></span></td>
+              <td><span title="<%= p.getSecond() %>"><%= p.getSecond().getEncodedName() %></span></td>
             </tr>
             <% } %>
 
@@ -244,8 +245,8 @@
               </tr>
               <% for (Pair<RegionInfo, RegionInfo> p : report.getOverlaps()) { %>
               <tr>
-                <td><%= p.getFirst() %></td>
-                <td><%= p.getSecond() %></td>
+                <td><span title="<%= p.getFirst() %>"><%= p.getFirst().getEncodedName() %></span></td>
+                <td><span title="<%= p.getSecond() %>"><%= p.getSecond().getEncodedName() %></span></td>
               </tr>
               <% } %>
 
@@ -265,7 +266,7 @@
               </tr>
               <% for (Pair<RegionInfo, ServerName> p: report.getUnknownServers()) { %>
               <tr>
-                <td><%= p.getFirst() %></td>
+                <td><span title="<%= p.getFirst() %>"><%= p.getFirst().getEncodedName() %></span></td>
                 <td><%= p.getSecond() %></td>
               </tr>
               <% } %>


### PR DESCRIPTION
Includes addendum

hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
 Fix weird brackets around each region name when logging.

hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetaFixer.java
  Log when we hit the max merge limit. Also up limit to 64.

hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
 Make logs make more sense to operator.

hbase-server/src/main/resources/hbase-webapps/master/hbck.jsp
 Make RegionName show when you mouseover so long names don't mess up
 display of holes and overlaps.

Address Mingliang Liu liuml07 feedback

Signed-off-by: Peter Somogyi <psomogyi@apache.org>
Signed-off-by: Mingliang Liu <liuml07@apache.org>

 Addendum to address minor feedback on text