### PR TITLE
HBASE-25648 Fix normalizer TestSimpleRegionNormalizerOnCluster branch-1

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1678,7 +1678,7 @@ public class HMaster extends HRegionServer implements MasterServices, Server {
       return false;
     }
 
-    if (isNormalizerOn()) {
+    if (!isNormalizerOn()) {
       LOG.debug("Region normalization is disabled, don't run region normalizer.");
       return false;
     }
@@ -1693,11 +1693,7 @@ public class HMaster extends HRegionServer implements MasterServices, Server {
 
       for (TableName table : allEnabledTables) {
         final NamespaceAuditor namespaceQuotaManager = quotaManager.getNamespaceQuotaManager();
-        if(namespaceQuotaManager == null) {
-          LOG.debug("Skipping normalizing since namespace quota is null");
-          return false;
-        }
-        if (namespaceQuotaManager.getState(table.getNamespaceAsString()) != null) {
+        if (namespaceQuotaManager != null && namespaceQuotaManager.getState(table.getNamespaceAsString()) != null) {
           LOG.debug("Skipping normalizing " + table + " since its namespace has quota");
           continue;
         }


### PR DESCRIPTION
[HBASE-25648](https://issues.apache.org/jira/browse/HBASE-25648)

From #2972 there was a change from
`if (!this.regionNormalizerTracker.isNormalizerOn()) {`
to
`if (isNormalizerOn()) {`
(missing `!` it looks like)

and then
```
        if (quotaManager.getNamespaceQuotaManager() != null &&
            quotaManager.getNamespaceQuotaManager().getState(table.getNamespaceAsString()) != null){
          LOG.debug("Skipping normalizing " + table + " since its namespace has quota");
          continue;
        }
```
changed to
```
        final NamespaceAuditor namespaceQuotaManager = quotaManager.getNamespaceQuotaManager();
        if(namespaceQuotaManager == null) {
          LOG.debug("Skipping normalizing since namespace quota is null");
          return false;
        }
        if (namespaceQuotaManager.getState(table.getNamespaceAsString()) != null) {
          LOG.debug("Skipping normalizing " + table + " since its namespace has quota");
          continue;
        }
```
which now requires `namespaceQuotaManager` to exist before allowing normalizer to work, which I think is unintended, and doesn't match the original behavior in [HBASE-23932](https://issues.apache.org/jira/browse/HBASE-23932)

@mnpoonia @virajjasani 