### PR TITLE
HBASE-25558:Adding audit log for execMasterService

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -965,6 +965,7 @@ public class MasterRpcServices extends RSRpcServices implements
       }
 
       String remoteAddress = RpcServer.getRemoteAddress().map(InetAddress::toString).orElse("");
+      User caller = RpcServer.getRequestUser().orElse(null);
       AUDITLOG.info("User {} (remote address: {}) master service request for {}.{}", caller,
         remoteAddress, serviceName, methodName);
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -963,6 +963,11 @@ public class MasterRpcServices extends RSRpcServices implements
       if (execController.getFailedOn() != null) {
         throw execController.getFailedOn();
       }
+
+      String remoteAddress = RpcServer.getRemoteAddress().map(InetAddress::toString).orElse("");
+      AUDITLOG.info("User {} (remote address: {}) master service request for {}.{}", caller,
+        remoteAddress, serviceName, methodName);
+
       return CoprocessorRpcUtils.getResponse(execResult, HConstants.EMPTY_BYTE_ARRAY);
     } catch (IOException ie) {
       throw new ServiceException(ie);


### PR DESCRIPTION
Hi:

I have found that in APIs, like execProcedure and execProcedureWithRet, have audit log to record who execute the master service. The log can be like:

LOG.info(master.getClientIdAuditPrefix() + " procedure request for: " + desc.getSignature());`

But it seems that we forget to audit execMasterService. We should add one.

old request is https://github.com/apache/hbase/pull/2937