### PR TITLE
HBASE-25586 Fix HBASE-22492 on branch-2 (SASL GapToken)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -281,9 +281,6 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
         }
       }
       bc = new BufferChain(responseBufs);
-      if (connection.useWrap) {
-        bc = wrapWithSasl(bc);
-      }
     } catch (IOException e) {
       RpcServer.LOG.warn("Exception while creating response " + e);
     }
@@ -547,6 +544,20 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
 
   @Override
   public synchronized BufferChain getResponse() {
-    return response;
+    if (connection.useWrap) {
+      /*
+       * wrapping result with SASL as the last step just before sending it out, so
+       * every message must have the right increasing sequence number
+       */
+      try {
+        return wrapWithSasl(response);
+      } catch (IOException e) {
+        /* it is exactly the same what setResponse() does */
+        RpcServer.LOG.warn("Exception while creating response " + e);
+        return null;
+      }
+    } else {
+      return response;
+    }
   }
 }


### PR DESCRIPTION
ServerCall.java: calling wrapWithSasl() was moved to getResponse(), so
the SASL wrapping is delayed until the reply is sent back to the client.