### PR TITLE
HBASE-25989 FanOutOneBlockAsyncDFSOutput using shaded protobuf in hdf…

### DIFF
--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/io/asyncfs/ProtobufDecoder.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/io/asyncfs/ProtobufDecoder.java
@@ -123,7 +123,7 @@ public class ProtobufDecoder extends MessageToMessageDecoder<ByteBuf> {
     try {
       protobufMessageLiteClass = Class.forName("org.apache.hadoop.thirdparty.protobuf.MessageLite");
       protobufMessageLiteBuilderClass = Class.forName(
-        "org.apache.hadoop.thirdparty.protobuf.MessageLite.Builder");
+        "org.apache.hadoop.thirdparty.protobuf.MessageLite$Builder");
       LOG.debug("Hadoop 3.3 and above shades protobuf.");
     } catch (ClassNotFoundException e) {
       LOG.debug("Hadoop 3.2 and below use unshaded protobuf.", e);


### PR DESCRIPTION
…s 3.3+

You need a '$' separator instead of a '.' when referencing and inner class when using Class.forName