### PR TITLE
 HBASE-25660 Print split policy in use on Region open (as well as spl…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/BusyRegionSplitPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/BusyRegionSplitPolicy.java
@@ -20,10 +20,10 @@ package org.apache.hadoop.hbase.regionserver;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 
 /**
  * This class represents a split policy which makes the split decision based
@@ -59,6 +59,12 @@ public class BusyRegionSplitPolicy extends IncreasingToUpperBoundRegionSplitPoli
   private long writeRequestCount;
   private long blockedRequestCount;
   private float blockedRate;
+
+  @Override
+  public String toString() {
+    return "BusyRegionSplitPolicy{" + "maxBlockedRequests=" + maxBlockedRequests + ", minAge="
+      + minAge + ", aggregationWindow=" + aggregationWindow + ", " + super.toString() + '}';
+  }
 
   @Override
   protected void configureForRegion(final HRegion region) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/ConstantSizeRegionSplitPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/ConstantSizeRegionSplitPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,14 +17,13 @@
  */
 package org.apache.hadoop.hbase.regionserver;
 
-import java.util.Random;
-
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.HConstants;
-import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.procedure2.util.StringUtils;
+import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -41,11 +40,15 @@ import org.slf4j.LoggerFactory;
 public class ConstantSizeRegionSplitPolicy extends RegionSplitPolicy {
   private static final Logger LOG =
     LoggerFactory.getLogger(ConstantSizeRegionSplitPolicy.class);
-  private static final Random RANDOM = new Random();
-
   private long desiredMaxFileSize;
   private double jitterRate;
   protected boolean overallHRegionFiles;
+
+  @Override
+  public String toString() {
+    return "ConstantSizeRegionSplitPolicy{" + "desiredMaxFileSize=" + desiredMaxFileSize
+      + ", jitterRate=" + jitterRate + '}';
+  }
 
   @Override
   protected void configureForRegion(HRegion region) {
@@ -62,9 +65,9 @@ public class ConstantSizeRegionSplitPolicy extends RegionSplitPolicy {
     this.overallHRegionFiles = conf.getBoolean(HConstants.OVERALL_HREGION_FILES,
       HConstants.DEFAULT_OVERALL_HREGION_FILES);
     double jitter = conf.getDouble("hbase.hregion.max.filesize.jitter", 0.25D);
-    this.jitterRate = (RANDOM.nextFloat() - 0.5D) * jitter;
+    this.jitterRate = (ThreadLocalRandom.current().nextFloat() - 0.5D) * jitter;
     long jitterValue = (long) (this.desiredMaxFileSize * this.jitterRate);
-    // make sure the long value won't overflow with jitter
+    // Default jitter is ~12% +/-. Make sure the long value won't overflow with jitter
     if (this.jitterRate > 0 && jitterValue > (Long.MAX_VALUE - this.desiredMaxFileSize)) {
       this.desiredMaxFileSize = Long.MAX_VALUE;
     } else {
@@ -100,7 +103,7 @@ public class ConstantSizeRegionSplitPolicy extends RegionSplitPolicy {
       }
       if (sumSize > sizeToCheck) {
         LOG.debug("ShouldSplit because region size is big enough "
-            + "size={}, sizeToCheck={}{}", StringUtils.humanSize(sumSize),
+            + "sumSize={}, sizeToCheck={}", StringUtils.humanSize(sumSize),
           StringUtils.humanSize(sizeToCheck));
         return true;
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/DelimitedKeyPrefixRegionSplitPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/DelimitedKeyPrefixRegionSplitPolicy.java
@@ -48,6 +48,12 @@ public class DelimitedKeyPrefixRegionSplitPolicy extends IncreasingToUpperBoundR
   private byte[] delimiter = null;
 
   @Override
+  public String toString() {
+    return "DelimitedKeyPrefixRegionSplitPolicy{" + "delimiter=" + Bytes.toStringBinary(delimiter) +
+      ", " + super.toString() + '}';
+  }
+
+  @Override
   protected void configureForRegion(HRegion region) {
     super.configureForRegion(region);
     // read the prefix length from the table descriptor

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/FlushAllStoresPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/FlushAllStoresPolicy.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -26,10 +26,13 @@ import org.apache.yetus.audience.InterfaceAudience;
  */
 @InterfaceAudience.Private
 public class FlushAllStoresPolicy extends FlushPolicy {
+  @Override
+  public String toString() {
+    return "FlushAllStoresPolicy";
+  }
 
   @Override
   public Collection<HStore> selectStoresToFlush() {
     return region.stores.values();
   }
-
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/FlushLargeStoresPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/FlushLargeStoresPolicy.java
@@ -43,6 +43,11 @@ public abstract class FlushLargeStoresPolicy extends FlushPolicy {
 
   protected long flushSizeLowerBound = -1;
 
+  @Override
+  public String toString() {
+    return "FlushLargeStoresPolicy{" + "flushSizeLowerBound=" + flushSizeLowerBound + '}';
+  }
+
   protected void setFlushSizeLowerBounds(HRegion region) {
     int familyNumber = region.getTableDescriptor().getColumnFamilyCount();
     // For multiple families, lower bound is the "average flush size" by default

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -1080,7 +1080,8 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
       }
     }
 
-    LOG.info("Opened {}; next sequenceid={}", this.getRegionInfo().getShortNameToLog(), nextSeqId);
+    LOG.info("Opened {}; next sequenceid={}; {}, {}",
+      this.getRegionInfo().getShortNameToLog(), nextSeqId, this.splitPolicy, this.flushPolicy);
 
     // A region can be reopened if failed a split; reset flags
     this.closing.set(false);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/IncreasingToUpperBoundRegionSplitPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/IncreasingToUpperBoundRegionSplitPolicy.java
@@ -50,6 +50,12 @@ public class IncreasingToUpperBoundRegionSplitPolicy extends ConstantSizeRegionS
   protected long initialSize;
 
   @Override
+  public String toString() {
+    return "IncreasingToUpperBoundRegionSplitPolicy{" + "initialSize=" + initialSize +
+      ", " + super.toString() + '}';
+  }
+
+  @Override
   protected void configureForRegion(HRegion region) {
     super.configureForRegion(region);
     Configuration conf = getConf();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyPrefixRegionSplitPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyPrefixRegionSplitPolicy.java
@@ -41,6 +41,12 @@ public class KeyPrefixRegionSplitPolicy extends IncreasingToUpperBoundRegionSpli
   private int prefixLength = 0;
 
   @Override
+  public String toString() {
+    return "KeyPrefixRegionSplitPolicy{" + "prefixLength=" + prefixLength + ", " +
+      super.toString() + '}';
+  }
+
+  @Override
   protected void configureForRegion(HRegion region) {
     super.configureForRegion(region);
     prefixLength = 0;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SteppingSplitPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SteppingSplitPolicy.java
@@ -21,6 +21,11 @@ import org.apache.yetus.audience.InterfaceAudience;
 
 @InterfaceAudience.Private
 public class SteppingSplitPolicy extends IncreasingToUpperBoundRegionSplitPolicy {
+  @Override
+  public String toString() {
+    return "SteppingSplitPolicysuper{" + super.toString() + "}";
+  }
+
   /**
    * @return flushSize * 2 if there's exactly one region of the table in question
    * found on this regionserver. Otherwise max file size.
@@ -31,6 +36,4 @@ public class SteppingSplitPolicy extends IncreasingToUpperBoundRegionSplitPolicy
   protected long getSizeToCheck(final int tableRegionsCount) {
     return tableRegionsCount == 1  ? this.initialSize : getDesiredMaxFileSize();
   }
-
-
 }


### PR DESCRIPTION
…it policy vitals)

 Add a toString to all split policy implementations listing name and
 vitals. Use this toString in the Region open message. Ditto for flush
 policy for the Region.