### PR TITLE
HBASE-25589 Update download page for HBase Operator Tools to 1.1.0

### DIFF
--- a/src/site/xdoc/downloads.xml
+++ b/src/site/xdoc/downloads.xml
@@ -204,22 +204,22 @@ under the License.
       </tr>
       <tr>
         <td style="test-align: left">
-          1.0.0
+          1.1.0
         </td>
         <td style="test-align: left">
-          2019/09/24
+          2021/02/20
         </td>
         <td style="test-align: left">
         </td>
         <td style="test-align: left">
-          <a href="https://apache.org/dist/hbase/hbase-operator-tools-1.0.0/CHANGES.md">Changes</a>
+          <a href="https://apache.org/dist/hbase/hbase-operator-tools-1.1.0/CHANGES.md">Changes</a>
         </td>
         <td style="test-align: left">
-          <a href="https://apache.org/dist/hbase/hbase-operator-tools-1.0.0/RELEASENOTES.md">Release Notes</a>
+          <a href="https://apache.org/dist/hbase/hbase-operator-tools-1.1.0/RELEASENOTES.md">Release Notes</a>
         </td>
         <td style="test-align: left">
-          <a href="https://www.apache.org/dyn/closer.lua/hbase/hbase-operator-tools-1.0.0/hbase-operator-tools-1.0.0-src.tar.gz">src</a> (<a href="https://www.apache.org/dist/hbase/hbase-operator-tools-1.0.0/hbase-operator-tools-1.0.0-src.tar.gz.sha512">sha512</a> <a href="https://www.apache.org/dist/hbase/hbase-operator-tools-1.0.0/hbase-operator-tools-1.0.0-src.tar.gz.asc">asc</a>) <br />
-          <a href="https://www.apache.org/dyn/closer.lua/hbase/hbase-operator-tools-1.0.0/hbase-operator-tools-1.0.0-bin.tar.gz">bin</a> (<a href="https://www.apache.org/dist/hbase/hbase-operator-tools-1.0.0/hbase-operator-tools-1.0.0-bin.tar.gz.sha512">sha512</a> <a href="https://www.apache.org/dist/hbase/hbase-operator-tools-1.0.0/hbase-operator-tools-1.0.0-bin.tar.gz.asc">asc</a>) <br />
+          <a href="https://www.apache.org/dyn/closer.lua/hbase/hbase-operator-tools-1.1.0/hbase-operator-tools-1.1.0-src.tar.gz">src</a> (<a href="https://www.apache.org/dist/hbase/hbase-operator-tools-1.1.0/hbase-operator-tools-1.1.0-src.tar.gz.sha512">sha512</a> <a href="https://www.apache.org/dist/hbase/hbase-operator-tools-1.1.0/hbase-operator-tools-1.1.0-src.tar.gz.asc">asc</a>) <br />
+          <a href="https://www.apache.org/dyn/closer.lua/hbase/hbase-operator-tools-1.1.0/hbase-operator-tools-1.1.0-bin.tar.gz">bin</a> (<a href="https://www.apache.org/dist/hbase/hbase-operator-tools-1.1.0/hbase-operator-tools-1.1.0-bin.tar.gz.sha512">sha512</a> <a href="https://www.apache.org/dist/hbase/hbase-operator-tools-1.1.0/hbase-operator-tools-1.1.0-bin.tar.gz.asc">asc</a>) <br />
         </td>
         <td>
         </td>


### PR DESCRIPTION
tested by building the website locally and browsing to the updated download page.