### PR TITLE
HBASE-25516 [JDK17] reflective access Field.class.getDeclaredField("modifiers") not supported

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/ReflectionUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/ReflectionUtils.java
@@ -25,6 +25,7 @@ import java.lang.management.ManagementFactory;
 import java.lang.management.ThreadInfo;
 import java.lang.management.ThreadMXBean;
 import java.lang.reflect.Constructor;
+import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.charset.Charset;
@@ -226,6 +227,37 @@ public class ReflectionUtils {
       parameterTypes[i] = params[i].getClass();
     }
     return parameterTypes;
+  }
+
+  public static Field getModifiersField() throws IllegalAccessException, NoSuchFieldException {
+    Field modifiersField = null;
+    try {
+      modifiersField = Field.class.getDeclaredField("modifiers");
+    } catch (NoSuchFieldException e) {
+      try {
+        Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
+        boolean accessibleBeforeSet = getDeclaredFields0.isAccessible();
+        getDeclaredFields0.setAccessible(true);
+        Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);
+        getDeclaredFields0.setAccessible(accessibleBeforeSet);
+        for (Field field : fields) {
+          if ("modifiers".equals(field.getName())) {
+            modifiersField = field;
+            break;
+          }
+        }
+        if (modifiersField == null) {
+          throw e;
+        }
+      } catch (NoSuchMethodException ex) {
+        e.addSuppressed(ex);
+        throw e;
+      } catch (InvocationTargetException ex) {
+        e.addSuppressed(ex);
+        throw e;
+      }
+    }
+    return modifiersField;
   }
 
 }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/ReflectionUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/ReflectionUtils.java
@@ -230,12 +230,15 @@ public class ReflectionUtils {
   }
 
   public static Field getModifiersField() throws IllegalAccessException, NoSuchFieldException {
+    // this is copied from https://github.com/powermock/powermock/pull/1010/files to work around
+    // JDK 12+
     Field modifiersField = null;
     try {
       modifiersField = Field.class.getDeclaredField("modifiers");
     } catch (NoSuchFieldException e) {
       try {
-        Method getDeclaredFields0 = Class.class.getDeclaredMethod("getDeclaredFields0", boolean.class);
+        Method getDeclaredFields0 = Class.class.getDeclaredMethod(
+          "getDeclaredFields0",boolean.class);
         boolean accessibleBeforeSet = getDeclaredFields0.isAccessible();
         getDeclaredFields0.setAccessible(true);
         Field[] fields = (Field[]) getDeclaredFields0.invoke(Field.class, false);

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteBufferUtils.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteBufferUtils.java
@@ -82,7 +82,7 @@ public class TestByteBufferUtils {
   private static void setUnsafe(String fieldName, boolean value) throws Exception {
     Field field = ByteBufferUtils.class.getDeclaredField(fieldName);
     field.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    Field modifiersField = ReflectionUtils.getModifiersField();
     modifiersField.setAccessible(true);
     int oldModifiers = field.getModifiers();
     modifiersField.setInt(field, oldModifiers & ~Modifier.FINAL);

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestBytes.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestBytes.java
@@ -24,6 +24,8 @@ import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.lang.reflect.Field;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
@@ -49,7 +51,8 @@ public class TestBytes extends TestCase {
   private static void setUnsafe(boolean value) throws Exception {
     Field field = Bytes.class.getDeclaredField("UNSAFE_UNALIGNED");
     field.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
+
+    Field modifiersField = ReflectionUtils.getModifiersField();
     modifiersField.setAccessible(true);
     int oldModifiers = field.getModifiers();
     modifiersField.setInt(field, oldModifiers & ~Modifier.FINAL);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/fs/HFileSystem.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/fs/HFileSystem.java
@@ -335,7 +335,7 @@ public class HFileSystem extends FilterFileSystem {
     try {
       Field nf = DFSClient.class.getDeclaredField("namenode");
       nf.setAccessible(true);
-      Field modifiersField = Field.class.getDeclaredField("modifiers");
+      Field modifiersField = ReflectionUtils.getModifiersField();
       modifiersField.setAccessible(true);
       modifiersField.setInt(nf, nf.getModifiers() & ~Modifier.FINAL);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
@@ -126,6 +126,7 @@ import org.apache.hadoop.hbase.util.JVMClusterUtil;
 import org.apache.hadoop.hbase.util.JVMClusterUtil.MasterThread;
 import org.apache.hadoop.hbase.util.JVMClusterUtil.RegionServerThread;
 import org.apache.hadoop.hbase.util.Pair;
+import org.apache.hadoop.hbase.util.ReflectionUtils;
 import org.apache.hadoop.hbase.util.RegionSplitter;
 import org.apache.hadoop.hbase.util.RegionSplitter.SplitAlgorithm;
 import org.apache.hadoop.hbase.util.RetryCounter;
@@ -2695,7 +2696,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
       logDirField = TaskLog.class.getDeclaredField("LOG_DIR");
       logDirField.setAccessible(true);
 
-      Field modifiersField = Field.class.getDeclaredField("modifiers");
+      Field modifiersField = ReflectionUtils.getModifiersField();
       modifiersField.setAccessible(true);
       modifiersField.setInt(logDirField, logDirField.getModifiers() & ~Modifier.FINAL);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupsKillRS.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupsKillRS.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RSGroupTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.JVMClusterUtil;
+import org.apache.hadoop.hbase.util.ReflectionUtils;
 import org.apache.hadoop.hbase.util.VersionInfo;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -282,7 +283,7 @@ public class TestRSGroupsKillRS extends TestRSGroupsBase {
 
   private static void setFinalStatic(Field field, Object newValue) throws Exception {
     field.setAccessible(true);
-    Field modifiersField = Field.class.getDeclaredField("modifiers");
+    Field modifiersField = ReflectionUtils.getModifiersField();
     modifiersField.setAccessible(true);
     modifiersField.setInt(field, field.getModifiers() & ~Modifier.FINAL);
     field.set(null, newValue);


### PR DESCRIPTION
The patch is inspired by powermock: https://github.com/powermock/powermock/pull/1010 to work around the forbidden access to the modifiers field.