### PR TITLE
HBASE-25674 - RegionInfo.parseFrom(DataInputStream) sometimes fails to read the protobuf magic marker

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfo.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfo.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.util.HashKey;
 import org.apache.hadoop.hbase.util.JenkinsHash;
 import org.apache.hadoop.hbase.util.MD5Hash;
 import org.apache.hadoop.io.DataInputBuffer;
+import org.apache.hadoop.io.IOUtils;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
@@ -752,8 +753,7 @@ public interface RegionInfo extends Comparable<RegionInfo> {
     }
 
     //assumption: if Writable serialization, it should be longer than pblen.
-    int read = in.read(pbuf);
-    if (read != pblen) throw new IOException("read=" + read + ", wanted=" + pblen);
+    IOUtils.readFully(in, pbuf, 0, pblen);
     if (ProtobufUtil.isPBMagicPrefix(pbuf)) {
       return ProtobufUtil.toRegionInfo(HBaseProtos.RegionInfo.parseDelimitedFrom(in));
     } else {


### PR DESCRIPTION
The RegionInfo class uses  `DataInputStream.read(byte[lengthOfPBMagic])` to read the protobuf magic marker from the beginning of the stream.

The code in RegionInfo assumes that the passed byte buffer will be filled, but the DataInputStream class only guarantees that it will read at most lengthOfPBMagic bytes.

This sometimes causes errors stating that region info file could not be parsed.

The fix is to simply issue multiple read calls until lengthOfPBMagic bytes have been read.