### PR TITLE
HBASE-25583: NoNodeException of the peer should call the remove peer workflow

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
@@ -62,7 +62,6 @@ import org.apache.hadoop.hbase.replication.ReplicationPeer;
 import org.apache.hadoop.hbase.replication.ReplicationPeers;
 import org.apache.hadoop.hbase.replication.ReplicationQueueInfo;
 import org.apache.hadoop.hbase.replication.ReplicationQueues;
-import org.apache.hadoop.hbase.replication.ReplicationSourceWithoutPeerException;
 import org.apache.hadoop.hbase.replication.SystemTableWALEntryFilter;
 import org.apache.hadoop.hbase.replication.WALEntryFilter;
 import org.apache.hadoop.hbase.replication.regionserver.ReplicationSourceWALReaderThread.WALEntryBatch;
@@ -795,13 +794,9 @@ public class ReplicationSource extends Thread implements ReplicationSourceInterf
     }
 
     private void updateLogPosition(long lastReadPosition) {
-      try {
-        manager.logPositionAndCleanOldLogs(lastLoggedPath, peerClusterZnode, lastReadPosition,
-          this.replicationQueueInfo.isQueueRecovered(), false);
-        lastLoggedPosition = lastReadPosition;
-      } catch (ReplicationSourceWithoutPeerException re) {
-        source.terminate("Replication peer is removed and source should terminate", re);
-      }
+      manager.logPositionAndCleanOldLogs(lastLoggedPath, peerClusterZnode, lastReadPosition,
+        this.replicationQueueInfo.isQueueRecovered(), false);
+      lastLoggedPosition = lastReadPosition;
     }
 
     public void startup() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceManager.java
@@ -253,7 +253,7 @@ public class ReplicationSourceManager implements ReplicationListener {
    * @return logs with the given prefix
    */
   public SortedSet<String> getLogsWithPrefix(String walGroupId, String logPrefix) {
-    return Collections.unmodifiableSortedSet(walsById.get(walGroupId).get(logPrefix));
+    return walsById.get(walGroupId).get(logPrefix);
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/ReplicationSourceDummyWithNoTermination.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/ReplicationSourceDummyWithNoTermination.java
@@ -16,13 +16,11 @@
 package org.apache.hadoop.hbase.replication;
 
 public class ReplicationSourceDummyWithNoTermination extends ReplicationSourceDummy {
-  boolean firstTime = true;
-  boolean isTerminateInvoked = false;
+  volatile boolean firstTime = true;
   @Override
   public void terminate(String reason) {
     // This is to block the zk listener to close the queues
     // to simulate the znodes getting deleted without zk listener getting invoked
-    isTerminateInvoked = true;
     if (firstTime) {
       firstTime = false;
       throw new RuntimeException(fakeExceptionMessage);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/ReplicationSourceDummyWithNoTermination.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/ReplicationSourceDummyWithNoTermination.java
@@ -16,11 +16,16 @@
 package org.apache.hadoop.hbase.replication;
 
 public class ReplicationSourceDummyWithNoTermination extends ReplicationSourceDummy {
-
+  boolean firstTime = true;
+  boolean isTerminateInvoked = false;
   @Override
   public void terminate(String reason) {
     // This is to block the zk listener to close the queues
     // to simulate the znodes getting deleted without zk listener getting invoked
-    throw new RuntimeException(fakeExceptionMessage);
+    isTerminateInvoked = true;
+    if (firstTime) {
+      firstTime = false;
+      throw new RuntimeException(fakeExceptionMessage);
+    }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationSource.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationSource.java
@@ -564,7 +564,7 @@ public class TestReplicationSource {
       }
     };
 
-    final ReplicationSource source = mocks.createReplicationSourceWithMocks(endpoint, false);
+    final ReplicationSource source = mocks.createReplicationSourceAndManagerWithMocks(endpoint);
     source.run();
     source.enqueueLog(log1);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSourceManagerBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSourceManagerBase.java
@@ -35,7 +35,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionInfo;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.replication.ReplicationSourceDummyWithNoTermination;
+import org.apache.hadoop.hbase.replication.ReplicationSourceDummy;
 import org.apache.hadoop.hbase.replication.ReplicationStateZKBase;
 import org.apache.hadoop.hbase.replication.regionserver.helper.DummyServer;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -51,10 +51,10 @@ import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.rules.TestName;
 
-public abstract class TestReplicationSourceBase {
+public abstract class TestReplicationSourceManagerBase {
 
   private static final Log LOG =
-    LogFactory.getLog(TestReplicationSourceBase.class);
+    LogFactory.getLog(TestReplicationSourceManagerBase.class);
 
   protected static Configuration conf;
   protected static HBaseTestingUtility utility;
@@ -75,11 +75,12 @@ public abstract class TestReplicationSourceBase {
   protected static Path logDir;
   protected static DummyServer server;
 
-  @BeforeClass public static void setUpBeforeClass() throws Exception {
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
 
     conf = HBaseConfiguration.create();
     conf.set("replication.replicationsource.implementation",
-      ReplicationSourceDummyWithNoTermination.class.getCanonicalName());
+      ReplicationSourceDummy.class.getCanonicalName());
     conf.setBoolean(HConstants.REPLICATION_ENABLE_KEY, HConstants.REPLICATION_ENABLE_DEFAULT);
     conf.setLong("replication.sleep.before.failover", 2000);
     conf.setInt("replication.source.maxretriesmultiplier", 10);


### PR DESCRIPTION
There was a review comment on the original of HBASE-25583 [here](https://github.com/apache/hbase/pull/2960#discussion_r579384941) for an improvement to call the remove peer workflow as a whole instead of just terminating source.
It makes sense to call the removePeer for no node exception on peer since it will do some aditional cleanup.


@shahrs87 Can you please review it here?

@apurtell @wchevreuil Can you please review it too since you reviewed the original PR for HBASE-25583.

