### PR TITLE
HBASE-25573 release script generated vote template has incorrect staging area

### DIFF
--- a/dev-support/create-release/release-build.sh
+++ b/dev-support/create-release/release-build.sh
@@ -213,6 +213,11 @@ fi
 
 git clean -d -f -x
 cd ..
+if [[ "$PROJECT" =~ ^hbase- ]]; then
+  DEST_DIR_NAME="${PROJECT}-${package_version_name}"
+else
+  DEST_DIR_NAME="$package_version_name"
+fi
 
 if [[ "$1" == "publish-dist" ]]; then
   # Source and binary tarballs
@@ -224,11 +229,6 @@ if [[ "$1" == "publish-dist" ]]; then
     make_binary_release "${PROJECT}" "${RELEASE_VERSION}"
   fi
 
-  if [[ "$PROJECT" =~ ^hbase- ]]; then
-    DEST_DIR_NAME="${PROJECT}-${package_version_name}"
-  else
-    DEST_DIR_NAME="$package_version_name"
-  fi
   svn_target="svn-${PROJECT}"
   svn co --depth=empty "$RELEASE_STAGING_LOCATION" "$svn_target"
   rm -rf "${svn_target:?}/${DEST_DIR_NAME}"

--- a/dev-support/create-release/vote.tmpl
+++ b/dev-support/create-release/vote.tmpl
@@ -13,7 +13,7 @@ The tag to be voted on is ${RELEASE_TAG}:
 The release files, including signatures, digests, as well as CHANGES.md
 and RELEASENOTES.md included in this RC can be found at:
 
-  https://dist.apache.org/repos/dist/dev/hbase/${RELEASE_TAG}/
+  https://dist.apache.org/repos/dist/dev/hbase/${DEST_DIR_NAME}/
 
 Maven artifacts are available in a staging repository at:
 


### PR DESCRIPTION
In the hbase project's RC staging area we use bare version/RC numbers only for the main project. We already have logic for getting the correct directory for copying things into svn, make that logic more visible and use it for the vote template as well.

tested by doing a local dryrun for hbase-thirdparty and examining the RC vote message generated.