### PR TITLE
HBASE-25548 Optionally allow snapshots to preserve cluster's max file…

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/SnapshotDescription.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/SnapshotDescription.java
@@ -38,6 +38,8 @@ public class SnapshotDescription {
   private final long ttl;
   private final int version;
 
+  private final long maxFileSize;
+
   public SnapshotDescription(String name) {
     this(name, null);
   }
@@ -90,13 +92,16 @@ public class SnapshotDescription {
     this.snapShotType = type;
     this.owner = owner;
     this.creationTime = creationTime;
-    this.ttl = getTtlFromSnapshotProps(snapshotProps);
+    this.ttl = getLongFromSnapshotProps(snapshotProps, "TTL");
     this.version = version;
+    this.maxFileSize = getLongFromSnapshotProps(snapshotProps, TableDescriptorBuilder.MAX_FILESIZE);
   }
 
-  private long getTtlFromSnapshotProps(Map<String, Object> snapshotProps) {
-    return MapUtils.getLongValue(snapshotProps, "TTL", -1);
+  private long getLongFromSnapshotProps(Map<String, Object> snapshotProps, String property) {
+    return MapUtils.getLongValue(snapshotProps, property, -1);
   }
+
+
 
   /**
    * SnapshotDescription Parameterized Constructor
@@ -144,6 +149,8 @@ public class SnapshotDescription {
     return this.version;
   }
 
+  public long getMaxFileSize() { return maxFileSize; }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this)
@@ -154,6 +161,7 @@ public class SnapshotDescription {
       .append("creationTime", creationTime)
       .append("ttl", ttl)
       .append("version", version)
+      .append("maxFileSize", maxFileSize)
       .toString();
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -3092,6 +3092,9 @@ public final class ProtobufUtil {
     if (snapshotDesc.getVersion() != -1) {
       builder.setVersion(snapshotDesc.getVersion());
     }
+    if (snapshotDesc.getMaxFileSize() != -1) {
+      builder.setMaxFileSize(snapshotDesc.getMaxFileSize());
+    }
     builder.setType(ProtobufUtil.createProtosSnapShotDescType(snapshotDesc.getType()));
     return builder.build();
   }
@@ -3107,6 +3110,7 @@ public final class ProtobufUtil {
       createSnapshotDesc(SnapshotProtos.SnapshotDescription snapshotDesc) {
     final Map<String, Object> snapshotProps = new HashMap<>();
     snapshotProps.put("TTL", snapshotDesc.getTtl());
+    snapshotProps.put(TableDescriptorBuilder.MAX_FILESIZE, snapshotDesc.getMaxFileSize());
     return new SnapshotDescription(snapshotDesc.getName(),
             snapshotDesc.hasTable() ? TableName.valueOf(snapshotDesc.getTable()) : null,
             createSnapshotType(snapshotDesc.getType()), snapshotDesc.getOwner(),

--- a/hbase-protocol-shaded/src/main/protobuf/server/Snapshot.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/Snapshot.proto
@@ -45,6 +45,7 @@ message SnapshotDescription {
   optional string owner = 6;
   optional UsersAndPermissions users_and_permissions = 7;
   optional int64 ttl = 8 [default = 0];
+  optional int64 max_file_size = 9 [default = 0];
 }
 
 message SnapshotFileInfo {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
@@ -150,6 +150,9 @@ public class SnapshotManager extends MasterProcedureManager implements Stoppable
   /** number of current operations running on the master */
   public static final int SNAPSHOT_POOL_THREADS_DEFAULT = 1;
 
+  /** Conf key for preserving original max file size configs */
+  public static final String SNAPSHOT_MAX_FILE_SIZE_PRESERVE = "hbase.snpashot.max.filesize.preserve";
+
   private boolean stopped;
   private MasterServices master;  // Needed by TableEventHandlers
   private ProcedureCoordinator coordinator;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
@@ -151,7 +151,8 @@ public class SnapshotManager extends MasterProcedureManager implements Stoppable
   public static final int SNAPSHOT_POOL_THREADS_DEFAULT = 1;
 
   /** Conf key for preserving original max file size configs */
-  public static final String SNAPSHOT_MAX_FILE_SIZE_PRESERVE = "hbase.snpashot.max.filesize.preserve";
+  public static final String SNAPSHOT_MAX_FILE_SIZE_PRESERVE =
+    "hbase.snapshot.max.filesize.preserve";
 
   private boolean stopped;
   private MasterServices master;  // Needed by TableEventHandlers

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
@@ -25,7 +25,6 @@ import java.util.concurrent.CancellationException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
@@ -146,7 +145,7 @@ public abstract class TakeSnapshotHandler extends EventHandler implements Snapsh
     if (htd == null) {
       throw new IOException("TableDescriptor missing for " + snapshotTable);
     }
-    if( htd.getMaxFileSize()==-1 &&
+    if (htd.getMaxFileSize()==-1 &&
         this.snapshot.getMaxFileSize()>0) {
       htd = TableDescriptorBuilder.newBuilder(htd).setValue(TableDescriptorBuilder.MAX_FILESIZE,
         Long.toString(this.snapshot.getMaxFileSize())).build();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.master.snapshot;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.util.HashSet;
 import java.util.List;
@@ -147,8 +146,8 @@ public abstract class TakeSnapshotHandler extends EventHandler implements Snapsh
     if (htd == null) {
       throw new IOException("TableDescriptor missing for " + snapshotTable);
     }
-    if( htd.getMaxFileSize()==-1 &&
-        conf.getBoolean(SnapshotManager.SNAPSHOT_MAX_FILE_SIZE_PRESERVE, false) ){
+    if(htd.getMaxFileSize()==-1 &&
+        conf.getBoolean(SnapshotManager.SNAPSHOT_MAX_FILE_SIZE_PRESERVE, false)){
       htd = TableDescriptorBuilder.newBuilder(htd).setValue(TableDescriptorBuilder.MAX_FILESIZE,
         conf.get(HConstants.HREGION_MAX_FILESIZE)).build();
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
@@ -146,10 +146,10 @@ public abstract class TakeSnapshotHandler extends EventHandler implements Snapsh
     if (htd == null) {
       throw new IOException("TableDescriptor missing for " + snapshotTable);
     }
-    if(htd.getMaxFileSize()==-1 &&
-        conf.getBoolean(SnapshotManager.SNAPSHOT_MAX_FILE_SIZE_PRESERVE, false)){
+    if( htd.getMaxFileSize()==-1 &&
+        this.snapshot.getMaxFileSize()>0) {
       htd = TableDescriptorBuilder.newBuilder(htd).setValue(TableDescriptorBuilder.MAX_FILESIZE,
-        conf.get(HConstants.HREGION_MAX_FILESIZE)).build();
+        Long.toString(this.snapshot.getMaxFileSize())).build();
     }
     return htd;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/snapshot/TestTakeSnapshotHandler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/snapshot/TestTakeSnapshotHandler.java
@@ -1,0 +1,110 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.snapshot;
+
+import static org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils.SNAPSHOT_WORKING_DIR;
+import static org.junit.Assert.assertEquals;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+/**
+ * Unfortunately, couldn't test TakeSnapshotHandler using mocks, because it relies on TableLock,
+ * which is tightly coupled to LockManager and LockProcedure classes, which are both final and
+ * prevents us from mocking its behaviour. Looks like an overkill having to emulate a
+ * whole cluster run for such a small optional property behaviour.
+ */
+@Category({ MediumTests.class})
+public class TestTakeSnapshotHandler {
+
+  private static HBaseTestingUtility UTIL;
+
+  @Rule
+  public TestName name = new TestName();
+
+  private Configuration createConfig() {
+    Configuration config = UTIL.getConfiguration();
+    config.set(HConstants.HREGION_MAX_FILESIZE, "21474836480");
+    return config;
+  }
+
+  @Before
+  public void setup()  {
+    UTIL = new HBaseTestingUtility();
+  }
+
+  public TableDescriptor createTableInsertDataAndTakeSnapshot() throws Exception {
+    TableDescriptor descriptor =
+      TableDescriptorBuilder.newBuilder(TableName.valueOf(name.getMethodName()))
+        .setColumnFamily(
+          ColumnFamilyDescriptorBuilder.newBuilder(Bytes.toBytes("f")).build()).build();
+    UTIL.getConnection().getAdmin().createTable(descriptor);
+    Table table = UTIL.getConnection().getTable(descriptor.getTableName());
+    Put put = new Put(Bytes.toBytes("1"));
+    put.addColumn(Bytes.toBytes("f"), Bytes.toBytes("1"), Bytes.toBytes("v1"));
+    table.put(put);
+    String snapName = "snap"+name.getMethodName();
+    UTIL.getAdmin().snapshot(snapName, descriptor.getTableName());
+    TableName cloned = TableName.valueOf(name.getMethodName() + "clone");
+    UTIL.getAdmin().cloneSnapshot(snapName, cloned);
+    return descriptor;
+  }
+
+  @Test
+  public void testPreparePreserveMaxFileSizeEnabled() throws Exception {
+    Configuration config = createConfig();
+    config.set(SnapshotManager.SNAPSHOT_MAX_FILE_SIZE_PRESERVE, "true");
+    UTIL.startMiniCluster();
+    TableDescriptor descriptor = createTableInsertDataAndTakeSnapshot();
+    TableName cloned = TableName.valueOf(name.getMethodName() + "clone");
+    assertEquals(-1,
+      UTIL.getAdmin().getDescriptor(descriptor.getTableName()).getMaxFileSize());
+    assertEquals(21474836480L, UTIL.getAdmin().getDescriptor(cloned).getMaxFileSize());
+  }
+
+  @Test
+  public void testPreparePreserveMaxFileSizeDisabled() throws Exception {
+    UTIL.startMiniCluster();
+    TableDescriptor descriptor = createTableInsertDataAndTakeSnapshot();
+    TableName cloned = TableName.valueOf(name.getMethodName() + "clone");
+    assertEquals(-1,
+      UTIL.getAdmin().getDescriptor(descriptor.getTableName()).getMaxFileSize());
+    assertEquals(-1, UTIL.getAdmin().getDescriptor(cloned).getMaxFileSize());
+  }
+
+  @After
+  public void shutdown() throws Exception {
+    UTIL.shutdownMiniCluster();
+  }
+  
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/snapshot/TestTakeSnapshotHandler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/snapshot/TestTakeSnapshotHandler.java
@@ -18,10 +18,11 @@
 package org.apache.hadoop.hbase.master.snapshot;
 
 import static org.junit.Assert.assertEquals;
-import org.apache.hadoop.conf.Configuration;
+
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Put;
@@ -38,8 +39,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
 
-import java.util.HashMap;
-import java.util.Map;
 
 /**
  * Unfortunately, couldn't test TakeSnapshotHandler using mocks, because it relies on TableLock,
@@ -65,7 +64,8 @@ public class TestTakeSnapshotHandler {
     UTIL = new HBaseTestingUtility();
   }
 
-  public TableDescriptor createTableInsertDataAndTakeSnapshot(Map<String, Object> snapshotProps) throws Exception {
+  public TableDescriptor createTableInsertDataAndTakeSnapshot(Map<String, Object> snapshotProps)
+      throws Exception {
     TableDescriptor descriptor =
       TableDescriptorBuilder.newBuilder(TableName.valueOf(name.getMethodName()))
         .setColumnFamily(
@@ -108,5 +108,4 @@ public class TestTakeSnapshotHandler {
   public void shutdown() throws Exception {
     UTIL.shutdownMiniCluster();
   }
-  
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/snapshot/TestTakeSnapshotHandler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/snapshot/TestTakeSnapshotHandler.java
@@ -17,10 +17,9 @@
  */
 package org.apache.hadoop.hbase.master.snapshot;
 
-import static org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils.SNAPSHOT_WORKING_DIR;
 import static org.junit.Assert.assertEquals;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
@@ -33,6 +32,7 @@ import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -48,6 +48,10 @@ import org.junit.rules.TestName;
 public class TestTakeSnapshotHandler {
 
   private static HBaseTestingUtility UTIL;
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestTakeSnapshotHandler.class);
 
   @Rule
   public TestName name = new TestName();

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -1206,6 +1206,9 @@ module Hbase
           ttl = ttl ? ttl.to_java(:long) : -1
           snapshot_props = java.util.HashMap.new
           snapshot_props.put("TTL", ttl)
+          max_filesize = arg[MAX_FILESIZE]
+          max_filesize = max_filesize ? max_filesize.to_java(:long) : -1
+          snapshot_props.put("MAX_FILESIZE", max_filesize)
           if arg[SKIP_FLUSH] == true
             @admin.snapshot(snapshot_name, table_name,
                             org.apache.hadoop.hbase.client.SnapshotType::SKIPFLUSH, snapshot_props)

--- a/hbase-shell/src/main/ruby/shell/commands/snapshot.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/snapshot.rb
@@ -24,7 +24,7 @@ module Shell
 Take a snapshot of specified table. Examples:
 
   hbase> snapshot 'sourceTable', 'snapshotName'
-  hbase> snapshot 'namespace:sourceTable', 'snapshotName', {SKIP_FLUSH => true | MAX_FILESIZE => 21474836480}
+  hbase> snapshot 'namespace:sourceTable', 'snapshotName', {SKIP_FLUSH => true, MAX_FILESIZE => 21474836480}
 EOF
       end
 

--- a/hbase-shell/src/main/ruby/shell/commands/snapshot.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/snapshot.rb
@@ -24,7 +24,7 @@ module Shell
 Take a snapshot of specified table. Examples:
 
   hbase> snapshot 'sourceTable', 'snapshotName'
-  hbase> snapshot 'namespace:sourceTable', 'snapshotName', {SKIP_FLUSH => true}
+  hbase> snapshot 'namespace:sourceTable', 'snapshotName', {SKIP_FLUSH => true | MAX_FILESIZE => 21474836480}
 EOF
       end
 

--- a/src/main/asciidoc/_chapters/ops_mgt.adoc
+++ b/src/main/asciidoc/_chapters/ops_mgt.adoc
@@ -3108,26 +3108,6 @@ To turn on the snapshot support just set the `hbase.snapshot.enabled`        pro
   </property>
 ----
 
-Optionally, snapshots can be configured to preserve the value of `hbase.hregion.max.filesize` property.
-This is mostly useful when exporting snapshots between different clusters. If the HBase cluster where
-the snapshot is originally taken has a much larger value set for `hbase.hregion.max.filesize` than
-one or more clusters where the snapshot is being exported to, a storm of region splits may occur when
-restoring the snapshot on destination clusters. Setting `hbase.snapshot.max.filesize.preserve`
-property to true will save `hbase.hregion.max.filesize` value into the table's `MAX_FILESIZE`
-decriptor at snapshot creation time. If the table already defines `MAX_FILESIZE` descriptor,
-`hbase.snapshot.max.filesize.preserve` would have no effect.
-
-[source,java]
-----
-
-  <property>
-    <name>hbase.snapshot.max.filesize.preserve</name>
-    <value>true</value>
-  </property>
-----
-
-The `hbase.snapshot.max.filesize.preserve` behaviour is *disabled* by default.
-
 [[ops.snapshots.takeasnapshot]]
 === Take a Snapshot
 
@@ -3187,6 +3167,21 @@ providing default TTL in sec for key: `hbase.master.snapshot.ttl`.
 Value 0 for this config indicates TTL: FOREVER
 
 
+.Take a snapshot with custom MAX_FILESIZE
+
+Optionally, snapshots can be created with a custom max file size configuration that will be
+used by cloned tables, instead of the global `hbase.hregion.max.filesize` configuration property.
+This is mostly useful when exporting snapshots between different clusters. If the HBase cluster where
+the snapshot is originally taken has a much larger value set for `hbase.hregion.max.filesize` than
+one or more clusters where the snapshot is being exported to, a storm of region splits may occur when
+restoring the snapshot on destination clusters. Specifying `MAX_FILESIZE` on properties passed to
+`snapshot` command will save informed value into the table's `MAX_FILESIZE`
+decriptor at snapshot creation time. If the table already defines `MAX_FILESIZE` descriptor,
+this property would be ignored and have no effect.
+
+----
+snapshot 'table01', 'snap01', {MAX_FILESIZE => 21474836480}
+----
 
 .Enable/Disable Snapshot Auto Cleanup on running cluster:
 

--- a/src/main/asciidoc/_chapters/ops_mgt.adoc
+++ b/src/main/asciidoc/_chapters/ops_mgt.adoc
@@ -3108,6 +3108,26 @@ To turn on the snapshot support just set the `hbase.snapshot.enabled`        pro
   </property>
 ----
 
+Optionally, snapshots can be configured to preserve the value of `hbase.hregion.max.filesize` property.
+This is mostly useful when exporting snapshots between different clusters. If the HBase cluster where
+the snapshot is originally taken has a much larger value set for `hbase.hregion.max.filesize` than
+one or more clusters where the snapshot is being exported to, a storm of region splits may occur when
+restoring the snapshot on destination clusters. Setting `hbase.snapshot.max.filesize.preserve`
+property to true will save `hbase.hregion.max.filesize` value into the table's `MAX_FILESIZE`
+decriptor at snapshot creation time. If the table already defines `MAX_FILESIZE` descriptor,
+`hbase.snapshot.max.filesize.preserve` would have no effect.
+
+[source,java]
+----
+
+  <property>
+    <name>hbase.snapshot.max.filesize.preserve</name>
+    <value>true</value>
+  </property>
+----
+
+The `hbase.snapshot.max.filesize.preserve` behaviour is *disabled* by default.
+
 [[ops.snapshots.takeasnapshot]]
 === Take a Snapshot
 


### PR DESCRIPTION
…size config by setting it into table descriptor