### PR TITLE
HBASE-25307 ThreadLocal pooling leads to NullPointerException

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
@@ -101,7 +101,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
       new ThreadFactoryBuilder().setNameFormat("Idle-Rpc-Conn-Sweeper-pool-%d").setDaemon(true)
         .setUncaughtExceptionHandler(Threads.LOGGING_EXCEPTION_HANDLER).build());
 
-  protected boolean running = true; // if client runs
+  private boolean running = true; // if client runs
 
   protected final Configuration conf;
   protected final String clusterId;
@@ -127,7 +127,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
   protected final int readTO;
   protected final int writeTO;
 
-  protected final PoolMap<ConnectionId, T> connections;
+  private final PoolMap<ConnectionId, T> connections;
 
   private final AtomicInteger callIdCnt = new AtomicInteger(0);
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
@@ -297,7 +297,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
     int poolSize = config.getInt(HConstants.HBASE_CLIENT_IPC_POOL_SIZE, 1);
 
     if (poolSize <= 0) {
-      LOG.warn("{} must be positive.", HConstants.HBASE_CLIENT_IPC_POOL_SIZE);
+      LOG.warn("{} must be positive. Using default value: 1", HConstants.HBASE_CLIENT_IPC_POOL_SIZE);
       return 1;
     } else {
       return poolSize;
@@ -357,11 +357,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
       if (!running) {
         throw new StoppedRpcClientException();
       }
-      conn = connections.get(remoteId);
-      if (conn == null) {
-        conn = createConnection(remoteId);
-        connections.put(remoteId, conn);
-      }
+      conn = connections.getOrCreate(remoteId, () -> createConnection(remoteId));
       conn.setLastTouched(EnvironmentEdgeManager.currentTime());
     }
     return conn;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
@@ -209,7 +209,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
           if (LOG.isTraceEnabled()) {
             LOG.trace("Cleanup idle connection to {}", conn.remoteId().address);
           }
-          connections.removeValue(conn.remoteId(), conn);
+          connections.remove(conn.remoteId(), conn);
           conn.cleanupConnection();
         }
       }
@@ -294,7 +294,14 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
    * @return the maximum pool size
    */
   private static int getPoolSize(Configuration config) {
-    return config.getInt(HConstants.HBASE_CLIENT_IPC_POOL_SIZE, 1);
+    int poolSize = config.getInt(HConstants.HBASE_CLIENT_IPC_POOL_SIZE, 1);
+
+    if (poolSize <= 0) {
+      LOG.warn("{} must be positive.", HConstants.HBASE_CLIENT_IPC_POOL_SIZE);
+      return 1;
+    } else {
+      return poolSize;
+    }
   }
 
   private int nextCallId() {
@@ -453,7 +460,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
             && remoteId.address.getHostName().equals(sn.getHostname())) {
           LOG.info("The server on " + sn.toString() + " is dead - stopping the connection "
               + connection.remoteId);
-          connections.removeValue(remoteId, connection);
+          connections.remove(remoteId, connection);
           connection.shutdown();
           connection.cleanupConnection();
         }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
@@ -343,13 +343,13 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
   @Override
   public void run() {
     if (LOG.isTraceEnabled()) {
-      LOG.trace(threadName + ": starting, connections " + this.rpcClient.connections.size());
+      LOG.trace(threadName + ": starting");
     }
     while (waitForWork()) {
       readResponse();
     }
     if (LOG.isTraceEnabled()) {
-      LOG.trace(threadName + ": stopped, connections " + this.rpcClient.connections.size());
+      LOG.trace(threadName + ": stopped");
     }
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/util/PoolMap.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/util/PoolMap.java
@@ -96,12 +96,6 @@ public class PoolMap<K, V> {
     }
   }
 
-  public void remove(K key) {
-    synchronized (pools) {
-      pools.remove(key);
-    }
-  }
-
   public List<V> values() {
     List<V> values = new ArrayList<>();
 
@@ -115,36 +109,6 @@ public class PoolMap<K, V> {
     }
 
     return values;
-  }
-
-  public List<V> values(K key) {
-    synchronized (pools) {
-      Pool<V> pool = pools.get(key);
-
-      if (pool == null) {
-        return Collections.emptyList();
-      } else {
-        return new ArrayList<>(pool.values());
-      }
-    }
-  }
-
-  public int size() {
-    synchronized (pools) {
-      return pools.size();
-    }
-  }
-
-  public int size(K key) {
-    synchronized (pools) {
-      Pool<V> pool = pools.get(key);
-
-      if (pool == null) {
-        return 0;
-      } else {
-        return pool.size();
-      }
-    }
   }
 
   public void clear() {
@@ -319,8 +283,8 @@ public class PoolMap<K, V> {
 
     @Override
     public boolean remove(R resource) {
-      Thread myself = Thread.currentThread();
-      return resources.remove(myself, resource);
+      /* remove can be called from any thread */
+      return resources.values().remove(resource);
     }
 
     @Override

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/PoolMapTestBase.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/PoolMapTestBase.java
@@ -41,34 +41,4 @@ public abstract class PoolMapTestBase {
   }
 
   protected abstract PoolType getPoolType();
-
-  protected void runThread(final String key, PoolMap.PoolResourceSupplier<String> supplier,
-      final String expectedValue) throws InterruptedException {
-    final AtomicReference<AssertionError> error = new AtomicReference<>();
-    Thread thread = new Thread(new Runnable() {
-      @Override
-      public void run() {
-        String actualValue = null;
-        try {
-          actualValue = poolMap.getOrCreate(key, supplier);
-        } catch (IOException e) {
-          error.set(new AssertionError("Unexpected throwable.", e));
-        }
-
-        try {
-          assertEquals(expectedValue, actualValue);
-        } catch (AssertionError e) {
-          error.set(e);
-        }
-      }
-    });
-    thread.start();
-    thread.join();
-
-    AssertionError e = error.get();
-
-    if (e != null) {
-      throw e;
-    }
-  }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/PoolMapTestBase.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/PoolMapTestBase.java
@@ -40,11 +40,6 @@ public abstract class PoolMapTestBase {
     this.poolMap = new PoolMap<>(getPoolType(), POOL_SIZE);
   }
 
-  @After
-  public void tearDown() throws Exception {
-    this.poolMap.clear();
-  }
-
   protected abstract PoolType getPoolType();
 
   protected void runThread(final String key, PoolMap.PoolResourceSupplier<String> supplier,

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/PoolMapTestBase.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/PoolMapTestBase.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.util;
 
 import static org.junit.Assert.assertTrue;
 
+import java.util.Objects;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.hbase.util.PoolMap.PoolType;
 import org.junit.After;
@@ -28,6 +29,7 @@ public abstract class PoolMapTestBase {
 
   protected PoolMap<String, String> poolMap;
 
+  protected static final int KEY_COUNT = 5;
   protected static final int POOL_SIZE = 3;
 
   @Before
@@ -42,16 +44,16 @@ public abstract class PoolMapTestBase {
 
   protected abstract PoolType getPoolType();
 
-  protected void runThread(final String randomKey, final String randomValue,
+  protected void runThread(final String key, final String value,
       final String expectedValue) throws InterruptedException {
     final AtomicBoolean matchFound = new AtomicBoolean(false);
     Thread thread = new Thread(new Runnable() {
       @Override
       public void run() {
-        poolMap.put(randomKey, randomValue);
-        String actualValue = poolMap.get(randomKey);
-        matchFound
-            .set(expectedValue == null ? actualValue == null : expectedValue.equals(actualValue));
+        poolMap.put(key, value);
+        String actualValue = poolMap.get(key);
+
+        matchFound.set(Objects.equals(expectedValue, actualValue));
       }
     });
     thread.start();

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestRoundRobinPoolMap.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestRoundRobinPoolMap.java
@@ -99,8 +99,7 @@ public class TestRoundRobinPoolMap extends PoolMapTestBase {
 
     assertEquals(POOL_SIZE, poolMap.values().size());
 
-    // pool is filled, get() should return elements round robin order
-    // starting from 1, because the first get was called by runThread()
+    /* pool is filled, get() should return elements round robin order */
     for (int i = 0; i < 2 * POOL_SIZE; i++) {
       String expected = Integer.toString(i % POOL_SIZE);
       assertEquals(expected, poolMap.getOrCreate(key, () -> {

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestRoundRobinPoolMap.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestRoundRobinPoolMap.java
@@ -51,8 +51,7 @@ public class TestRoundRobinPoolMap extends PoolMapTestBase {
     String value = "value";
     // As long as the pool is not full, get calls the supplier
     runThread(key, () -> value, value);
-    assertEquals(1, poolMap.size(key));
-    assertEquals(1, poolMap.size());
+    assertEquals(1, poolMap.values().size());
   }
 
   @Test
@@ -60,25 +59,22 @@ public class TestRoundRobinPoolMap extends PoolMapTestBase {
     for (int i = 0; i < KEY_COUNT; i++) {
       String key = Integer.toString(i);
       String value = Integer.toString(2 * i);
-      // As long as the pool is not full, get calls the supplier
+      // As long as the pool is not full, we'll get the supplied value back
       runThread(key, () -> value, value);
-      assertEquals(1, poolMap.size(key));
     }
 
-    assertEquals(KEY_COUNT, poolMap.size());
+    assertEquals(KEY_COUNT, poolMap.values().size());
     poolMap.clear();
 
     String key = "key";
-    for (int i = 0; i < POOL_SIZE - 1; i++) {
+    for (int i = 0; i < POOL_SIZE; i++) {
       String value = Integer.toString(i);
-      // As long as the pool is not full, we'll get null back
+      // As long as the pool is not full, we'll get the supplied value back
       runThread(key, () -> value, value);
-      // since we use the same key, the pool size should grow
-      assertEquals(i + 1, poolMap.size(key));
     }
+
     // at the end of the day, there should be as many values as we put
-    assertEquals(POOL_SIZE - 1, poolMap.size(key));
-    assertEquals(1, poolMap.size());
+    assertEquals(POOL_SIZE, poolMap.values().size());
   }
 
   @Test
@@ -90,14 +86,13 @@ public class TestRoundRobinPoolMap extends PoolMapTestBase {
       runThread(key, () -> value, value);
     }
 
-    assertEquals(POOL_SIZE, poolMap.size(key));
-    assertEquals(1, poolMap.size());
+    assertEquals(POOL_SIZE, poolMap.values().size());
 
     // pool is filled, get() should return elements round robin order
     // starting from 1, because the first get was called by runThread()
     for (int i = 0; i < 2 * POOL_SIZE; i++) {
       String expected = Integer.toString(i % POOL_SIZE);
-      assertEquals(expected, poolMap.getOrCreate(key, null));
+      assertEquals(expected, poolMap.getOrCreate(key, () -> null));
     }
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestThreadLocalPoolMap.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestThreadLocalPoolMap.java
@@ -47,7 +47,7 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
     Random rand = ThreadLocalRandom.current();
     String key = "key";
     String value = "value";
-    runThread(key, value, value);
+    runThread(key, () -> value, value);
     assertEquals(1, poolMap.size(key));
     assertEquals(1, poolMap.size());
   }
@@ -57,7 +57,7 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
     for (int i = 0; i < KEY_COUNT; i++) {
       String key = Integer.toString(i);
       String value = Integer.toString(2 * i);
-      runThread(key, value, value);
+      runThread(key, () -> value, value);
       assertEquals(1, poolMap.size(key));
     }
 
@@ -67,7 +67,7 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
     String key = "key";
     for (int i = 0; i < POOL_SIZE - 1; i++) {
       String value = Integer.toString(i);
-      runThread(key, value, value);
+      runThread(key, () -> value, value);
       assertEquals(i + 1, poolMap.size(key));
     }
 
@@ -79,7 +79,7 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
     String key = "key";
     for (int i = 0; i < POOL_SIZE * 2; i++) {
       String value = Integer.toString(i);
-      runThread(key, value, value);
+      runThread(key, () -> value, value);
     }
     /* we never discard values automatically, even if the thread exited */
     assertEquals(POOL_SIZE * 2, poolMap.size(key));

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestThreadLocalPoolMap.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestThreadLocalPoolMap.java
@@ -43,42 +43,46 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
   }
 
   @Test
-  public void testSingleThreadedClient() throws InterruptedException, ExecutionException {
+  public void testSingleThreadedClient() throws InterruptedException {
     Random rand = ThreadLocalRandom.current();
-    String randomKey = String.valueOf(rand.nextInt());
-    String randomValue = String.valueOf(rand.nextInt());
-    // As long as the pool is not full, we should get back what we put
-    runThread(randomKey, randomValue, randomValue);
-    assertEquals(1, poolMap.size(randomKey));
+    String key = "key";
+    String value = "value";
+    runThread(key, value, value);
+    assertEquals(1, poolMap.size(key));
+    assertEquals(1, poolMap.size());
   }
 
   @Test
-  public void testMultiThreadedClients() throws InterruptedException, ExecutionException {
-    Random rand = ThreadLocalRandom.current();
-    // As long as the pool is not full, we should get back what we put
-    for (int i = 0; i < POOL_SIZE; i++) {
-      String randomKey = String.valueOf(rand.nextInt());
-      String randomValue = String.valueOf(rand.nextInt());
-      runThread(randomKey, randomValue, randomValue);
-      assertEquals(1, poolMap.size(randomKey));
+  public void testMultiThreadedClients() throws InterruptedException {
+    for (int i = 0; i < KEY_COUNT; i++) {
+      String key = Integer.toString(i);
+      String value = Integer.toString(2 * i);
+      runThread(key, value, value);
+      assertEquals(1, poolMap.size(key));
     }
-    String randomKey = String.valueOf(rand.nextInt());
-    for (int i = 0; i < POOL_SIZE; i++) {
-      String randomValue = String.valueOf(rand.nextInt());
-      runThread(randomKey, randomValue, randomValue);
-      assertEquals(i + 1, poolMap.size(randomKey));
+
+    assertEquals(KEY_COUNT, poolMap.size());
+    poolMap.clear();
+
+    String key = "key";
+    for (int i = 0; i < POOL_SIZE - 1; i++) {
+      String value = Integer.toString(i);
+      runThread(key, value, value);
+      assertEquals(i + 1, poolMap.size(key));
     }
+
+    assertEquals(1, poolMap.size());
   }
 
   @Test
-  public void testPoolCap() throws InterruptedException, ExecutionException {
-    Random rand = ThreadLocalRandom.current();
-    String randomKey = String.valueOf(rand.nextInt());
+  public void testPoolCap() throws InterruptedException {
+    String key = "key";
     for (int i = 0; i < POOL_SIZE * 2; i++) {
-      String randomValue = String.valueOf(rand.nextInt());
-      // as of HBASE-4150, pool limit is no longer used with ThreadLocalPool
-      runThread(randomKey, randomValue, randomValue);
+      String value = Integer.toString(i);
+      runThread(key, value, value);
     }
-    assertEquals(POOL_SIZE * 2, poolMap.size(randomKey));
+    /* we never discard values automatically, even if the thread exited */
+    assertEquals(POOL_SIZE * 2, poolMap.size(key));
+    assertEquals(1, poolMap.size());
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestThreadLocalPoolMap.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestThreadLocalPoolMap.java
@@ -19,9 +19,13 @@ package org.apache.hadoop.hbase.util;
 
 import static org.junit.Assert.assertEquals;
 
+import java.io.IOException;
 import java.util.Random;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CompletionException;
 import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
@@ -43,42 +47,71 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
   }
 
   @Test
-  public void testSingleThreadedClient() throws InterruptedException {
-    Random rand = ThreadLocalRandom.current();
+  public void testGetOrCreate() throws IOException {
     String key = "key";
     String value = "value";
-    runThread(key, () -> value, value);
+    String result = poolMap.getOrCreate(key, () -> value);
+
+    assertEquals(value, result);
     assertEquals(1, poolMap.values().size());
   }
 
   @Test
-  public void testMultiThreadedClients() throws InterruptedException {
+  public void testMultipleKeys() throws IOException {
     for (int i = 0; i < KEY_COUNT; i++) {
       String key = Integer.toString(i);
       String value = Integer.toString(2 * i);
-      runThread(key, () -> value, value);
+      String result = poolMap.getOrCreate(key, () -> value);
+
+      assertEquals(value, result);
     }
 
     assertEquals(KEY_COUNT, poolMap.values().size());
-    poolMap.clear();
-
-    String key = "key";
-    for (int i = 0; i < POOL_SIZE; i++) {
-      String value = Integer.toString(i);
-      runThread(key, () -> value, value);
-    }
-
-    assertEquals(POOL_SIZE, poolMap.values().size());
   }
 
   @Test
-  public void testPoolCap() throws InterruptedException {
+  public void testFull() throws IOException {
     String key = "key";
-    for (int i = 0; i < POOL_SIZE * 2; i++) {
-      String value = Integer.toString(i);
-      runThread(key, () -> value, value);
-    }
-    /* we never discard values automatically, even if the thread exited */
-    assertEquals(POOL_SIZE * 2, poolMap.values().size());
+    String value = "value";
+
+    String result = poolMap.getOrCreate(key, () -> value);
+    assertEquals(value, result);
+
+    String result2 = poolMap.getOrCreate(key, () -> {
+      throw new IOException("must not call me");
+    });
+
+    assertEquals(value, result2);
+    assertEquals(1, poolMap.values().size());
+  }
+
+  @Test
+  public void testLocality() throws ExecutionException, InterruptedException {
+    String key = "key";
+    AtomicInteger id = new AtomicInteger();
+
+    Runnable runnable = () -> {
+      try {
+        String myId = Integer.toString(id.getAndIncrement());
+
+        for (int i = 0; i < 3; i++) {
+          String result = poolMap.getOrCreate(key, () -> myId);
+          assertEquals(myId, result);
+
+          Thread.yield();
+        }
+      } catch (IOException e) {
+        throw new CompletionException(e);
+      }
+    };
+
+    CompletableFuture<Void> future1 = CompletableFuture.runAsync(runnable);
+    CompletableFuture<Void> future2 = CompletableFuture.runAsync(runnable);
+
+    /* test for successful completion */
+    future1.get();
+    future2.get();
+
+    assertEquals(2, poolMap.values().size());
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestThreadLocalPoolMap.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/util/TestThreadLocalPoolMap.java
@@ -48,8 +48,7 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
     String key = "key";
     String value = "value";
     runThread(key, () -> value, value);
-    assertEquals(1, poolMap.size(key));
-    assertEquals(1, poolMap.size());
+    assertEquals(1, poolMap.values().size());
   }
 
   @Test
@@ -58,20 +57,18 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
       String key = Integer.toString(i);
       String value = Integer.toString(2 * i);
       runThread(key, () -> value, value);
-      assertEquals(1, poolMap.size(key));
     }
 
-    assertEquals(KEY_COUNT, poolMap.size());
+    assertEquals(KEY_COUNT, poolMap.values().size());
     poolMap.clear();
 
     String key = "key";
-    for (int i = 0; i < POOL_SIZE - 1; i++) {
+    for (int i = 0; i < POOL_SIZE; i++) {
       String value = Integer.toString(i);
       runThread(key, () -> value, value);
-      assertEquals(i + 1, poolMap.size(key));
     }
 
-    assertEquals(1, poolMap.size());
+    assertEquals(POOL_SIZE, poolMap.values().size());
   }
 
   @Test
@@ -82,7 +79,6 @@ public class TestThreadLocalPoolMap extends PoolMapTestBase {
       runThread(key, () -> value, value);
     }
     /* we never discard values automatically, even if the thread exited */
-    assertEquals(POOL_SIZE * 2, poolMap.size(key));
-    assertEquals(1, poolMap.size());
+    assertEquals(POOL_SIZE * 2, poolMap.values().size());
   }
 }


### PR DESCRIPTION
* PoolMap does not discard any elements anymore. If an element is put,
it always stores it. The reason: it stores expensive resources (rpc
connections) which would lead to resource leak if we simple discard it.
RpcClients can reference netty ByteBufs which are reference counted.
Resource cleanup is done by AbstractRpcClient.cleanupIdleConnections().
* Removed concurrency from PoolMap. It is called only from
AbstractRpcClient in synchronized blocks, so it doesn't have to be
thread-safe.
* Max size is a hint for RoundRobinPool. Until maxSize is not reached,
it will force users to create new resources. So it works the same as
before, but it does not prevent putting more elements then maxSize.
* ThreadLocalPool doesn't uses ThreadLocal class anymore. It stores
resources on thread basis, but it doesn't remove values when a thread
exits. Again, proper cleanup is done by cleanupIdleConnections().