### PR TITLE
HBASE-26083 L1 miss metric is incorrect when using CombinedBlockCache

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CombinedBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CombinedBlockCache.java
@@ -82,7 +82,12 @@ public class CombinedBlockCache implements ResizableBlockCache, HeapSize {
     // we end up calling l2Cache.getBlock.
     // We are not in a position to exactly look at LRU cache or BC as BlockType may not be getting
     // passed always.
-    return l1Cache.containsBlock(cacheKey)?
+    boolean existInL1 = l1Cache.containsBlock(cacheKey);
+    if (!existInL1 && updateCacheMetrics && !repeat) {
+      // If the block does not exist in L1, the containsBlock should be counted as one miss.
+      l1Cache.getStats().miss(caching, cacheKey.isPrimary(), cacheKey.getBlockType());
+    }
+    return existInL1 ?
         l1Cache.getBlock(cacheKey, caching, repeat, updateCacheMetrics):
         l2Cache.getBlock(cacheKey, caching, repeat, updateCacheMetrics);
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-26083