### PR TITLE
Patch to improve SEEK vs NEXT performance based on config

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -327,6 +327,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     private ByteBufferKeyOnlyKeyValue bufBackedKeyOnlyKv = new ByteBufferKeyOnlyKeyValue();
     // A pair for reusing in blockSeek() so that we don't garbage lot of objects
     final ObjectIntPair<ByteBuffer> pair = new ObjectIntPair<>();
+    private boolean seekToSameBlock;
 
     /**
      * The next indexed key is to keep track of the indexed key of the next data block.
@@ -383,6 +384,11 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     @Override
     public boolean isSeeked(){
       return blockBuffer != null;
+    }
+
+    @Override
+    public boolean isSeekToSameBlock() {
+      return seekToSameBlock;
     }
 
     @Override
@@ -981,8 +987,11 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
         Cell key, boolean seekBefore) throws IOException {
       if (this.curBlock == null || this.curBlock.getOffset() != seekToBlock.getOffset()) {
         updateCurrentBlock(seekToBlock);
+        seekToSameBlock = true;
       } else if (rewind) {
         blockBuffer.rewind();
+      } else {
+        seekToSameBlock = true;
       }
       // Update the nextIndexedKey
       this.nextIndexedKey = nextIndexedKey;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java
@@ -164,6 +164,13 @@ public interface HFileScanner extends Shipper, Closeable {
   Cell getNextIndexedKey();
 
   /**
+   * @return true if we seeked to the current block(based on the seek key)
+   */
+  default boolean isSeekToSameBlock() {
+    return false;
+  }
+
+  /**
    * Close this HFile scanner and do necessary cleanup.
    */
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
@@ -432,6 +432,11 @@ public class KeyValueHeap extends NonReversedNonLazyKeyValueScanner
   }
 
   @Override
+  public boolean isSeekToSameBlock() {
+    return current == null ? false : current.isSeekToSameBlock();
+  }
+
+  @Override
   public void shipped() throws IOException {
     for (KeyValueScanner scanner : this.scannersForDelayedClose) {
       scanner.close(); // There wont be further fetch of Cells from these scanners. Just close.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueScanner.java
@@ -181,4 +181,11 @@ public interface KeyValueScanner extends Shipper, Closeable {
    * see HFileWriterImpl#getMidpoint, or null if not known.
    */
   public Cell getNextIndexedKey();
+
+  /**
+   * @return true if we seeked to the current block(based on the seek key)
+   */
+  public default boolean isSeekToSameBlock() {
+    return false;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -575,4 +575,9 @@ public class StoreFileScanner implements KeyValueScanner {
   public void shipped() throws IOException {
     this.hfs.shipped();
   }
+
+  @Override
+  public boolean isSeekToSameBlock() {
+    return hfs.isSeekToSameBlock();
+  }
 }


### PR DESCRIPTION
This patch depends on what the scans or reads does with the blocks till the configured size. Just for understanding or initial review I have based this on the pread size (which is 4 * block size). This needs a better measure may be based on the number of blocks purely rather than the block size. But the idea is that if based on that config we find that the seekOrSkipToNextcol() has always landed in the immediate next block always go with next() rather than this seekToSkiptoNextcol(). In our tests it is revealed that the comparison that we do here in case of ensuring whether to seek or skipping is adding to the performance rather than the actual seek. 