### PR TITLE
HBASE-25902 HMaster failed to start with NoSuchColumnFamilyException during upgrade from HBase 1.x to HBase 2.x

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1601,6 +1601,16 @@ public final class HConstants {
    */
   public static final int BATCH_ROWS_THRESHOLD_DEFAULT = 5000;
 
+  /**
+   * List of column families that cannot be deleted from the hbase:meta table.
+   * They are critical to cluster operation. This is a bit of an odd place to
+   * keep this list but then this is the tooling that does add/remove. Keeping
+   * it local!
+   */
+  public static final List<byte[]> UNDELETABLE_META_COLUMNFAMILIES = Collections.unmodifiableList(
+    Arrays.asList(HConstants.CATALOG_FAMILY, HConstants.TABLE_FAMILY,
+      HConstants.REPLICATION_BARRIER_FAMILY));
+
   private HConstants() {
     // Can't be instantiated with this ctor.
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -19,8 +19,6 @@
 package org.apache.hadoop.hbase.master.procedure;
 
 import java.io.IOException;
-import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
 import java.util.Set;
 import java.util.function.Supplier;
@@ -59,15 +57,6 @@ public class ModifyTableProcedure
   private TableDescriptor modifiedTableDescriptor;
   private boolean deleteColumnFamilyInModify;
   private boolean shouldCheckDescriptor;
-  /**
-   * List of column families that cannot be deleted from the hbase:meta table.
-   * They are critical to cluster operation. This is a bit of an odd place to
-   * keep this list but then this is the tooling that does add/remove. Keeping
-   * it local!
-   */
-  private static final List<byte []> UNDELETABLE_META_COLUMNFAMILIES =
-    Collections.unmodifiableList(Arrays.asList(
-      HConstants.CATALOG_FAMILY, HConstants.TABLE_FAMILY, HConstants.REPLICATION_BARRIER_FAMILY));
 
   public ModifyTableProcedure() {
     super();
@@ -102,7 +91,7 @@ public class ModifyTableProcedure
       // If we are modifying the hbase:meta table, make sure we are not deleting critical
       // column families else we'll damage the cluster.
       Set<byte []> cfs = this.modifiedTableDescriptor.getColumnFamilyNames();
-      for (byte[] family : UNDELETABLE_META_COLUMNFAMILIES) {
+      for (byte[] family : HConstants.UNDELETABLE_META_COLUMNFAMILIES) {
         if (!cfs.contains(family)) {
           throw new HBaseIOException("Delete of hbase:meta column family " +
             Bytes.toString(family));


### PR DESCRIPTION
HMaste should validate the meta table descriptor during startup and rewrite if any mismatch, meanwhile RegionServer should read the default meta table descriptor to avoid inconsistencies.