### PR TITLE
HBASE-25449 'dfs.client.read.shortcircuit' should not be set in hbase-default.xml

### DIFF
--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -1471,7 +1471,7 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
     <name>dfs.domain.socket.path</name>
-    <value>none</value>
+    <value></value>
     <description>
       This is a path to a UNIX domain socket that will be used for
       communication between the DataNode and local HDFS clients, if

--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -1463,7 +1463,7 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
     <name>dfs.client.read.shortcircuit</name>
-    <value>false</value>
+    <value></value>
     <description>
       If set to true, this configuration parameter enables short-circuit local
       reads.

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TestHBaseConfiguration.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TestHBaseConfiguration.java
@@ -115,6 +115,19 @@ public class TestHBaseConfiguration {
     conf.set("hbase.security.authentication", "KERBeros");
     Assert.assertTrue(User.isHBaseSecurityEnabled(conf));
   }
+  
+  @Test
+  public void testGetConfigOfShortcircuitRead() throws Exception {
+    Configuration conf = HBaseConfiguration.create();
+    Configuration.addDefaultResource("hdfs-default.xml");
+    assertEquals("hdfs-default.xml",
+            conf.getPropertySources("dfs.client.read.shortcircuit")[0]);
+    assertEquals("false", conf.get("dfs.client.read.shortcircuit"));
+    Configuration.addDefaultResource("hdfs-site.xml");
+    assertEquals("hdfs-site.xml",
+            conf.getPropertySources("dfs.client.read.shortcircuit")[0]);
+    assertEquals("true", conf.get("dfs.client.read.shortcircuit"));
+  }
 
   private static class ReflectiveCredentialProviderClient {
     public static final String HADOOP_CRED_PROVIDER_FACTORY_CLASS_NAME =

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TestHBaseConfiguration.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TestHBaseConfiguration.java
@@ -123,10 +123,14 @@ public class TestHBaseConfiguration {
     assertEquals("hdfs-default.xml",
             conf.getPropertySources("dfs.client.read.shortcircuit")[0]);
     assertEquals("false", conf.get("dfs.client.read.shortcircuit"));
-    Configuration.addDefaultResource("hdfs-site.xml");
-    assertEquals("hdfs-site.xml",
+    assertNull(conf.get("dfs.domain.socket.path"));
+    Configuration.addDefaultResource("hdfs-scr-enabled.xml");
+    assertEquals("hdfs-scr-enabled.xml",
             conf.getPropertySources("dfs.client.read.shortcircuit")[0]);
+    assertEquals("hdfs-scr-enabled.xml",
+            conf.getPropertySources("dfs.domain.socket.path")[0]);
     assertEquals("true", conf.get("dfs.client.read.shortcircuit"));
+    assertEquals("/var/lib/hadoop-hdfs/dn_socket", conf.get("dfs.domain.socket.path"));
   }
 
   private static class ReflectiveCredentialProviderClient {

--- a/hbase-common/src/test/resources/hdfs-default.xml
+++ b/hbase-common/src/test/resources/hdfs-default.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<configuration>
+  <property>
+    <name>dfs.client.read.shortcircuit</name>
+    <value>false</value>
+    <description>
+      If set to true, this configuration parameter enables short-circuit local
+      reads.
+    </description>
+  </property>
+</configuration>

--- a/hbase-common/src/test/resources/hdfs-default.xml
+++ b/hbase-common/src/test/resources/hdfs-default.xml
@@ -29,4 +29,14 @@
       reads.
     </description>
   </property>
+  <property>
+    <name>dfs.domain.socket.path</name>
+    <value></value>
+    <description>
+    Optional.  This is a path to a UNIX domain socket that will be used for
+      communication between the DataNode and local HDFS clients.
+      If the string "_PORT" is present in this path, it will be replaced by the
+      TCP port of the DataNode.
+    </description>
+  </property>
 </configuration>

--- a/hbase-common/src/test/resources/hdfs-scr-enabled.xml
+++ b/hbase-common/src/test/resources/hdfs-scr-enabled.xml
@@ -29,4 +29,14 @@
       reads.
     </description>
   </property>
+  <property>
+    <name>dfs.domain.socket.path</name>
+    <value>/var/lib/hadoop-hdfs/dn_socket</value>
+    <description>
+    Optional.  This is a path to a UNIX domain socket that will be used for
+      communication between the DataNode and local HDFS clients.
+      If the string "_PORT" is present in this path, it will be replaced by the
+      TCP port of the DataNode.
+    </description>
+  </property>
 </configuration>

--- a/hbase-common/src/test/resources/hdfs-site.xml
+++ b/hbase-common/src/test/resources/hdfs-site.xml
@@ -1,0 +1,32 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<configuration>
+  <property>
+    <name>dfs.client.read.shortcircuit</name>
+    <value>true</value>
+    <description>
+      If set to true, this configuration parameter enables short-circuit local
+      reads.
+    </description>
+  </property>
+</configuration>


### PR DESCRIPTION
Remove the default value for this parameter.