### PR TITLE
HBASE-25370 Fix flaky test TestClassFinder#testClassFinderDefaultsToOwnPackage

### DIFF
--- a/hbase-common/pom.xml
+++ b/hbase-common/pom.xml
@@ -1,4 +1,3 @@
-<?xml version="1.0"?>
 <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 <!--
 /**
@@ -210,6 +209,12 @@
       <artifactId>findbugs-annotations</artifactId>
       <scope>compile</scope>
       <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <version>${hamcrest.version}</version>
+      <scope>test</scope>
     </dependency>
     <dependency>
       <groupId>org.mockito</groupId>

--- a/hbase-common/pom.xml
+++ b/hbase-common/pom.xml
@@ -1,3 +1,4 @@
+<?xml version="1.0"?>
 <project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
 <!--
 /**
@@ -213,7 +214,6 @@
     <dependency>
       <groupId>org.hamcrest</groupId>
       <artifactId>hamcrest-library</artifactId>
-      <version>${hamcrest.version}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/ClassFinder.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/ClassFinder.java
@@ -23,9 +23,8 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.LinkedHashSet;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -187,7 +186,7 @@ public class ClassFinder {
       }
     }
 
-    Set<Class<?>> classes = new LinkedHashSet<>();
+    Set<Class<?>> classes = new HashSet<>();
     for (File directory : dirs) {
       classes.addAll(findClassesFromFiles(directory, packageName, proceedOnExceptions));
     }
@@ -208,7 +207,7 @@ public class ClassFinder {
       throw ioEx;
     }
 
-    Set<Class<?>> classes = new LinkedHashSet<>();
+    Set<Class<?>> classes = new HashSet<>();
     JarEntry entry;
     try {
       while (true) {
@@ -255,14 +254,13 @@ public class ClassFinder {
 
   private Set<Class<?>> findClassesFromFiles(File baseDirectory, String packageName,
       boolean proceedOnExceptions) throws ClassNotFoundException, LinkageError {
-    Set<Class<?>> classes = new LinkedHashSet<>();
+    Set<Class<?>> classes = new HashSet<>();
     if (!baseDirectory.exists()) {
       LOG.warn(baseDirectory.getAbsolutePath() + " does not exist");
       return classes;
     }
 
     File[] files = baseDirectory.listFiles(this.fileFilter);
-    Arrays.sort(files);
     if (files == null) {
       LOG.warn("Failed to get files from " + baseDirectory.getAbsolutePath());
       return classes;

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/ClassFinder.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/ClassFinder.java
@@ -23,8 +23,9 @@ import java.io.FileInputStream;
 import java.io.IOException;
 import java.net.URL;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Enumeration;
-import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.jar.JarEntry;
@@ -186,7 +187,7 @@ public class ClassFinder {
       }
     }
 
-    Set<Class<?>> classes = new HashSet<>();
+    Set<Class<?>> classes = new LinkedHashSet<>();
     for (File directory : dirs) {
       classes.addAll(findClassesFromFiles(directory, packageName, proceedOnExceptions));
     }
@@ -207,7 +208,7 @@ public class ClassFinder {
       throw ioEx;
     }
 
-    Set<Class<?>> classes = new HashSet<>();
+    Set<Class<?>> classes = new LinkedHashSet<>();
     JarEntry entry;
     try {
       while (true) {
@@ -254,13 +255,14 @@ public class ClassFinder {
 
   private Set<Class<?>> findClassesFromFiles(File baseDirectory, String packageName,
       boolean proceedOnExceptions) throws ClassNotFoundException, LinkageError {
-    Set<Class<?>> classes = new HashSet<>();
+    Set<Class<?>> classes = new LinkedHashSet<>();
     if (!baseDirectory.exists()) {
       LOG.warn(baseDirectory.getAbsolutePath() + " does not exist");
       return classes;
     }
 
     File[] files = baseDirectory.listFiles(this.fileFilter);
+    Arrays.sort(files);
     if (files == null) {
       LOG.warn("Failed to get files from " + baseDirectory.getAbsolutePath());
       return classes;

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TestClassFinder.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TestClassFinder.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase;
 
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.arrayContainingInAnyOrder;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -295,7 +297,10 @@ public class TestClassFinder {
     Set<Class<?>> pkgClasses = allClassesFinder.findClasses(
         ClassFinder.class.getPackage().getName(), false);
     Set<Class<?>> defaultClasses = allClassesFinder.findClasses(false);
-    assertArrayEquals(pkgClasses.toArray(), defaultClasses.toArray());
+    Object[] pkgClassesArray = pkgClasses.toArray();
+    Object[] defaultClassesArray = defaultClasses.toArray();
+    assertEquals(pkgClassesArray.length, defaultClassesArray.length);
+    assertThat(pkgClassesArray, arrayContainingInAnyOrder(defaultClassesArray));
   }
 
   private static class FileAndPath {


### PR DESCRIPTION
The test `TestClassFinder#testClassFinderDefaultsToOwnPackage` compares two sets from `allClassesFinder.findClasses`. However, the function `allClassesFinder.findClasses` does not return the deterministic order result. From code trace, the root cause is at `ClassFinder.findClassesFromJar` and `ClassFinder.findClassesFromFiles`. They use `HashSet` to store `classes` and `listFiles` to get file array. However, `HashSet` and `listFiles` do not guarantee that order, and the assertion can fail if the order differs. 

The PR uses `LinkedHashSet` and sorts file array to make the order deterministic.