### PR TITLE
HBASE-25475: Unset zk based wal splitting explicitly in tests

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestSplitWALManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestSplitWALManager.java
@@ -248,6 +248,7 @@ public class TestSplitWALManager {
   @Test
   public void testSplitLogsWithDifferentWalAndRootFS() throws Exception{
     HBaseTestingUtility testUtil2 = new HBaseTestingUtility();
+    testUtil2.getConfiguration().setBoolean(HBASE_SPLIT_WAL_COORDINATED_BY_ZK, false);
     testUtil2.getConfiguration().setInt(HBASE_SPLIT_WAL_MAX_SPLITTER, 1);
     Path dir = TEST_UTIL.getDataTestDirOnTestFS("testWalDir");
     testUtil2.getConfiguration().set(CommonFSUtils.HBASE_WAL_DIR, dir.toString());


### PR DESCRIPTION
- zk based wal splitting was deprecated as part of HBASE-24632 and the changes still aren't there in branch-2.3. Hence the assumption of default wal splitting to be procedure-based rather than zk-based doesn't hold for the said branch. The same needs to be considered while setting up the tests in TestSplitWALManager in absence of which the tests were failing in the branch due to NPE. 
- The changes have been tested on branch-2.3 and the test failures are also gone. 