### PR TITLE
HBASE-25680  Non-idempotent test in TestReplicationHFileCleaner

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/cleaner/TestReplicationHFileCleaner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/cleaner/TestReplicationHFileCleaner.java
@@ -26,6 +26,7 @@ import static org.mockito.Mockito.spy;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
@@ -146,6 +147,7 @@ public class TestReplicationHFileCleaner {
     assertFalse("Cleaner should not allow to delete this file as there is a hfile reference node "
         + "for it in the queue.",
       cleaner.isFileDeletable(fs.getFileStatus(file)));
+    rq.removeHFileRefs(peerId, Arrays.asList("testIsFileDeletableWithNoHFileRefs"));
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/cleaner/TestReplicationHFileCleaner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/cleaner/TestReplicationHFileCleaner.java
@@ -26,7 +26,6 @@ import static org.mockito.Mockito.spy;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Arrays;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
@@ -122,6 +121,8 @@ public class TestReplicationHFileCleaner {
     } catch (IOException e) {
       LOG.warn("Failed to delete files recursively from path " + root);
     }
+    // Remove all HFileRefs (if any)
+    rq.removeHFileRefs(peerId, rq.getReplicableHFiles(peerId));
     rp.getPeerStorage().removePeer(peerId);
   }
 
@@ -147,7 +148,6 @@ public class TestReplicationHFileCleaner {
     assertFalse("Cleaner should not allow to delete this file as there is a hfile reference node "
         + "for it in the queue.",
       cleaner.isFileDeletable(fs.getFileStatus(file)));
-    rq.removeHFileRefs(peerId, Arrays.asList("testIsFileDeletableWithNoHFileRefs"));
   }
 
   @Test


### PR DESCRIPTION
The test `org.apache.hadoop.hbase.master.cleaner.TestReplicationHFileCleaner.testIsFileDeletable` is not idempotent and fail if run twice in the same JVM, because it pollutes some states shared among tests. It may be good to clean this state pollution so that some other tests do not fail in the future due to the shared state polluted by this test.

### Detail
Running `TestReplicationHFileCleaner.testIsFileDeletable` twice would result in the second run failing due to the following assertion error:
```
java.lang.AssertionError: Cleaner should allow to delete this file as there is no hfile reference node for it in the queue.
```
The root cause is that the a hfile reference is added during the first test run, which doesn't get removed upon test exits. Therefore, in the second test run , `cleaner.isFileDeletable(fs.getFileStatus(file)))` would return `false`, resulting in the assertion error.

The suggested fix is to remove the hfile reference created during the test when the test exits.

With the proposed fix, the test does not pollute the shared state (and passes when run twice in the same JVM).

Jira link: https://issues.apache.org/jira/browse/HBASE-25680