### PR TITLE
HBASE-25499 False-positive findbugs issue on branch-2.2

### DIFF
--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/client/Client.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/client/Client.java
@@ -149,6 +149,8 @@ public class Client {
    *
    * @throws ClientTrustStoreInitializationException if the trust store file can not be loaded
    */
+  @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "OBL_UNSATISFIED_OBLIGATION",
+          justification = "Correct use of try-with-resource")
   public Client(Cluster cluster, String trustStorePath,
     Optional<String> trustStorePassword, Optional<String> trustStoreType) {
 


### PR DESCRIPTION
HBase Nightly test on branch-2.2 reports warning on InputStream
cleanup while it is used in a try-with-resource block. This commit adds
a SuppressWarnings annotation.