### PR TITLE
HBASE-25910 - Fix port assignment test

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -2268,6 +2268,7 @@ public class HRegionServer extends Thread implements
         // auto bind enabled, try to use another port
         LOG.info("Failed binding http info server to port: " + port);
         port++;
+        LOG.info("Retry starting http info server with port: " + port);
       }
     }
     port = this.infoServer.getPort();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
@@ -22,7 +22,6 @@ import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.lang.Throwable;
 import java.net.BindException;
-import java.net.ServerSocket;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.junit.ClassRule;
@@ -61,14 +60,6 @@ public class TestClusterPortAssignment {
       TEST_UTIL.getConfiguration().setInt(HConstants.REGIONSERVER_PORT, rsPort);
       TEST_UTIL.getConfiguration().setInt(HConstants.REGIONSERVER_INFO_PORT, rsInfoPort);
       LOG.info("Ports: " + masterPort + ", " + masterInfoPort + ", " + rsPort + ", " + rsInfoPort);
-      ServerSocket sock = null;
-	  if (retryCount < 2) {
-        try {
-          LOG.info("Hijack port: " + rsInfoPort);
-          sock = new ServerSocket(rsInfoPort);
-        } catch (Exception e) {
-        }
-      }
       try {
         MiniHBaseCluster cluster = TEST_UTIL.startMiniCluster();
         assertTrue("Cluster failed to come up", cluster.waitForActiveAndReadyMaster(30000));
@@ -93,12 +84,6 @@ public class TestClusterPortAssignment {
         }
       } finally {
         TEST_UTIL.shutdownMiniCluster();
-      }
-      if (sock != null) {
-        try {
-          sock.close();
-        } catch (Exception e) {
-        }
       }
     } while (retry && retryCount < 10);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
@@ -19,7 +19,10 @@ package org.apache.hadoop.hbase;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+import java.lang.Throwable;
 import java.net.BindException;
+import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -27,7 +30,6 @@ import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@org.junit.Ignore // See HBASE-24342. This test can't pass 100% of time as written so disabling
 @Category(MediumTests.class)
 public class TestClusterPortAssignment {
   @ClassRule
@@ -44,16 +46,19 @@ public class TestClusterPortAssignment {
   @Test
   public void testClusterPortAssignment() throws Exception {
     boolean retry = false;
+    int retryCount = 0;
     do {
       int masterPort =  HBaseTestingUtility.randomFreePort();
       int masterInfoPort =  HBaseTestingUtility.randomFreePort();
       int rsPort =  HBaseTestingUtility.randomFreePort();
       int rsInfoPort =  HBaseTestingUtility.randomFreePort();
       TEST_UTIL.getConfiguration().setBoolean(LocalHBaseCluster.ASSIGN_RANDOM_PORTS, false);
+      TEST_UTIL.getConfiguration().setBoolean(HConstants.REGIONSERVER_INFO_PORT_AUTO, false);
       TEST_UTIL.getConfiguration().setInt(HConstants.MASTER_PORT, masterPort);
       TEST_UTIL.getConfiguration().setInt(HConstants.MASTER_INFO_PORT, masterInfoPort);
       TEST_UTIL.getConfiguration().setInt(HConstants.REGIONSERVER_PORT, rsPort);
       TEST_UTIL.getConfiguration().setInt(HConstants.REGIONSERVER_INFO_PORT, rsInfoPort);
+      LOG.info("Ports: " + masterPort + ", " + masterInfoPort + ", " + rsPort + ", " + rsInfoPort);
       try {
         MiniHBaseCluster cluster = TEST_UTIL.startMiniCluster();
         assertTrue("Cluster failed to come up", cluster.waitForActiveAndReadyMaster(30000));
@@ -67,17 +72,22 @@ public class TestClusterPortAssignment {
         assertEquals("RS info port is incorrect", rsInfoPort,
           cluster.getRegionServer(0).getInfoServer().getPort());
       } catch (Exception e) {
-        if (e instanceof  BindException || e.getCause() != null &&
-            (e.getCause() instanceof BindException || e.getCause().getCause() != null &&
-              e.getCause().getCause() instanceof BindException)) {
+        Throwable rootCause = ExceptionUtils.getRootCause(e);
+        if (rootCause instanceof BindException) {
           LOG.info("Failed bind, need to retry", e);
           retry = true;
+          retryCount++;
         } else {
-          throw e;
+          retry = false;
+          fail("Failed to start mini cluster" + e);
         }
       } finally {
         TEST_UTIL.shutdownMiniCluster();
       }
-    } while (retry);
+    } while (retry && retryCount < 10);
+
+    if (retry) {
+      fail("Retry exhausted.");
+    }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hbase;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
-import java.lang.Throwable;
 import java.net.BindException;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.hbase.testclassification.MediumTests;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import java.net.BindException;
-import java.net.ServerSocket;
 import org.apache.commons.lang3.exception.ExceptionUtils;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.junit.ClassRule;
@@ -59,14 +58,6 @@ public class TestClusterPortAssignment {
       TEST_UTIL.getConfiguration().setInt(HConstants.REGIONSERVER_PORT, rsPort);
       TEST_UTIL.getConfiguration().setInt(HConstants.REGIONSERVER_INFO_PORT, rsInfoPort);
       LOG.info("Ports: {}, {}, {}, {}", masterPort, masterInfoPort, rsPort, rsInfoPort);
-      ServerSocket sock = null;
-	  if (!retry) {
-        try {
-          LOG.info("Hijack port: " + rsInfoPort);
-          sock = new ServerSocket(rsInfoPort);
-        } catch (Exception e) {
-        }
-      }
       try {
         MiniHBaseCluster cluster = TEST_UTIL.startMiniCluster();
         assertTrue("Cluster failed to come up", cluster.waitForActiveAndReadyMaster(30000));
@@ -91,12 +82,6 @@ public class TestClusterPortAssignment {
         }
       } finally {
         TEST_UTIL.shutdownMiniCluster();
-      }
-      if (sock != null) {
-        try {
-          sock.close();
-        } catch (Exception e) {
-        }
       }
     } while (retry);
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
@@ -42,7 +42,7 @@ public class TestClusterPortAssignment {
    * Check that we can start an HBase cluster specifying a custom set of
    * RPC and infoserver ports.
    */
-  @Test
+  @Test(timeout = 300000)
   public void testClusterPortAssignment() throws Exception {
     boolean retry = false;
     do {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
@@ -76,7 +76,7 @@ public class TestClusterPortAssignment {
           LOG.info("Failed bind, need to retry", e);
           retry = true;
         } else {
-          LOG.info("Failed to start mini cluster" + e);
+          LOG.info("Failed to start mini cluster", e);
           retry = false;
           fail("Failed to start mini cluster with assigned ports.");
         }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClusterPortAssignment.java
@@ -76,7 +76,7 @@ public class TestClusterPortAssignment {
           LOG.info("Failed bind, need to retry", e);
           retry = true;
         } else {
-          LOG.info("Failed to start mini cluster", e);
+          LOG.error("Failed to start mini cluster", e);
           retry = false;
           fail("Failed to start mini cluster with assigned ports.");
         }


### PR DESCRIPTION
Disabled port auto assignment when port is in use.
Disabled hdfs cache as restart mini cluster will fail in one jvm if hdfs cache is enabled.
Use exception root case to determine address/port in use with BindException.