### PR TITLE
HBASE-25993 Make excluded SSL cipher suites configurable for all Web UIs

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.security.authentication.server.AuthenticationFilter;
 import org.apache.hadoop.security.authorize.AccessControlList;
 import org.apache.hadoop.security.authorize.ProxyUsers;
 import org.apache.hadoop.util.Shell;
+import org.apache.hadoop.util.StringUtils;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 import org.slf4j.Logger;
@@ -197,6 +198,7 @@ public class HttpServer implements FilterContainer {
     private String usernameConfKey;
     private String keytabConfKey;
     private boolean needsClientAuth;
+    private String excludeCiphers;
 
     private String hostName;
     private String appDir = APP_DIR;
@@ -374,6 +376,10 @@ public class HttpServer implements FilterContainer {
       return this;
     }
 
+    public void excludeCiphers(String excludeCiphers) {
+      this.excludeCiphers = excludeCiphers;
+    }
+
     public HttpServer build() throws IOException {
 
       // Do we still need to assert this non null name if it is deprecated?
@@ -433,8 +439,13 @@ public class HttpServer implements FilterContainer {
             sslCtxFactory.setTrustStorePath(trustStore);
             sslCtxFactory.setTrustStoreType(trustStoreType);
             sslCtxFactory.setTrustStorePassword(trustStorePassword);
-
           }
+
+          if (excludeCiphers != null && !excludeCiphers.trim().isEmpty()) {
+            sslCtxFactory.setExcludeCipherSuites(StringUtils.getTrimmedStrings(excludeCiphers));
+            LOG.debug("Excluded SSL Cipher List:" + excludeCiphers);
+          }
+
           listener = new ServerConnector(server.webServer, new SslConnectionFactory(sslCtxFactory,
               HttpVersion.HTTP_1_1.toString()), new HttpConnectionFactory(httpsConfig));
         } else {

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/InfoServer.java
@@ -78,6 +78,7 @@ public class InfoServer {
         .trustStore(c.get("ssl.server.truststore.location"),
                 HBaseConfiguration.getPassword(c, "ssl.server.truststore.password", null),
                 c.get("ssl.server.truststore.type", "jks"));
+      builder.excludeCiphers(c.get("ssl.server.exclude.cipher.list"));
     }
     // Enable SPNEGO authentication
     if ("kerberos".equalsIgnoreCase(c.get(HttpServer.HTTP_UI_AUTHENTICATION, null))) {


### PR DESCRIPTION
When starting a jetty http server, one can explicitly exclude certain (unsecure) SSL cipher suites. This can be especially important, when the HBase cluster needs to be compliant with security regulations (e.g. FIPS).

Currently it is possible to set the excluded ciphers for the ThriftServer ("hbase.thrift.ssl.exclude.cipher.suites") or for the RestServer ("hbase.rest.ssl.exclude.cipher.suites"), but one can not configure it for the regular InfoServer started by e.g. the master or region servers.

In this commit I want to introduce a new configuration "ssl.server.exclude.cipher.list" to configure the excluded cipher suites for the http server started by the InfoServer. This parameter has the same name and will work in the same way, as it was already implemented in hadoop (e.g. for hdfs/yarn). See: HADOOP-12668, HADOOP-14341