### PR TITLE
HBASE-25594 Make easier to use graceful_stop on localhost mode

### DIFF
--- a/bin/graceful_stop.sh
+++ b/bin/graceful_stop.sh
@@ -33,7 +33,7 @@ moving regions"
   echo " maxthreads xx  Limit the number of threads used by the region mover. Default value is 1."
   echo " movetimeout xx Timeout for moving regions. If regions are not moved by the timeout value,\
 exit with error. Default value is INT_MAX."
-  echo " hostname       Hostname of server we are to stop"
+  echo " hostname       Hostname to stop; match what HBase uses; pass 'localhost' if local to avoid ssh"
   echo " e|failfast     Set -e so exit immediately if any command exits with non-zero status"
   echo " nob|nobalancer Do not manage balancer states. This is only used as optimization in \
 rolling_restart.sh to avoid multiple calls to hbase shell"
@@ -107,6 +107,10 @@ localhostname=`/bin/hostname -f`
 
 if [ "$localhostname" == "$hostname" ]; then
   local=true
+fi
+if [ "$localhostname" == "$hostname" ] || [ "$hostname" == "localhost" ]; then
+  local=true
+  hostname=$localhostname
 fi
 
 if [ "$nob" == "true"  ]; then


### PR DESCRIPTION
This is just a very minor improvement over https://github.com/apache/hbase/pull/2973 (that was actually pushed by @saintstack at https://github.com/apache/hbase/commit/59ec375d679dcbf1701a92d4206ecc676a8fb069).

However, I like the approach to use "localhost" as the argument hostname for the purpose instead of having to pass the fqdn itself, so I would like to add such option (see https://github.com/apache/hbase/pull/3048).