### PR TITLE
HBASE-26146: Add support for HBASE_HBCK_OPTS

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -54,6 +54,8 @@
 #   HBASE_SHELL_OPTS Extra options passed to the hbase shell.
 #                    Empty by default.
 #
+#   HBASE_HBCK_OPTS  Extra options passed to hbck.
+#                    Defaults to HBASE_SERVER_JAAS_OPTS if specified, or HBASE_REGIONSERVER_OPTS.
 bin=`dirname "$0"`
 bin=`cd "$bin">/dev/null; pwd`
 
@@ -423,12 +425,18 @@ else
 	HBASE_OPTS="$HBASE_OPTS $CLIENT_GC_OPTS"
 fi
 
-if [ "$AUTH_AS_SERVER" == "true" ] || [ "$COMMAND" = "hbck" ]; then
-   if [ -n "$HBASE_SERVER_JAAS_OPTS" ]; then
-     HBASE_OPTS="$HBASE_OPTS $HBASE_SERVER_JAAS_OPTS"
-   else
-     HBASE_OPTS="$HBASE_OPTS $HBASE_REGIONSERVER_OPTS"
-   fi
+if [ -n "$HBASE_SERVER_JAAS_OPTS" ]; then
+  AUTH_AS_SERVER_OPTS="$HBASE_SERVER_JAAS_OPTS"
+else
+  AUTH_AS_SERVER_OPTS="$HBASE_REGIONSERVER_OPTS"
+fi
+
+if [ "$AUTH_AS_SERVER" == "true" ]; then
+  HBASE_OPTS="$HBASE_OPTS $AUTH_AS_SERVER_OPTS"
+elif [ -z "$HBASE_HBCK_OPTS" ]; then
+  # The default for hbck should be to use auth-as-server args, for compatibility
+  # with HBASE-15145
+  HBASE_HBCK_OPTS="$AUTH_AS_SERVER_OPTS"
 fi
 
 # check if the command needs jline
@@ -545,6 +553,7 @@ elif [ "$COMMAND" = "hbck" ] ; then
     CLASS='org.apache.hadoop.hbase.util.HBaseFsck'
     ;;
   esac
+  HBASE_OPTS="$HBASE_OPTS $HBASE_HBCK_OPTS"
 elif [ "$COMMAND" = "wal" ] ; then
   CLASS='org.apache.hadoop.hbase.wal.WALPrettyPrinter'
 elif [ "$COMMAND" = "hfile" ] ; then


### PR DESCRIPTION
Backports HBASE-26146 to 2.4.

Let me know if there's a better convention for naming these PRs and/or commits for backports.