### PR TITLE
HBASE-25880 remove files from filesCompacting when clear compaction queue

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -1953,6 +1953,22 @@ public class HStore implements Store, HeapSize, StoreConfigInformation,
     Collections.sort(filesCompacting, storeEngine.getStoreFileManager().getStoreFileComparator());
   }
 
+  /**
+   * Remove the files from compacting files. This usually happens when we clear compaction queues.
+   */
+  public void removeFromCompactingFiles(Collection<HStoreFile> filesToRemove) {
+    synchronized (filesCompacting) {
+      filesCompacting.removeAll(filesToRemove);
+      Collections.sort(filesCompacting, storeEngine.getStoreFileManager().getStoreFileComparator());
+    }
+  }
+
+  public List<HStoreFile> getFilesCompacting() {
+    synchronized (filesCompacting) {
+      return Lists.newArrayList(filesCompacting);
+    }
+  }
+
   private void removeUnneededFiles() throws IOException {
     if (!conf.getBoolean("hbase.store.delete.expired.storefile", true)) {
       return;


### PR DESCRIPTION
When clear compaction queues, we just clear the workQueue of ThreadPoolExecutor, but files in compaction request are still in filesCompacting list. maybe we should clear it also.


https://issues.apache.org/jira/browse/HBASE-25880