### PR TITLE
HBASE-25776 Use Class.asSubclass to fix the warning in StochasticLoadBalancer.loadCustomCostFunctions

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -249,7 +249,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     costFunctions.addAll(Arrays.stream(functionsNames).map(c -> {
       Class<? extends CostFunction> klass = null;
       try {
-        klass = (Class<? extends CostFunction>) Class.forName(c);
+        klass = Class.forName(c).asSubclass(CostFunction.class);
       } catch (ClassNotFoundException e) {
         LOG.warn("Cannot load class " + c + "': " + e.getMessage());
       }


### PR DESCRIPTION
fix [HBASE-25776](https://issues.apache.org/jira/browse/HBASE-25776)