### PR TITLE
HBASE-25875 RegionServer failed to start with IllegalThreadStateException due to race condition in AuthenticationTokenSecretManager

### DIFF
--- a/dev-support/spotbugs-exclude.xml
+++ b/dev-support/spotbugs-exclude.xml
@@ -247,4 +247,23 @@
     <Bug pattern="SC_START_IN_CTOR"/>
   </Match>
 
+  <Match>
+    <!--
+      False positives, NettyRpcServer#start & SimpleRpcServer#start are already synchronized and
+      there is check to ensure single initialization of authTokenSecretMgr field.
+      Ignore the warning, see HBASE-25875.
+    !-->
+    <Or>
+      <And>
+        <Class name="org.apache.hadoop.hbase.ipc.NettyRpcServer"/>
+        <Method name="start"/>
+      </And>
+      <And>
+        <Class name="org.apache.hadoop.hbase.ipc.SimpleRpcServer"/>
+        <Method name="start"/>
+      </And>
+    </Or>
+    <Bug pattern="ML_SYNC_ON_UPDATED_FIELD"/>
+  </Match>
+
 </FindBugsFilter>

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcServer.java
@@ -136,8 +136,12 @@ public class NettyRpcServer extends RpcServer {
     }
     authTokenSecretMgr = createSecretManager();
     if (authTokenSecretMgr != null) {
-      setSecretManager(authTokenSecretMgr);
-      authTokenSecretMgr.start();
+      // Start AuthenticationTokenSecretManager in synchronized way to avoid race conditions in
+      // LeaderElector start. See HBASE-25875
+      synchronized (authTokenSecretMgr) {
+        setSecretManager(authTokenSecretMgr);
+        authTokenSecretMgr.start();
+      }
     }
     this.authManager = new ServiceAuthorizationManager();
     HBasePolicyProvider.init(conf, authManager);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleRpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleRpcServer.java
@@ -423,8 +423,12 @@ public class SimpleRpcServer extends RpcServer {
     }
     authTokenSecretMgr = createSecretManager();
     if (authTokenSecretMgr != null) {
-      setSecretManager(authTokenSecretMgr);
-      authTokenSecretMgr.start();
+      // Start AuthenticationTokenSecretManager in synchronized way to avoid race conditions in
+      // LeaderElector start. See HBASE-25875
+      synchronized (authTokenSecretMgr) {
+        setSecretManager(authTokenSecretMgr);
+        authTokenSecretMgr.start();
+      }
     }
     this.authManager = new ServiceAuthorizationManager();
     HBasePolicyProvider.init(conf, authManager);


### PR DESCRIPTION
RegionServer failed to start with IllegalThreadStateException due to race condition in AuthenticationTokenSecretManager's start & retrievePassword method