### PR TITLE
HBASE-25543 When configuration hadoop.security.authorization is set to false, the system will still try to authorize an RPC and raise AccessDeniedException

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
@@ -1973,7 +1973,7 @@ public class RpcServer implements RpcServerInterface, ConfigurationObserver {
       } else {
         processConnectionHeader(buf);
         this.connectionHeaderRead = true;
-        if (!authorizeConnection()) {
+        if (authorize && !authorizeConnection()) {
           // Throw FatalConnectionException wrapping ACE so client does right thing and closes
           // down the connection instead of trying to read non-existent retun.
           throw new AccessDeniedException("Connection from " + this + " for service " +


### PR DESCRIPTION
The bug is already fixed in master branch and branch-2, the JIRA link is:
https://issues.apache.org/jira/browse/HBASE-25543