### PR TITLE
HBASE-25603 Add switch for compaction after bulkload

### DIFF
--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -594,6 +594,13 @@ possible configurations would overwhelm and obscure the important.
     0 means never give up.</description>
   </property>
   <property>
+    <name>hbase.compaction.after.bulkload.enable</name>
+    <value>true</value>
+    <description>Request Compaction after bulkload immediately.
+      If bulkload is continuous, the triggered compactions may increase load,
+      bring about performance side effect.</description>
+  </property>
+  <property>
     <name>hbase.master.balancer.maxRitPercent</name>
     <value>1.0</value>
     <description>The max percent of regions in transition when balancing.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -244,6 +244,10 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
   public static final String WAL_HSYNC_CONF_KEY = "hbase.wal.hsync";
   public static final boolean DEFAULT_WAL_HSYNC = false;
 
+  /** Parameter name for compaction after bulkload */
+  public static final String COMPACTION_AFTER_BULKLOAD_ENABLE =
+      "hbase.compaction.after.bulkload.enable";
+
   /**
    * This is for for using HRegion as a local storage, where we may put the recovered edits in a
    * special place. Once this is set, we will only replay the recovered edits under this directory
@@ -7025,19 +7029,23 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
       }
 
       isSuccessful = true;
-      //request compaction
-      familyWithFinalPath.keySet().forEach(family -> {
-        HStore store = getStore(family);
-        try {
-          if (this.rsServices != null && store.needsCompaction()) {
-            this.rsServices.getCompactionRequestor().requestCompaction(this, store,
-              "bulkload hfiles request compaction", Store.PRIORITY_USER + 1,
-              CompactionLifeCycleTracker.DUMMY, null);
+      if (conf.getBoolean(COMPACTION_AFTER_BULKLOAD_ENABLE, true)) {
+        // request compaction
+        familyWithFinalPath.keySet().forEach(family -> {
+          HStore store = getStore(family);
+          try {
+            if (this.rsServices != null && store.needsCompaction()) {
+              this.rsServices.getCompactionRequestor().requestCompaction(this, store,
+                "bulkload hfiles request compaction", Store.PRIORITY_USER + 1,
+                CompactionLifeCycleTracker.DUMMY, null);
+              LOG.debug("bulkload hfiles request compaction region : {}, family : {}",
+                this.getRegionInfo(), family);
+            }
+          } catch (IOException e) {
+            LOG.error("bulkload hfiles request compaction error ", e);
           }
-        } catch (IOException e) {
-          LOG.error("bulkload hfiles request compaction error ", e);
-        }
-      });
+        });
+      }
     } finally {
       if (wal != null && !storeFiles.isEmpty()) {
         // Write a bulk load event for hfiles that are loaded

--- a/src/main/asciidoc/_chapters/hbase-default.adoc
+++ b/src/main/asciidoc/_chapters/hbase-default.adoc
@@ -756,6 +756,17 @@ Maximum retries. This is a maximum number of iterations
 `10`
 
 
+[[hbase.compaction.after.bulkload.enable]]
+*`hbase.compaction.after.bulkload.enable`*::
++
+.Description
+Request Compaction after bulkload immediately.
+If bulkload is continuous, the triggered compactions may increase load,
+bring about performance side effect.
++
+.Default
+`true`
+
 [[hbase.balancer.period
     ]]
 *`hbase.balancer.period


### PR DESCRIPTION
when compaction after bulkload is enable,  if bulkload is continuous,  considerable compaction events will be triggered, which increase load, bring about performance impact