### PR TITLE
HBASE-26018 Perf improvement in L1 cache - Optimistic call to buffer.retain()

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hbase.io.HeapSize;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.util.ClassSize;
 import org.apache.hadoop.util.StringUtils;
+import org.apache.hbase.thirdparty.io.netty.util.IllegalReferenceCountException;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -145,14 +146,7 @@ public class LruBlockCache implements FirstLevelBlockCache {
   private static final String LRU_MAX_BLOCK_SIZE = "hbase.lru.max.block.size";
   private static final long DEFAULT_MAX_BLOCK_SIZE = 16L * 1024L * 1024L;
 
-  /**
-   * Defined the cache map as {@link ConcurrentHashMap} here, because in
-   * {@link LruBlockCache#getBlock}, we need to guarantee the atomicity of map#computeIfPresent
-   * (key, func). Besides, the func method must execute exactly once only when the key is present
-   * and under the lock context, otherwise the reference count will be messed up. Notice that the
-   * {@link java.util.concurrent.ConcurrentSkipListMap} can not guarantee that.
-   */
-  private transient final ConcurrentHashMap<BlockCacheKey, LruCachedBlock> map;
+  private transient final Map<BlockCacheKey, LruCachedBlock> map;
 
   /** Eviction lock (locked when eviction in process) */
   private transient final ReentrantLock evictionLock = new ReentrantLock(true);
@@ -510,14 +504,16 @@ public class LruBlockCache implements FirstLevelBlockCache {
   @Override
   public Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
       boolean updateCacheMetrics) {
-    LruCachedBlock cb = map.computeIfPresent(cacheKey, (key, val) -> {
-      // It will be referenced by RPC path, so increase here. NOTICE: Must do the retain inside
-      // this block. because if retain outside the map#computeIfPresent, the evictBlock may remove
-      // the block and release, then we're retaining a block with refCnt=0 which is disallowed.
-      // see HBASE-22422.
-      val.getBuffer().retain();
-      return val;
-    });
+    LruCachedBlock cb = map.get(cacheKey);
+    if (cb != null) {
+      try {
+        cb.getBuffer().retain();
+      } catch (IllegalReferenceCountException e) {
+        cb = null;
+        LOG.debug("LRU cache block retain caused refCount Exception. Treating this as L1 cache"
+            + " miss. Exception: {}", e.getMessage());
+      }
+    }
     if (cb == null) {
       if (!repeat && updateCacheMetrics) {
         stats.miss(caching, cacheKey.isPrimary(), cacheKey.getBlockType());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
@@ -910,7 +910,7 @@ public class TestHFile  {
   }
 
   /**
-   * Test case for CombinedBlockCache with AdaptiveLRU as L1 cache
+   * Test case for CombinedBlockCache with LRU as L1 cache
    */
   @Test
   public void testReaderWithLruCombinedBlockCache() throws Exception {


### PR DESCRIPTION
* CHM#computeIfPresent takes lock on bucket but CHM#get is lockless
* Atomically retaining refCount is coming up bit expensive in terms of performance
* When we see aggressive cache hits for meta blocks (with major blocks in cache), we would want to get away from coarse grained locking
* Treat cache read API as optimistic read