### PR TITLE
HBASE-25743: Retry REQUESTTIMEOUT based KeeperExceptions in ZK client.

### DIFF
--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/RecoverableZooKeeper.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/RecoverableZooKeeper.java
@@ -182,9 +182,8 @@ public class RecoverableZooKeeper {
               throw e;
 
             case CONNECTIONLOSS:
-              retryOrThrow(retryCounter, e, "delete");
-              break;
             case OPERATIONTIMEOUT:
+            case REQUESTTIMEOUT:
               retryOrThrow(retryCounter, e, "delete");
               break;
 
@@ -222,9 +221,8 @@ public class RecoverableZooKeeper {
         } catch (KeeperException e) {
           switch (e.code()) {
             case CONNECTIONLOSS:
-              retryOrThrow(retryCounter, e, "exists");
-              break;
             case OPERATIONTIMEOUT:
+            case REQUESTTIMEOUT:
               retryOrThrow(retryCounter, e, "exists");
               break;
 
@@ -279,9 +277,8 @@ public class RecoverableZooKeeper {
         } catch (KeeperException e) {
           switch (e.code()) {
             case CONNECTIONLOSS:
-              retryOrThrow(retryCounter, e, "getChildren");
-              break;
             case OPERATIONTIMEOUT:
+            case REQUESTTIMEOUT:
               retryOrThrow(retryCounter, e, "getChildren");
               break;
 
@@ -328,9 +325,8 @@ public class RecoverableZooKeeper {
         } catch (KeeperException e) {
           switch (e.code()) {
             case CONNECTIONLOSS:
-              retryOrThrow(retryCounter, e, "getData");
-              break;
             case OPERATIONTIMEOUT:
+            case REQUESTTIMEOUT:
               retryOrThrow(retryCounter, e, "getData");
               break;
 
@@ -370,9 +366,8 @@ public class RecoverableZooKeeper {
         } catch (KeeperException e) {
           switch (e.code()) {
             case CONNECTIONLOSS:
-              retryOrThrow(retryCounter, e, "setData");
-              break;
             case OPERATIONTIMEOUT:
+            case REQUESTTIMEOUT:
               retryOrThrow(retryCounter, e, "setData");
               break;
             case BADVERSION:
@@ -415,9 +410,8 @@ public class RecoverableZooKeeper {
         } catch (KeeperException e) {
           switch (e.code()) {
             case CONNECTIONLOSS:
-              retryOrThrow(retryCounter, e, "getAcl");
-              break;
             case OPERATIONTIMEOUT:
+            case REQUESTTIMEOUT:
               retryOrThrow(retryCounter, e, "getAcl");
               break;
 
@@ -444,8 +438,6 @@ public class RecoverableZooKeeper {
         } catch (KeeperException e) {
           switch (e.code()) {
             case CONNECTIONLOSS:
-              retryOrThrow(retryCounter, e, "setAcl");
-              break;
             case OPERATIONTIMEOUT:
               retryOrThrow(retryCounter, e, "setAcl");
               break;
@@ -524,9 +516,8 @@ public class RecoverableZooKeeper {
             throw e;
 
           case CONNECTIONLOSS:
-            retryOrThrow(retryCounter, e, "create");
-            break;
           case OPERATIONTIMEOUT:
+          case REQUESTTIMEOUT:
             retryOrThrow(retryCounter, e, "create");
             break;
 
@@ -559,9 +550,8 @@ public class RecoverableZooKeeper {
       } catch (KeeperException e) {
         switch (e.code()) {
           case CONNECTIONLOSS:
-            retryOrThrow(retryCounter, e, "create");
-            break;
           case OPERATIONTIMEOUT:
+          case REQUESTTIMEOUT:
             retryOrThrow(retryCounter, e, "create");
             break;
 
@@ -615,9 +605,8 @@ public class RecoverableZooKeeper {
         } catch (KeeperException e) {
           switch (e.code()) {
             case CONNECTIONLOSS:
-              retryOrThrow(retryCounter, e, "multi");
-              break;
             case OPERATIONTIMEOUT:
+            case REQUESTTIMEOUT:
               retryOrThrow(retryCounter, e, "multi");
               break;
 


### PR DESCRIPTION
Starting ZOOKEEPER-2251, client requests exceeding a timeout can throw
a KeeperException with REQUESTTIMEOUT opcode set. RecoverableZookeeper
doesn't transparently retry in such cases.