### PR TITLE
HBASE-26087 JVM crash when displaying RPC params by MonitoredRPCHandler

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredRPCHandlerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredRPCHandlerImpl.java
@@ -22,10 +22,10 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.Map;
 
-import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hadoop.hbase.client.Operation;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hbase.thirdparty.com.google.protobuf.Message;
 
 /**
@@ -43,6 +43,8 @@ public class MonitoredRPCHandlerImpl extends MonitoredTaskImpl
   private String methodName = "";
   private Object [] params = {};
   private Message packet;
+  private boolean snapshot = false;
+  private Map<String, Object> callInfoMap = new HashMap<>();
 
   public MonitoredRPCHandlerImpl() {
     super();
@@ -53,11 +55,14 @@ public class MonitoredRPCHandlerImpl extends MonitoredTaskImpl
 
   @Override
   public synchronized MonitoredRPCHandlerImpl clone() {
-    return (MonitoredRPCHandlerImpl) super.clone();
+    MonitoredRPCHandlerImpl clone = (MonitoredRPCHandlerImpl) super.clone();
+    clone.setCallInfoMap(generateCallInfoMap());
+    clone.setSnapshot(true);
+    return clone;
   }
 
   /**
-   * Gets the status of this handler; if it is currently servicing an RPC, 
+   * Gets the status of this handler; if it is currently servicing an RPC,
    * this status will include the RPC information.
    * @return a String describing the current status.
    */
@@ -233,6 +238,18 @@ public class MonitoredRPCHandlerImpl extends MonitoredTaskImpl
 
   @Override
   public synchronized Map<String, Object> toMap() {
+    return this.snapshot ? this.callInfoMap : generateCallInfoMap();
+  }
+
+  public void setSnapshot(boolean snapshot) {
+    this.snapshot = snapshot;
+  }
+
+  public void setCallInfoMap(Map<String, Object> callInfoMap) {
+    this.callInfoMap = callInfoMap;
+  }
+
+  private Map<String, Object> generateCallInfoMap() {
     // only include RPC info if the Handler is actively servicing an RPC call
     Map<String, Object> map = super.toMap();
     if (getState() != State.RUNNING) {


### PR DESCRIPTION
Please see more details at https://issues.apache.org/jira/browse/HBASE-26087
The added UT TestTaskMonitor#testClone will fail without this patch. It simulates the referred offheap ByteBuffer of the param change in the clone MonitoredRPCHandler.