### PR TITLE
HBASE-25445: Use WAL FS instead of master FS in SplitWALManager

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
@@ -85,8 +85,7 @@ public class SplitWALManager {
     this.splitWorkerAssigner = new SplitWorkerAssigner(this.master,
         conf.getInt(HBASE_SPLIT_WAL_MAX_SPLITTER, DEFAULT_HBASE_SPLIT_WAL_MAX_SPLITTER));
     this.rootDir = master.getMasterFileSystem().getWALRootDir();
-    // TODO: This should be the WAL FS, not the Master FS?
-    this.fs = master.getMasterFileSystem().getFileSystem();
+    this.fs = master.getMasterFileSystem().getWALFileSystem();
     this.walArchiveDir = new Path(this.rootDir, HConstants.HREGION_OLDLOGDIR_NAME);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestSplitWALManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestSplitWALManager.java
@@ -31,6 +31,15 @@ import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.master.assignment.SplitTableRegionProcedure;
+import org.apache.hadoop.hbase.master.assignment.TransitRegionStateProcedure;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
 import org.apache.hadoop.hbase.master.procedure.ServerProcedureInterface;
 import org.apache.hadoop.hbase.procedure2.Procedure;
@@ -43,6 +52,7 @@ import org.apache.hadoop.hbase.procedure2.StateMachineProcedure;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.JVMClusterUtil;
 import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
 import org.junit.After;
@@ -54,6 +64,8 @@ import org.junit.experimental.categories.Category;
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Category({ MasterTests.class, LargeTests.class })
 
@@ -63,6 +75,7 @@ public class TestSplitWALManager {
   public static final HBaseClassTestRule CLASS_RULE =
       HBaseClassTestRule.forClass(TestSplitWALManager.class);
 
+  private static final Logger LOG = LoggerFactory.getLogger(TestSplitWALManager.class);
   private static HBaseTestingUtility TEST_UTIL;
   private HMaster master;
   private SplitWALManager splitWALManager;
@@ -84,6 +97,59 @@ public class TestSplitWALManager {
   @After
   public void teardown() throws Exception {
     TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testWALArchiveWithDifferentWalAndRootFS() throws Exception{
+    HBaseTestingUtility TEST_UTIL_2 = new HBaseTestingUtility();
+    Path dir = TEST_UTIL.getDataTestDirOnTestFS("testWalDir");
+    TEST_UTIL_2.getConfiguration().set(CommonFSUtils.HBASE_WAL_DIR, dir.toString());
+    CommonFSUtils.setWALRootDir(TEST_UTIL_2.getConfiguration(), dir);
+    TEST_UTIL_2.startMiniCluster(3);
+    HMaster TU2_master = TEST_UTIL_2.getHBaseCluster().getMaster();
+    LOG.info("The Master FS is pointing to: " + TU2_master.getMasterFileSystem()
+      .getFileSystem().getUri());
+    LOG.info("The WAL FS is pointing to: " + TU2_master.getMasterFileSystem()
+      .getWALFileSystem().getUri());
+    Table TABLE = TEST_UTIL_2.createTable(TABLE_NAME, FAMILY);
+    TEST_UTIL_2.waitTableAvailable(TABLE_NAME);
+    Admin admin = TEST_UTIL_2.getAdmin();
+    MasterProcedureEnv env = TEST_UTIL_2.getMiniHBaseCluster().getMaster()
+      .getMasterProcedureExecutor().getEnvironment();
+    final ProcedureExecutor<MasterProcedureEnv> executor = TEST_UTIL_2.getMiniHBaseCluster()
+      .getMaster().getMasterProcedureExecutor();
+    List<RegionInfo> regionInfos = admin.getRegions(TABLE_NAME);
+    SplitTableRegionProcedure splitProcedure = new SplitTableRegionProcedure(
+      env, regionInfos.get(0), Bytes.toBytes("row5"));
+    // Populate some rows in the table
+    LOG.info("Beginning put data to the table: " + TABLE.toString());
+    int rowCount = 5;
+    for (int i = 0; i < rowCount; i++) {
+      byte[] row = Bytes.toBytes("row" + i);
+      Put put = new Put(row);
+      put.addColumn(FAMILY, FAMILY, FAMILY);
+      TABLE.put(put);
+    }
+    executor.submitProcedure(splitProcedure);
+    LOG.info("Submitted SplitProcedure.");
+    TEST_UTIL_2.waitFor(30000, () -> executor.getProcedures().stream()
+      .filter(p -> p instanceof TransitRegionStateProcedure)
+      .map(p -> (TransitRegionStateProcedure) p)
+      .anyMatch(p -> TABLE_NAME.equals(p.getTableName())));
+    TEST_UTIL_2.getMiniHBaseCluster().killRegionServer(
+      TEST_UTIL_2.getMiniHBaseCluster().getRegionServer(0).getServerName());
+    TEST_UTIL_2.getMiniHBaseCluster().startRegionServer();
+    TEST_UTIL_2.waitUntilNoRegionsInTransition();
+    Scan scan = new Scan();
+    ResultScanner results = TABLE.getScanner(scan);
+    int scanRowCount = 0;
+    Result result = null;
+    while ((result = results.next()) != null) {
+      scanRowCount++;
+    }
+    Assert.assertEquals("Got " + scanRowCount + " rows when " + rowCount +
+      " were expected.", rowCount, scanRowCount);
+    TEST_UTIL_2.shutdownMiniCluster();
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestSplitWALManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestSplitWALManager.java
@@ -122,7 +122,7 @@ public class TestSplitWALManager {
     SplitTableRegionProcedure splitProcedure = new SplitTableRegionProcedure(
       env, regionInfos.get(0), Bytes.toBytes("row5"));
     // Populate some rows in the table
-    LOG.info("Beginning put data to the table: " + TABLE.toString());
+    LOG.info("Beginning put data to the table: " + TABLE_NAME.toString());
     int rowCount = 5;
     for (int i = 0; i < rowCount; i++) {
       byte[] row = Bytes.toBytes("row" + i);


### PR DESCRIPTION
- If 'hbase.wal.dir' and 'hbase.rootdir' are configured to different filesystem instances, SplitWALRemoteProcedure archived split WAL failed since SplitWALManager using wrong fs instance. SplitWALManager should use WAL corresponding fs instance.