### PR TITLE
HBASE-25366 [Documentation] Fix spelling error in sync_replication.adoc

### DIFF
--- a/src/main/asciidoc/_chapters/sync_replication.adoc
+++ b/src/main/asciidoc/_chapters/sync_replication.adoc
@@ -99,7 +99,7 @@ hbase> transit_peer_sync_replication_state '1', 'ACTIVE'
 Case.3 How to operate when active cluster crashed::
 
 If the active cluster has been crashed (it may be not reachable now), so let's just transit the standby cluster to
-DOWNGRANDE_ACTIVE state, and after that, we should redirect all the requests from client to the DOWNGRADE_ACTIVE cluster.
+DOWNGRADE_ACTIVE state, and after that, we should redirect all the requests from client to the DOWNGRADE_ACTIVE cluster.
 
 [source,ruby]
 ----


### PR DESCRIPTION
Fix spelling error :
from DOWNGRANDE_ACTIVE to DOWNGRADE_ACTIVE