### PR TITLE
HBASE-25379 Make retry pause time configurable for regionserver short operation RPC (reportRegionStateTransition/reportProcedureDone)

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -966,15 +966,15 @@ public final class HConstants {
   public static final int DEFAULT_HBASE_RPC_SHORTOPERATION_TIMEOUT = 10000;
 
   /**
-   * Pause time for short operation RPC
+   * Retry pause time for short operation RPC
    */
-  public static final String HBASE_RPC_SHORTOPERATION_PAUSE_TIME =
-      "hbase.rpc.shortoperation.pause.time";
+  public static final String HBASE_RPC_SHORTOPERATION_RETRY_PAUSE_TIME =
+      "hbase.rpc.shortoperation.retry.pause.time";
 
   /**
-   * Default value of {@link #HBASE_RPC_SHORTOPERATION_PAUSE_TIME}
+   * Default value of {@link #HBASE_RPC_SHORTOPERATION_RETRY_PAUSE_TIME}
    */
-  public static final long DEFAULT_HBASE_RPC_SHORTOPERATION_PAUSE_TIME = 1000;
+  public static final long DEFAULT_HBASE_RPC_SHORTOPERATION_RETRY_PAUSE_TIME = 1000;
 
   /**
    * Value indicating the server name was saved with no sequence number.

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -966,6 +966,17 @@ public final class HConstants {
   public static final int DEFAULT_HBASE_RPC_SHORTOPERATION_TIMEOUT = 10000;
 
   /**
+   * Pause time for short operation RPC
+   */
+  public static final String HBASE_RPC_SHORTOPERATION_PAUSE_TIME =
+      "hbase.rpc.shortoperation.pause.time";
+
+  /**
+   * Default value of {@link #HBASE_RPC_SHORTOPERATION_PAUSE_TIME}
+   */
+  public static final long DEFAULT_HBASE_RPC_SHORTOPERATION_PAUSE_TIME = 1000;
+
+  /**
    * Value indicating the server name was saved with no sequence number.
    */
   public static final long NO_SEQNUM = -1;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -618,8 +618,8 @@ public class HRegionServer extends Thread implements
       this.shortOperationTimeout = conf.getInt(HConstants.HBASE_RPC_SHORTOPERATION_TIMEOUT_KEY,
           HConstants.DEFAULT_HBASE_RPC_SHORTOPERATION_TIMEOUT);
 
-      this.retryPauseTime = conf.getLong(HConstants.HBASE_RPC_SHORTOPERATION_PAUSE_TIME,
-        HConstants.DEFAULT_HBASE_RPC_SHORTOPERATION_PAUSE_TIME);
+      this.retryPauseTime = conf.getLong(HConstants.HBASE_RPC_SHORTOPERATION_RETRY_PAUSE_TIME,
+        HConstants.DEFAULT_HBASE_RPC_SHORTOPERATION_RETRY_PAUSE_TIME);
 
       this.abortRequested = new AtomicBoolean(false);
       this.stopped = false;
@@ -3944,7 +3944,7 @@ public class HRegionServer extends Thread implements
   }
 
   /**
-   * Return pause time configured in {@link HConstants#HBASE_RPC_SHORTOPERATION_PAUSE_TIME}}
+   * Return pause time configured in {@link HConstants#HBASE_RPC_SHORTOPERATION_RETRY_PAUSE_TIME}}
    * @return pause time
    */
   @InterfaceAudience.Private

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -435,6 +435,9 @@ public class HRegionServer extends Thread implements
 
   private final int shortOperationTimeout;
 
+  // Time to pause if master says 'please hold'
+  private final long retryPauseTime;
+
   private final RegionServerAccounting regionServerAccounting;
 
   private SlowLogTableOpsChore slowLogTableOpsChore = null;
@@ -614,6 +617,9 @@ public class HRegionServer extends Thread implements
 
       this.shortOperationTimeout = conf.getInt(HConstants.HBASE_RPC_SHORTOPERATION_TIMEOUT_KEY,
           HConstants.DEFAULT_HBASE_RPC_SHORTOPERATION_TIMEOUT);
+
+      this.retryPauseTime = conf.getLong(HConstants.HBASE_RPC_SHORTOPERATION_PAUSE_TIME,
+        HConstants.DEFAULT_HBASE_RPC_SHORTOPERATION_PAUSE_TIME);
 
       this.abortRequested = new AtomicBoolean(false);
       this.stopped = false;
@@ -2436,10 +2442,8 @@ public class HRegionServer extends Thread implements
     final ReportRegionStateTransitionRequest request =
         createReportRegionStateTransitionRequest(context);
 
-    // Time to pause if master says 'please hold'. Make configurable if needed.
-    final long initPauseTime = 1000;
     int tries = 0;
-    long pauseTime;
+    long pauseTime = this.retryPauseTime;
     // Keep looping till we get an error. We want to send reports even though server is going down.
     // Only go down if clusterConnection is null. It is set to null almost as last thing as the
     // HRegionServer does down.
@@ -2470,9 +2474,9 @@ public class HRegionServer extends Thread implements
                 || ioe instanceof CallQueueTooBigException;
         if (pause) {
           // Do backoff else we flood the Master with requests.
-          pauseTime = ConnectionUtils.getPauseTime(initPauseTime, tries);
+          pauseTime = ConnectionUtils.getPauseTime(this.retryPauseTime, tries);
         } else {
-          pauseTime = initPauseTime; // Reset.
+          pauseTime = this.retryPauseTime; // Reset.
         }
         LOG.info("Failed report transition " +
           TextFormat.shortDebugString(request) + "; retry (#" + tries + ")" +

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -3942,4 +3942,13 @@ public class HRegionServer extends Thread implements
   public CompactedHFilesDischarger getCompactedHFilesDischarger() {
     return compactedFileDischarger;
   }
+
+  /**
+   * Return pause time configured in {@link HConstants#HBASE_RPC_SHORTOPERATION_PAUSE_TIME}}
+   * @return pause time
+   */
+  @InterfaceAudience.Private
+  public long getRetryPauseTime() {
+    return this.retryPauseTime;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RemoteProcedureResultReporter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RemoteProcedureResultReporter.java
@@ -41,9 +41,6 @@ class RemoteProcedureResultReporter extends Thread {
 
   private static final Logger LOG = LoggerFactory.getLogger(RemoteProcedureResultReporter.class);
 
-  // Time to pause if master says 'please hold'. Make configurable if needed.
-  private static final int INIT_PAUSE_TIME_MS = 1000;
-
   private static final int MAX_BATCH = 100;
 
   private final HRegionServer server;
@@ -98,9 +95,9 @@ class RemoteProcedureResultReporter extends Thread {
         long pauseTime;
         if (pause) {
           // Do backoff else we flood the Master with requests.
-          pauseTime = ConnectionUtils.getPauseTime(INIT_PAUSE_TIME_MS, tries);
+          pauseTime = ConnectionUtils.getPauseTime(server.getRetryPauseTime(), tries);
         } else {
-          pauseTime = INIT_PAUSE_TIME_MS; // Reset.
+          pauseTime = server.getRetryPauseTime(); // Reset.
         }
         LOG.info("Failed procedure report " + TextFormat.shortDebugString(request) + "; retry (#" +
           tries + ")" + (pause ? " after " + pauseTime + "ms delay (Master is coming online...)."


### PR DESCRIPTION
Added "hbase.rpc.shortoperation.pause.time" for initial pause for reportRegionStateTransition.