### PR TITLE
HBASE-25699 [branch-1] UnsupportedOperationException in DumpClusterStatusAction

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/DumpClusterStatusAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/DumpClusterStatusAction.java
@@ -63,7 +63,7 @@ public class DumpClusterStatusAction extends Action {
    */
   private static Set<Address> collectKnownRegionServers(final ClusterStatus clusterStatus) {
     final Set<Address> regionServers = new HashSet<>();
-    final Set<ServerName> serverNames = clusterStatus.getLiveServersLoad().keySet();
+    final Set<ServerName> serverNames = new HashSet<>(clusterStatus.getLiveServersLoad().keySet());
     serverNames.addAll(clusterStatus.getDeadServerNames());
 
     for (final ServerName serverName : serverNames) {


### PR DESCRIPTION
Trivial fix for

    java.lang.UnsupportedOperationException
        at java.util.Collections$UnmodifiableCollection.addAll(Collections.java:1067)
        at org.apache.hadoop.hbase.chaos.actions.DumpClusterStatusAction.collectKnownRegionServers(DumpClusterStatusAction.java:67)
        at org.apache.hadoop.hbase.chaos.actions.DumpClusterStatusAction.init(DumpClusterStatusAction.java:49)
        at org.apache.hadoop.hbase.chaos.policies.PeriodicRandomActionPolicy.init(PeriodicRandomActionPolicy.java:70)
        at org.apache.hadoop.hbase.chaos.monkies.PolicyBasedChaosMonkey.start(PolicyBasedChaosMonkey.java:127)
        at org.apache.hadoop.hbase.IntegrationTestBase.startMonkey(IntegrationTestBase.java:199)
        at org.apache.hadoop.hbase.IntegrationTestBase.setUpMonkey(IntegrationTestBase.java:189)
        at org.apache.hadoop.hbase.IntegrationTestBase.setUp(IntegrationTestBase.java:170)
        at org.apache.hadoop.hbase.IntegrationTestBase.doWork(IntegrationTestBase.java:152)
        at org.apache.hadoop.hbase.util.AbstractHBaseTool.run(AbstractHBaseTool.java:106)
        at org.apache.hadoop.util.ToolRunner.run(ToolRunner.java:76)
        at org.apache.hadoop.hbase.test.IntegrationTestBigLinkedList.main(IntegrationTestBigLinkedList.java:1990)