### PR TITLE
HBASE-25364 Redo the getMidPoint() in HFileWriterImpl to get rid of t…

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
@@ -759,6 +759,21 @@ public class TestHFile  {
       .compareKeyIgnoresMvcc(CellComparatorImpl.COMPARATOR, mid, right) <= 0);
     assertEquals(1, mid.getQualifierLength());
 
+    // Verify boundary conditions
+    left = getCell(Bytes.toBytes("a"), Bytes.toBytes("a"), new byte[] { 0x00, (byte)0xFE });
+    right = getCell(Bytes.toBytes("a"), Bytes.toBytes("a"), new byte[] { 0x00, (byte)0xFF });
+    mid = HFileWriterImpl.getMidpoint(CellComparatorImpl.COMPARATOR, left, right);
+    assertTrue(PrivateCellUtil
+      .compareKeyIgnoresMvcc(CellComparatorImpl.COMPARATOR, left, mid) < 0);
+    assertTrue(PrivateCellUtil
+      .compareKeyIgnoresMvcc(CellComparatorImpl.COMPARATOR, mid, right) == 0);
+    left = getCell(Bytes.toBytes("a"), Bytes.toBytes("a"), new byte[] { 0x00, 0x12 });
+    right = getCell(Bytes.toBytes("a"), Bytes.toBytes("a"), new byte[] { 0x00, 0x12, 0x00 });
+    mid = HFileWriterImpl.getMidpoint(CellComparatorImpl.COMPARATOR, left, right);
+    assertTrue(PrivateCellUtil.compareKeyIgnoresMvcc(CellComparatorImpl.COMPARATOR, left, mid) < 0);
+    assertTrue(
+      PrivateCellUtil.compareKeyIgnoresMvcc(CellComparatorImpl.COMPARATOR, mid, right) == 0);
+
     // Assert that if meta comparator, it returns the right cell -- i.e. no
     // optimization done.
     left = getCell(Bytes.toBytes("g"), Bytes.toBytes("a"), Bytes.toBytes("a"));


### PR DESCRIPTION
…he double comparison process


There is a TODO like this "TODO: Redo so only a single pass over the arrays rather than one to  compare and then a second composing midpoint." in getMidpoint()  of class ​HFileWriteImpl​
 
The old logic compares the left byte array and the right byte array twice： 

1. A comparison is performed before composing MinimumMidpointArray
2. During composing of MinimumMidpointArray, bytes were comparing again
 
My optimization  combines them into one
