### PR TITLE
HBASE-25473 [create-release] checkcompatibility.py failing with "KeyE…

### DIFF
--- a/dev-support/checkcompatibility.py
+++ b/dev-support/checkcompatibility.py
@@ -229,7 +229,7 @@ def compare_results(tool_results, known_issues, compare_warnings):
                                       observed_count=tool_results[check][issue_type])
                      for check, known_issue_counts in known_issues.items()
                         for issue_type, known_count in known_issue_counts.items()
-                            if tool_results[check][issue_type] > known_count]
+                           if compare_tool_results_count(tool_results, check, issue_type, known_count)]
 
     if not compare_warnings:
         unexpected_issues = [tup for tup in unexpected_issues
@@ -241,6 +241,14 @@ def compare_results(tool_results, known_issues, compare_warnings):
 
     return bool(unexpected_issues)
 
+def compare_tool_results_count(tool_results, check, issue_type, known_count):
+    """ Check problem counts are no more than the known count.
+    (This function exists just so can add in logging; previous was inlined
+    one-liner but this made it hard debugging)
+    """
+    # logging.info("known_count=%s, check key=%s, tool_results=%s, issue_type=%s",
+    #        str(known_count), str(check), str(tool_results), str(issue_type))
+   return tool_results[check][issue_type] > known_count
 
 def process_java_acc_output(output):
     """ Process the output string to find the problems and warnings in both the

--- a/dev-support/create-release/release-util.sh
+++ b/dev-support/create-release/release-util.sh
@@ -478,8 +478,18 @@ function generate_api_report {
   local timing_token
   timing_token="$(start_step)"
   # Generate api report.
+  # Filter out some jar types. Filters are tricky. Python regex on
+  # file basename. Exclude the saved-aside original jars... they are
+  # not included in resulting artifact. Also, do not include the
+  # hbase-shaded-testing-util.*  jars. This jar is unzip'able on mac
+  # os x as is because has it a META_INF/LICENSE file and then a
+  # META_INF/license directory for the included jar's licenses;
+  # it fails to unjar on mac os x which this tool does making its checks
+  # (Its exclusion should be fine; it is just an aggregate of other jars).
   "${project}"/dev-support/checkcompatibility.py --annotation \
     org.apache.yetus.audience.InterfaceAudience.Public  \
+    -e "original-hbase.*.jar" \
+    -e "hbase-shaded-testing-util.*.jar" \
     "$previous_tag" "$release_tag"
   previous_version="$(echo "${previous_tag}" | sed -e 's/rel\///')"
   cp "${project}/target/compat-check/report.html" "./api_compare_${previous_version}_to_${release_tag}.html"


### PR DESCRIPTION
…rror: 'binary'"

Exclude hbase-shaded-testing-util*.jar from checkcompatibility; this
jar can not be unzipped on a case-insensitive filesystem. Added
some means of debug into the checkcompatibility to help when
cryptic failures.