### PR TITLE
HBASE-25580 Release scripts should include in the vote email the git hash that the RC tag points to

### DIFF
--- a/dev-support/create-release/release-build.sh
+++ b/dev-support/create-release/release-build.sh
@@ -192,6 +192,7 @@ fi
 cd "${PROJECT}"
 git checkout "$GIT_REF"
 git_hash="$(git rev-parse --short HEAD)"
+GIT_LONG_HASH="$(git rev-parse HEAD)"
 log "Checked out ${PROJECT} at ${GIT_REF} commit $git_hash"
 
 if [ -z "${RELEASE_VERSION}" ]; then

--- a/dev-support/create-release/vote.tmpl
+++ b/dev-support/create-release/vote.tmpl
@@ -10,6 +10,10 @@ The tag to be voted on is ${RELEASE_TAG}:
 
   https://github.com/apache/${PROJECT}/tree/${RELEASE_TAG}
 
+This tag currently points to git reference
+
+  ${GIT_LONG_HASH}
+
 The release files, including signatures, digests, as well as CHANGES.md
 and RELEASENOTES.md included in this RC can be found at:
 


### PR DESCRIPTION
tested locally by doing a dry run of the hbase-operator-tools repo.