### PR TITLE
HBASE-25449 'dfs.client.read.shortcircuit' should not be set in hbase…

### DIFF
--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -1461,7 +1461,7 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
     <name>dfs.client.read.shortcircuit</name>
-    <value>false</value>
+    <value></value>
     <description>
       If set to true, this configuration parameter enables short-circuit local
       reads.
@@ -1469,7 +1469,7 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
     <name>dfs.domain.socket.path</name>
-    <value>none</value>
+    <value></value>
     <description>
       This is a path to a UNIX domain socket that will be used for
       communication between the DataNode and local HDFS clients, if

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TestHBaseConfiguration.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TestHBaseConfiguration.java
@@ -115,6 +115,23 @@ public class TestHBaseConfiguration {
     conf.set("hbase.security.authentication", "KERBeros");
     Assert.assertTrue(User.isHBaseSecurityEnabled(conf));
   }
+  
+  @Test
+  public void testGetConfigOfShortcircuitRead() throws Exception {
+    Configuration conf = HBaseConfiguration.create();
+    Configuration.addDefaultResource("hdfs-scr-disabled.xml");
+    assertEquals("hdfs-scr-disabled.xml",
+            conf.getPropertySources("dfs.client.read.shortcircuit")[0]);
+    assertEquals("false", conf.get("dfs.client.read.shortcircuit"));
+    assertNull(conf.get("dfs.domain.socket.path"));
+    Configuration.addDefaultResource("hdfs-scr-enabled.xml");
+    assertEquals("hdfs-scr-enabled.xml",
+            conf.getPropertySources("dfs.client.read.shortcircuit")[0]);
+    assertEquals("hdfs-scr-enabled.xml",
+            conf.getPropertySources("dfs.domain.socket.path")[0]);
+    assertEquals("true", conf.get("dfs.client.read.shortcircuit"));
+    assertEquals("/var/lib/hadoop-hdfs/dn_socket", conf.get("dfs.domain.socket.path"));
+  }
 
   private static class ReflectiveCredentialProviderClient {
     public static final String HADOOP_CRED_PROVIDER_FACTORY_CLASS_NAME =

--- a/hbase-common/src/test/resources/hdfs-scr-disabled.xml
+++ b/hbase-common/src/test/resources/hdfs-scr-disabled.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<configuration>
+  <property>
+    <name>dfs.client.read.shortcircuit</name>
+    <value>false</value>
+    <description>
+      If set to true, this configuration parameter enables short-circuit local
+      reads.
+    </description>
+  </property>
+  <property>
+    <name>dfs.domain.socket.path</name>
+    <value></value>
+    <description>
+    Optional.  This is a path to a UNIX domain socket that will be used for
+      communication between the DataNode and local HDFS clients.
+      If the string "_PORT" is present in this path, it will be replaced by the
+      TCP port of the DataNode.
+    </description>
+  </property>
+</configuration>

--- a/hbase-common/src/test/resources/hdfs-scr-enabled.xml
+++ b/hbase-common/src/test/resources/hdfs-scr-enabled.xml
@@ -1,0 +1,42 @@
+<?xml version="1.0"?>
+<?xml-stylesheet type="text/xsl" href="configuration.xsl"?>
+<!--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+-->
+
+<configuration>
+  <property>
+    <name>dfs.client.read.shortcircuit</name>
+    <value>true</value>
+    <description>
+      If set to true, this configuration parameter enables short-circuit local
+      reads.
+    </description>
+  </property>
+  <property>
+    <name>dfs.domain.socket.path</name>
+    <value>/var/lib/hadoop-hdfs/dn_socket</value>
+    <description>
+    Optional.  This is a path to a UNIX domain socket that will be used for
+      communication between the DataNode and local HDFS clients.
+      If the string "_PORT" is present in this path, it will be replaced by the
+      TCP port of the DataNode.
+    </description>
+  </property>
+</configuration>

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -20,6 +20,7 @@
  */
 -->
   <modelVersion>4.0.0</modelVersion>
+  <!-- Hack to force hbase-server tests to run -->
   <parent>
     <artifactId>hbase-build-configuration</artifactId>
     <groupId>org.apache.hbase</groupId>


### PR DESCRIPTION
…-default.xml

Revert of the revert -- re-applying HBASE-25449 with a change
of renaming the test hdfs XML configuration file as it was adversely
affecting tests using MiniDFS

This reverts commit c218e576fe54df208e277365f1ac24f993f2a4b1.

Co-authored-by: Josh Elser <elserj@apache.org>

fyi @shenshengli 