### PR TITLE
HBASE-25482 Improve SimpleRegionNormalizer#getAverageRegionSizeMb

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
@@ -263,7 +263,7 @@ class SimpleRegionNormalizer implements RegionNormalizer, ConfigurationObserver 
     double avgRegionSize;
     try {
       TableDescriptor tableDescriptor = masterServices.getTableDescriptors().get(table);
-      if (tableDescriptor != null && LOG.isDebugEnabled()) {
+      if (tableDescriptor != null) {
         targetRegionCount = tableDescriptor.getNormalizerTargetRegionCount();
         targetRegionSize = tableDescriptor.getNormalizerTargetRegionSize();
         LOG.debug("Table {} configured with target region count {}, target region size {}", table,


### PR DESCRIPTION
[HBASE-25482](https://issues.apache.org/jira/browse/HBASE-25482)
If the table is set NormalizerTargetRegionSize, we take NormalizerTargetRegionSize as avgRegionSize and return it. So the totalSizeMb of table is not always calculated.