### PR TITLE
HBASE-25739 TableSkewCostFunction need to use aggregated deviation

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
@@ -294,7 +294,7 @@ class BalancerClusterState {
     }
 
     numTables = tables.size();
-    LOG.info("number of tables = {}", numTables);
+    LOG.debug("number of tables = {}", numTables);
     numRegionsPerServerPerTable = new int[numServers][numTables];
     numRegionsPerTable = new int[numTables];
 
@@ -325,10 +325,9 @@ class BalancerClusterState {
 
     for (int[] aNumRegionsPerServerPerTable : numRegionsPerServerPerTable) {
       for (int tableIdx = 0; tableIdx < aNumRegionsPerServerPerTable.length; tableIdx++) {
-        regionSkewByTable[tableIdx] += Math.abs(aNumRegionsPerServerPerTable[tableIdx]
-          - meanRegionsPerTable[tableIdx]);
+        regionSkewByTable[tableIdx] += Math.abs(aNumRegionsPerServerPerTable[tableIdx] - meanRegionsPerTable[tableIdx]);
       }
-     }
+    }
 
     for (int i = 0; i < regions.length; i++) {
       RegionInfo info = regions[i];

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
@@ -325,7 +325,8 @@ class BalancerClusterState {
 
     for (int[] aNumRegionsPerServerPerTable : numRegionsPerServerPerTable) {
       for (int tableIdx = 0; tableIdx < aNumRegionsPerServerPerTable.length; tableIdx++) {
-        regionSkewByTable[tableIdx] += Math.abs(aNumRegionsPerServerPerTable[tableIdx] - meanRegionsPerTable[tableIdx]);
+        regionSkewByTable[tableIdx] += Math.abs(aNumRegionsPerServerPerTable[tableIdx]
+          - meanRegionsPerTable[tableIdx]);
       }
     }
 

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CostFunction.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CostFunction.java
@@ -89,10 +89,11 @@ abstract class CostFunction {
    * @return The scaled value.
    */
   protected static double scale(double min, double max, double value) {
-    if (max <= min || value <= min) {
+    if (max <= min || value <= min
+      || Math.abs(max - min) <= 0.01 || Math.abs(value - min) <= 0.01) {
       return 0;
     }
-    if ((max - min) == 0) {
+    if (max <= min || Math.abs(max - min) <= 0.01) {
       return 0;
     }
 

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CostFunction.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CostFunction.java
@@ -25,6 +25,8 @@ import org.apache.yetus.audience.InterfaceAudience;
 @InterfaceAudience.Private
 abstract class CostFunction {
 
+  public static final double COST_EPSILON = 0.0001;
+
   private float multiplier = 0;
 
   protected BalancerClusterState cluster;
@@ -90,10 +92,10 @@ abstract class CostFunction {
    */
   protected static double scale(double min, double max, double value) {
     if (max <= min || value <= min
-      || Math.abs(max - min) <= 0.01 || Math.abs(value - min) <= 0.01) {
+      || Math.abs(max - min) <= COST_EPSILON || Math.abs(value - min) <= COST_EPSILON) {
       return 0;
     }
-    if (max <= min || Math.abs(max - min) <= 0.01) {
+    if (max <= min || Math.abs(max - min) <= COST_EPSILON) {
       return 0;
     }
 

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/DoubleArrayCost.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/DoubleArrayCost.java
@@ -91,6 +91,7 @@ final class DoubleArrayCost {
 
   /**
    * Return the min skew of distribution
+   * @param total is total number of regions
    */
   public static double getMinSkew(double total, double numServers) {
     double mean = total / numServers;

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/DoubleArrayCost.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/DoubleArrayCost.java
@@ -72,31 +72,13 @@ final class DoubleArrayCost {
     double count = stats.length;
     double mean = total / count;
 
-    // Compute max as if all region servers had 0 and one had the sum of all costs. This must be
-    // a zero sum cost for this to make sense.
-    double max = ((count - 1) * mean) + (total - mean);
-
-    // It's possible that there aren't enough regions to go around
-    double min;
-    if (count > total) {
-      min = ((count - total) * mean) + ((1 - mean) * total);
-    } else {
-      // Some will have 1 more than everything else.
-      int numHigh = (int) (total - (Math.floor(mean) * count));
-      int numLow = (int) (count - numHigh);
-
-      min = (numHigh * (Math.ceil(mean) - mean)) + (numLow * (mean - Math.floor(mean)));
-
-    }
-    min = Math.max(0, min);
     for (int i = 0; i < stats.length; i++) {
       double n = stats[i];
       double diff = Math.abs(mean - n);
       totalCost += diff;
     }
-
-    double scaled = CostFunction.scale(min, max, totalCost);
-    return scaled;
+    return CostFunction.scale(getMinSkew(total, count),
+      getMaxSkew(total, count), totalCost);
   }
 
   private static double getSum(double[] stats) {
@@ -105,5 +87,33 @@ final class DoubleArrayCost {
       total += s;
     }
     return total;
+  }
+
+  /**
+   * Return the min skew of distribution
+   */
+  public static double getMinSkew(double total, double numServers) {
+    double mean = total / numServers;
+    // It's possible that there aren't enough regions to go around
+    double min;
+    if (numServers > total) {
+      min = ((numServers - total) * mean + (1 - mean) * total) ;
+    } else {
+      // Some will have 1 more than everything else.
+      int numHigh = (int) (total - (Math.floor(mean) * numServers));
+      int numLow = (int) (numServers - numHigh);
+      min = numHigh * (Math.ceil(mean) - mean) + numLow * (mean - Math.floor(mean));
+    }
+    return min;
+  }
+
+  /**
+   * Return the max deviation of distribution
+   * Compute max as if all region servers had 0 and one had the sum of all costs.  This must be
+   * a zero sum cost for this to make sense.
+   */
+  public static double getMaxSkew(double total, double numServers) {
+    double mean = total / numServers;
+    return (total - mean) + (numServers - 1) * mean;
   }
 }

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -125,7 +125,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
   private int stepsPerRegion = 800;
   private long maxRunningTime = 30 * 1000 * 1; // 30 seconds.
   private int numRegionLoadsToRemember = 15;
-  private float minCostNeedBalance = 0.05f;
+  private float minCostNeedBalance = 0.025f;
 
   private List<CandidateGenerator> candidateGenerators;
   private List<CostFunction> costFunctions; // FindBugs: Wants this protected; IS2_INCONSISTENT_SYNC

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -240,7 +240,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     curFunctionCosts = new double[costFunctions.size()];
     tempFunctionCosts = new double[costFunctions.size()];
 
-    LOG.info("Loaded config; maxSteps=" + maxSteps + " ,runMaxSteps=" + runMaxSteps,
+    LOG.info("Loaded config; maxSteps=" + maxSteps + ", runMaxSteps=" + runMaxSteps,
       ", stepsPerRegion=" + stepsPerRegion +
       ", maxRunningTime=" + maxRunningTime + ", isByTable=" + isByTable + ", CostFunctions=" +
       Arrays.toString(getCostFunctionNames()) + " etc.");

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -240,7 +240,8 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     curFunctionCosts = new double[costFunctions.size()];
     tempFunctionCosts = new double[costFunctions.size()];
 
-    LOG.info("Loaded config; maxSteps=" + maxSteps + ", stepsPerRegion=" + stepsPerRegion +
+    LOG.info("Loaded config; maxSteps=" + maxSteps + " ,runMaxSteps=" + runMaxSteps,
+      ", stepsPerRegion=" + stepsPerRegion +
       ", maxRunningTime=" + maxRunningTime + ", isByTable=" + isByTable + ", CostFunctions=" +
       Arrays.toString(getCostFunctionNames()) + " etc.");
   }

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/TableSkewCostFunction.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/TableSkewCostFunction.java
@@ -26,7 +26,6 @@ import org.apache.yetus.audience.InterfaceAudience;
  */
 @InterfaceAudience.Private
 class TableSkewCostFunction extends CostFunction {
-
   private static final String TABLE_SKEW_COST_KEY =
     "hbase.master.balancer.stochastic.tableSkewCost";
   private static final float DEFAULT_TABLE_SKEW_COST = 35;
@@ -37,14 +36,11 @@ class TableSkewCostFunction extends CostFunction {
 
   @Override
   protected double cost() {
-    double max = cluster.numRegions;
-    double min = ((double) cluster.numRegions) / cluster.numServers;
-    double value = 0;
-
-    for (int i = 0; i < cluster.numMaxRegionsPerTable.length; i++) {
-      value += cluster.numMaxRegionsPerTable[i];
+    double cost = 0;
+    for (int tableIdx = 0; tableIdx < cluster.numTables; tableIdx++) {
+      cost += scale(cluster.minRegionSkewByTable[tableIdx],
+        cluster.maxRegionSkewByTable[tableIdx], cluster.regionSkewByTable[tableIdx]);
     }
-
-    return scale(min, max, value);
+    return cost;
   }
 }

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/StochasticBalancerTestBase.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/StochasticBalancerTestBase.java
@@ -47,6 +47,7 @@ public class StochasticBalancerTestBase extends BalancerTestBase {
     conf.setFloat("hbase.regions.slop", 0.0f);
     conf.setFloat("hbase.master.balancer.stochastic.localityCost", 0);
     conf.setLong(StochasticLoadBalancer.MAX_RUNNING_TIME_KEY, 3 * 60 * 1000L);
+    conf.setLong(StochasticLoadBalancer.MAX_STEPS_KEY, 20000000L);
     loadBalancer = new StochasticLoadBalancer();
     loadBalancer.setClusterInfoProvider(new DummyClusterInfoProvider(conf));
     loadBalancer.initialize();

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/StochasticBalancerTestBase.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/StochasticBalancerTestBase.java
@@ -46,8 +46,7 @@ public class StochasticBalancerTestBase extends BalancerTestBase {
     conf.setFloat("hbase.master.balancer.stochastic.maxMovePercent", 0.75f);
     conf.setFloat("hbase.regions.slop", 0.0f);
     conf.setFloat("hbase.master.balancer.stochastic.localityCost", 0);
-    conf.setLong(StochasticLoadBalancer.MAX_RUNNING_TIME_KEY, 3 * 60 * 1000L);
-    conf.setLong(StochasticLoadBalancer.MAX_STEPS_KEY, 20000000L);
+    conf.setBoolean("hbase.master.balancer.stochastic.runMaxSteps", true);
     loadBalancer = new StochasticLoadBalancer();
     loadBalancer.setClusterInfoProvider(new DummyClusterInfoProvider(conf));
     loadBalancer.initialize();

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBaseLoadBalancer.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBaseLoadBalancer.java
@@ -355,8 +355,8 @@ public class TestBaseLoadBalancer extends BalancerTestBase {
 
     // now move region1 from servers[0] to servers[2]
     cluster.doAction(new MoveRegionAction(0, 0, 2));
-    // check that the numMaxRegionsPerTable for "table" has increased to 2
-    assertEquals(2, cluster.numMaxRegionsPerTable[0]);
+    // check that the regionSkewByTable for "table" has increased to 2
+    assertEquals(2, cluster.regionSkewByTable[0], 0.01);
     // now repeat check whether moving region1 from servers[1] to servers[2]
     // would lower availability
     assertTrue(cluster.wouldLowerAvailability(hri1, servers[2]));

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerBalanceCluster.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerBalanceCluster.java
@@ -51,8 +51,6 @@ public class TestStochasticLoadBalancerBalanceCluster extends StochasticBalancer
    */
   @Test
   public void testBalanceCluster() throws Exception {
-    conf.setLong(StochasticLoadBalancer.MAX_STEPS_KEY, 20000000L);
-    conf.setLong("hbase.master.balancer.stochastic.maxRunningTime", 300 * 1000); // 300 sec
     conf.setFloat("hbase.master.balancer.stochastic.maxMovePercent", 1.0f);
     loadBalancer.onConfigurationChange(conf);
     for (int[] mockCluster : clusterStateMocks) {

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerBalanceCluster.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerBalanceCluster.java
@@ -51,15 +51,14 @@ public class TestStochasticLoadBalancerBalanceCluster extends StochasticBalancer
    */
   @Test
   public void testBalanceCluster() throws Exception {
-    conf.setLong(StochasticLoadBalancer.MAX_STEPS_KEY, 2000000L);
-    conf.setLong("hbase.master.balancer.stochastic.maxRunningTime", 90 * 1000); // 90 sec
+    conf.setLong(StochasticLoadBalancer.MAX_STEPS_KEY, 20000000L);
+    conf.setLong("hbase.master.balancer.stochastic.maxRunningTime", 300 * 1000); // 300 sec
     conf.setFloat("hbase.master.balancer.stochastic.maxMovePercent", 1.0f);
     loadBalancer.onConfigurationChange(conf);
     for (int[] mockCluster : clusterStateMocks) {
       Map<ServerName, List<RegionInfo>> servers = mockClusterServers(mockCluster);
       List<ServerAndLoad> list = convertToList(servers);
       LOG.info("Mock Cluster : " + printMock(list) + " " + printStats(list));
-
       Map<TableName, Map<ServerName, List<RegionInfo>>> LoadOfAllTable =
           (Map) mockClusterServersWithTables(servers);
       List<RegionPlan> plans = loadBalancer.balanceCluster(LoadOfAllTable);

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerHeterogeneousCost.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerHeterogeneousCost.java
@@ -70,7 +70,6 @@ public class TestStochasticLoadBalancerHeterogeneousCost extends StochasticBalan
     conf.setFloat("hbase.master.balancer.stochastic.regionCountCost", 0);
     conf.setFloat("hbase.master.balancer.stochastic.primaryRegionCountCost", 0);
     conf.setFloat("hbase.master.balancer.stochastic.tableSkewCost", 0);
-    conf.setBoolean("hbase.master.balancer.stochastic.runMaxSteps", true);
     conf.set(StochasticLoadBalancer.COST_FUNCTIONS_COST_FUNCTIONS_KEY,
       HeterogeneousRegionCountCostFunction.class.getName());
     // Need to ensure test dir has been created.

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerLargeCluster.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerLargeCluster.java
@@ -38,6 +38,9 @@ public class TestStochasticLoadBalancerLargeCluster extends StochasticBalancerTe
     int numRegionsPerServer = 80; // all servers except one
     int numTables = 100;
     int replication = 1;
+    conf.setLong("hbase.master.balancer.stochastic.maxRunningTime", 6 * 60 * 1000);
+    conf.setFloat("hbase.master.balancer.stochastic.maxMovePercent", 1.0f);
+    loadBalancer.onConfigurationChange(conf);
     testWithCluster(numNodes, numRegions, numRegionsPerServer, replication, numTables, true, true);
   }
 }


### PR DESCRIPTION
Re-apply the patch that was merged and reverted for flaky test because of refactoring afterwards.

The flaky tests was actually caused by two bugs: incorrect implementation of TableSkewCostfunction in the old codes and the tests were bent to pass.

There is another bug in the original tableSkew cost function for aggregation of the cost per table:
If we have 10 regions, one per table, evenly distributed on 10 nodes, the cost is scale to 1.0.
The more tables we have, the closer the value will be to 1.0. The cost function becomes useless.
All the balancer tests were set up with large numbers of tables with minimal regions per table. This artificially inflates the total cost and trigger balancer runs. Because of the fix, the default 0.05 minCostNeedBalance will not quite work. As a gap-stopper before I check in auto-tuning threshold, I reduce the default value to 0.025 so to keep the user experience consistent. We in production use an even lower value for a very large cluster.