### PR TITLE
HBASE-26055 Master local region "table" should be considered a system…

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/NamespaceDescriptor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/NamespaceDescriptor.java
@@ -47,6 +47,10 @@ public class NamespaceDescriptor {
   public static final byte [] DEFAULT_NAMESPACE_NAME = Bytes.toBytes("default");
   public static final String DEFAULT_NAMESPACE_NAME_STR =
       Bytes.toString(DEFAULT_NAMESPACE_NAME);
+  /** Master local region namespace name. */
+  public static final byte [] MASTER_NAMESPACE_NAME = Bytes.toBytes("master");
+  public static final String MASTER_NAMESPACE_NAME_STR =
+    Bytes.toString(MASTER_NAMESPACE_NAME);
 
   public static final NamespaceDescriptor DEFAULT_NAMESPACE = NamespaceDescriptor.create(
     DEFAULT_NAMESPACE_NAME_STR).build();
@@ -58,6 +62,7 @@ public class NamespaceDescriptor {
     Set<String> set = new HashSet<>();
     set.add(NamespaceDescriptor.DEFAULT_NAMESPACE_NAME_STR);
     set.add(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR);
+    set.add(NamespaceDescriptor.MASTER_NAMESPACE_NAME_STR);
     RESERVED_NAMESPACES = Collections.unmodifiableSet(set);
   }
   public final static Set<byte[]> RESERVED_NAMESPACES_BYTES;

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
@@ -338,7 +338,11 @@ public final class TableName implements Comparable<TableName> {
         this.namespace = NamespaceDescriptor.SYSTEM_NAMESPACE_NAME;
         this.namespaceAsString = NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR;
         this.systemTable = true;
-      } else {
+      } else if (Bytes.equals(NamespaceDescriptor.MASTER_NAMESPACE_NAME, namespace)) {
+        this.namespace = NamespaceDescriptor.MASTER_NAMESPACE_NAME;
+        this.namespaceAsString = NamespaceDescriptor.MASTER_NAMESPACE_NAME_STR;
+        this.systemTable = true;
+      }  else {
         this.namespace = new byte[namespace.remaining()];
         namespace.duplicate().get(this.namespace);
         this.namespaceAsString = Bytes.toString(this.namespace);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestNamespace.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestNamespace.java
@@ -169,6 +169,15 @@ public class TestNamespace {
     } finally {
       assertTrue(exceptionCaught);
     }
+
+    try {
+      admin.deleteNamespace(NamespaceDescriptor.MASTER_NAMESPACE_NAME_STR);
+    } catch (IOException exp) {
+      LOG.warn(exp.toString(), exp);
+      exceptionCaught = true;
+    } finally {
+      assertTrue(exceptionCaught);
+    }
   }
 
   @Test


### PR DESCRIPTION
… table

The master local region is not a typical Table/Region, however, we should consider it a system table when creating the TableName so that if we call isSystemTable() it returns true.