### PR TITLE
HBASE-25840 CatalogJanitor warns about skipping gc of regions during RIT, but does not actually skip

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
@@ -168,10 +168,6 @@ public class CatalogJanitor extends ScheduledChore {
       }
       updateAssignmentManagerMetrics();
 
-      if (isRIT(this.services.getAssignmentManager())) {
-        LOG.warn("Playing-it-safe skipping merge/split gc'ing of regions from hbase:meta while " +
-          "regions-in-transition (RIT)");
-      }
       Map<RegionInfo, Result> mergedRegions = this.lastReport.mergedRegions;
       for (Map.Entry<RegionInfo, Result> e : mergedRegions.entrySet()) {
         if (this.services.isInMaintenanceMode()) {


### PR DESCRIPTION
We claim in a WARN level log line to be 

    "Playing-it-safe skipping merge/ split gc'ing of regions from hbase:meta while regions-in-transition (RIT)" 

but do not actually skip because of a missing return. 

Playing it safe has proven unnecessary, I would say. Nonetheless here is a patch that adds the missing return, for discussion. 