### PR TITLE
fix pretty tool print header missing last indexblock and bloomchunk

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -355,9 +355,9 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       FixedFileTrailer trailer =
         FixedFileTrailer.readFromStream(fsdis.getStream(false), fileSize);
       long offset = trailer.getFirstDataBlockOffset(),
-        max = trailer.getLastDataBlockOffset();
+        max = trailer.getLoadOnOpenDataOffset();
       HFileBlock block;
-      while (offset <= max) {
+      while (offset < max) {
         block = reader.readBlock(offset, -1, /* cacheBlock */ false, /* pread */ false,
           /* isCompaction */ false, /* updateCacheMetrics */ false, null, null);
         offset += block.getOnDiskSizeWithHeader();


### PR DESCRIPTION
when use hfilepretty tool to print block headers, last bloomchunk and indexblock  will not show. because we get max as lastdatablockoffset, but index and bloom block are behind the last datablock. so we fix by get max as getLoadOnOpenDataOffset. 