### PR TITLE
HBASE-25570 On largish cluster, "CleanerChore: Could not delete dir..…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/CleanerChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/CleanerChore.java
@@ -468,9 +468,14 @@ public abstract class CleanerChore<T extends FileCleanerDelegate> extends Schedu
       LOG.debug("Couldn't delete '{}' yet because it isn't empty w/exception.", dir, exception);
       deleted = false;
     } catch (IOException ioe) {
-      LOG.info("Could not delete {} under {}. might be transient; we'll retry. if it keeps "
-          + "happening, use following exception when asking on mailing list.",
-        type, dir, ioe);
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Could not delete {} under {}; will retry. If it keeps happening, " +
+            "quote the exception when asking on mailing list.", type, dir, ioe);
+      } else {
+        LOG.info("Could not delete {} under {} because {}; will retry. If it  keeps happening, enable" +
+            "TRACE-level logging and quote the exception when asking on mailing list.",
+            type, dir, ioe.getMessage());
+      }
       deleted = false;
     } catch (Exception e) {
       LOG.info("unexpected exception: ", e);


### PR DESCRIPTION
…." makes master log unreadable

Turn down the amount we log. If you want to see the full exception
enable TRACE-level logging.