### PR TITLE
HBASE-25541: Setting the path to null when we dequeue the current log

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStream.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStream.java
@@ -252,6 +252,7 @@ class WALEntryStream implements Closeable {
     LOG.debug("EOF, closing {}", currentPath);
     closeReader();
     logQueue.remove();
+    setCurrentPath(null);
     setPosition(0);
     metrics.decrSizeOfLogQueue();
   }


### PR DESCRIPTION
Currently, when we deque we do not reset the current wal path, and it blows up while opening the next log, the current path still points to previous wal which is not correct.

```java
private boolean openNextLog() throws IOException {
  Path nextPath = logQueue.peek();
  if (nextPath != null) {
    openReader(nextPath); <=== if we blow up here
    if (reader != null) {
      return true;
    }
  } else {
    // no more files in queue, this could happen for recovered queue, or for a wal group of a sync
    // replication peer which has already been transited to DA or S.
    setCurrentPath(null);
  }
  return false;
} 
```