### PR TITLE
HBASE-25313 [branch-1] Fix the broken pre-commit

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -125,7 +125,7 @@ RUN apt-add-repository ppa:brightbox/ruby-ng
 RUN apt-get -q update
 
 RUN apt-get -q install --no-install-recommends -y ruby2.3 ruby2.3-dev ruby-switch
-RUN ruby-switch --set ruby2.3
+RUN ruby-switch --set ruby2.5
 
 ####
 # Install rubocop

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -124,7 +124,7 @@ RUN echo 'gem: --no-rdoc --no-ri' >> /root/.gemrc
 RUN apt-add-repository ppa:brightbox/ruby-ng
 RUN apt-get -q update
 
-RUN apt-get -q install --no-install-recommends -y ruby2.3 ruby2.3-dev ruby-switch
+RUN apt-get -q install --no-install-recommends -y ruby2.5 ruby2.5-dev ruby-switch
 RUN ruby-switch --set ruby2.5
 
 ####


### PR DESCRIPTION
I saw following in the output
```
[2020-11-20T02:58:46.571Z] ERROR:  Error installing rubocop:
[2020-11-20T02:58:46.571Z] 	parallel requires Ruby version >= 2.5.
[2020-11-20T02:58:46.571Z] Successfully installed jaro_winkler-1.5.4
```
So I update the ruby version to 2.5.