### PR TITLE
HBASE-25543 When configuration "hadoop.security.authorization" is set to false, the system will still try to authorize an RPC and raise AccessDeniedException

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
@@ -822,4 +822,7 @@ public abstract class RpcServer implements RpcServerInterface,
     this.namedQueueRecorder = namedQueueRecorder;
   }
 
+  protected boolean needAuthorization() {
+    return authorize;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
@@ -449,7 +449,7 @@ abstract class ServerRpcConnection implements Closeable {
     } else {
       processConnectionHeader(buf);
       this.connectionHeaderRead = true;
-      if (!authorizeConnection()) {
+      if (rpcServer.needAuthorization() && !authorizeConnection()) {
         // Throw FatalConnectionException wrapping ACE so client does right thing and closes
         // down the connection instead of trying to read non-existent retun.
         throw new AccessDeniedException("Connection from " + this + " for service " +


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-25543#