### PR TITLE
Backport "HBASE-25167 Normalizer support for hot config reloading (#2523)" to branch-2

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/conf/ConfigurationManager.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/conf/ConfigurationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -25,23 +25,25 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.hbase.thirdparty.com.google.common.annotations.VisibleForTesting;
 
 /**
  * Maintains the set of all the classes which would like to get notified
  * when the Configuration is reloaded from the disk in the Online Configuration
  * Change mechanism, which lets you update certain configuration properties
  * on-the-fly, without having to restart the cluster.
- *
+ * <p>
  * If a class has configuration properties which you would like to be able to
  * change on-the-fly, do the following:
- * 1. Implement the {@link ConfigurationObserver} interface. This would require
+ * <ol>
+ *   <li>Implement the {@link ConfigurationObserver} interface. This would require
  *    you to implement the
  *    {@link ConfigurationObserver#onConfigurationChange(Configuration)}
  *    method.  This is a callback that is used to notify your class' instance
  *    that the configuration has changed. In this method, you need to check
  *    if the new values for the properties that are of interest to your class
  *    are different from the cached values. If yes, update them.
- *
+ *    <br />
  *    However, be careful with this. Certain properties might be trivially
  *    mutable online, but others might not. Two properties might be trivially
  *    mutable by themselves, but not when changed together. For example, if a
@@ -50,21 +52,23 @@ import org.slf4j.LoggerFactory;
  *    yet updated "b", it might make a decision on the basis of a new value of
  *    "a", and an old value of "b". This might introduce subtle bugs. This
  *    needs to be dealt on a case-by-case basis, and this class does not provide
- *    any protection from such cases.
+ *    any protection from such cases.</li>
  *
- * 2. Register the appropriate instance of the class with the
+ *   <li>Register the appropriate instance of the class with the
  *    {@link ConfigurationManager} instance, using the
  *    {@link ConfigurationManager#registerObserver(ConfigurationObserver)}
  *    method. Be careful not to do this in the constructor, as you might cause
  *    the 'this' reference to escape. Use a factory method, or an initialize()
- *    method which is called after the construction of the object.
+ *    method which is called after the construction of the object.</li>
  *
- * 3. Deregister the instance using the
+ *   <li>Deregister the instance using the
  *    {@link ConfigurationManager#deregisterObserver(ConfigurationObserver)}
  *    method when it is going out of scope. In case you are not able to do that
  *    for any reason, it is still okay, since entries for dead observers are
  *    automatically collected during GC. But nonetheless, it is still a good
- *    practice to deregister your observer, whenever possible.
+ *    practice to deregister your observer, whenever possible.</li>
+ * </ol>
+ * </p>
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving
@@ -117,8 +121,8 @@ public class ConfigurationManager {
             observer.onConfigurationChange(conf);
           }
         } catch (Throwable t) {
-          LOG.error("Encountered a throwable while notifying observers: " + " of type : " +
-              observer.getClass().getCanonicalName() + "(" + observer + ")", t);
+          LOG.error("Encountered a throwable while notifying observers: of type : {}({})",
+            observer.getClass().getCanonicalName(), observer, t);
         }
       }
     }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/conf/ConfigurationObserver.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/conf/ConfigurationObserver.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -24,7 +24,7 @@ import org.apache.yetus.audience.InterfaceStability;
 /**
  * Every class that wants to observe changes in Configuration properties,
  * must implement interface (and also, register itself with the
- * <code>ConfigurationManager</code> object.
+ * {@link ConfigurationManager}.
  */
 @InterfaceAudience.Private
 @InterfaceStability.Evolving

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/conf/TestConfigurationManager.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/conf/TestConfigurationManager.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -19,7 +19,6 @@ package org.apache.hadoop.hbase.conf;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
@@ -39,9 +38,9 @@ public class TestConfigurationManager {
 
   private static final Logger LOG = LoggerFactory.getLogger(TestConfigurationManager.class);
 
-  class DummyConfigurationObserver implements ConfigurationObserver {
+  static class DummyConfigurationObserver implements ConfigurationObserver {
     private boolean notifiedOnChange = false;
-    private ConfigurationManager cm;
+    private final ConfigurationManager cm;
 
     public DummyConfigurationObserver(ConfigurationManager cm) {
       this.cm = cm;
@@ -63,11 +62,11 @@ public class TestConfigurationManager {
     }
 
     public void register() {
-      this.cm.registerObserver(this);
+      cm.registerObserver(this);
     }
 
     public void deregister() {
-      this.cm.deregisterObserver(this);
+      cm.deregisterObserver(this);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -771,6 +771,7 @@ public class HMaster extends HRegionServer implements MasterServices {
 
     this.regionNormalizerManager =
       RegionNormalizerFactory.createNormalizerManager(conf, zooKeeper, this);
+    this.configurationManager.registerObserver(regionNormalizerManager);
     this.regionNormalizerManager.start();
 
     this.splitOrMergeTracker = new SplitOrMergeTracker(zooKeeper, conf, this);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestRegionNormalizerManagerConfigurationObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestRegionNormalizerManagerConfigurationObserver.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.normalizer;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.conf.ConfigurationManager;
+import org.apache.hadoop.hbase.master.MasterServices;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.zookeeper.RegionNormalizerTracker;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.apache.hbase.thirdparty.com.google.common.util.concurrent.RateLimiter;
+
+/**
+ * Test that configuration changes are propagated to all children.
+ */
+@Category({ MasterTests.class, SmallTests.class})
+public class TestRegionNormalizerManagerConfigurationObserver {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestRegionNormalizerManagerConfigurationObserver.class);
+
+  private static final HBaseTestingUtility testUtil = new HBaseTestingUtility();
+  private static final Pattern rateLimitPattern =
+    Pattern.compile("RateLimiter\\[stableRate=(?<rate>.+)qps]");
+
+  private Configuration conf;
+  private SimpleRegionNormalizer normalizer;
+  @Mock private MasterServices masterServices;
+  @Mock private RegionNormalizerTracker tracker;
+  @Mock private RegionNormalizerChore chore;
+  @Mock private RegionNormalizerWorkQueue<TableName> queue;
+  private RegionNormalizerWorker worker;
+  private ConfigurationManager configurationManager;
+
+  @Before
+  public void before() {
+    MockitoAnnotations.initMocks(this);
+    conf = testUtil.getConfiguration();
+    normalizer = new SimpleRegionNormalizer();
+    worker = new RegionNormalizerWorker(conf, masterServices, normalizer, queue);
+    final RegionNormalizerManager normalizerManager =
+      new RegionNormalizerManager(tracker, chore, queue, worker);
+    configurationManager = new ConfigurationManager();
+    configurationManager.registerObserver(normalizerManager);
+  }
+
+  @Test
+  public void test() {
+    assertTrue(normalizer.isMergeEnabled());
+    assertEquals(3, normalizer.getMinRegionCount());
+    assertEquals(1_000_000L, parseConfiguredRateLimit(worker.getRateLimiter()));
+
+    final Configuration newConf = new Configuration(conf);
+    // configs on SimpleRegionNormalizer
+    newConf.setBoolean("hbase.normalizer.merge.enabled", false);
+    newConf.setInt("hbase.normalizer.min.region.count", 100);
+    // config on RegionNormalizerWorker
+    newConf.set("hbase.normalizer.throughput.max_bytes_per_sec", "12g");
+
+    configurationManager.notifyAllObservers(newConf);
+    assertFalse(normalizer.isMergeEnabled());
+    assertEquals(100, normalizer.getMinRegionCount());
+    assertEquals(12_884L, parseConfiguredRateLimit(worker.getRateLimiter()));
+  }
+
+  /**
+   * The {@link RateLimiter} class does not publicly expose its currently configured rate. It does
+   * offer this information in the {@link RateLimiter#toString()} method. It's fragile, but parse
+   * this value. The alternative would be to track the value explicitly in the worker, and the
+   * associated coordination overhead paid at runtime. See the related note on
+   * {@link RegionNormalizerWorker#getRateLimiter()}.
+   */
+  private static long parseConfiguredRateLimit(final RateLimiter rateLimiter) {
+    final String val = rateLimiter.toString();
+    final Matcher matcher = rateLimitPattern.matcher(val);
+    assertTrue(matcher.matches());
+    final String parsedRate = matcher.group("rate");
+    return (long) Double.parseDouble(parsedRate);
+  }
+}


### PR DESCRIPTION
Wire up the `ConfigurationObserver` chain for
`RegionNormalizerManager`. The following configuration keys support
hot-reloading:
 * hbase.normalizer.throughput.max_bytes_per_sec
 * hbase.normalizer.split.enabled
 * hbase.normalizer.merge.enabled
 * hbase.normalizer.min.region.count
 * hbase.normalizer.merge.min_region_age.days
 * hbase.normalizer.merge.min_region_size.mb

Note that support for `hbase.normalizer.period` is not provided
here. Support would need to be implemented generally for the `Chore`
subsystem.

Signed-off-by: Bharath Vissapragada <bharathv@apache.org>
Signed-off-by: Viraj Jasani <vjasani@apache.org>
Signed-off-by: Aman Poonia <aman.poonia.29@gmail.com>