### PR TITLE
HBASE-25378 Legacy comparator in Hfile trailer will fail to load

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/FixedFileTrailer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/FixedFileTrailer.java
@@ -612,6 +612,8 @@ public class FixedFileTrailer {
       comparatorKlass = CellComparatorImpl.class;
     } else if (comparatorClassName.equals(KeyValue.META_COMPARATOR.getLegacyKeyComparatorName())
       || comparatorClassName.equals(KeyValue.META_COMPARATOR.getClass().getName())
+      || (comparatorClassName.equals("org.apache.hadoop.hbase.CellComparator$MetaCellComparator"))      
+      || (comparatorClassName.equals("org.apache.hadoop.hbase.CellComparatorImpl$MetaCellComparator"))      
       || (comparatorClassName.equals("org.apache.hadoop.hbase.MetaCellComparator"))) {
       comparatorKlass = MetaCellComparator.class;
     } else if (comparatorClassName.equals("org.apache.hadoop.hbase.KeyValue$RawBytesComparator")

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestFixedFileTrailer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestFixedFileTrailer.java
@@ -130,6 +130,11 @@ public class TestFixedFileTrailer {
           t.createComparator(KeyValue.META_COMPARATOR.getLegacyKeyComparatorName()).getClass());
       assertEquals(MetaCellComparator.class,
           t.createComparator(KeyValue.META_COMPARATOR.getClass().getName()).getClass());
+      assertEquals(MetaCellComparator.class,
+        t.createComparator("org.apache.hadoop.hbase.CellComparator$MetaCellComparator").getClass());
+      assertEquals(MetaCellComparator.class,
+        t.createComparator("org.apache.hadoop.hbase.CellComparatorImpl$MetaCellComparator")
+            .getClass());
       assertEquals(MetaCellComparator.class, t.createComparator(
           MetaCellComparator.META_COMPARATOR.getClass().getName()).getClass());
       assertEquals(MetaCellComparator.META_COMPARATOR.getClass(), t.createComparator(
@@ -139,7 +144,8 @@ public class TestFixedFileTrailer {
       assertNull(t.createComparator(Bytes.BYTES_RAWCOMPARATOR.getClass().getName()));
       assertNull(t.createComparator("org.apache.hadoop.hbase.KeyValue$RawBytesComparator"));
     } catch (IOException e) {
-      fail("Unexpected exception while testing FixedFileTrailer#createComparator()");
+      fail("Unexpected exception while testing FixedFileTrailer#createComparator(), "
+          + e.getMessage());
     }
 
     // Test an invalid comparatorClassName


### PR DESCRIPTION
Fallback to MetaCellComparator when "org.apache.hadoop.hbase.CellComparator$MetaCellComparator" or "org.apache.hadoop.hbase.CellComparatorImpl$MetaCellComparator" is set in Hfile trailer