### PR TITLE
HBASE-25554 NPE when init RegionMover

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
@@ -87,7 +87,6 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
   public static final int DEFAULT_MOVE_RETRIES_MAX = 5;
   public static final int DEFAULT_MOVE_WAIT_MAX = 60;
   public static final int DEFAULT_SERVERSTART_WAIT_MAX = 180;
-  private final RackManager rackManager;
 
   private static final Logger LOG = LoggerFactory.getLogger(RegionMover.class);
 
@@ -103,6 +102,7 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
   private int port;
   private Connection conn;
   private Admin admin;
+  private RackManager rackManager;
 
   private RegionMover(RegionMoverBuilder builder) throws IOException {
     this.hostname = builder.hostname;
@@ -125,7 +125,6 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
   }
 
   private RegionMover() {
-    rackManager = new RackManager(conf);
   }
 
   @Override


### PR DESCRIPTION
The key point is that the conf variable has not been initialized before init RackManager.