### PR TITLE
HBASE-25750 Upgrade RpcControllerFactory and HBaseRpcController from Private to LimitedPrivate(COPROC,PHOENIX)

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcController.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcController.java
@@ -25,9 +25,11 @@ import java.io.IOException;
 
 import org.apache.hadoop.hbase.CellScannable;
 import org.apache.hadoop.hbase.CellScanner;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
 
 /**
  * Optionally carries Cells across the proxy/service interface down into ipc. On its way out it
@@ -37,7 +39,9 @@ import org.apache.yetus.audience.InterfaceAudience;
  * RegionInfo we're making the call against if relevant (useful adding info to exceptions and logs).
  * Used by client and server ipc'ing.
  */
-@InterfaceAudience.Private
+@InterfaceAudience.LimitedPrivate({HBaseInterfaceAudience.COPROC, HBaseInterfaceAudience.PHOENIX,
+  HBaseInterfaceAudience.REPLICATION})
+@InterfaceStability.Evolving
 public interface HBaseRpcController extends RpcController, CellScannable {
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcControllerFactory.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcControllerFactory.java
@@ -21,16 +21,19 @@ import java.util.List;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.CellScannable;
 import org.apache.hadoop.hbase.CellScanner;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.util.ReflectionUtils;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
  * Factory to create a {@link HBaseRpcController}
  */
-@InterfaceAudience.Private
+@InterfaceAudience.LimitedPrivate({HBaseInterfaceAudience.COPROC, HBaseInterfaceAudience.PHOENIX})
+@InterfaceStability.Evolving
 public class RpcControllerFactory {
   private static final Logger LOG = LoggerFactory.getLogger(RpcControllerFactory.class);
 


### PR DESCRIPTION
Apache Phoenix has had an unrecognized dependency on RpcControllerFactory and HBaseRpcController. These interfaces are used to override setPriority for appropriate dispatch of requests for Phoenix system or index tables to separate pools. This is a reasonable use of these interfaces but the audience annotations were never updated to reflect this usage. Also seems reasonable to do so as there has been no issue here for four years. (Phoenix commit was made in 2017.) 