### PR TITLE
HBASE-25376 [create-release] Fix double .asc

### DIFF
--- a/dev-support/create-release/release-util.sh
+++ b/dev-support/create-release/release-util.sh
@@ -685,7 +685,7 @@ function maven_deploy { #inputs: <snapshot|release> <log_file_path>
   maven_set_version "$RELEASE_VERSION"
   # Prepare for signing
   kick_gpg_agent
-  declare -a mvn_goals=(clean install)
+  declare -a mvn_goals=(clean)
   if ! is_dry_run; then
     mvn_goals=("${mvn_goals[@]}" deploy)
   fi


### PR DESCRIPTION
Don't install when we call deploy -- makes for doubling of .asc.
Added more to the README while in here and added logging
timestamp so we can tell where we are spending time.