### PR TITLE
HBASE-25558:Adding audit log for execMasterService

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -949,6 +949,8 @@ public class MasterRpcServices extends RSRpcServices implements
       MethodDescriptor methodDesc =
           CoprocessorRpcUtils.getMethodDescriptor(methodName, serviceDesc);
 
+      LOG.info(master.getClientIdAuditPrefix() + " master service request for: " +
+        serviceName + "." + methodName);
       Message execRequest =
           CoprocessorRpcUtils.getRequest(service, methodDesc, call.getRequest());
       final Message.Builder responseBuilder =


### PR DESCRIPTION
Hi:

I have found that in APIs, like execProcedure and execProcedureWithRet, have audit log to record who execute the master service. The log can be like:

`LOG.info(master.getClientIdAuditPrefix()` + " procedure request for: " + desc.getSignature());`

But it seems that we forget to audit execMasterService. We should add one.