### PR TITLE
HBASE-25693 NPE getting metrics from standby masters (MetricsMasterWrapperImpl.getMergePlanCount)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
@@ -55,11 +55,17 @@ public class MetricsMasterWrapperImpl implements MetricsMasterWrapper {
 
   @Override
   public long getSplitPlanCount() {
+    if (master.getRegionNormalizerManager() == null) {
+      return 0;
+    }
     return master.getRegionNormalizerManager().getSplitPlanCount();
   }
 
   @Override
   public long getMergePlanCount() {
+    if (master.getRegionNormalizerManager() == null) {
+      return 0;
+    }
     return master.getRegionNormalizerManager().getMergePlanCount();
   }
 


### PR DESCRIPTION
When a metrics source is configured in the metrics properties file for a standby master, because the master is not in the active role, getRegionNormalizerManager() returns null and some methods of MetricsMasterWrapperImpl do not properly test for this.