### PR TITLE
HBASE-25869 WAL value compression

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/KeyValue.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/KeyValue.java
@@ -230,6 +230,11 @@ public class KeyValue implements ExtendedCell, Cloneable {
     DeleteColumn((byte)12),
     DeleteFamily((byte)14),
 
+    // Effective maximum is 127 (Byte.MAX_VALUE). We set the high order bit of the
+    // type byte in the WAL codecs to indicate, in a backwards compatible way, if the
+    // value is compressed there.
+    EffectiveMaximum((byte)Byte.MAX_VALUE),
+
     // Maximum is used when searching; you look from maximum on down.
     Maximum((byte)255);
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/KeyValue.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/KeyValue.java
@@ -76,8 +76,6 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.Private
 public class KeyValue implements ExtendedCell, Cloneable {
-  private static final ArrayList<Tag> EMPTY_ARRAY_LIST = new ArrayList<>();
-
   private static final Logger LOG = LoggerFactory.getLogger(KeyValue.class);
 
   public static final int FIXED_OVERHEAD = ClassSize.OBJECT + // the KeyValue object itself
@@ -229,11 +227,6 @@ public class KeyValue implements ExtendedCell, Cloneable {
     DeleteFamilyVersion((byte)10),
     DeleteColumn((byte)12),
     DeleteFamily((byte)14),
-
-    // Effective maximum is 127 (Byte.MAX_VALUE). We set the high order bit of the
-    // type byte in the WAL codecs to indicate, in a backwards compatible way, if the
-    // value is compressed there.
-    EffectiveMaximum((byte)Byte.MAX_VALUE),
 
     // Maximum is used when searching; you look from maximum on down.
     Maximum((byte)255);

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/BoundedDelegatingInputStream.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/BoundedDelegatingInputStream.java
@@ -96,8 +96,8 @@ public class BoundedDelegatingInputStream extends DelegatingInputStream {
 
   /**
    * Call the delegate's {@code available()} method.
-   * @return the delegate's available bytes if the current position is less than the limit,
-   * or 0 otherwise
+   * @return the delegate's available bytes if the current position is less than the
+   *   limit, or 0 otherwise.
    */
   @Override
   public int available() throws IOException {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/BoundedDelegatingInputStream.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/BoundedDelegatingInputStream.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * This is a stream that will only supply bytes from its delegate up to a certain limit.
+ * When there is an attempt to set the position beyond that it will signal that the input
+ * is finished.
+ */
+@InterfaceAudience.Private
+public class BoundedDelegatingInputStream extends DelegatingInputStream {
+
+  protected long limit;
+  protected long pos;
+
+  public BoundedDelegatingInputStream(InputStream in, long limit) {
+    super(in);
+    this.limit = limit;
+    this.pos = 0;
+  }
+
+  public void setDelegate(InputStream in, long limit) {
+    this.in = in;
+    this.limit = limit;
+    this.pos = 0;
+  }
+
+  /**
+   * Call the delegate's {@code read()} method if the current position is less than the limit.
+   * @return the byte read or -1 if the end of stream or the limit has been reached.
+   */
+  @Override
+  public int read() throws IOException {
+    if (pos >= limit) {
+      return -1;
+    }
+    int result = in.read();
+    pos++;
+    return result;
+  }
+
+  /**
+   * Call the delegate's {@code read(byte[], int, int)} method if the current position is less
+   * than the limit.
+   * @param b read buffer
+   * @param off Start offset
+   * @param len The number of bytes to read
+   * @return the number of bytes read or -1 if the end of stream or the limit has been reached.
+   */
+  @Override
+  public int read(final byte[] b, final int off, final int len) throws IOException {
+    if (pos >= limit) {
+      return -1;
+    }
+    long readLen = Math.min(len, limit - pos);
+    int read = in.read(b, off, (int)readLen);
+    if (read < 0) {
+      return -1;
+    }
+    pos += read;
+    return read;
+  }
+
+  /**
+   * Call the delegate's {@code skip(long)} method.
+   * @param len the number of bytes to skip
+   * @return the actual number of bytes skipped
+   */
+  @Override
+  public long skip(final long len) throws IOException {
+    long skipped = in.skip(Math.min(len, limit - pos));
+    pos += skipped;
+    return skipped;
+  }
+
+  /**
+   * Call the delegate's {@code available()} method.
+   * @return the delegate's available bytes if the current position is less than the limit,
+   * or 0 otherwise
+   */
+  @Override
+  public int available() throws IOException {
+    if (pos >= limit) {
+      return 0;
+    }
+    int available = in.available();
+    return (int) Math.min(available, limit - pos);
+  }
+
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/DelegatingInputStream.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/DelegatingInputStream.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/DelegatingInputStream.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/DelegatingInputStream.java
@@ -1,0 +1,99 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+
+import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
+
+/**
+ * An input stream that delegates all operations to another input stream.
+ * The delegate can be switched out for another at any time but to minimize the
+ * possibility of violating the InputStream contract it would be best to replace
+ * the delegate only once it has been fully consumed. <p> For example, a
+ * ByteArrayInputStream, which is implicitly bounded by the size of the underlying
+ * byte array can be converted into an unbounded stream fed by multiple instances
+ * of ByteArrayInputStream, switched out one for the other in sequence.
+ */
+@InterfaceAudience.Private
+@InterfaceStability.Evolving
+public class DelegatingInputStream extends InputStream {
+
+  InputStream lowerStream;
+
+  public DelegatingInputStream(InputStream lowerStream) {
+    this.lowerStream = lowerStream;
+  }
+
+  public InputStream getDelegate() {
+    return lowerStream;
+  }
+
+  public void setDelegate(InputStream lowerStream) {
+    this.lowerStream = lowerStream;
+  }
+
+  @Override
+  public int read() throws IOException {
+    return lowerStream.read();
+  }
+
+  @Override
+  public int read(byte[] b) throws IOException {
+    return lowerStream.read(b);
+  }
+
+  @Override
+  public int read(byte[] b, int off, int len) throws IOException {
+    return lowerStream.read(b, off, len);
+  }
+
+  @Override
+  public long skip(long n) throws IOException {
+    return lowerStream.skip(n);
+  }
+
+  @Override
+  public int available() throws IOException {
+    return lowerStream.available();
+  }
+
+  @Override
+  public void close() throws IOException {
+    lowerStream.close();
+  }
+
+  @Override
+  public synchronized void mark(int readlimit) {
+    lowerStream.mark(readlimit);
+  }
+
+  @Override
+  public synchronized void reset() throws IOException {
+    lowerStream.reset();
+  }
+
+  @Override
+  public boolean markSupported() {
+    return lowerStream.markSupported();
+  }
+
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/DelegatingInputStream.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/DelegatingInputStream.java
@@ -18,9 +18,8 @@
 
 package org.apache.hadoop.hbase.io;
 
-import java.io.IOException;
+import java.io.FilterInputStream;
 import java.io.InputStream;
-import java.util.concurrent.atomic.AtomicReference;
 
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -38,65 +37,18 @@ import org.apache.yetus.audience.InterfaceAudience;
  * another in a way that provides a valid view of stream contents.
  */
 @InterfaceAudience.Private
-public class DelegatingInputStream extends InputStream {
+public class DelegatingInputStream extends FilterInputStream {
 
-  final AtomicReference<InputStream> lowerStream = new AtomicReference<>();
-
-  public DelegatingInputStream(InputStream lowerStream) {
-    this.lowerStream.set(lowerStream);
+  public DelegatingInputStream(InputStream in) {
+    super(in);
   }
 
   public InputStream getDelegate() {
-    return lowerStream.get();
+    return this.in;
   }
 
-  public void setDelegate(InputStream lowerStream) {
-    this.lowerStream.set(lowerStream);
-  }
-
-  @Override
-  public int read() throws IOException {
-    return lowerStream.get().read();
-  }
-
-  @Override
-  public int read(byte[] b) throws IOException {
-    return lowerStream.get().read(b);
-  }
-
-  @Override
-  public int read(byte[] b, int off, int len) throws IOException {
-    return lowerStream.get().read(b, off, len);
-  }
-
-  @Override
-  public long skip(long n) throws IOException {
-    return lowerStream.get().skip(n);
-  }
-
-  @Override
-  public int available() throws IOException {
-    return lowerStream.get().available();
-  }
-
-  @Override
-  public void close() throws IOException {
-    lowerStream.get().close();
-  }
-
-  @Override
-  public synchronized void mark(int readlimit) {
-    lowerStream.get().mark(readlimit);
-  }
-
-  @Override
-  public synchronized void reset() throws IOException {
-    lowerStream.get().reset();
-  }
-
-  @Override
-  public boolean markSupported() {
-    return lowerStream.get().markSupported();
+  public void setDelegate(InputStream in) {
+    this.in = in;
   }
 
 }

--- a/hbase-protocol-shaded/src/main/protobuf/server/region/WAL.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/region/WAL.proto
@@ -33,7 +33,7 @@ message WALHeader {
   optional string writer_cls_name = 4;
   optional string cell_codec_cls_name = 5;
   optional bool has_value_compression = 6;
-  optional uint32 value_compression_codec = 7;
+  optional uint32 value_compression_algorithm = 7;
 }
 
 /*

--- a/hbase-protocol-shaded/src/main/protobuf/server/region/WAL.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/region/WAL.proto
@@ -32,6 +32,7 @@ message WALHeader {
   optional bool has_tag_compression = 3;
   optional string writer_cls_name = 4;
   optional string cell_codec_cls_name = 5;
+  optional bool has_value_compression = 6;
 }
 
 /*

--- a/hbase-protocol-shaded/src/main/protobuf/server/region/WAL.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/region/WAL.proto
@@ -33,6 +33,7 @@ message WALHeader {
   optional string writer_cls_name = 4;
   optional string cell_codec_cls_name = 5;
   optional bool has_value_compression = 6;
+  optional uint32 value_compression_codec = 7;
 }
 
 /*

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
@@ -150,9 +150,10 @@ public abstract class AbstractProtobufLogWriter {
         final boolean useValueCompression =
           conf.getBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, false);
         final Compression.Algorithm valueCompressionType =
-          CompressionContext.getValueCompressionAlgorithm(conf);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Initializing compression context for {}: isRecoveredEdits={}" +
+          useValueCompression ? CompressionContext.getValueCompressionAlgorithm(conf) :
+            Compression.Algorithm.NONE;
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Initializing compression context for {}: isRecoveredEdits={}" +
             ", hasTagCompression={}, hasValueCompression={}, valueCompressionType={}", path,
             CommonFSUtils.isRecoveredEdits(path), useTagCompression, useValueCompression,
             valueCompressionType);
@@ -187,7 +188,7 @@ public abstract class AbstractProtobufLogWriter {
       .setHasTagCompression(doTagCompress)
       .setHasValueCompression(doValueCompress);
     if (doValueCompress) {
-      headerBuilder.setValueCompressionCodec(
+      headerBuilder.setValueCompressionAlgorithm(
         CompressionContext.getValueCompressionAlgorithm(conf).ordinal());
     }
     length.set(writeMagicAndWALHeader(ProtobufLogReader.PB_WAL_MAGIC,
@@ -197,8 +198,10 @@ public abstract class AbstractProtobufLogWriter {
 
     // instantiate trailer to default value.
     trailer = WALTrailer.newBuilder().build();
+
     if (LOG.isTraceEnabled()) {
-      LOG.trace("Initialized protobuf WAL=" + path + ", compression=" + doCompress);
+      LOG.trace("Initialized protobuf WAL={}, compression={}, tagCompression={}" +
+        ", valueCompression={}", path, doCompress, doTagCompress, doValueCompress);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
@@ -146,7 +146,8 @@ public abstract class AbstractProtobufLogWriter {
       try {
         this.compressionContext =
           new CompressionContext(LRUDictionary.class, CommonFSUtils.isRecoveredEdits(path),
-            conf.getBoolean(CompressionContext.ENABLE_WAL_TAGS_COMPRESSION, true));
+            conf.getBoolean(CompressionContext.ENABLE_WAL_TAGS_COMPRESSION, true),
+            conf.getBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, false));
       } catch (Exception e) {
         throw new IOException("Failed to initiate CompressionContext", e);
       }
@@ -167,8 +168,13 @@ public abstract class AbstractProtobufLogWriter {
 
     boolean doTagCompress = doCompress
         && conf.getBoolean(CompressionContext.ENABLE_WAL_TAGS_COMPRESSION, true);
-    length.set(writeMagicAndWALHeader(ProtobufLogReader.PB_WAL_MAGIC, buildWALHeader(conf,
-      WALHeader.newBuilder().setHasCompression(doCompress).setHasTagCompression(doTagCompress))));
+    boolean doValueCompress = doCompress
+        && conf.getBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, false);
+    length.set(writeMagicAndWALHeader(ProtobufLogReader.PB_WAL_MAGIC,
+      buildWALHeader(conf, WALHeader.newBuilder()
+        .setHasCompression(doCompress)
+        .setHasTagCompression(doTagCompress)
+        .setHasValueCompression(doValueCompress))));
 
     initAfterHeader(doCompress);
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/CompressionContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/CompressionContext.java
@@ -50,8 +50,8 @@ public class CompressionContext {
    * Encapsulates the zlib deflater/inflater pair we will use for value compression in this WAL.
    */
   static class ValueCompressor {
-    final int DEFAULT_DEFLATE_BUFFER_SIZE = 8*1024;
-    final int MAX_DEFLATE_BUFFER_SIZE = 256*1024;
+    final static int DEFAULT_DEFLATE_BUFFER_SIZE = 8*1024;
+    final static int MAX_DEFLATE_BUFFER_SIZE = 256*1024;
 
     final Deflater deflater;
     final Inflater inflater;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/CompressionContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/CompressionContext.java
@@ -65,7 +65,7 @@ public class CompressionContext {
    * compression in this WAL.
    */
   static class ValueCompressor {
-  
+
     static final int IO_BUFFER_SIZE = 4096;
 
     private final Compression.Algorithm algorithm;
@@ -101,7 +101,7 @@ public class CompressionContext {
         int outLength) throws IOException {
 
       // Our input is a sequence of bounded byte ranges (call them segments), with
-      // BoundedDelegatingInputStream providing a way to switch in a new segment when the 
+      // BoundedDelegatingInputStream providing a way to switch in a new segment when the
       // previous segment has been fully consumed.
 
       // Create the input streams here the first time around.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/CompressionContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/CompressionContext.java
@@ -93,7 +93,7 @@ public class CompressionContext {
       return lowerOut.toByteArray();
     }
 
-    public void decompress(InputStream in, int inLength, byte[] outArray, int outOffset,
+    public int decompress(InputStream in, int inLength, byte[] outArray, int outOffset,
         int outLength) throws IOException {
       // Read all of the compressed bytes into a buffer.
       byte[] inBuffer = new byte[inLength];
@@ -106,7 +106,7 @@ public class CompressionContext {
       } else {
         lowerIn.setDelegate(new ByteArrayInputStream(inBuffer));
       }
-      compressedIn.read(outArray, outOffset, outLength);
+      return compressedIn.read(outArray, outOffset, outLength);
     }
 
     public void clear() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogReader.java
@@ -81,6 +81,7 @@ public class ProtobufLogReader extends ReaderBase {
   protected WALCellCodec.ByteStringUncompressor byteStringUncompressor;
   protected boolean hasCompression = false;
   protected boolean hasTagCompression = false;
+  protected boolean hasValueCompression = false;
   // walEditsStopOffset is the position of the last byte to read. After reading the last WALEdit
   // entry in the wal, the inputstream's position is equal to walEditsStopOffset.
   private long walEditsStopOffset;
@@ -227,6 +228,7 @@ public class ProtobufLogReader extends ReaderBase {
       WALProtos.WALHeader header = builder.build();
       this.hasCompression = header.hasHasCompression() && header.getHasCompression();
       this.hasTagCompression = header.hasHasTagCompression() && header.getHasTagCompression();
+      this.hasValueCompression = header.hasHasValueCompression() && header.getHasValueCompression();
     }
     this.inputStream = stream;
     this.walEditsStopOffset = this.fileLength;
@@ -325,6 +327,11 @@ public class ProtobufLogReader extends ReaderBase {
   @Override
   protected boolean hasTagCompression() {
     return this.hasTagCompression;
+  }
+
+  @Override
+  protected boolean hasValueCompression() {
+    return this.hasValueCompression;
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogReader.java
@@ -230,11 +230,12 @@ public class ProtobufLogReader extends ReaderBase {
       WALProtos.WALHeader header = builder.build();
       this.hasCompression = header.hasHasCompression() && header.getHasCompression();
       this.hasTagCompression = header.hasHasTagCompression() && header.getHasTagCompression();
-      this.hasValueCompression = header.hasHasValueCompression() && header.getHasValueCompression();
-      if (header.hasValueCompressionCodec()) {
+      this.hasValueCompression = header.hasHasValueCompression() &&
+        header.getHasValueCompression();
+      if (header.hasValueCompressionAlgorithm()) {
         try {
           this.valueCompressionType =
-            Compression.Algorithm.values()[header.getValueCompressionCodec()];
+            Compression.Algorithm.values()[header.getValueCompressionAlgorithm()];
         } catch (ArrayIndexOutOfBoundsException e) {
           throw new IOException("Invalid compression type", e);
         }
@@ -247,7 +248,9 @@ public class ProtobufLogReader extends ReaderBase {
     this.seekOnFs(currentPosition);
     if (LOG.isTraceEnabled()) {
       LOG.trace("After reading the trailer: walEditsStopOffset: " + this.walEditsStopOffset
-          + ", fileLength: " + this.fileLength + ", " + "trailerPresent: " + (trailerPresent ? "true, size: " + trailer.getSerializedSize() : "false") + ", currentPosition: " + currentPosition);
+          + ", fileLength: " + this.fileLength + ", " + "trailerPresent: " +
+          (trailerPresent ? "true, size: " + trailer.getSerializedSize() : "false") +
+          ", currentPosition: " + currentPosition);
     }
     
     codecClsName = hdrCtxt.getCellCodecClsName();
@@ -345,7 +348,7 @@ public class ProtobufLogReader extends ReaderBase {
   }
 
   @Override
-  protected Compression.Algorithm getValueCompressionType() {
+  protected Compression.Algorithm getValueCompressionAlgorithm() {
     return this.valueCompressionType;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ReaderBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ReaderBase.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.util.LRUDictionary;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
@@ -68,8 +69,15 @@ public abstract class ReaderBase implements AbstractFSWALProvider.Reader {
       // If compression is enabled, new dictionaries are created here.
       try {
         if (compressionContext == null) {
+          if (LOG.isDebugEnabled()) {
+            LOG.debug("Initializing compression context for {}: isRecoveredEdits={}" +
+              ", hasTagCompression={}, hasValueCompression={}, valueCompressionType={}", path,
+              CommonFSUtils.isRecoveredEdits(path), hasTagCompression(), hasValueCompression(),
+              getValueCompressionType());
+          }
           compressionContext = new CompressionContext(LRUDictionary.class,
-            CommonFSUtils.isRecoveredEdits(path), hasTagCompression(), hasValueCompression());
+            CommonFSUtils.isRecoveredEdits(path), hasTagCompression(),
+            hasValueCompression(), getValueCompressionType());
         } else {
           compressionContext.clear();
         }
@@ -155,6 +163,11 @@ public abstract class ReaderBase implements AbstractFSWALProvider.Reader {
    * @return Whether value compression is enabled for this log.
    */
   protected abstract boolean hasValueCompression();
+
+  /**
+   * @return Value compression algorithm for this log.
+   */
+  protected abstract Compression.Algorithm getValueCompressionType();
 
   /**
    * Read next entry.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ReaderBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ReaderBase.java
@@ -69,7 +69,7 @@ public abstract class ReaderBase implements AbstractFSWALProvider.Reader {
       try {
         if (compressionContext == null) {
           compressionContext = new CompressionContext(LRUDictionary.class,
-            CommonFSUtils.isRecoveredEdits(path), hasTagCompression());
+            CommonFSUtils.isRecoveredEdits(path), hasTagCompression(), hasValueCompression());
         } else {
           compressionContext.clear();
         }
@@ -150,6 +150,11 @@ public abstract class ReaderBase implements AbstractFSWALProvider.Reader {
    * @return Whether tag compression is enabled for this log.
    */
   protected abstract boolean hasTagCompression();
+
+  /**
+   * @return Whether value compression is enabled for this log.
+   */
+  protected abstract boolean hasValueCompression();
 
   /**
    * Read next entry.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ReaderBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ReaderBase.java
@@ -73,11 +73,11 @@ public abstract class ReaderBase implements AbstractFSWALProvider.Reader {
             LOG.debug("Initializing compression context for {}: isRecoveredEdits={}" +
               ", hasTagCompression={}, hasValueCompression={}, valueCompressionType={}", path,
               CommonFSUtils.isRecoveredEdits(path), hasTagCompression(), hasValueCompression(),
-              getValueCompressionType());
+              getValueCompressionAlgorithm());
           }
           compressionContext = new CompressionContext(LRUDictionary.class,
             CommonFSUtils.isRecoveredEdits(path), hasTagCompression(),
-            hasValueCompression(), getValueCompressionType());
+            hasValueCompression(), getValueCompressionAlgorithm());
         } else {
           compressionContext.clear();
         }
@@ -167,7 +167,7 @@ public abstract class ReaderBase implements AbstractFSWALProvider.Reader {
   /**
    * @return Value compression algorithm for this log.
    */
-  protected abstract Compression.Algorithm getValueCompressionType();
+  protected abstract Compression.Algorithm getValueCompressionAlgorithm();
 
   /**
    * Read next entry.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/WALCellCodec.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/WALCellCodec.java
@@ -381,7 +381,11 @@ public class WALCellCodec implements Codec {
     private void readCompressedValue(InputStream in, byte[] outArray, int outOffset,
         int expectedLength) throws IOException {
       int compressedLen = StreamUtils.readRawVarint32(in);
-      compression.getValueCompressor().decompress(in, compressedLen, outArray, outOffset, expectedLength);
+      int read = compression.getValueCompressor().decompress(in, compressedLen, outArray,
+        outOffset, expectedLength);
+      if (read != expectedLength) {
+        throw new IOException("ValueCompressor state error: short read");
+      }
     }
 
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/WALCellCodec.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/WALCellCodec.java
@@ -21,9 +21,6 @@ import java.io.ByteArrayOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
-import java.util.zip.DataFormatException;
-import java.util.zip.Deflater;
-import java.util.zip.Inflater;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
@@ -42,7 +39,6 @@ import org.apache.hadoop.hbase.io.ByteBufferWriterOutputStream;
 import org.apache.hadoop.hbase.io.util.Dictionary;
 import org.apache.hadoop.hbase.io.util.StreamUtils;
 import org.apache.hadoop.hbase.nio.ByteBuff;
-import org.apache.hadoop.hbase.regionserver.wal.CompressionContext.ValueCompressor;
 import org.apache.hadoop.hbase.util.ByteBufferUtils;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.ReflectionUtils;
@@ -253,9 +249,7 @@ public class WALCellCodec implements Codec {
       StreamUtils.writeLong(out, cell.getTimestamp());
       out.write(cell.getTypeByte());
       if (hasValueCompression) {
-        byte[] compressedBytes = compressValue(cell);
-        StreamUtils.writeRawVInt32(out, compressedBytes.length);
-        out.write(compressedBytes);
+        writeCompressedValue(out, cell);
       } else {
         PrivateCellUtil.writeValue(out, cell, cell.getValueLength());
       }
@@ -271,52 +265,11 @@ public class WALCellCodec implements Codec {
       }
     }
 
-    private byte[] compressValue(Cell cell) throws IOException {
-      ValueCompressor valueCompressor = compression.getValueCompressor();
-      Deflater deflater = valueCompressor.getDeflater();
-      deflater.setInput(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength());
-      ByteArrayOutputStream baos = new ByteArrayOutputStream();
-      // Deflater#deflate will return 0 only if more input is required. We iterate until
-      // that condition is met, sending the content of 'buffer' to the output stream at
-      // each step, until deflate returns 0. Then the compressor must be flushed in order
-      // for all of the value's output to be written into the corresponding edit. (Otherwise
-      // the compressor would carry over some of the output for this value into the output
-      // of the next.) To flush the compressor we call deflate again using the method option
-      // that allows us to specify the SYNC_FLUSH flag. The sync output will be placed into
-      // the buffer. When flushing we iterate until there is no more output. Then the flush
-      // is complete and the compressor is ready for more input.
-      int bytesOut;
-      do {
-        bytesOut = deflater.deflate(valueCompressor.getDeflateBuffer());
-        if (bytesOut > 0) {
-          baos.write(valueCompressor.getDeflateBuffer(), 0, bytesOut);
-        }
-      } while (bytesOut > 0);
-      // Done compressing value, now flush until deflater buffers are empty.
-      // If we don't have enough space in the buffer to fully flush, the buffer must be
-      // resized.
-      boolean finished = false;
-      do {
-        bytesOut = deflater.deflate(valueCompressor.getDeflateBuffer(), 0,
-          valueCompressor.getDeflateBufferSize(), Deflater.SYNC_FLUSH);
-        if (bytesOut == 0) {
-          throw new IOException("Deflater state error: SYNC_FLUSH did not flush");
-        }
-        if (bytesOut == valueCompressor.getDeflateBufferSize()) {
-          // Resize the output buffer.
-          // If we eventually ask for a buffer size that is too large, setDeflateBufferSize
-          // will throw an IllegalArgumentException.
-          try {
-            valueCompressor.setDeflateBufferSize(valueCompressor.getDeflateBufferSize() * 2);
-          } catch (IllegalArgumentException e) {
-            throw new IOException("Deflater state error: exceeded max deflate buffer size", e);
-          }
-        } else {
-          baos.write(valueCompressor.getDeflateBuffer(), 0, bytesOut);
-          finished = true;
-        }
-      } while (!finished);
-      return baos.toByteArray();
+    private void writeCompressedValue(OutputStream out, Cell cell) throws IOException {
+      byte[] compressed = compression.getValueCompressor().compress(cell.getValueArray(),
+        cell.getValueOffset(), cell.getValueLength());
+      StreamUtils.writeRawVInt32(out, compressed.length);
+      out.write(compressed);
     }
 
   }
@@ -376,8 +329,7 @@ public class WALCellCodec implements Codec {
       if (tagsLength > 0) {
         typeValLen = typeValLen - tagsLength - KeyValue.TAGS_LENGTH_SIZE;
       }
-      byte type = (byte)in.read();
-      pos = Bytes.putByte(backingArray, pos, type);
+      pos = Bytes.putByte(backingArray, pos, (byte)in.read());
       int valLen = typeValLen - 1;
       if (hasValueCompression) {
         readCompressedValue(in, backingArray, pos, valLen);
@@ -428,37 +380,8 @@ public class WALCellCodec implements Codec {
 
     private void readCompressedValue(InputStream in, byte[] outArray, int outOffset,
         int expectedLength) throws IOException {
-      // Read the size of the compressed value. We serialized it as a vint32.
-      int compressedLength = StreamUtils.readRawVarint32(in);
-      // Read all of the compressed value into a buffer for the Inflater.
-      byte[] buffer = new byte[compressedLength];
-      IOUtils.readFully(in, buffer, 0, compressedLength);
-      // Inflate the compressed value. We know the uncompressed size. Inflator#inflate will
-      // return nonzero for as long as some compressed input remains, and 0 when done.
-      Inflater inflater = compression.getValueCompressor().getInflater();
-      inflater.setInput(buffer);
-      int remaining = expectedLength;
-      boolean finished = false;
-      do {
-        try {
-          int inflatedBytes = inflater.inflate(outArray, outOffset, remaining);
-          if (inflatedBytes == 0) {
-            finished = true;
-          }
-          outOffset += inflatedBytes;
-          remaining -= inflatedBytes;
-          if (remaining == 0) {
-            finished = true;
-          } else if (remaining < 0) {
-            throw new IOException("Inflater state error: 'remaining' went negative");
-          }
-        } catch (DataFormatException e) {
-          throw new IOException(e);
-        }
-      } while (!finished);
-      if (remaining > 0) {
-        throw new IOException("Inflater state error: inflator finished early");
-      }
+      int compressedLen = StreamUtils.readRawVarint32(in);
+      compression.getValueCompressor().decompress(in, compressedLen, outArray, outOffset, expectedLength);
     }
 
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestAsyncWALReplayValueCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestAsyncWALReplayValueCompression.java
@@ -15,30 +15,29 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hbase.wal;
+package org.apache.hadoop.hbase.regionserver.wal;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.regionserver.wal.CompressionContext;
-import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.experimental.categories.Category;
 
-@Category({RegionServerTests.class, LargeTests.class})
-public class TestWALSplitValueCompression extends TestWALSplit {
+@Category({ RegionServerTests.class, MediumTests.class })
+public class TestAsyncWALReplayValueCompression extends TestAsyncWALReplay {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-      HBaseClassTestRule.forClass(TestWALSplitValueCompression.class);
+      HBaseClassTestRule.forClass(TestAsyncWALReplayValueCompression.class);
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    TEST_UTIL.getConfiguration()
-      .setBoolean(HConstants.ENABLE_WAL_COMPRESSION, true);
-    TEST_UTIL.getConfiguration()
-      .setBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, true);
-    TestWALSplit.setUpBeforeClass();
+    Configuration conf = AbstractTestWALReplay.TEST_UTIL.getConfiguration();
+    conf.setBoolean(HConstants.ENABLE_WAL_COMPRESSION, true);
+    conf.setBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, true);
+    TestAsyncWALReplay.setUpBeforeClass();
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALCellCodecWithCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALCellCodecWithCompression.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hbase.PrivateCellUtil;
 import org.apache.hadoop.hbase.Tag;
 import org.apache.hadoop.hbase.codec.Codec.Decoder;
 import org.apache.hadoop.hbase.codec.Codec.Encoder;
+import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.util.LRUDictionary;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
@@ -54,22 +55,22 @@ public class TestWALCellCodecWithCompression {
 
   @Test
   public void testEncodeDecodeKVsWithTags() throws Exception {
-    doTest(false, false, false);
+    doTest(false, false);
   }
 
   @Test
   public void testEncodeDecodeKVsWithTagsWithTagsCompression() throws Exception {
-    doTest(true, false, false);
+    doTest(true, false);
   }
 
   @Test
   public void testEncodeDecodeOffKVsWithTagsWithTagsCompression() throws Exception {
-    doTest(true, false, true);
+    doTest(true, false);
   }
 
   @Test
   public void testValueCompressionEnabled() throws Exception {
-    doTest(false, true, false);
+    doTest(false, true);
   }
 
   @Test
@@ -92,7 +93,7 @@ public class TestWALCellCodecWithCompression {
 
     Configuration conf = new Configuration(false);
     WALCellCodec codec = new WALCellCodec(conf, new CompressionContext(LRUDictionary.class,
-      false, true, true));
+      false, true, true, Compression.Algorithm.GZ));
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     Encoder encoder = codec.getEncoder(bos);
     encoder.write(createKV(row_1, value_1, 0));
@@ -148,15 +149,14 @@ public class TestWALCellCodecWithCompression {
     }
   }
 
-  private void doTest(boolean compressTags, boolean compressValue, boolean offheapKV)
+  private void doTest(boolean compressTags, boolean offheapKV)
       throws Exception {
     final byte[] key = Bytes.toBytes("myRow");
     final byte[] value = Bytes.toBytes("myValue");
     Configuration conf = new Configuration(false);
     conf.setBoolean(CompressionContext.ENABLE_WAL_TAGS_COMPRESSION, compressTags);
-    conf.setBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, compressValue);
     WALCellCodec codec = new WALCellCodec(conf, new CompressionContext(LRUDictionary.class,
-      false, compressTags, compressValue));
+      false, compressTags));
     ByteArrayOutputStream bos = new ByteArrayOutputStream(1024);
     Encoder encoder = codec.getEncoder(bos);
     if (offheapKV) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALCellCodecWithCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALCellCodecWithCompression.java
@@ -148,34 +148,6 @@ public class TestWALCellCodecWithCompression {
     }
   }
 
-  @Test
-  public void testValueCompressionCompatibility() throws Exception {
-    final byte[] key = Bytes.toBytes("myRow");
-    final byte[] value = Bytes.toBytes("myValue");
-    Configuration conf = new Configuration(false);
-    WALCellCodec outCodec = new WALCellCodec(conf, new CompressionContext(LRUDictionary.class,
-      false, false, false));
-    ByteArrayOutputStream bos = new ByteArrayOutputStream();
-    Encoder encoder = outCodec.getEncoder(bos);
-    for (int i = 0; i < 10; i++) {
-      encoder.write(createOffheapKV(key, value, 0));
-    }
-    encoder.flush();
-    WALCellCodec inCodec = new WALCellCodec(conf, new CompressionContext(LRUDictionary.class,
-      false, false, true));
-    try (InputStream is = new ByteArrayInputStream(bos.toByteArray())) {
-      Decoder decoder = inCodec.getDecoder(is);
-      for (int i = 0 ; i < 10; i++) {
-        decoder.advance();
-        KeyValue kv = (KeyValue) decoder.current();
-        assertTrue(Bytes.equals(key, 0, key.length,
-          kv.getRowArray(), kv.getRowOffset(), kv.getRowLength()));
-        assertTrue(Bytes.equals(value, 0, value.length,
-          kv.getValueArray(), kv.getValueOffset(), kv.getValueLength()));
-      }
-    }
-  }
-
   private void doTest(boolean compressTags, boolean compressValue, boolean offheapKV)
       throws Exception {
     final byte[] key = Bytes.toBytes("myRow");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALCellCodecWithCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALCellCodecWithCompression.java
@@ -75,19 +75,19 @@ public class TestWALCellCodecWithCompression {
   @Test
   public void testValueCompression() throws Exception {
     final byte[] row_1 = Bytes.toBytes("row_1");
-    final byte[] value_1 = new byte[WALCellCodec.VALUE_COMPRESS_THRESHOLD];
+    final byte[] value_1 = new byte[20];
     Bytes.zero(value_1);
     final byte[] row_2 = Bytes.toBytes("row_2");
     final byte[] value_2 = new byte[Bytes.SIZEOF_LONG];
     Bytes.random(value_2);
     final byte[] row_3 = Bytes.toBytes("row_3");
-    final byte[] value_3 = new byte[WALCellCodec.VALUE_COMPRESS_THRESHOLD];
+    final byte[] value_3 = new byte[100];
     Bytes.random(value_3);
     final byte[] row_4 = Bytes.toBytes("row_4");
-    final byte[] value_4 = new byte[WALCellCodec.VALUE_COMPRESS_THRESHOLD * 4];
+    final byte[] value_4 = new byte[128];
     fillBytes(value_4, Bytes.toBytes("DEADBEEF"));
     final byte[] row_5 = Bytes.toBytes("row_5");
-    final byte[] value_5 = new byte[WALCellCodec.VALUE_COMPRESS_THRESHOLD * 2];
+    final byte[] value_5 = new byte[64];
     fillBytes(value_5, Bytes.toBytes("CAFEBABE"));
 
     Configuration conf = new Configuration(false);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALCellCodecWithCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALCellCodecWithCompression.java
@@ -96,9 +96,9 @@ public class TestWALCellCodecWithCompression {
     ByteArrayOutputStream bos = new ByteArrayOutputStream();
     Encoder encoder = codec.getEncoder(bos);
     encoder.write(createKV(row_1, value_1, 0));
-    encoder.write(createKV(row_2, value_2, 0));
+    encoder.write(createOffheapKV(row_2, value_2, 0));
     encoder.write(createKV(row_3, value_3, 0));
-    encoder.write(createKV(row_4, value_4, 0));
+    encoder.write(createOffheapKV(row_4, value_4, 0));
     encoder.write(createKV(row_5, value_5, 0));
     encoder.flush();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALReplayValueCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestWALReplayValueCompression.java
@@ -1,0 +1,46 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver.wal;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Enables compression and runs the TestWALReplay tests.
+ */
+@Category({ RegionServerTests.class, LargeTests.class })
+public class TestWALReplayValueCompression extends TestWALReplay {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestWALReplayValueCompression.class);
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    Configuration conf = AbstractTestWALReplay.TEST_UTIL.getConfiguration();
+    conf.setBoolean(HConstants.ENABLE_WAL_COMPRESSION, true);
+    conf.setBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, true);
+    TestWALReplay.setUpBeforeClass();
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestCompressedWAL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestCompressedWAL.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.wal;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.NavigableMap;
+import java.util.TreeMap;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.regionserver.MultiVersionConcurrencyControl;
+import org.apache.hadoop.hbase.regionserver.wal.CompressionContext;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameter;
+import org.junit.runners.Parameterized.Parameters;
+
+@RunWith(Parameterized.class)
+@Category({ RegionServerTests.class, MediumTests.class })
+public class TestCompressedWAL {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestCompressedWAL.class);
+
+  static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  @Rule
+  public TestName name = new TestName();
+
+  @Parameter
+  public String walProvider;
+
+  @Parameters(name = "{index}: provider={0}")
+  public static Iterable<Object[]> data() {
+    return Arrays.asList(new Object[] { "defaultProvider" }, new Object[] { "asyncfs" });
+  }
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    CommonFSUtils.setRootDir(conf, TEST_UTIL.getDataTestDirOnTestFS());
+    TEST_UTIL.startMiniDFSCluster(3);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Before
+  public void setUp() {
+    TEST_UTIL.getConfiguration().set(WALFactory.WAL_PROVIDER, walProvider);
+    TEST_UTIL.getConfiguration()
+      .setBoolean(HConstants.ENABLE_WAL_COMPRESSION, true);
+  }
+
+  @Test
+  public void testCompressedWAL() throws Exception {
+    TEST_UTIL.getConfiguration()
+      .setBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, false);
+    doTest();
+  }
+
+  @Test
+  public void testCompressedWALWithValueCompression() throws Exception {
+    TEST_UTIL.getConfiguration()
+      .setBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, true);
+    doTest();
+  }
+
+  private void doTest() throws Exception {
+    TableName tableName = TableName.valueOf(name.getMethodName().replaceAll("[^a-zA-Z0-9]", "_"));
+    NavigableMap<byte[], Integer> scopes = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+    scopes.put(tableName.getName(), 0);
+    RegionInfo regionInfo = RegionInfoBuilder.newBuilder(tableName).build();
+    final int total = 1000;
+    final byte[] row = Bytes.toBytes("row");
+    final byte[] family = Bytes.toBytes("family");
+    final byte[] value = Bytes.toBytes("Test value");
+    FileSystem fs = TEST_UTIL.getDFSCluster().getFileSystem();
+    final WALFactory wals =
+      new WALFactory(TEST_UTIL.getConfiguration(), tableName.getNameAsString());
+
+    // Write the WAL
+    final WAL wal = wals.getWAL(regionInfo);
+
+    MultiVersionConcurrencyControl mvcc = new MultiVersionConcurrencyControl();
+
+    for (int i = 0; i < total; i++) {
+      WALEdit kvs = new WALEdit();
+      kvs.add(new KeyValue(row, family, Bytes.toBytes(i), value));
+      wal.appendData(regionInfo, new WALKeyImpl(regionInfo.getEncodedNameAsBytes(), tableName,
+        System.currentTimeMillis(), mvcc, scopes), kvs);
+    }
+    wal.sync();
+    final Path walPath = AbstractFSWALProvider.getCurrentFileName(wal);
+    wals.shutdown();
+
+    // Confirm the WAL can be read back
+    WAL.Reader reader = wals.createReader(TEST_UTIL.getTestFileSystem(), walPath);
+    int count = 0;
+    WAL.Entry entry = new WAL.Entry();
+    while (reader.next(entry) != null) {
+      count++;
+      List<Cell> cells = entry.getEdit().getCells();
+      assertTrue("Should be one KV per WALEdit", cells.size() == 1);
+      for (Cell cell: cells) {
+        assertTrue("Incorrect row", Bytes.equals(cell.getRowArray(), cell.getRowOffset(),
+          cell.getRowLength(), row, 0, row.length));
+        assertTrue("Incorrect family", Bytes.equals(cell.getFamilyArray(), cell.getFamilyOffset(),
+          cell.getFamilyLength(), family, 0, family.length));
+        assertTrue("Incorrect value", Bytes.equals(cell.getValueArray(), cell.getValueOffset(),
+          cell.getValueLength(), value, 0, value.length));
+      }
+    }
+    assertEquals("Should have read back as many KVs as written", total, count);
+    reader.close();
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALSplitValueCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALSplitValueCompression.java
@@ -1,0 +1,44 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.wal;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.regionserver.wal.CompressionContext;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.experimental.categories.Category;
+
+@Category({RegionServerTests.class, LargeTests.class})
+public class TestWALSplitValueCompression extends TestWALSplit {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestWALSplitValueCompression.class);
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    TestWALSplit.setUpBeforeClass();
+    TEST_UTIL.getConfiguration()
+      .setBoolean(HConstants.ENABLE_WAL_COMPRESSION, true);
+    TEST_UTIL.getConfiguration()
+      .setBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, true);
+  }
+}


### PR DESCRIPTION
WAL storage can be expensive, especially if the cell values represented in the edits are large, consisting of blobs or significant lengths of text. Such WALs might need to be kept around for a fairly long time to satisfy replication constraints on a space limited (or space-contended) filesystem.

We have a custom dictionary compression scheme for cell metadata that is engaged when WAL compression is enabled in site configuration. This is fine for that application, where we can expect the universe of values and their lengths in the custom dictionaries to be constrained. For arbitrary cell values it is better to use one of the available compression codecs, which are suitable for arbitrary albeit compressible data.

**Microbrenchmark Results**

Site configuration used:

    <!-- retain all WALs  -->
    <property>
      <name>hbase.master.logcleaner.ttl</name>
      <value>604800000</value>
    </property>
    <!-- enable compression -->
    <property>
     <name>hbase.regionserver.wal.enablecompression</name>
     <value>true</value>
    </property>
    <!-- enable value compression -->
    <property>
     <name>hbase.regionserver.wal.value.enablecompression</name>
     <value>true</value>
    </property>
    <!-- set value compression algorithm —>
    <property>
     <name>hbase.regionserver.wal.value.compression.type</name>
     <value>snappy</value>
    </property>

Loader: IntegrationTestLoadCommonCrawl

Input: s3n://commoncrawl/crawl-data/CC-MAIN-2021-10/segments/1614178347293.1/warc/CC-MAIN-20210224165708-20210224195708-00000.warc.gz

SNAPPY or ZSTD at level 1 are recommended, all other options provided for comparison. 

Microbenchmarks are collected with [this change](https://gist.github.com/apurtell/596310d08b5ad75cd9677466d36360e4).
Statistics are collected over the lifetime of the regionserver and are dumped at end of test at shutdown. Statistics are updated under synchronization but this is done in a way that excludes that overhead from measurement. The normal patch does not contain either the instrumentation or the synchronization point. Nanoseconds are converted to milliseconds for the table.

Mode | WALs aggregate size | WALs aggregate size difference | WAL writer append time (ms avg)
-- | -- | -- | --
Default | 5,117,369,553 | - | 0.290 (stdev 0.328)
Compression enabled, value compression not enabled | 5,002,683,600 | (2.241%) | 0.372 (stddev 0.336)
~~Compression enabled, value compression enabled, v1 patch, Deflate (best speed)~~  | ~~1,209,947,515~~  | ~~(76.4%)~~  | ~~12.694 (stddev 8.48)~~ 
Compression enabled, value compression enabled, v2 patch, algorithm=SNAPPY | 1,616,387,702 | (68.4%) | 0.027 (stddev 0.204) 
Compression enabled, value compression enabled, v2 patch, algorithm=ZSTD (best speed) | 1,149,008,133 | (77.55%) | 0.043 (stddev 0.195)
Compression enabled, value compression enabled, v2 patch, algorithm=ZSTD (default) | 1,089,241,811 | (78.7%) | 0.056 (stdev 0.310)
Compression enabled, value compression enabled, v2 patch, algorithm=ZSTD (best compression) | 941,452,655 | (81.2%) | 0.231 (stddev 1.11)
_Options below not recommended._ | - | - | -
Compression enabled, value compression enabled, v2 patch, algorithm=GZ | 1,082,414,015 | (78.9%) | 0.267 (stddev 1.325)
Compression enabled, value compression enabled, v2 patch, algorithm=LZMA (level 1) | 1,013,951,637 | (80.2%) | 2.157 (stddev 3.302)
Compression enabled, value compression enabled, v2 patch, algorithm=LZMA (default) | 940,884,618 | (81.7%) | 4.739 (stdev 8.609)

