### PR TITLE
HBASE-26035 Redundant null check in the compareTo function

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionSourceImpl.java
@@ -180,13 +180,7 @@ public class MetricsRegionSourceImpl implements MetricsRegionSource {
     if (!(source instanceof MetricsRegionSourceImpl)) {
       return -1;
     }
-
-    MetricsRegionSourceImpl impl = (MetricsRegionSourceImpl) source;
-    if (impl == null) {
-      return -1;
-    }
-
-    return Long.compare(hashCode, impl.hashCode);
+    return Long.compare(hashCode, ((MetricsRegionSourceImpl) source).hashCode);
   }
 
   void snapshot(MetricsRecordBuilder mrb, boolean ignored) {


### PR DESCRIPTION
Useless check, impl cannot be null (guarded by instanceof)

https://issues.apache.org/jira/browse/HBASE-26035