### PR TITLE
HBASE-26084 Add owner of replication queue for ReplicationQueueInfo

### DIFF
--- a/hbase-replication/src/main/java/org/apache/hadoop/hbase/replication/ReplicationQueueInfo.java
+++ b/hbase-replication/src/main/java/org/apache/hadoop/hbase/replication/ReplicationQueueInfo.java
@@ -36,6 +36,7 @@ import org.slf4j.LoggerFactory;
 public class ReplicationQueueInfo {
   private static final Logger LOG = LoggerFactory.getLogger(ReplicationQueueInfo.class);
 
+  private final ServerName owner;
   private final String peerId;
   private final String queueId;
   private boolean queueRecovered;
@@ -46,7 +47,8 @@ public class ReplicationQueueInfo {
    * The passed queueId will be either the id of the peer or the handling story of that queue
    * in the form of id-servername-*
    */
-  public ReplicationQueueInfo(String queueId) {
+  public ReplicationQueueInfo(ServerName owner, String queueId) {
+    this.owner = owner;
     this.queueId = queueId;
     String[] parts = queueId.split("-", 2);
     this.queueRecovered = parts.length != 1;
@@ -55,6 +57,22 @@ public class ReplicationQueueInfo {
       // extract dead servers
       extractDeadServersFromZNodeString(parts[1], this.deadRegionServers);
     }
+  }
+
+  /**
+   * A util method to parse the peerId from queueId.
+   */
+  public static String parsePeerId(String queueId) {
+    String[] parts = queueId.split("-", 2);
+    return parts.length != 1 ? parts[0] : queueId;
+  }
+
+  /**
+   * A util method to check whether a queue is recovered.
+   */
+  public static boolean isQueueRecovered(String queueId) {
+    String[] parts = queueId.split("-", 2);
+    return parts.length != 1;
   }
 
   /**
@@ -112,6 +130,10 @@ public class ReplicationQueueInfo {
 
   public List<ServerName> getDeadRegionServers() {
     return Collections.unmodifiableList(this.deadRegionServers);
+  }
+
+  public ServerName getOwner() {
+    return this.owner;
   }
 
   public String getPeerId() {

--- a/hbase-replication/src/main/java/org/apache/hadoop/hbase/replication/ReplicationUtils.java
+++ b/hbase-replication/src/main/java/org/apache/hadoop/hbase/replication/ReplicationUtils.java
@@ -86,8 +86,7 @@ public final class ReplicationUtils {
     for (ServerName replicator : queueStorage.getListOfReplicators()) {
       List<String> queueIds = queueStorage.getAllQueues(replicator);
       for (String queueId : queueIds) {
-        ReplicationQueueInfo queueInfo = new ReplicationQueueInfo(queueId);
-        if (queueInfo.getPeerId().equals(peerId)) {
+        if (ReplicationQueueInfo.parsePeerId(queueId).equals(peerId)) {
           queueStorage.removeQueue(replicator, queueId);
         }
       }

--- a/hbase-replication/src/main/java/org/apache/hadoop/hbase/replication/ZKReplicationQueueStorage.java
+++ b/hbase-replication/src/main/java/org/apache/hadoop/hbase/replication/ZKReplicationQueueStorage.java
@@ -205,7 +205,7 @@ public class ZKReplicationQueueStorage extends ZKReplicationStorageBase
 
   private void addLastSeqIdsToOps(String queueId, Map<String, Long> lastSeqIds,
       List<ZKUtilOp> listOfOps) throws KeeperException, ReplicationException {
-    String peerId = new ReplicationQueueInfo(queueId).getPeerId();
+    String peerId = ReplicationQueueInfo.parsePeerId(queueId);
     for (Entry<String, Long> lastSeqEntry : lastSeqIds.entrySet()) {
       String path = getSerialReplicationRegionPeerNode(lastSeqEntry.getKey(), peerId);
       Pair<Long, Integer> p = getLastSequenceIdWithVersion(lastSeqEntry.getKey(), peerId);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/ReplicationPeerManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/ReplicationPeerManager.java
@@ -103,8 +103,7 @@ public class ReplicationPeerManager {
     for (ServerName replicator : queueStorage.getListOfReplicators()) {
       List<String> queueIds = queueStorage.getAllQueues(replicator);
       for (String queueId : queueIds) {
-        ReplicationQueueInfo queueInfo = new ReplicationQueueInfo(queueId);
-        if (queueInfo.getPeerId().equals(peerId)) {
+        if (ReplicationQueueInfo.parsePeerId(queueId).equals(peerId)) {
           throw new DoNotRetryIOException("undeleted queue for peerId: " + peerId +
             ", replicator: " + replicator + ", queueId: " + queueId);
         }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/DumpReplicationQueues.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/DumpReplicationQueues.java
@@ -316,7 +316,7 @@ public class DumpReplicationQueues extends Configured implements Tool {
         deadRegionServers.add(regionserver.getServerName());
       }
       for (String queueId : queueIds) {
-        ReplicationQueueInfo queueInfo = new ReplicationQueueInfo(queueId);
+        ReplicationQueueInfo queueInfo = new ReplicationQueueInfo(regionserver, queueId);
         List<String> wals = queueStorage.getWALsInQueue(regionserver, queueId);
         Collections.sort(wals);
         if (!peerIds.contains(queueInfo.getPeerId())) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RecoveredReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RecoveredReplicationSource.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Server;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.replication.ReplicationPeer;
+import org.apache.hadoop.hbase.replication.ReplicationQueueInfo;
 import org.apache.hadoop.hbase.replication.ReplicationQueueStorage;
 import org.apache.hadoop.hbase.replication.ReplicationSourceController;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
@@ -51,11 +52,11 @@ public class RecoveredReplicationSource extends ReplicationSource {
   @Override
   public void init(Configuration conf, FileSystem fs, Path walDir,
     ReplicationSourceController overallController, ReplicationQueueStorage queueStorage,
-    ReplicationPeer replicationPeer, Server server, ServerName producer, String queueId,
+    ReplicationPeer replicationPeer, Server server, ReplicationQueueInfo queueInfo,
     UUID clusterId, WALFileLengthProvider walFileLengthProvider, MetricsSource metrics)
     throws IOException {
-    super.init(conf, fs, walDir, overallController, queueStorage, replicationPeer, server, producer,
-      queueId, clusterId, walFileLengthProvider, metrics);
+    super.init(conf, fs, walDir, overallController, queueStorage, replicationPeer, server,
+      queueInfo, clusterId, walFileLengthProvider, metrics);
     this.actualPeerId = this.replicationQueueInfo.getPeerId();
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceFactory.java
@@ -36,8 +36,7 @@ public final class ReplicationSourceFactory {
   private ReplicationSourceFactory() {}
 
   public static ReplicationSourceInterface create(Configuration conf, String queueId) {
-    ReplicationQueueInfo replicationQueueInfo = new ReplicationQueueInfo(queueId);
-    boolean isQueueRecovered = replicationQueueInfo.isQueueRecovered();
+    boolean isQueueRecovered = ReplicationQueueInfo.isQueueRecovered(queueId);
     ReplicationSourceInterface src;
     try {
       String defaultReplicationSourceImpl =

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceInterface.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceInterface.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hbase.Server;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.replication.ReplicationEndpoint;
 import org.apache.hadoop.hbase.replication.ReplicationPeer;
+import org.apache.hadoop.hbase.replication.ReplicationQueueInfo;
 import org.apache.hadoop.hbase.replication.ReplicationQueueStorage;
 import org.apache.hadoop.hbase.replication.ReplicationSourceController;
 import org.apache.hadoop.hbase.wal.WAL.Entry;
@@ -50,15 +51,14 @@ public interface ReplicationSourceInterface {
    * @param queueStorage the replication queue storage
    * @param replicationPeer the replication peer
    * @param server the server which start and run this replication source
-   * @param producer the name of region server which produce WAL to the replication queue
-   * @param queueId the id of our replication queue
+   * @param queueInfo the replication queue
    * @param clusterId unique UUID for the cluster
    * @param walFileLengthProvider used to get the WAL length
    * @param metrics metrics for this replication source
    */
   void init(Configuration conf, FileSystem fs, Path walDir,
     ReplicationSourceController overallController, ReplicationQueueStorage queueStorage,
-    ReplicationPeer replicationPeer, Server server, ServerName producer, String queueId,
+    ReplicationPeer replicationPeer, Server server, ReplicationQueueInfo queueInfo,
     UUID clusterId, WALFileLengthProvider walFileLengthProvider, MetricsSource metrics)
     throws IOException;
 
@@ -105,7 +105,16 @@ public interface ReplicationSourceInterface {
    *
    * @return queue id
    */
-  String getQueueId();
+  default String getQueueId() {
+    return getReplicationQueueInfo().getQueueId();
+  }
+
+  /**
+   * Get the replication queue info
+   *
+   * @return the replication queue info
+   */
+  ReplicationQueueInfo getReplicationQueueInfo();
 
   /**
    * Get the id that the source is replicating to.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/hbck/ReplicationChecker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/hbck/ReplicationChecker.java
@@ -69,13 +69,11 @@ public class ReplicationChecker {
     Set<String> peerIds = new HashSet<>(peerStorage.listPeerIds());
     for (ServerName replicator : queueStorage.getListOfReplicators()) {
       for (String queueId : queueStorage.getAllQueues(replicator)) {
-        ReplicationQueueInfo queueInfo = new ReplicationQueueInfo(queueId);
-        if (!peerIds.contains(queueInfo.getPeerId())) {
+        String peerId = ReplicationQueueInfo.parsePeerId(queueId);
+        if (!peerIds.contains(peerId)) {
           undeletedQueues.computeIfAbsent(replicator, key -> new ArrayList<>()).add(queueId);
-          LOG.debug(
-            "Undeleted replication queue for removed peer found: " +
-              "[removedPeerId={}, replicator={}, queueId={}]",
-            queueInfo.getPeerId(), replicator, queueId);
+          LOG.debug("Undeleted replication queue for removed peer found: " +
+              "[removedPeerId={}, replicator={}, queueId={}]", peerId, replicator, queueId);
         }
       }
     }
@@ -99,10 +97,9 @@ public class ReplicationChecker {
     undeletedQueueIds = getUnDeletedQueues();
     undeletedQueueIds.forEach((replicator, queueIds) -> {
       queueIds.forEach(queueId -> {
-        ReplicationQueueInfo queueInfo = new ReplicationQueueInfo(queueId);
         String msg = "Undeleted replication queue for removed peer found: " +
-          String.format("[removedPeerId=%s, replicator=%s, queueId=%s]", queueInfo.getPeerId(),
-            replicator, queueId);
+          String.format("[removedPeerId=%s, replicator=%s, queueId=%s]",
+            ReplicationQueueInfo.parsePeerId(queueId), replicator, queueId);
         errorReporter.reportError(HbckErrorReporter.ERROR_CODE.UNDELETED_REPLICATION_QUEUE, msg);
       });
     });

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/ReplicationSourceDummy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/ReplicationSourceDummy.java
@@ -39,7 +39,7 @@ import org.apache.hadoop.hbase.wal.WAL.Entry;
 public class ReplicationSourceDummy implements ReplicationSourceInterface {
 
   private ReplicationPeer replicationPeer;
-  private String queueId;
+  private ReplicationQueueInfo replicationQueueInfo;
   private Path currentPath;
   private MetricsSource metrics;
   private WALFileLengthProvider walFileLengthProvider;
@@ -48,10 +48,10 @@ public class ReplicationSourceDummy implements ReplicationSourceInterface {
   @Override
   public void init(Configuration conf, FileSystem fs, Path walDir,
     ReplicationSourceController overallController, ReplicationQueueStorage queueStorage,
-    ReplicationPeer replicationPeer, Server server, ServerName producer, String queueId,
+    ReplicationPeer replicationPeer, Server server, ReplicationQueueInfo queueInfo,
     UUID clusterId, WALFileLengthProvider walFileLengthProvider, MetricsSource metrics)
     throws IOException {
-    this.queueId = queueId;
+    this.replicationQueueInfo = queueInfo;
     this.metrics = metrics;
     this.walFileLengthProvider = walFileLengthProvider;
     this.replicationPeer = replicationPeer;
@@ -66,6 +66,11 @@ public class ReplicationSourceDummy implements ReplicationSourceInterface {
   @Override
   public Path getCurrentPath() {
     return this.currentPath;
+  }
+
+  @Override
+  public ReplicationQueueInfo getReplicationQueueInfo() {
+    return this.replicationQueueInfo;
   }
 
   @Override
@@ -96,15 +101,8 @@ public class ReplicationSourceDummy implements ReplicationSourceInterface {
   }
 
   @Override
-  public String getQueueId() {
-    return queueId;
-  }
-
-  @Override
   public String getPeerId() {
-    String[] parts = queueId.split("-", 2);
-    return parts.length != 1 ?
-        parts[0] : queueId;
+    return this.replicationQueueInfo.getPeerId();
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSource.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSource.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.hbase.regionserver.RegionServerServices;
 import org.apache.hadoop.hbase.replication.ReplicationEndpoint;
 import org.apache.hadoop.hbase.replication.ReplicationPeer;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
+import org.apache.hadoop.hbase.replication.ReplicationQueueInfo;
 import org.apache.hadoop.hbase.replication.ReplicationQueueStorage;
 import org.apache.hadoop.hbase.replication.WALEntryFilter;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
@@ -139,7 +140,8 @@ public class TestReplicationSource {
     String queueId = "qid";
     RegionServerServices rss =
       TEST_UTIL.createMockRegionServerService(ServerName.parseServerName("a.b.c,1,1"));
-    rs.init(conf, null, null, manager, null, mockPeer, rss, rss.getServerName(), queueId, null,
+    rs.init(conf, null, null, manager, null, mockPeer, rss,
+      new ReplicationQueueInfo(rss.getServerName(), queueId), null,
       p -> OptionalLong.empty(), new MetricsSource(queueId));
     try {
       rs.startup();
@@ -177,7 +179,8 @@ public class TestReplicationSource {
     String queueId = "qid";
     RegionServerServices rss =
       TEST_UTIL.createMockRegionServerService(ServerName.parseServerName("a.b.c,1,1"));
-    rs.init(conf, null, null, manager, null, mockPeer, rss, rss.getServerName(), queueId, uuid,
+    rs.init(conf, null, null, manager, null, mockPeer, rss,
+      new ReplicationQueueInfo(rss.getServerName(), queueId), uuid,
       p -> OptionalLong.empty(), new MetricsSource(queueId));
     try {
       rs.startup();
@@ -265,8 +268,8 @@ public class TestReplicationSource {
       testConf.setInt("replication.source.maxretriesmultiplier", 1);
       ReplicationSourceManager manager = Mockito.mock(ReplicationSourceManager.class);
       Mockito.when(manager.getTotalBufferUsed()).thenReturn(new AtomicLong(0));
-      source.init(testConf, null, null, manager, null, mockPeer, null, null, "testPeer", null,
-        p -> OptionalLong.empty(), null);
+      source.init(testConf, null, null, manager, null, mockPeer, null,
+        new ReplicationQueueInfo(null, "testPeer"), null, p -> OptionalLong.empty(), null);
       ExecutorService executor = Executors.newSingleThreadExecutor();
       Future<?> future = executor.submit(
         () -> source.terminate("testing source termination"));
@@ -289,8 +292,9 @@ public class TestReplicationSource {
     ReplicationPeer mockPeer = mock(ReplicationPeer.class);
     Mockito.when(mockPeer.getPeerBandwidth()).thenReturn(0L);
     Configuration testConf = HBaseConfiguration.create();
-    source.init(testConf, null, null, mockManager, null, mockPeer, null, null,
-      "testPeer", null, p -> OptionalLong.empty(), mock(MetricsSource.class));
+    source.init(testConf, null, null, mockManager, null, mockPeer, null,
+      new ReplicationQueueInfo(null, "testPeer"), null, p -> OptionalLong.empty(),
+      mock(MetricsSource.class));
     ReplicationSourceWALReader reader = new ReplicationSourceWALReader(null,
       conf, null, 0, null, source, null);
     ReplicationSourceShipper shipper =
@@ -536,7 +540,8 @@ public class TestReplicationSource {
     String queueId = "qid";
     RegionServerServices rss =
       TEST_UTIL.createMockRegionServerService(ServerName.parseServerName("a.b.c,1,1"));
-    rs.init(conf, null, null, manager, null, mockPeer, rss, rss.getServerName(), queueId, null,
+    rs.init(conf, null, null, manager, null, mockPeer, rss,
+      new ReplicationQueueInfo(rss.getServerName(), queueId), null,
       p -> OptionalLong.empty(), new MetricsSource(queueId));
     return rss;
   }
@@ -655,7 +660,8 @@ public class TestReplicationSource {
         TEST_UTIL.createMockRegionServerService(ServerName.parseServerName("a.b.c,1,1"));
 
       ReplicationSource source = new ReplicationSource();
-      source.init(conf, null, null, manager, null, mockPeer, rss, rss.getServerName(), id, null,
+      source.init(conf, null, null, manager, null, mockPeer, rss,
+        new ReplicationQueueInfo(rss.getServerName(), id), null,
         p -> OptionalLong.empty(), metrics);
 
       final Path log1 = new Path(logDir, "log-walgroup-a.8");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSourceManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSourceManager.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.hbase.replication.ReplicationFactory;
 import org.apache.hadoop.hbase.replication.ReplicationPeer;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
 import org.apache.hadoop.hbase.replication.ReplicationPeers;
+import org.apache.hadoop.hbase.replication.ReplicationQueueInfo;
 import org.apache.hadoop.hbase.replication.ReplicationQueueStorage;
 import org.apache.hadoop.hbase.replication.ReplicationSourceController;
 import org.apache.hadoop.hbase.replication.ReplicationSourceDummy;
@@ -414,8 +415,8 @@ public abstract class TestReplicationSourceManager {
     assertEquals(files, manager.getWalsByIdRecoveredQueues().get(id).get(group));
     ReplicationSourceInterface source = new ReplicationSource();
     source.init(conf, fs, null, manager, manager.getQueueStorage(), rp1.getPeer("1"),
-      manager.getServer(), manager.getServer().getServerName(), id, null, p -> OptionalLong.empty(),
-      null);
+      manager.getServer(), new ReplicationQueueInfo(manager.getServer().getServerName(), id), null,
+      p -> OptionalLong.empty(), null);
     source.cleanOldWALs(file2, false);
     // log1 should be deleted
     assertEquals(Sets.newHashSet(file2), manager.getWalsByIdRecoveredQueues().get(id).get(group));
@@ -632,7 +633,8 @@ public abstract class TestReplicationSourceManager {
       ReplicationSourceInterface source = new ReplicationSource();
       source.init(conf, fs, null, manager, manager.getQueueStorage(),
         mockReplicationPeerForSyncReplication(peerId2), manager.getServer(),
-        manager.getServer().getServerName(), peerId2, null, p -> OptionalLong.empty(), null);
+        new ReplicationQueueInfo(manager.getServer().getServerName(), peerId2), null,
+        p -> OptionalLong.empty(), null);
       source.cleanOldWALs(walName, true);
       // still there if peer id does not match
       assertTrue(fs.exists(remoteWAL));
@@ -640,7 +642,8 @@ public abstract class TestReplicationSourceManager {
       source = new ReplicationSource();
       source.init(conf, fs, null, manager, manager.getQueueStorage(),
         mockReplicationPeerForSyncReplication(slaveId), manager.getServer(),
-        manager.getServer().getServerName(), slaveId, null, p -> OptionalLong.empty(), null);
+        new ReplicationQueueInfo(manager.getServer().getServerName(), slaveId), null,
+        p -> OptionalLong.empty(), null);
       source.cleanOldWALs(walName, true);
       assertFalse(fs.exists(remoteWAL));
     } finally {
@@ -821,7 +824,7 @@ public abstract class TestReplicationSourceManager {
     @Override
     public void init(Configuration conf, FileSystem fs, Path walDir,
       ReplicationSourceController overallController, ReplicationQueueStorage queueStorage,
-      ReplicationPeer replicationPeer, Server server, ServerName producer, String queueId,
+      ReplicationPeer replicationPeer, Server server, ReplicationQueueInfo queueInfo,
       UUID clusterId, WALFileLengthProvider walFileLengthProvider, MetricsSource metrics)
       throws IOException {
       throw new IOException("Failing deliberately");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSourceManagerZkImpl.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSourceManagerZkImpl.java
@@ -95,7 +95,8 @@ public class TestReplicationSourceManagerZkImpl extends TestReplicationSourceMan
         queueStorage.claimQueue(serverName, unclaimed.get(0), s3.getServerName()).getFirst();
     queueStorage.removeReplicatorIfQueueIsEmpty(serverName);
 
-    ReplicationQueueInfo replicationQueueInfo = new ReplicationQueueInfo(queue3);
+    ReplicationQueueInfo replicationQueueInfo =
+      new ReplicationQueueInfo(s3.getServerName(), queue3);
     List<ServerName> result = replicationQueueInfo.getDeadRegionServers();
     // verify
     assertTrue(result.contains(server.getServerName()));


### PR DESCRIPTION
The current `ReplicationQueueInfo` only has `queueId`, which is not enough to distinguish queues in ReplicationServer,  so we need to add the RS holding the queue for `ReplicationQueueInfo`.