### PR TITLE
HBASE-25549 Provide a switch that allows avoiding reopening all regions when modifying a table to prevent RIT storms.

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -1049,8 +1049,8 @@ public interface Admin extends Abortable, Closeable {
   }
 
   /**
-   * Same as {@link #modifyTableAsync(TableDescriptor td)}. except {@code lazyMode} will control
-   * whether user lazy mode to modify a table
+   * The same as {@link #modifyTableAsync(TableDescriptor td)}, except for the reopenRegions
+   * parameter, which controls whether the process of modifying the table should reopen all regions.
    *
    * @param td            description of the table
    * @param reopenRegions By default, 'modifyTable' reopens all regions, potentially causing a RIT

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -1044,14 +1044,13 @@ public interface Admin extends Abortable, Closeable {
    * @return the result of the async modify. You can use Future.get(long, TimeUnit) to wait on the
    *         operation to complete
    */
-  default Future<Void> modifyTableAsync(TableDescriptor td) throws IOException{
+  default Future<Void> modifyTableAsync(TableDescriptor td) throws IOException {
     return modifyTableAsync(td, true);
   }
 
   /**
    * The same as {@link #modifyTableAsync(TableDescriptor td)}, except for the reopenRegions
    * parameter, which controls whether the process of modifying the table should reopen all regions.
-   *
    * @param td            description of the table
    * @param reopenRegions By default, 'modifyTable' reopens all regions, potentially causing a RIT
    *                      (Region In Transition) storm in large tables. If set to 'false', regions
@@ -1059,7 +1058,7 @@ public interface Admin extends Abortable, Closeable {
    *                      reopened. Please note that this may temporarily result in configuration
    *                      inconsistencies among regions.
    * @return the result of the async modify. You can use Future.get(long, TimeUnit) to wait on the
-   * operation to complete
+   *         operation to complete
    * @throws IOException if a remote or network exception occurs
    */
   Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -1044,7 +1044,25 @@ public interface Admin extends Abortable, Closeable {
    * @return the result of the async modify. You can use Future.get(long, TimeUnit) to wait on the
    *         operation to complete
    */
-  Future<Void> modifyTableAsync(TableDescriptor td) throws IOException;
+  default Future<Void> modifyTableAsync(TableDescriptor td) throws IOException{
+    return modifyTableAsync(td, true);
+  }
+
+  /**
+   * Same as {@link #modifyTableAsync(TableDescriptor td)}. except {@code lazyMode} will control
+   * whether user lazy mode to modify a table
+   *
+   * @param td            description of the table
+   * @param reopenRegions By default, 'modifyTable' reopens all regions, potentially causing a RIT
+   *                      (Region In Transition) storm in large tables. If set to 'false', regions
+   *                      will remain unaware of the modification until they are individually
+   *                      reopened. Please note that this may temporarily result in configuration
+   *                      inconsistencies among regions.
+   * @return the result of the async modify. You can use Future.get(long, TimeUnit) to wait on the
+   * operation to complete
+   * @throws IOException if a remote or network exception occurs
+   */
+  Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException;
 
   /**
    * Change the store file tracker of the given table.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
@@ -496,7 +496,8 @@ class AdminOverAsyncAdmin implements Admin {
   }
 
   @Override
-  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException {
+  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions)
+    throws IOException {
     return admin.modifyTable(td, reopenRegions);
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
@@ -492,7 +492,12 @@ class AdminOverAsyncAdmin implements Admin {
 
   @Override
   public Future<Void> modifyTableAsync(TableDescriptor td) throws IOException {
-    return admin.modifyTable(td);
+    return modifyTableAsync(td, true);
+  }
+
+  @Override
+  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException {
+    return admin.modifyTable(td, reopenRegions);
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -198,7 +198,22 @@ public interface AsyncAdmin {
    * Modify an existing table, more IRB friendly version.
    * @param desc modified description of the table
    */
-  CompletableFuture<Void> modifyTable(TableDescriptor desc);
+  default CompletableFuture<Void> modifyTable(TableDescriptor desc){
+    return modifyTable(desc, true);
+  }
+
+  /**
+   * Modify an existing table, more IRB friendly version.
+   *
+   * @param desc          description of the table
+   * @param reopenRegions By default, 'modifyTable' reopens all regions, potentially causing a RIT
+   *                      (Region In Transition) storm in large tables. If set to 'false', regions
+   *                      will remain unaware of the modification until they are individually
+   *                      reopened. Please note that this may temporarily result in configuration
+   *                      inconsistencies among regions.
+   */
+  CompletableFuture<Void> modifyTable(TableDescriptor desc, boolean reopenRegions);
+
 
   /**
    * Change the store file tracker of the given table.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -198,13 +198,12 @@ public interface AsyncAdmin {
    * Modify an existing table, more IRB friendly version.
    * @param desc modified description of the table
    */
-  default CompletableFuture<Void> modifyTable(TableDescriptor desc){
+  default CompletableFuture<Void> modifyTable(TableDescriptor desc) {
     return modifyTable(desc, true);
   }
 
   /**
    * Modify an existing table, more IRB friendly version.
-   *
    * @param desc          description of the table
    * @param reopenRegions By default, 'modifyTable' reopens all regions, potentially causing a RIT
    *                      (Region In Transition) storm in large tables. If set to 'false', regions
@@ -213,7 +212,6 @@ public interface AsyncAdmin {
    *                      inconsistencies among regions.
    */
   CompletableFuture<Void> modifyTable(TableDescriptor desc, boolean reopenRegions);
-
 
   /**
    * Change the store file tracker of the given table.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
@@ -153,7 +153,12 @@ class AsyncHBaseAdmin implements AsyncAdmin {
 
   @Override
   public CompletableFuture<Void> modifyTable(TableDescriptor desc) {
-    return wrap(rawAdmin.modifyTable(desc));
+    return modifyTable(desc, true);
+  }
+
+  @Override
+  public CompletableFuture<Void> modifyTable(TableDescriptor desc, boolean reopenRegions) {
+    return wrap(rawAdmin.modifyTable(desc, reopenRegions));
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -692,9 +692,14 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
 
   @Override
   public CompletableFuture<Void> modifyTable(TableDescriptor desc) {
+    return modifyTable(desc, true);
+  }
+
+  @Override
+  public CompletableFuture<Void> modifyTable(TableDescriptor desc, boolean reopenRegions) {
     return this.<ModifyTableRequest, ModifyTableResponse> procedureCall(desc.getTableName(),
       RequestConverter.buildModifyTableRequest(desc.getTableName(), desc, ng.getNonceGroup(),
-        ng.newNonce()),
+        ng.newNonce(), reopenRegions),
       (s, c, req, done) -> s.modifyTable(c, req, done), (resp) -> resp.getProcId(),
       new ModifyTableProcedureBiConsumer(this, desc.getTableName()));
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
@@ -53,24 +53,9 @@ public interface TableDescriptor {
       if (result != 0) {
         return result;
       }
-      result = getColumnFamilyComparator(cfComparator).compare(lhs, rhs);
-      if (result != 0) {
-        return result;
-      }
-      // punt on comparison for ordering, just calculate difference
-      return Integer.compare(lhs.getValues().hashCode(), rhs.getValues().hashCode());
-    };
-  }
-
-  /**
-   * Check if the ColumnFamilyDescriptors in two tableDescriptors are consistent.
-   */
-  static Comparator<TableDescriptor>
-    getColumnFamilyComparator(Comparator<ColumnFamilyDescriptor> cfComparator) {
-    return (TableDescriptor lhs, TableDescriptor rhs) -> {
       Collection<ColumnFamilyDescriptor> lhsFamilies = Arrays.asList(lhs.getColumnFamilies());
       Collection<ColumnFamilyDescriptor> rhsFamilies = Arrays.asList(rhs.getColumnFamilies());
-      int result = Integer.compare(lhsFamilies.size(), rhsFamilies.size());
+      result = Integer.compare(lhsFamilies.size(), rhsFamilies.size());
       if (result != 0) {
         return result;
       }
@@ -83,7 +68,7 @@ public interface TableDescriptor {
         }
       }
       // punt on comparison for ordering, just calculate difference
-      return 0;
+      return Integer.compare(lhs.getValues().hashCode(), rhs.getValues().hashCode());
     };
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
@@ -53,9 +53,25 @@ public interface TableDescriptor {
       if (result != 0) {
         return result;
       }
+      result = getColumnFamilyComparator(cfComparator).compare(lhs, rhs);
+      if (result != 0){
+        return result;
+      }
+      // punt on comparison for ordering, just calculate difference
+      return Integer.compare(lhs.getValues().hashCode(), rhs.getValues().hashCode());
+    };
+  }
+
+  /**
+   * This comparator only compare ColumnFamilyDescriptor between two tables
+   */
+  static Comparator<TableDescriptor>
+  getColumnFamilyComparator(
+          Comparator<ColumnFamilyDescriptor> cfComparator) {
+    return (TableDescriptor lhs, TableDescriptor rhs) -> {
       Collection<ColumnFamilyDescriptor> lhsFamilies = Arrays.asList(lhs.getColumnFamilies());
       Collection<ColumnFamilyDescriptor> rhsFamilies = Arrays.asList(rhs.getColumnFamilies());
-      result = Integer.compare(lhsFamilies.size(), rhsFamilies.size());
+      int result = Integer.compare(lhsFamilies.size(), rhsFamilies.size());
       if (result != 0) {
         return result;
       }
@@ -68,7 +84,7 @@ public interface TableDescriptor {
         }
       }
       // punt on comparison for ordering, just calculate difference
-      return Integer.compare(lhs.getValues().hashCode(), rhs.getValues().hashCode());
+      return 0;
     };
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
@@ -54,7 +54,7 @@ public interface TableDescriptor {
         return result;
       }
       result = getColumnFamilyComparator(cfComparator).compare(lhs, rhs);
-      if (result != 0){
+      if (result != 0) {
         return result;
       }
       // punt on comparison for ordering, just calculate difference
@@ -66,8 +66,7 @@ public interface TableDescriptor {
    * Check if the ColumnFamilyDescriptors in two tableDescriptors are consistent.
    */
   static Comparator<TableDescriptor>
-  getColumnFamilyComparator(
-          Comparator<ColumnFamilyDescriptor> cfComparator) {
+    getColumnFamilyComparator(Comparator<ColumnFamilyDescriptor> cfComparator) {
     return (TableDescriptor lhs, TableDescriptor rhs) -> {
       Collection<ColumnFamilyDescriptor> lhsFamilies = Arrays.asList(lhs.getColumnFamilies());
       Collection<ColumnFamilyDescriptor> rhsFamilies = Arrays.asList(rhs.getColumnFamilies());

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
@@ -63,7 +63,7 @@ public interface TableDescriptor {
   }
 
   /**
-   * This comparator only compare ColumnFamilyDescriptor between two tables
+   * Check if the ColumnFamilyDescriptors in two tableDescriptors are consistent.
    */
   static Comparator<TableDescriptor>
   getColumnFamilyComparator(

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
@@ -1098,7 +1098,7 @@ public final class RequestConverter {
    */
   public static ModifyTableRequest buildModifyTableRequest(final TableName tableName,
     final TableDescriptor tableDesc, final long nonceGroup, final long nonce,
-          final boolean reopenRegions) {
+    final boolean reopenRegions) {
     ModifyTableRequest.Builder builder = ModifyTableRequest.newBuilder();
     builder.setTableName(ProtobufUtil.toProtoTableName(tableName));
     builder.setTableSchema(ProtobufUtil.toTableSchema(tableDesc));

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
@@ -1097,12 +1097,14 @@ public final class RequestConverter {
    * @return a ModifyTableRequest
    */
   public static ModifyTableRequest buildModifyTableRequest(final TableName tableName,
-    final TableDescriptor tableDesc, final long nonceGroup, final long nonce) {
+    final TableDescriptor tableDesc, final long nonceGroup, final long nonce,
+          final boolean reopenRegions) {
     ModifyTableRequest.Builder builder = ModifyTableRequest.newBuilder();
     builder.setTableName(ProtobufUtil.toProtoTableName(tableName));
     builder.setTableSchema(ProtobufUtil.toTableSchema(tableDesc));
     builder.setNonceGroup(nonceGroup);
     builder.setNonce(nonce);
+    builder.setReopenRegions(reopenRegions);
     return builder.build();
   }
 

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/Master.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/Master.proto
@@ -194,6 +194,7 @@ message ModifyTableRequest {
   required TableSchema table_schema = 2;
   optional uint64 nonce_group = 3 [default = 0];
   optional uint64 nonce = 4 [default = 0];
+  optional bool reopen_regions = 5 [default = true];
 }
 
 message ModifyTableResponse {

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
@@ -82,6 +82,7 @@ message ModifyTableStateData {
   required TableSchema modified_table_schema = 3;
   required bool delete_column_family_in_modify = 4;
   optional bool should_check_descriptor = 5;
+  optional bool reopen_regions = 6;
 }
 
 enum TruncateTableState {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -2585,7 +2585,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
 
         return TableDescriptorBuilder.newBuilder(old).setColumnFamily(column).build();
       }
-    }, nonceGroup, nonce, true, true);
+    }, nonceGroup, nonce, true);
   }
 
   /**
@@ -2612,7 +2612,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
 
         return TableDescriptorBuilder.newBuilder(old).modifyColumnFamily(descriptor).build();
       }
-    }, nonceGroup, nonce, true, true);
+    }, nonceGroup, nonce, true);
   }
 
   @Override
@@ -2663,7 +2663,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         }
         return TableDescriptorBuilder.newBuilder(old).removeColumnFamily(columnName).build();
       }
-    }, nonceGroup, nonce, true, true);
+    }, nonceGroup, nonce, true);
   }
 
   @Override
@@ -2758,6 +2758,13 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
           return "DisableTableProcedure";
         }
       });
+  }
+
+  private long modifyTable(final TableName tableName,
+          final TableDescriptorGetter newDescriptorGetter, final long nonceGroup, final long nonce,
+          final boolean shouldCheckDescriptor) throws IOException {
+    return modifyTable(tableName, newDescriptorGetter, nonceGroup, nonce, shouldCheckDescriptor,
+            true);
   }
 
   private long modifyTable(final TableName tableName,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1163,7 +1163,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
           procedureExecutor.submitProcedure(new ModifyTableProcedure(
             procedureExecutor.getEnvironment(), TableDescriptorBuilder.newBuilder(metaDesc)
               .setRegionReplication(replicasNumInConf).build(),
-            null, metaDesc, false));
+            null, metaDesc, false, true));
         }
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -2761,10 +2761,10 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   }
 
   private long modifyTable(final TableName tableName,
-          final TableDescriptorGetter newDescriptorGetter, final long nonceGroup, final long nonce,
-          final boolean shouldCheckDescriptor) throws IOException {
+    final TableDescriptorGetter newDescriptorGetter, final long nonceGroup, final long nonce,
+    final boolean shouldCheckDescriptor) throws IOException {
     return modifyTable(tableName, newDescriptorGetter, nonceGroup, nonce, shouldCheckDescriptor,
-            true);
+      true);
   }
 
   private long modifyTable(final TableName tableName,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -1530,8 +1530,8 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
     throws ServiceException {
     try {
       long procId = server.modifyTable(ProtobufUtil.toTableName(req.getTableName()),
-              ProtobufUtil.toTableDescriptor(req.getTableSchema()), req.getNonceGroup(),
-              req.getNonce(), req.getReopenRegions());
+        ProtobufUtil.toTableDescriptor(req.getTableSchema()), req.getNonceGroup(), req.getNonce(),
+        req.getReopenRegions());
       return ModifyTableResponse.newBuilder().setProcId(procId).build();
     } catch (IOException ioe) {
       throw new ServiceException(ioe);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -1530,7 +1530,8 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
     throws ServiceException {
     try {
       long procId = server.modifyTable(ProtobufUtil.toTableName(req.getTableName()),
-        ProtobufUtil.toTableDescriptor(req.getTableSchema()), req.getNonceGroup(), req.getNonce());
+              ProtobufUtil.toTableDescriptor(req.getTableSchema()), req.getNonceGroup(),
+              req.getNonce(), req.getReopenRegions());
       return ModifyTableResponse.newBuilder().setProcId(procId).build();
     } catch (IOException ioe) {
       throw new ServiceException(ioe);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
@@ -159,15 +159,9 @@ public interface MasterServices extends Server {
    * @param descriptor The updated table descriptor
    */
   default long modifyTable(final TableName tableName, final TableDescriptor descriptor,
-    final long nonceGroup, final long nonce) throws IOException{
+    final long nonceGroup, final long nonce) throws IOException {
     return modifyTable(tableName, descriptor, nonceGroup, nonce, true);
   }
-
-  /**
-   * Modify the store file tracker of an existing table
-   */
-  long modifyTableStoreFileTracker(final TableName tableName, final String dstSFT,
-    final long nonceGroup, final long nonce) throws IOException;
 
   /**
    * Modify the descriptor of an existing table
@@ -180,6 +174,12 @@ public interface MasterServices extends Server {
    */
   long modifyTable(final TableName tableName, final TableDescriptor descriptor,
           final long nonceGroup, final long nonce, final boolean reopenRegions) throws IOException;
+
+  /**
+   * Modify the store file tracker of an existing table
+   */
+  long modifyTableStoreFileTracker(final TableName tableName, final String dstSFT,
+    final long nonceGroup, final long nonce) throws IOException;
 
   /**
    * Enable an existing table

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
@@ -165,15 +165,12 @@ public interface MasterServices extends Server {
 
   /**
    * Modify the descriptor of an existing table
-   * @param tableName The table name
-   * @param descriptor The updated table descriptor
-   * @param nonceGroup
-   * @param nonce
+   * @param tableName     The table name
+   * @param descriptor    The updated table descriptor
    * @param reopenRegions Whether to reopen regions after modifying the table descriptor
-   * @throws IOException
    */
   long modifyTable(final TableName tableName, final TableDescriptor descriptor,
-          final long nonceGroup, final long nonce, final boolean reopenRegions) throws IOException;
+    final long nonceGroup, final long nonce, final boolean reopenRegions) throws IOException;
 
   /**
    * Modify the store file tracker of an existing table

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
@@ -158,14 +158,28 @@ public interface MasterServices extends Server {
    * @param tableName  The table name
    * @param descriptor The updated table descriptor
    */
-  long modifyTable(final TableName tableName, final TableDescriptor descriptor,
-    final long nonceGroup, final long nonce) throws IOException;
+  default long modifyTable(final TableName tableName, final TableDescriptor descriptor,
+    final long nonceGroup, final long nonce) throws IOException{
+    return modifyTable(tableName, descriptor, nonceGroup, nonce, true);
+  }
 
   /**
    * Modify the store file tracker of an existing table
    */
   long modifyTableStoreFileTracker(final TableName tableName, final String dstSFT,
     final long nonceGroup, final long nonce) throws IOException;
+
+  /**
+   * Modify the descriptor of an existing table
+   * @param tableName The table name
+   * @param descriptor The updated table descriptor
+   * @param nonceGroup
+   * @param nonce
+   * @param reopenRegions Whether to reopen regions after modifying the table descriptor
+   * @throws IOException
+   */
+  long modifyTable(final TableName tableName, final TableDescriptor descriptor,
+          final long nonceGroup, final long nonce, final boolean reopenRegions) throws IOException;
 
   /**
    * Enable an existing table

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -97,6 +97,7 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
           final boolean reopenRegions)
     throws HBaseIOException {
     super(env, latch);
+    this.reopenRegions = reopenRegions;
     initialize(oldTableDescriptor, shouldCheckDescriptor);
     this.modifiedTableDescriptor = newTableDescriptor;
     preflightChecks(env, null/* No table checks; if changing peers, table can be online */);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -147,6 +147,13 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
     }
   }
 
+  /**
+   * Comparing the value associated with a given key across two TableDescriptor instances' properties.
+   * @param oldDescriptor
+   * @param newDescriptor
+   * @param key
+   * @return True if the table property <code>key</code> is the same in both.
+   * */
   private boolean isTablePropertyModified(TableDescriptor oldDescriptor,
     TableDescriptor newDescriptor, String key) {
     String oldV = oldDescriptor.getValue(key);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -113,8 +113,10 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
         throw new HBaseIOException(
           "unmodifiedTableDescriptor cannot be null when this table modification won't reopen regions");
       }
-      if (!this.unmodifiedTableDescriptor.getTableName()
-              .equals(this.modifiedTableDescriptor.getTableName())) {
+      if (
+        !this.unmodifiedTableDescriptor.getTableName()
+          .equals(this.modifiedTableDescriptor.getTableName())
+      ) {
         throw new HBaseIOException(
           "Cannot change the table name when this modification won't " + "reopen regions.");
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -148,12 +148,10 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
   }
 
   /**
-   * Comparing the value associated with a given key across two TableDescriptor instances' properties.
-   * @param oldDescriptor
-   * @param newDescriptor
-   * @param key
+   * Comparing the value associated with a given key across two TableDescriptor instances'
+   * properties.
    * @return True if the table property <code>key</code> is the same in both.
-   * */
+   */
   private boolean isTablePropertyModified(TableDescriptor oldDescriptor,
     TableDescriptor newDescriptor, String key) {
     String oldV = oldDescriptor.getValue(key);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -85,6 +85,13 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
   }
 
   public ModifyTableProcedure(final MasterProcedureEnv env,
+          final TableDescriptor newTableDescriptor, final ProcedurePrepareLatch latch,
+          final TableDescriptor oldTableDescriptor, final boolean shouldCheckDescriptor)
+          throws HBaseIOException {
+    this(env, newTableDescriptor, latch, oldTableDescriptor, shouldCheckDescriptor, true);
+  }
+
+  public ModifyTableProcedure(final MasterProcedureEnv env,
     final TableDescriptor newTableDescriptor, final ProcedurePrepareLatch latch,
     final TableDescriptor oldTableDescriptor, final boolean shouldCheckDescriptor,
           final boolean reopenRegions)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.master.procedure;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -31,9 +32,11 @@ import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.master.MasterCoprocessorHost;
 import org.apache.hadoop.hbase.master.zksyncer.MetaLocationSyncer;
 import org.apache.hadoop.hbase.procedure2.ProcedureStateSerializer;
@@ -56,6 +59,7 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
   private TableDescriptor modifiedTableDescriptor;
   private boolean deleteColumnFamilyInModify;
   private boolean shouldCheckDescriptor;
+  private boolean reopenRegions;
   /**
    * List of column families that cannot be deleted from the hbase:meta table. They are critical to
    * cluster operation. This is a bit of an odd place to keep this list but then this is the tooling
@@ -77,12 +81,13 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
 
   public ModifyTableProcedure(final MasterProcedureEnv env, final TableDescriptor htd,
     final ProcedurePrepareLatch latch) throws HBaseIOException {
-    this(env, htd, latch, null, false);
+    this(env, htd, latch, null, false, true);
   }
 
   public ModifyTableProcedure(final MasterProcedureEnv env,
     final TableDescriptor newTableDescriptor, final ProcedurePrepareLatch latch,
-    final TableDescriptor oldTableDescriptor, final boolean shouldCheckDescriptor)
+    final TableDescriptor oldTableDescriptor, final boolean shouldCheckDescriptor,
+          final boolean reopenRegions)
     throws HBaseIOException {
     super(env, latch);
     initialize(oldTableDescriptor, shouldCheckDescriptor);
@@ -104,6 +109,49 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
         }
       }
     }
+    if (!reopenRegions) {
+      if (this.unmodifiedTableDescriptor == null) {
+        throw new HBaseIOException(
+          "unmodifiedTableDescriptor cannot be null when this table modification won't reopen regions");
+      }
+      if (0 != this.unmodifiedTableDescriptor.getTableName()
+        .compareTo(this.modifiedTableDescriptor.getTableName())) {
+        throw new HBaseIOException("Cannot change the table name when this modification won't " +
+                "reopen regions.");
+      }
+      if (0 != TableDescriptor.getColumnFamilyComparator(ColumnFamilyDescriptor.COMPARATOR)
+        .compare(this.unmodifiedTableDescriptor, this.modifiedTableDescriptor)){
+        throw new HBaseIOException("Cannot modify column families when this modification won't " +
+                "reopen regions.");
+      }
+      if (this.unmodifiedTableDescriptor.getCoprocessorDescriptors().hashCode()
+        != this.modifiedTableDescriptor.getCoprocessorDescriptors().hashCode()) {
+        throw new HBaseIOException("Can not modify Coprocessor when table modification won't reopen regions");
+      }
+      final Set<String> s = new HashSet<>(
+        Arrays.asList(
+          TableDescriptorBuilder.REGION_REPLICATION,
+          TableDescriptorBuilder.REGION_MEMSTORE_REPLICATION,
+          RSGroupInfo.TABLE_DESC_PROP_GROUP));
+      for (String k : s) {
+        if (isTablePropertyModified(this.unmodifiedTableDescriptor, this.modifiedTableDescriptor, k)) {
+          throw new HBaseIOException(
+                  "Can not modify " + k + " of a table when modification won't reopen regions");
+        }
+      }
+    }
+  }
+
+  private boolean isTablePropertyModified(TableDescriptor oldDescriptor, TableDescriptor newDescriptor,
+    String key) {
+    String oldV = oldDescriptor.getValue(key);
+    String newV = newDescriptor.getValue(key);
+    if (oldV == null && newV == null) {
+      return false;
+    } else if (oldV != null && newV != null && oldV.equals(newV)) {
+      return false;
+    }
+    return true;
   }
 
   private void initialize(final TableDescriptor unmodifiedTableDescriptor,
@@ -125,7 +173,11 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
           break;
         case MODIFY_TABLE_PRE_OPERATION:
           preModify(env, state);
-          setNextState(ModifyTableState.MODIFY_TABLE_CLOSE_EXCESS_REPLICAS);
+          if (reopenRegions){
+            setNextState(ModifyTableState.MODIFY_TABLE_CLOSE_EXCESS_REPLICAS);
+          }else {
+            setNextState(ModifyTableState.MODIFY_TABLE_UPDATE_TABLE_DESCRIPTOR);
+          }
           break;
         case MODIFY_TABLE_CLOSE_EXCESS_REPLICAS:
           if (isTableEnabled(env)) {
@@ -135,7 +187,11 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
           break;
         case MODIFY_TABLE_UPDATE_TABLE_DESCRIPTOR:
           updateTableDescriptor(env);
-          setNextState(ModifyTableState.MODIFY_TABLE_REMOVE_REPLICA_COLUMN);
+          if(reopenRegions){
+            setNextState(ModifyTableState.MODIFY_TABLE_REMOVE_REPLICA_COLUMN);
+          }else {
+            setNextState(ModifyTableState.MODIFY_TABLE_POST_OPERATION);
+          }
           break;
         case MODIFY_TABLE_REMOVE_REPLICA_COLUMN:
           removeReplicaColumnsIfNeeded(env);
@@ -143,7 +199,12 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
           break;
         case MODIFY_TABLE_POST_OPERATION:
           postModify(env, state);
-          setNextState(ModifyTableState.MODIFY_TABLE_REOPEN_ALL_REGIONS);
+          if (reopenRegions){
+            setNextState(ModifyTableState.MODIFY_TABLE_REOPEN_ALL_REGIONS);
+          }
+          else {
+            return Flow.NO_MORE_STATE;
+          }
           break;
         case MODIFY_TABLE_REOPEN_ALL_REGIONS:
           if (isTableEnabled(env)) {
@@ -238,7 +299,8 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
         .setUserInfo(MasterProcedureUtil.toProtoUserInfo(getUser()))
         .setModifiedTableSchema(ProtobufUtil.toTableSchema(modifiedTableDescriptor))
         .setDeleteColumnFamilyInModify(deleteColumnFamilyInModify)
-        .setShouldCheckDescriptor(shouldCheckDescriptor);
+        .setShouldCheckDescriptor(shouldCheckDescriptor)
+        .setReopenRegions(reopenRegions);
 
     if (unmodifiedTableDescriptor != null) {
       modifyTableMsg
@@ -260,6 +322,7 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
     deleteColumnFamilyInModify = modifyTableMsg.getDeleteColumnFamilyInModify();
     shouldCheckDescriptor =
       modifyTableMsg.hasShouldCheckDescriptor() ? modifyTableMsg.getShouldCheckDescriptor() : false;
+    reopenRegions = modifyTableMsg.hasReopenRegions() ? modifyTableMsg.getReopenRegions() : true;
 
     if (modifyTableMsg.hasUnmodifiedTableSchema()) {
       unmodifiedTableDescriptor =

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
@@ -259,7 +259,7 @@ public class MockNoopMasterServices implements MasterServices {
 
   @Override
   public long modifyTable(TableName tableName, TableDescriptor descriptor, long nonceGroup,
-          long nonce, boolean reopenRegions) throws IOException {
+    long nonce, boolean reopenRegions) throws IOException {
     return -1;
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
@@ -258,8 +258,13 @@ public class MockNoopMasterServices implements MasterServices {
   }
 
   @Override
-  public long enableTable(final TableName tableName, final long nonceGroup, final long nonce,
-          final boolean reopenRegions)
+  public long modifyTable(TableName tableName, TableDescriptor descriptor, long nonceGroup,
+          long nonce, boolean reopenRegions) throws IOException {
+    return modifyTable(tableName, descriptor, nonceGroup, nonce, reopenRegions);
+  }
+
+  @Override
+  public long enableTable(final TableName tableName, final long nonceGroup, final long nonce)
     throws IOException {
     return -1;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
@@ -258,7 +258,8 @@ public class MockNoopMasterServices implements MasterServices {
   }
 
   @Override
-  public long enableTable(final TableName tableName, final long nonceGroup, final long nonce)
+  public long enableTable(final TableName tableName, final long nonceGroup, final long nonce,
+          final boolean reopenRegions)
     throws IOException {
     return -1;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
@@ -260,7 +260,7 @@ public class MockNoopMasterServices implements MasterServices {
   @Override
   public long modifyTable(TableName tableName, TableDescriptor descriptor, long nonceGroup,
           long nonce, boolean reopenRegions) throws IOException {
-    return modifyTable(tableName, descriptor, nonceGroup, nonce, reopenRegions);
+    return -1;
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
@@ -685,5 +685,18 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
     }
     currentHtd = UTIL.getAdmin().getDescriptor(tableName);
     assertEquals(0, currentHtd.getCoprocessorDescriptors().size());
+
+    // Test 6: Modifying  is not allowed
+    htd = UTIL.getAdmin().getDescriptor(tableName);
+    modifiedDescriptor =
+            TableDescriptorBuilder.newBuilder(htd).setRegionReplication(3).build();
+    try {
+      ProcedureTestingUtility.submitAndWait(procExec, new ModifyTableProcedure(
+              procExec.getEnvironment(), modifiedDescriptor, null, htd, false, reopenRegions));
+      Assert.fail("Should have thrown an exception while modifying coprocessor!");
+    } catch (HBaseIOException e) {
+      System.out.println(e.getMessage());
+      assertTrue(e.getMessage().contains("Can not modify REGION_REPLICATION"));
+    }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
@@ -17,26 +17,25 @@
  */
 package org.apache.hadoop.hbase.master.procedure;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
-import java.io.IOException;
 import org.apache.hadoop.hbase.ConcurrentTableModificationException;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.InvalidFamilyOperationException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.CoprocessorDescriptorBuilder;
 import org.apache.hadoop.hbase.client.PerClientRandomNonceGenerator;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureTestingUtility.StepHook;
 import org.apache.hadoop.hbase.procedure2.Procedure;
 import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
 import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -48,6 +47,14 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
+
+import java.io.IOException;
+import java.util.List;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
 
 @Category({ MasterTests.class, LargeTests.class })
 public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
@@ -583,5 +590,104 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
     t1.join();
     t2.join();
     assertFalse("Expected ConcurrentTableModificationException.", (t1.exception || t2.exception));
+  }
+
+  @Test
+  public void testModifyWillNotReopenRegions() throws IOException {
+    final boolean reopenRegions = false;
+    final TableName tableName = TableName.valueOf(name.getMethodName());
+    final ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, "cf");
+    UTIL.getAdmin().disableTable(tableName);
+
+    // Test 1: Modify table without reopening any regions
+    TableDescriptor htd = UTIL.getAdmin().getDescriptor(tableName);
+    TableDescriptor modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd)
+                                                               .setValue("test.hbase.conf",
+                                                                       "test.hbase.conf.value")
+                                                               .build();
+    long procId1 = ProcedureTestingUtility.submitAndWait(procExec,
+            new ModifyTableProcedure(procExec.getEnvironment(), modifiedDescriptor, null, htd,
+                    false, reopenRegions));
+    ProcedureTestingUtility.assertProcNotFailed(procExec.getResult(procId1));
+    TableDescriptor currentHtd = UTIL.getAdmin().getDescriptor(tableName);
+    assertEquals("test.hbase.conf.value", currentHtd.getValue("test.hbase.conf"));
+    List<HRegion> onlineRegions = UTIL.getHBaseCluster().getRegions(tableName);
+    //Regions should not aware of any changes.
+    for (HRegion r : onlineRegions) {
+      Assert.assertNull(r.getTableDescriptor().getValue("test.hbase.conf"));
+    }
+    //Force regions to reopen
+    for (HRegion r : onlineRegions) {
+      getMaster().getAssignmentManager().move(r.getRegionInfo());
+    }
+    //After the regions reopen, ensure that the configuration is updated.
+    for (HRegion r : onlineRegions) {
+      assertEquals("test.hbase.conf.value",
+              r.getTableDescriptor().getValue("test.hbase.conf.value"));
+    }
+
+    // Test 2: Modifying region replication is not allowed
+    htd = UTIL.getAdmin().getDescriptor(tableName);
+    long oldRegionReplication = htd.getRegionReplication();
+    modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd).setRegionReplication(3).build();
+    try {
+      new ModifyTableProcedure(procExec.getEnvironment(), modifiedDescriptor, null, htd, false,
+              reopenRegions);
+      Assert.fail(
+            "An exception should have been thrown while modifying region replication properties.");
+    } catch (HBaseIOException e) {
+      assertTrue(e.getMessage().contains("Can not modify"));
+    }
+    currentHtd = UTIL.getAdmin().getDescriptor(tableName);
+    //Nothing changed
+    assertEquals(oldRegionReplication, currentHtd.getRegionReplication());
+
+    // Test 3: Adding CFs is not allowed
+    htd = UTIL.getAdmin().getDescriptor(tableName);
+    modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd).setColumnFamily(
+            ColumnFamilyDescriptorBuilder.newBuilder("NewCF".getBytes()).build()).build();
+    try {
+      new ModifyTableProcedure(procExec.getEnvironment(), modifiedDescriptor, null, htd, false,
+              reopenRegions);
+      Assert.fail("Should have thrown an exception while modifying CF!");
+    } catch (HBaseIOException e) {
+      assertTrue(e.getMessage().contains("Cannot modify column families"));
+    }
+    currentHtd = UTIL.getAdmin().getDescriptor(tableName);
+    Assert.assertNull(currentHtd.getColumnFamily("NewCF".getBytes()));
+
+    // Test 4: Modifying CF property is not allowed
+    htd = UTIL.getAdmin().getDescriptor(tableName);
+    modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd).modifyColumnFamily(
+            ColumnFamilyDescriptorBuilder.newBuilder("cf".getBytes())
+                                         .setCompressionType(Compression.Algorithm.SNAPPY).build())
+                                               .build();
+    try {
+      new ModifyTableProcedure(procExec.getEnvironment(), modifiedDescriptor, null, htd, false,
+              reopenRegions);
+      Assert.fail("Should have thrown an exception while modifying CF!");
+    } catch (HBaseIOException e) {
+      assertTrue(e.getMessage().contains("Cannot modify column families"));
+    }
+    currentHtd = UTIL.getAdmin().getDescriptor(tableName);
+    assertEquals(Compression.Algorithm.NONE,
+            currentHtd.getColumnFamily("cf".getBytes()).getCompressionType());
+
+    // Test 5: Modifying coprocessor is not allowed
+    htd = UTIL.getAdmin().getDescriptor(tableName);
+    modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd).setCoprocessor(
+            CoprocessorDescriptorBuilder.newBuilder("any.coprocessor.name").setJarPath("fake/path")
+                                        .build()).build();
+    try {
+      new ModifyTableProcedure(procExec.getEnvironment(), modifiedDescriptor, null, htd, false,
+              reopenRegions);
+      Assert.fail("Should have thrown an exception while modifying coprocessor!");
+    } catch (HBaseIOException e) {
+      assertTrue(e.getMessage().contains("Can not modify Coprocessor"));
+    }
+    currentHtd = UTIL.getAdmin().getDescriptor(tableName);
+    assertEquals(0, currentHtd.getCoprocessorDescriptors().size());
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
@@ -686,13 +686,12 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
     currentHtd = UTIL.getAdmin().getDescriptor(tableName);
     assertEquals(0, currentHtd.getCoprocessorDescriptors().size());
 
-    // Test 6: Modifying  is not allowed
+    // Test 6: Modifying is not allowed
     htd = UTIL.getAdmin().getDescriptor(tableName);
-    modifiedDescriptor =
-            TableDescriptorBuilder.newBuilder(htd).setRegionReplication(3).build();
+    modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd).setRegionReplication(3).build();
     try {
       ProcedureTestingUtility.submitAndWait(procExec, new ModifyTableProcedure(
-              procExec.getEnvironment(), modifiedDescriptor, null, htd, false, reopenRegions));
+        procExec.getEnvironment(), modifiedDescriptor, null, htd, false, reopenRegions));
       Assert.fail("Should have thrown an exception while modifying coprocessor!");
     } catch (HBaseIOException e) {
       System.out.println(e.getMessage());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
@@ -17,6 +17,12 @@
  */
 package org.apache.hadoop.hbase.master.procedure;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
 import org.apache.hadoop.hbase.ConcurrentTableModificationException;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
@@ -47,14 +53,6 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
-
-import java.io.IOException;
-import java.util.List;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
-
 
 @Category({ MasterTests.class, LargeTests.class })
 public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
@@ -603,10 +601,8 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
 
     // Test 1: Modify table without reopening any regions
     TableDescriptor htd = UTIL.getAdmin().getDescriptor(tableName);
-    TableDescriptor modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd)
-                                                               .setValue("test.hbase.conf",
-                                                                       "test.hbase.conf.value")
-                                                               .build();
+    TableDescriptor modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd).setValue("test" +
+            ".hbase.conf", "test.hbase.conf.value").build();
     long procId1 = ProcedureTestingUtility.submitAndWait(procExec,
             new ModifyTableProcedure(procExec.getEnvironment(), modifiedDescriptor, null, htd,
                     false, reopenRegions));
@@ -614,15 +610,15 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
     TableDescriptor currentHtd = UTIL.getAdmin().getDescriptor(tableName);
     assertEquals("test.hbase.conf.value", currentHtd.getValue("test.hbase.conf"));
     List<HRegion> onlineRegions = UTIL.getHBaseCluster().getRegions(tableName);
-    //Regions should not aware of any changes.
+    // Regions should not aware of any changes.
     for (HRegion r : onlineRegions) {
       Assert.assertNull(r.getTableDescriptor().getValue("test.hbase.conf"));
     }
-    //Force regions to reopen
+    // Force regions to reopen
     for (HRegion r : onlineRegions) {
       getMaster().getAssignmentManager().move(r.getRegionInfo());
     }
-    //After the regions reopen, ensure that the configuration is updated.
+    // After the regions reopen, ensure that the configuration is updated.
     for (HRegion r : onlineRegions) {
       assertEquals("test.hbase.conf.value",
               r.getTableDescriptor().getValue("test.hbase.conf.value"));
@@ -662,8 +658,7 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
     htd = UTIL.getAdmin().getDescriptor(tableName);
     modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd).modifyColumnFamily(
             ColumnFamilyDescriptorBuilder.newBuilder("cf".getBytes())
-                                         .setCompressionType(Compression.Algorithm.SNAPPY).build())
-                                               .build();
+                    .setCompressionType(Compression.Algorithm.SNAPPY).build()).build();
     try {
       new ModifyTableProcedure(procExec.getEnvironment(), modifiedDescriptor, null, htd, false,
               reopenRegions);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
@@ -597,7 +597,6 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
     final ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
 
     MasterProcedureTestingUtility.createTable(procExec, tableName, null, "cf");
-    UTIL.getAdmin().disableTable(tableName);
 
     // Test 1: Modify table without reopening any regions
     TableDescriptor htd = UTIL.getAdmin().getDescriptor(tableName);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
@@ -606,17 +606,14 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
     ProcedureTestingUtility.assertProcNotFailed(procExec.getResult(procId1));
     TableDescriptor currentHtd = UTIL.getAdmin().getDescriptor(tableName);
     assertEquals("test.hbase.conf.value", currentHtd.getValue("test.hbase.conf"));
-
     // Regions should not aware of any changes.
     for (HRegion r : UTIL.getHBaseCluster().getRegions(tableName)) {
       Assert.assertNull(r.getTableDescriptor().getValue("test.hbase.conf"));
     }
-
     // Force regions to reopen
     for (HRegion r : UTIL.getHBaseCluster().getRegions(tableName)) {
       getMaster().getAssignmentManager().move(r.getRegionInfo());
     }
-
     // After the regions reopen, ensure that the configuration is updated.
     for (HRegion r : UTIL.getHBaseCluster().getRegions(tableName)) {
       assertEquals("test.hbase.conf.value", r.getTableDescriptor().getValue("test.hbase.conf"));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
@@ -416,7 +416,8 @@ public class VerifyingRSGroupAdmin implements Admin, Closeable {
     return modifyTableAsync(td, true);
   }
 
-  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException {
+  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions)
+    throws IOException {
     return admin.modifyTableAsync(td, reopenRegions);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
@@ -413,7 +413,11 @@ public class VerifyingRSGroupAdmin implements Admin, Closeable {
   }
 
   public Future<Void> modifyTableAsync(TableDescriptor td) throws IOException {
-    return admin.modifyTableAsync(td);
+    return modifyTableAsync(td, true);
+  }
+
+  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException {
+    return admin.modifyTableAsync(td, reopenRegions);
   }
 
   public void shutdown() throws IOException {

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -788,7 +788,7 @@ module Hbase
         # 1) Column family spec. Distinguished by having a NAME and no METHOD.
         method = arg.delete(METHOD)
 
-        if !method.nil? && method == 'no_reopen_regions'
+        if !method.nil? && method == 'avoid_reopening_regions'
           reopen_regions = false;
           method = nil
         end
@@ -915,7 +915,7 @@ module Hbase
       if hasTableUpdate
         future = @admin.modifyTableAsync(tdb.build, reopen_regions)
         if reopen_regions == false
-          puts("WARNING: You are using 'no_reopen_regions' to modify a table, which will result in
+          puts("WARNING: You are using 'avoid_reopening_regions' to modify a table, which will result in
           inconsistencies in the configuration of online regions and other risks. If you encounter
           any issues, use the original 'alter' command to make the modification again!")
           future.get

--- a/hbase-shell/src/main/ruby/hbase_constants.rb
+++ b/hbase-shell/src/main/ruby/hbase_constants.rb
@@ -107,6 +107,7 @@ module HBaseConstants
   VALUE = 'VALUE'.freeze
   VERSIONS = org.apache.hadoop.hbase.HConstants::VERSIONS
   VISIBILITY = 'VISIBILITY'.freeze
+  REOPEN_REGIONS = 'REOPEN_REGIONS'.freeze
 
   # aliases
   ENDKEY = STOPROW

--- a/hbase-shell/src/main/ruby/shell/commands/alter.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/alter.rb
@@ -76,8 +76,22 @@ You can also set configuration setting with REOPEN_REGIONS=>'false' to avoid reg
 let the modification take effect after regions was reopened (Be careful, the regions of the table
 may be configured inconsistently If regions are not reopened after the modification)
 
+  hbase> alter 't1', REOPEN_REGIONS => 'false', MAX_FILESIZE => '134217728'
   hbase> alter 't1', REOPEN_REGIONS => 'false', CONFIGURATION => {'hbase.hregion.scan
-  .loadColumnFamiliesOnDemand' => 'true'}
+    .loadColumnFamiliesOnDemand' => 'true'}
+
+However, be aware that:
+1. Inconsistency Risks: If the regions are not reopened after the modification, the table's regions
+may become inconsistently configured. Ensure that you manually reopen the regions as soon as
+possible to apply the changes consistently across the entire table.
+2. If changes are made to the table without reopening the regions, we currently only allow
+lightweight operations. The following types of changes, which may lead to unknown situations,
+will throw an exception:
+    a. Adding or removing CFs, coprocessors.
+    b. Modifying the table name.
+    c. Changing region replica related configurations such as 'REGION_REPLICATION'
+       and 'REGION_MEMSTORE_REPLICATION'.
+    d. Changing the rsgroup.
 
 You can also unset configuration settings specific to this table:
 

--- a/hbase-shell/src/main/ruby/shell/commands/alter.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/alter.rb
@@ -72,11 +72,11 @@ You can also set configuration settings specific to this table or column family:
   hbase> alter 't1', CONFIGURATION => {'hbase.hregion.scan.loadColumnFamiliesOnDemand' => 'true'}
   hbase> alter 't1', {NAME => 'f2', CONFIGURATION => {'hbase.hstore.blockingStoreFiles' => '10'}}
 
-You can also set configuration setting with 'avoid_reopening_regions' to avoid regions RIT, which let the
-modification take effect after regions was reopened (Be careful, the regions of the table may be
-configured inconsistently If regions are not reopened after the modification)
+You can also set configuration setting with REOPEN_REGIONS=>'false' to avoid regions RIT, which
+let the modification take effect after regions was reopened (Be careful, the regions of the table
+may be configured inconsistently If regions are not reopened after the modification)
 
-  hbase> alter 't1', METHOD => 'avoid_reopening_regions', CONFIGURATION => {'hbase.hregion.scan
+  hbase> alter 't1', REOPEN_REGIONS => 'false', CONFIGURATION => {'hbase.hregion.scan
   .loadColumnFamiliesOnDemand' => 'true'}
 
 You can also unset configuration settings specific to this table:

--- a/hbase-shell/src/main/ruby/shell/commands/alter.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/alter.rb
@@ -72,6 +72,13 @@ You can also set configuration settings specific to this table or column family:
   hbase> alter 't1', CONFIGURATION => {'hbase.hregion.scan.loadColumnFamiliesOnDemand' => 'true'}
   hbase> alter 't1', {NAME => 'f2', CONFIGURATION => {'hbase.hstore.blockingStoreFiles' => '10'}}
 
+You can also set configuration setting with 'no_reopen_regions' to avoid regions RIT, which let the
+modification take effect after regions was reopened (Be careful, the regions of the table may be
+configured inconsistently If regions are not reopened after the modification)
+
+  hbase> alter 't1', METHOD => 'no_reopen_regions', CONFIGURATION => {'hbase.hregion.scan
+  .loadColumnFamiliesOnDemand' => 'true'}
+
 You can also unset configuration settings specific to this table:
 
   hbase> alter 't1', METHOD => 'table_conf_unset', NAME => 'hbase.hregion.majorcompaction'

--- a/hbase-shell/src/main/ruby/shell/commands/alter.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/alter.rb
@@ -72,11 +72,11 @@ You can also set configuration settings specific to this table or column family:
   hbase> alter 't1', CONFIGURATION => {'hbase.hregion.scan.loadColumnFamiliesOnDemand' => 'true'}
   hbase> alter 't1', {NAME => 'f2', CONFIGURATION => {'hbase.hstore.blockingStoreFiles' => '10'}}
 
-You can also set configuration setting with 'no_reopen_regions' to avoid regions RIT, which let the
+You can also set configuration setting with 'avoid_reopening_regions' to avoid regions RIT, which let the
 modification take effect after regions was reopened (Be careful, the regions of the table may be
 configured inconsistently If regions are not reopened after the modification)
 
-  hbase> alter 't1', METHOD => 'no_reopen_regions', CONFIGURATION => {'hbase.hregion.scan
+  hbase> alter 't1', METHOD => 'avoid_reopening_regions', CONFIGURATION => {'hbase.hregion.scan
   .loadColumnFamiliesOnDemand' => 'true'}
 
 You can also unset configuration settings specific to this table:

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
@@ -735,7 +735,8 @@ public class ThriftAdmin implements Admin {
     throw new NotImplementedException("modifyTableAsync not supported in ThriftAdmin");
   }
 
-  @Override public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions){
+  @Override
+  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) {
     throw new NotImplementedException("modifyTableAsync not supported in ThriftAdmin");
   }
 

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
@@ -735,6 +735,10 @@ public class ThriftAdmin implements Admin {
     throw new NotImplementedException("modifyTableAsync not supported in ThriftAdmin");
   }
 
+  @Override public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions){
+    throw new NotImplementedException("modifyTableAsync not supported in ThriftAdmin");
+  }
+
   @Override
   public void shutdown() {
     throw new NotImplementedException("shutdown not supported in ThriftAdmin");

--- a/pom.xml
+++ b/pom.xml
@@ -2819,6 +2819,7 @@
             <excludes>
               <exclude>**/generated/*</exclude>
               <exclude>**/package-info.java</exclude>
+              <exclude>**/.idea/**</exclude>
             </excludes>
             <!--
               e.g., remove the following lines:
@@ -2888,6 +2889,7 @@
               <excludes>
                 <exclude>**/target/**</exclude>
                 <exclude>**/dependency-reduced-pom.xml</exclude>
+                <exclude>**/.idea/**</exclude>
               </excludes>
               <!-- define the steps to apply to those files -->
               <trimTrailingWhitespace/>


### PR DESCRIPTION
Provide an optional lazy_mode for the alter command to modify the TableDescriptor without the region entering the RIT. The modification will take effect when the region is reopened.

