### PR TITLE
Backport "HBASE-25744 Change default of `hbase.normalizer.merge.min_region_size.mb` to `0`" to branch-2

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
@@ -72,7 +72,7 @@ class SimpleRegionNormalizer implements RegionNormalizer, ConfigurationObserver 
   static final String MERGE_MIN_REGION_AGE_DAYS_KEY = "hbase.normalizer.merge.min_region_age.days";
   static final int DEFAULT_MERGE_MIN_REGION_AGE_DAYS = 3;
   static final String MERGE_MIN_REGION_SIZE_MB_KEY = "hbase.normalizer.merge.min_region_size.mb";
-  static final int DEFAULT_MERGE_MIN_REGION_SIZE_MB = 1;
+  static final int DEFAULT_MERGE_MIN_REGION_SIZE_MB = 0;
 
   private MasterServices masterServices;
   private NormalizerConfiguration normalizerConfiguration;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/package-info.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/package-info.java
@@ -65,7 +65,7 @@
  *     </ul>
  *     <p>
  *       To see detailed logging of the application of these configuration values, set the log
- *       level for this package to `TRACE`.
+ *       level for this package to {@code TRACE}.
  *     </p>
  *   </li>
  * </ul>


### PR DESCRIPTION
Signed-off-by: Michael Stack <stack@apache.org>
Signed-off-by: Reid Chan <reidchan@apache.org>