### PR TITLE
HBASE-25987 Make SSL keystore type configurable for HBase ThriftServer

### DIFF
--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/Constants.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/Constants.java
@@ -65,6 +65,10 @@ public final class Constants {
       "hbase.thrift.ssl.exclude.protocols";
   public static final String THRIFT_SSL_INCLUDE_PROTOCOLS_KEY =
       "hbase.thrift.ssl.include.protocols";
+  public static final String THRIFT_SSL_KEYSTORE_TYPE_KEY =
+    "hbase.thrift.ssl.keystore.type";
+  public static final String THRIFT_SSL_KEYSTORE_TYPE_DEFAULT =
+    "jks";
 
 
   public static final String THRIFT_SUPPORT_PROXYUSER_KEY = "hbase.thrift.support.proxyuser";

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftServer.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftServer.java
@@ -71,6 +71,8 @@ import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SSL_INCLUDE_PROTOC
 import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SSL_KEYSTORE_KEYPASSWORD_KEY;
 import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SSL_KEYSTORE_PASSWORD_KEY;
 import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SSL_KEYSTORE_STORE_KEY;
+import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SSL_KEYSTORE_TYPE_DEFAULT;
+import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SSL_KEYSTORE_TYPE_KEY;
 import static org.apache.hadoop.hbase.thrift.Constants.THRIFT_SUPPORT_PROXYUSER_KEY;
 import static org.apache.hadoop.hbase.thrift.Constants.USE_HTTP_CONF_KEY;
 
@@ -425,6 +427,8 @@ public class ThriftServer  extends Configured implements Tool {
       sslCtxFactory.setKeyStorePath(keystore);
       sslCtxFactory.setKeyStorePassword(password);
       sslCtxFactory.setKeyManagerPassword(keyPassword);
+      sslCtxFactory.setKeyStoreType(conf.get(
+        THRIFT_SSL_KEYSTORE_TYPE_KEY, THRIFT_SSL_KEYSTORE_TYPE_DEFAULT));
 
       String[] excludeCiphers = conf.getStrings(
           THRIFT_SSL_EXCLUDE_CIPHER_SUITES_KEY, ArrayUtils.EMPTY_STRING_ARRAY);


### PR DESCRIPTION
Before HBASE-25930, the InfoServer was started first and it set the keystore type in the global keystore manager, which setting propagated to the thrift http server too, based on the InfoServer configuration "ssl.server.keystore.type". In HBASE-25930 the startup order changed, and the thrift http server configuration happens before the InfoServer start, so we lack this accidental configuration change now.

Given that we have independent keystore file path / password parameters already for the thrift http server, the proper solution is to create a new parameter for the keystore type of the thrift http server: hbase.thrift.ssl.keystore.type (defaulting to "jks").