### PR TITLE
HBASE-25809 [branch-1] TestAtomicOperation.testMultiRowMutationMultiThreads deadlock

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -8980,7 +8980,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
     // cost of some potential blocking on the object monitor that would not happen if
     // we had computeIfPresent. (The implementation of this method on branch-2 and up
     // uses computeIfPresent.)
-    synchronized (this) {
+    synchronized (regionLockHolders) {
       Thread currentThread = Thread.currentThread();
       Boolean value = regionLockHolders.get(currentThread);
       if (value != null) {
@@ -8999,7 +8999,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
     // cost of some potential blocking on the object monitor that would not happen if
     // we had computeIfPresent. (The implementation of this method on branch-2 and up
     // uses computeIfPresent.)
-    synchronized (this) {
+    synchronized (regionLockHolders) {
       Thread currentThread = Thread.currentThread();
       Boolean value = regionLockHolders.get(currentThread);
       if (value != null) {


### PR DESCRIPTION
TestAtomicOperation.testMultiRowMutationMultiThreads deadlocks.

There is an easy fix for the test that synchronizes on the CHM instead of the object. We already have a Findbugs exceptions for synchronization on the CHM and get-then-set on it is what we synchronizing for anyway.

This is only relevant for branch-1 because we have to synchronize get-then-set due to Java 7 compatibility. For branch-2 and master we use CHM#computeIfPresent. 