### PR TITLE
fix pe tool totalRows exceed maximum of int

### DIFF
--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -3031,12 +3031,24 @@ public class PerformanceEvaluation extends Configured implements Tool {
         && (opts.getCmdName().equals(RANDOM_READ) || opts.getCmdName().equals(RANDOM_SEEK_SCAN)))
         && opts.size != DEFAULT_OPTS.size
         && opts.perClientRunRows != DEFAULT_OPTS.perClientRunRows) {
+      if(Integer.MAX_VALUE / rowsPerGB < opts.size) {
+        throw new RuntimeException("totalRows is larger than maximum of int");
+      }
+	  
       opts.totalRows = (int) opts.size * rowsPerGB;
     } else if (opts.size != DEFAULT_OPTS.size) {
       // total size in GB specified
+      if(Integer.MAX_VALUE / rowsPerGB < opts.size) {
+        throw new RuntimeException("totalRows is larger than maximum of int");
+      }
+
       opts.totalRows = (int) opts.size * rowsPerGB;
       opts.perClientRunRows = opts.totalRows / opts.numClientThreads;
     } else {
+      if(Integer.MAX_VALUE / opts.numClientThreads < opts.perClientRunRows) {
+        throw new RuntimeException("totalRows is larger than maximum of int");
+      }
+
       opts.totalRows = opts.perClientRunRows * opts.numClientThreads;
       opts.size = opts.totalRows / rowsPerGB;
     }


### PR DESCRIPTION
fix pe tool totalRows exceed maximum of int.
when totalRows exceed maximum of int, we throws RunTimeException.  already create https://issues.apache.org/jira/browse/HBASE-26017