### PR TITLE
HBASE-25762 Improvement for some debug-logging guards

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcDuplexHandler.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcDuplexHandler.java
@@ -150,9 +150,9 @@ class NettyRpcDuplexHandler extends ChannelDuplexHandler {
       // to return a response. There is nothing we can do w/ the response at this stage. Clean
       // out the wire of the response so its out of the way and we can get other responses on
       // this connection.
-      int readSoFar = IPCUtil.getTotalSizeWhenWrittenDelimited(responseHeader);
-      int whatIsLeftToRead = totalSize - readSoFar;
       if (LOG.isDebugEnabled()) {
+        int readSoFar = IPCUtil.getTotalSizeWhenWrittenDelimited(responseHeader);
+        int whatIsLeftToRead = totalSize - readSoFar;
         LOG.debug("Unknown callId: " + id + ", skipping over this response of " + whatIsLeftToRead
             + " bytes");
       }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/ChoreService.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/ChoreService.java
@@ -403,9 +403,9 @@ public class ChoreService {
    * Prints a summary of important details about the chore. Used for debugging purposes
    */
   private void printChoreDetails(final String header, ScheduledChore chore) {
-    if (!LOG.isTraceEnabled())
+    if (!LOG.isTraceEnabled()) {
       return;
-
+    }
     LinkedHashMap<String, String> output = new LinkedHashMap<>();
     output.put(header, "");
     output.put("Chore name: ", chore.getName());
@@ -421,9 +421,9 @@ public class ChoreService {
    * Prints a summary of important details about the service. Used for debugging purposes
    */
   private void printChoreServiceDetails(final String header) {
-    if (!LOG.isTraceEnabled())
+    if (!LOG.isTraceEnabled()) {
       return;
-
+    }
     LinkedHashMap<String, String> output = new LinkedHashMap<>();
     output.put(header, "");
     output.put("ChoreService corePoolSize: ", Integer.toString(getCorePoolSize()));

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/ChoreService.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/ChoreService.java
@@ -403,6 +403,9 @@ public class ChoreService {
    * Prints a summary of important details about the chore. Used for debugging purposes
    */
   private void printChoreDetails(final String header, ScheduledChore chore) {
+    if (!LOG.isTraceEnabled())
+      return;
+
     LinkedHashMap<String, String> output = new LinkedHashMap<>();
     output.put(header, "");
     output.put("Chore name: ", chore.getName());
@@ -410,7 +413,7 @@ public class ChoreService {
     output.put("Chore timeBetweenRuns: ", Long.toString(chore.getTimeBetweenRuns()));
 
     for (Entry<String, String> entry : output.entrySet()) {
-      if (LOG.isTraceEnabled()) LOG.trace(entry.getKey() + entry.getValue());
+      LOG.trace(entry.getKey() + entry.getValue());
     }
   }
 
@@ -418,6 +421,9 @@ public class ChoreService {
    * Prints a summary of important details about the service. Used for debugging purposes
    */
   private void printChoreServiceDetails(final String header) {
+    if (!LOG.isTraceEnabled())
+      return;
+
     LinkedHashMap<String, String> output = new LinkedHashMap<>();
     output.put(header, "");
     output.put("ChoreService corePoolSize: ", Integer.toString(getCorePoolSize()));
@@ -426,7 +432,7 @@ public class ChoreService {
       Integer.toString(getNumberOfChoresMissingStartTime()));
 
     for (Entry<String, String> entry : output.entrySet()) {
-      if (LOG.isTraceEnabled()) LOG.trace(entry.getKey() + entry.getValue());
+      LOG.trace(entry.getKey() + entry.getValue());
     }
   }
 }


### PR DESCRIPTION
Some potential expensive debug-logging calls are partially guarded by `isXXXEnabled()`. Therefore,
- Moving some potential expensive statements into the adjacent `isDebugEnabled` in `NettyRpcDuplexHandler.java`
- Moving the `isTraceEnabled` up to the beginning of `printChoreDetails` and `printChoreServiceDetails` in `ChoreService.java `.