### PR TITLE
HBASE-26045 Master control the global throughput of all compaction servers

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -2257,6 +2257,17 @@ public interface Admin extends Abortable, Closeable {
   boolean isCompactionOffloadEnabled() throws IOException;
 
   /**
+   * update compaction server total throughput bound
+   * @param upperBound the total throughput upper bound of all compaction servers
+   * @param lowerBound the total throughput lower bound of all compaction servers
+   * @param offPeak the total throughput offPeak bound of all compaction servers
+   * @return the now total throughput of all compaction servers
+   * @throws IOException if a remote or network exception occurs
+   */
+  Map<String, Long> updateCompactionServerTotalThroughput(Long upperBound, Long lowerBound,
+      Long offPeak) throws IOException;
+
+  /**
    * Switch the exceed throttle quota. If enabled, user/table/namespace throttle quota
    * can be exceeded if region server has availble quota.
    * @param enable Set to <code>true</code> to enable, <code>false</code> to disable.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -2264,8 +2264,8 @@ public interface Admin extends Abortable, Closeable {
    * @return the now total throughput of all compaction servers
    * @throws IOException if a remote or network exception occurs
    */
-  Map<String, Long> updateCompactionServerTotalThroughput(Long upperBound, Long lowerBound,
-      Long offPeak) throws IOException;
+  Map<String, Long> updateCompactionServerTotalThroughput(long upperBound, long lowerBound,
+      long offPeak) throws IOException;
 
   /**
    * Switch the exceed throttle quota. If enabled, user/table/namespace throttle quota

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
@@ -919,8 +919,8 @@ class AdminOverAsyncAdmin implements Admin {
   }
 
   @Override
-  public Map<String, Long> updateCompactionServerTotalThroughput(Long upperBound, Long lowerBound,
-      Long offPeak) throws IOException {
+  public Map<String, Long> updateCompactionServerTotalThroughput(long upperBound, long lowerBound,
+      long offPeak) throws IOException {
     return get(admin.updateCompactionServerTotalThroughput(upperBound, lowerBound, offPeak));
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
@@ -919,6 +919,12 @@ class AdminOverAsyncAdmin implements Admin {
   }
 
   @Override
+  public Map<String, Long> updateCompactionServerTotalThroughput(Long upperBound, Long lowerBound,
+      Long offPeak) throws IOException {
+    return get(admin.updateCompactionServerTotalThroughput(upperBound, lowerBound, offPeak));
+  }
+
+  @Override
   public boolean isCompactionOffloadEnabled() throws IOException {
     return get(admin.isCompactionOffloadEnabled());
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -1466,8 +1466,8 @@ public interface AsyncAdmin {
    * @param offPeak the total throughput offPeak bound of all compaction servers
    * @return the now total throughput of all compaction servers
    */
-  CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(Long upperBound,
-    Long lowerBound, Long offPeak);
+  CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(long upperBound,
+    long lowerBound, long offPeak);
 
   /**
    * Get if the compaction offload is enabled.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -1460,6 +1460,16 @@ public interface AsyncAdmin {
   CompletableFuture<Boolean> switchCompactionOffload(boolean enable);
 
   /**
+   * update compaction server total throughput bound
+   * @param upperBound the total throughput upper bound of all compaction servers
+   * @param lowerBound the total throughput lower bound of all compaction servers
+   * @param offPeak the total throughput offPeak bound of all compaction servers
+   * @return the now total throughput of all compaction servers
+   */
+  CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(Long upperBound,
+    Long lowerBound, Long offPeak);
+
+  /**
    * Get if the compaction offload is enabled.
    * @return True if compaction offload is enabled
    */

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
@@ -798,8 +798,8 @@ class AsyncHBaseAdmin implements AsyncAdmin {
   }
 
   @Override
-  public CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(Long upperBound,
-      Long lowerBound, Long offPeak) {
+  public CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(long upperBound,
+      long lowerBound, long offPeak) {
     return wrap(rawAdmin.updateCompactionServerTotalThroughput(upperBound, lowerBound, offPeak));
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
@@ -798,6 +798,12 @@ class AsyncHBaseAdmin implements AsyncAdmin {
   }
 
   @Override
+  public CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(Long upperBound,
+      Long lowerBound, Long offPeak) {
+    return wrap(rawAdmin.updateCompactionServerTotalThroughput(upperBound, lowerBound, offPeak));
+  }
+
+  @Override
   public CompletableFuture<Boolean> isCompactionOffloadEnabled() {
     return wrap(rawAdmin.isCompactionOffloadEnabled());
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -3825,8 +3825,8 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
   }
 
   @Override
-  public CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(Long upperBound,
-      Long lowerBound, Long offPeak) {
+  public CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(long upperBound,
+      long lowerBound, long offPeak) {
     CompletableFuture<Map<String, Long>> future = this.<Map<String, Long>> newMasterCaller().action(
       (controller, stub) -> this
           .<UpdateCompactionServerTotalThroughputRequest, UpdateCompactionServerTotalThroughputResponse, Map<String, Long>> call(

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -283,6 +283,8 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.TruncateTa
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.TruncateTableResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.UnassignRegionRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.UnassignRegionResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.UpdateCompactionServerTotalThroughputRequest;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.UpdateCompactionServerTotalThroughputResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.QuotaProtos.GetQuotaStatesRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.QuotaProtos.GetQuotaStatesResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.QuotaProtos.GetSpaceQuotaRegionSizesRequest;
@@ -3818,6 +3820,27 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
                   .build(),
               (s, c, req, done) -> s.switchCompactionOffload(c, req, done),
               resp -> resp.getPreviousCompactionOffloadEnabled()))
+        .call();
+    return future;
+  }
+
+  @Override
+  public CompletableFuture<Map<String, Long>> updateCompactionServerTotalThroughput(Long upperBound,
+      Long lowerBound, Long offPeak) {
+    CompletableFuture<Map<String, Long>> future = this.<Map<String, Long>> newMasterCaller().action(
+      (controller, stub) -> this
+          .<UpdateCompactionServerTotalThroughputRequest, UpdateCompactionServerTotalThroughputResponse, Map<String, Long>> call(
+            controller, stub,
+            UpdateCompactionServerTotalThroughputRequest.newBuilder()
+                .setMaxThroughputUpperBound(upperBound).setMaxThroughputLowerBound(lowerBound)
+                .setMaxThroughputOffPeak(offPeak).build(),
+            (s, c, req, done) -> s.updateCompactionServerTotalThroughput(c, req, done), resp -> {
+              Map<String, Long> result = new HashMap<>();
+              result.put("UpperBound", resp.getMaxThroughputUpperBound());
+              result.put("LowerBound", resp.getMaxThroughputLowerBound());
+              result.put("OffPeak", resp.getMaxThroughputOffPeak());
+              return result;
+            }))
         .call();
     return future;
   }

--- a/hbase-protocol-shaded/src/main/protobuf/server/CompactionServerStatus.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/CompactionServerStatus.proto
@@ -37,6 +37,9 @@ message CompactionServerReportRequest {
 }
 
 message CompactionServerReportResponse {
+  required int64 max_throughput_upper_bound = 1 ;
+  required int64 max_throughput_lower_bound = 2 ;
+  required int64 max_throughput_off_peak = 3 ;
 }
 
 service CompactionServerStatusService {

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/Master.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/Master.proto
@@ -732,6 +732,18 @@ message SwitchCompactionOffloadResponse {
   required bool previous_compaction_offload_enabled = 1;
 }
 
+message UpdateCompactionServerTotalThroughputRequest {
+  required int64 max_throughput_upper_bound = 1;
+  required int64 max_throughput_lower_bound = 2;
+  required int64 max_throughput_off_peak = 3;
+}
+
+message UpdateCompactionServerTotalThroughputResponse {
+  required int64 max_throughput_upper_bound = 1;
+  required int64 max_throughput_lower_bound = 2;
+  required int64 max_throughput_off_peak = 3;
+}
+
 service MasterService {
   /** Used by the client to get the number of regions that have received the updated schema */
   rpc GetSchemaAlterStatus(GetSchemaAlterStatusRequest)
@@ -1111,6 +1123,9 @@ service MasterService {
   /** Turn the compaction offload on or off */
   rpc SwitchCompactionOffload (SwitchCompactionOffloadRequest)
     returns (SwitchCompactionOffloadResponse);
+
+  rpc UpdateCompactionServerTotalThroughput(UpdateCompactionServerTotalThroughputRequest)
+    returns (UpdateCompactionServerTotalThroughputResponse);
 
   /** Get if is compaction offload enabled */
   rpc IsCompactionOffloadEnabled (IsCompactionOffloadEnabledRequest)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/compactionserver/CompactionThreadManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/compactionserver/CompactionThreadManager.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hbase.regionserver.HStore;
 import org.apache.hadoop.hbase.regionserver.HStoreFile;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionContext;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionLifeCycleTracker;
+import org.apache.hadoop.hbase.regionserver.throttle.ThroughputController;
 import org.apache.hadoop.hbase.regionserver.throttle.ThroughputControllerService;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
@@ -93,6 +94,10 @@ public class CompactionThreadManager implements ThroughputControllerService {
   private ConcurrentHashMap<String, CompactionTask> runningCompactionTasks =
       new ConcurrentHashMap<>();
   private static CompactionFilesCache compactionFilesCache = new CompactionFilesCache();
+
+  public ThroughputController getCompactionThroughputController() {
+    return compactThreadControl.getCompactionThroughputController();
+  }
 
   CompactionThreadManager(final Configuration conf, HCompactionServer server) {
     this.conf = conf;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/compactionserver/HCompactionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/compactionserver/HCompactionServer.java
@@ -146,7 +146,7 @@ public class HCompactionServer extends AbstractServer {
       SecurityConstants.COMPACTION_SERVER_KRB_PRINCIPAL, host);
   }
 
-  private ClusterStatusProtos.CompactionServerLoad buildServerLoad(long reportStartTime,
+  protected ClusterStatusProtos.CompactionServerLoad buildServerLoad(long reportStartTime,
     long reportEndTime) {
     ClusterStatusProtos.CompactionServerLoad.Builder serverLoad =
       ClusterStatusProtos.CompactionServerLoad.newBuilder();
@@ -185,7 +185,8 @@ public class HCompactionServer extends AbstractServer {
           this.cssStub.compactionServerReport(null, request.build());
       ThroughputController throughputController =
           compactionThreadManager.getCompactionThroughputController();
-      if (throughputController instanceof PressureAwareCompactionThroughputController) {
+      if (throughputController instanceof PressureAwareCompactionThroughputController
+          && compactionServerReportResponse.getMaxThroughputUpperBound() > 0) {
         ((PressureAwareCompactionThroughputController) throughputController)
             .setMaxThroughputUpperBound(
               compactionServerReportResponse.getMaxThroughputUpperBound());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -687,12 +687,12 @@ public class MasterRpcServices extends RSRpcServices implements
       ServerName serverName = ProtobufUtil.toServerName(request.getServer());
       CompactionServerMetrics newLoad = CompactionServerMetricsBuilder
           .toCompactionServerMetrics(serverName, versionNumber, version, request.getLoad());
-      Triple<Long, Long, Long> throughput =
+      Triple<Double, Double, Double> throughput =
           master.getCompactionOffloadManager().compactionServerReport(serverName, newLoad);
       return CompactionServerReportResponse.newBuilder()
-          .setMaxThroughputUpperBound(throughput.getFirst())
-          .setMaxThroughputLowerBound(throughput.getSecond())
-          .setMaxThroughputOffPeak(throughput.getThird()).build();
+          .setMaxThroughputUpperBound(throughput.getFirst().longValue())
+          .setMaxThroughputLowerBound(throughput.getSecond().longValue())
+          .setMaxThroughputOffPeak(throughput.getThird().longValue()).build();
     } catch (IOException ioe) {
       throw new ServiceException(ioe);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/compaction/CompactionOffloadManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/compaction/CompactionOffloadManager.java
@@ -116,12 +116,14 @@ public class CompactionOffloadManager {
       COMPACTION_SERVER_MAX_THROUGHPUT_OFFPEAK, DEFAULT_COMPACTION_SERVER_MAX_THROUGHPUT_OFFPEAK);
   }
 
-  public Triple<Long, Long, Long> compactionServerReport(ServerName sn,
-    CompactionServerMetrics sl) {
+  public Triple<Double, Double, Double> compactionServerReport(ServerName sn,
+      CompactionServerMetrics sl) {
     this.onlineServers.put(sn, sl);
-    long size = Math.max(onlineServers.size(), 1);
-    return new Triple<>(maxThroughputUpperBound / size, maxThroughputLowerBound / size,
-      maxThroughputOffPeak / size);
+    int totalTask = Math.max(onlineServers.asMap().values().stream()
+        .mapToInt(metric -> metric.getCompactionTasks().size()).sum(), 1);
+    double factor = 1.0 * onlineServers.asMap().get(sn).getCompactionTasks().size() / totalTask;
+    return new Triple<>(maxThroughputUpperBound * factor, maxThroughputLowerBound * factor,
+        maxThroughputOffPeak * factor);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/throttle/PressureAwareCompactionThroughputController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/throttle/PressureAwareCompactionThroughputController.java
@@ -70,7 +70,7 @@ public class PressureAwareCompactionThroughputController extends PressureAwareTh
   private static final String HBASE_HSTORE_COMPACTION_THROUGHPUT_CONTROL_CHECK_INTERVAL =
     "hbase.hstore.compaction.throughput.control.check.interval";
 
-  private long maxThroughputOffpeak;
+  private long maxThroughputOffPeak;
 
   @Override
   public void setup(final ThroughputControllerService server) {
@@ -90,7 +90,7 @@ public class PressureAwareCompactionThroughputController extends PressureAwareTh
       // set to unlimited if some stores already reach the blocking store file count
       maxThroughputToSet = Double.MAX_VALUE;
     } else if (offPeakHours.isOffPeakHour()) {
-      maxThroughputToSet = maxThroughputOffpeak;
+      maxThroughputToSet = maxThroughputOffPeak;
     } else {
       // compactionPressure is between 0.0 and 1.0, we use a simple linear formula to
       // calculate the throughput limitation.
@@ -122,7 +122,7 @@ public class PressureAwareCompactionThroughputController extends PressureAwareTh
     this.maxThroughputLowerBound =
         conf.getLong(HBASE_HSTORE_COMPACTION_MAX_THROUGHPUT_LOWER_BOUND,
           DEFAULT_HBASE_HSTORE_COMPACTION_MAX_THROUGHPUT_LOWER_BOUND);
-    this.maxThroughputOffpeak =
+    this.maxThroughputOffPeak =
         conf.getLong(HBASE_HSTORE_COMPACTION_MAX_THROUGHPUT_OFFPEAK,
           DEFAULT_HBASE_HSTORE_COMPACTION_MAX_THROUGHPUT_OFFPEAK);
     this.offPeakHours = OffPeakHours.getInstance(conf);
@@ -136,7 +136,7 @@ public class PressureAwareCompactionThroughputController extends PressureAwareTh
     LOG.info("Compaction throughput configurations, higher bound: "
         + throughputDesc(maxThroughputUpperBound) + ", lower bound "
         + throughputDesc(maxThroughputLowerBound) + ", off peak: "
-        + throughputDesc(maxThroughputOffpeak) + ", tuning period: " + tuningPeriod + " ms");
+        + throughputDesc(maxThroughputOffPeak) + ", tuning period: " + tuningPeriod + " ms");
   }
 
   @Override
@@ -144,5 +144,13 @@ public class PressureAwareCompactionThroughputController extends PressureAwareTh
     return "DefaultCompactionThroughputController [maxThroughput="
         + throughputDesc(getMaxThroughput()) + ", activeCompactions=" + activeOperations.size()
         + "]";
+  }
+
+  public void setMaxThroughputOffPeak(long maxThroughputOffPeak) {
+    this.maxThroughputOffPeak = maxThroughputOffPeak;
+  }
+
+  public long getMaxThroughputOffPeak() {
+    return maxThroughputOffPeak;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/throttle/PressureAwareThroughputController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/throttle/PressureAwareThroughputController.java
@@ -64,9 +64,9 @@ public abstract class PressureAwareThroughputController extends Configured imple
     }
   }
 
-  protected long maxThroughputUpperBound;
+  protected volatile long maxThroughputUpperBound;
 
-  protected long maxThroughputLowerBound;
+  protected volatile long maxThroughputLowerBound;
 
   protected OffPeakHours offPeakHours;
 
@@ -169,5 +169,21 @@ public abstract class PressureAwareThroughputController extends Configured imple
   public void setMaxThroughput(double maxThroughput) {
     this.maxThroughput = maxThroughput;
     maxThroughputPerOperation = getMaxThroughput() / activeOperations.size();
+  }
+
+  public void setMaxThroughputUpperBound(long maxThroughputUpperBound) {
+    this.maxThroughputUpperBound = maxThroughputUpperBound;
+  }
+
+  public void setMaxThroughputLowerBound(long maxThroughputLowerBound) {
+    this.maxThroughputLowerBound = maxThroughputLowerBound;
+  }
+
+  public long getMaxThroughputUpperBound() {
+    return maxThroughputUpperBound;
+  }
+
+  public long getMaxThroughputLowerBound() {
+    return maxThroughputLowerBound;
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
@@ -1115,7 +1115,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
     TraceUtil.initTracer(c);
     this.hbaseCluster = new MiniHBaseCluster(c, option.getNumMasters(),
       option.getNumAlwaysStandByMasters(), option.getNumRegionServers(), option.getRsPorts(),
-      option.getNumCompactionServers(), option.getMasterClass(), option.getRsClass());
+      option.getNumCompactionServers(), option.getMasterClass(), option.getRsClass(), option.getCsClass());
     // Populate the master address configuration from mini cluster configuration.
     conf.set(HConstants.MASTER_ADDRS_KEY, MasterRegistry.getMasterAddr(c));
     // Don't leave here till we've done a successful scan of the hbase:meta

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/MiniHBaseCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/MiniHBaseCluster.java
@@ -107,6 +107,15 @@ public class MiniHBaseCluster extends HBaseCluster {
         regionserverClass);
   }
 
+  public MiniHBaseCluster(Configuration conf, int numMasters, int numAlwaysStandByMasters,
+      int numRegionServers, List<Integer> rsPorts, int numCompactionServers,
+      Class<? extends HMaster> masterClass,
+      Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> regionserverClass)
+      throws IOException, InterruptedException {
+    this(conf, numMasters, numAlwaysStandByMasters, numRegionServers, rsPorts, numCompactionServers,
+        masterClass, regionserverClass, null);
+  }
+
   /**
    * @param numCompactionServers initial number of compaction servers to start.
    * @throws IOException
@@ -115,7 +124,8 @@ public class MiniHBaseCluster extends HBaseCluster {
   public MiniHBaseCluster(Configuration conf, int numMasters, int numAlwaysStandByMasters,
       int numRegionServers, List<Integer> rsPorts, int numCompactionServers,
       Class<? extends HMaster> masterClass,
-      Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> regionserverClass)
+      Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> regionserverClass,
+      Class<? extends HCompactionServer> compactionserverClass)
       throws IOException, InterruptedException {
     super(conf);
 
@@ -123,7 +133,7 @@ public class MiniHBaseCluster extends HBaseCluster {
     CompatibilityFactory.getInstance(MetricsAssertHelper.class).init();
 
     init(numMasters, numAlwaysStandByMasters, numRegionServers, rsPorts, numCompactionServers,
-      masterClass, regionserverClass);
+      masterClass, regionserverClass, compactionserverClass);
     this.initialClusterStatus = getClusterMetrics();
   }
 
@@ -242,7 +252,8 @@ public class MiniHBaseCluster extends HBaseCluster {
   private void init(final int nMasterNodes, final int numAlwaysStandByMasters,
       final int nRegionNodes, List<Integer> rsPorts, int numCompactionServers,
       Class<? extends HMaster> masterClass,
-      Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> regionserverClass)
+      Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> regionserverClass,
+      Class<? extends HCompactionServer> compactionserverClass)
       throws IOException, InterruptedException {
     try {
       if (masterClass == null) {
@@ -251,10 +262,13 @@ public class MiniHBaseCluster extends HBaseCluster {
       if (regionserverClass == null) {
         regionserverClass = MiniHBaseCluster.MiniHBaseClusterRegionServer.class;
       }
+      if (compactionserverClass == null) {
+        compactionserverClass = HCompactionServer.class;
+      }
 
       // start up a LocalHBaseCluster
-      hbaseCluster = new LocalHBaseCluster(conf, nMasterNodes, numAlwaysStandByMasters, 0,
-          masterClass, regionserverClass);
+      hbaseCluster = new LocalHBaseCluster(conf, nMasterNodes, numAlwaysStandByMasters, 0, 0,
+          masterClass, regionserverClass, compactionserverClass);
 
       // manually add the regionservers as other users
       for (int i = 0; i < nRegionNodes; i++) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/StartMiniClusterOption.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/StartMiniClusterOption.java
@@ -22,6 +22,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hbase.compactionserver.HCompactionServer;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -77,6 +78,11 @@ public final class StartMiniClusterOption {
   private Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> rsClass;
 
   /**
+   * The class to use as CompactionServer, or null for default.
+   */
+  private Class<? extends HCompactionServer> csClass;
+
+  /**
    * Number of compaction servers to start up.
    */
   private final int numCompactionServers;
@@ -115,8 +121,8 @@ public final class StartMiniClusterOption {
   private StartMiniClusterOption(int numMasters, int numAlwaysStandByMasters,
       Class<? extends HMaster> masterClass, int numRegionServers, List<Integer> rsPorts,
       Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> rsClass,
-      int numCompactionServers, int numDataNodes, String[] dataNodeHosts, int numZkServers,
-      boolean createRootDir, boolean createWALDir) {
+      int numCompactionServers, Class<? extends HCompactionServer> csClass, int numDataNodes,
+      String[] dataNodeHosts, int numZkServers, boolean createRootDir, boolean createWALDir) {
     this.numMasters = numMasters;
     this.numAlwaysStandByMasters = numAlwaysStandByMasters;
     this.masterClass = masterClass;
@@ -124,6 +130,7 @@ public final class StartMiniClusterOption {
     this.rsPorts = rsPorts;
     this.rsClass = rsClass;
     this.numCompactionServers = numCompactionServers;
+    this.csClass = csClass;
     this.numDataNodes = numDataNodes;
     this.dataNodeHosts = dataNodeHosts;
     this.numZkServers = numZkServers;
@@ -153,6 +160,10 @@ public final class StartMiniClusterOption {
 
   public Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> getRsClass() {
     return rsClass;
+  }
+
+  public Class<? extends HCompactionServer> getCsClass() {
+    return csClass;
   }
 
   public int getNumCompactionServers() {
@@ -210,6 +221,7 @@ public final class StartMiniClusterOption {
     private List<Integer> rsPorts = null;
     private int numCompactionServers;
     private Class<? extends MiniHBaseCluster.MiniHBaseClusterRegionServer> rsClass = null;
+    private Class<? extends HCompactionServer> csClass = null;
     private int numDataNodes = 1;
     private String[] dataNodeHosts = null;
     private int numZkServers = 1;
@@ -224,8 +236,8 @@ public final class StartMiniClusterOption {
         numDataNodes = dataNodeHosts.length;
       }
       return new StartMiniClusterOption(numMasters, numAlwaysStandByMasters, masterClass,
-          numRegionServers, rsPorts, rsClass, numCompactionServers, numDataNodes, dataNodeHosts,
-          numZkServers, createRootDir, createWALDir);
+          numRegionServers, rsPorts, rsClass, numCompactionServers, csClass, numDataNodes,
+          dataNodeHosts, numZkServers, createRootDir, createWALDir);
     }
 
     public Builder numMasters(int numMasters) {
@@ -263,6 +275,11 @@ public final class StartMiniClusterOption {
       return this;
     }
 
+    public Builder csClass(Class<? extends HCompactionServer> csClass) {
+      this.csClass = csClass;
+      return this;
+    }    
+    
     public Builder numDataNodes(int numDataNodes) {
       this.numDataNodes = numDataNodes;
       return this;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/compactionserver/TestCompactionServerWithThroughputController.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/compactionserver/TestCompactionServerWithThroughputController.java
@@ -1,0 +1,91 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one or more contributor license
+ * agreements. See the NOTICE file distributed with this work for additional information regarding
+ * copyright ownership. The ASF licenses this file to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance with the License. You may obtain a
+ * copy of the License at http://www.apache.org/licenses/LICENSE-2.0 Unless required by applicable
+ * law or agreed to in writing, software distributed under the License is distributed on an "AS IS"
+ * BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the License
+ * for the specific language governing permissions and limitations under the License.
+ */
+package org.apache.hadoop.hbase.compactionserver;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.StartMiniClusterOption;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.master.compaction.CompactionOffloadManager;
+import org.apache.hadoop.hbase.regionserver.throttle.PressureAwareCompactionThroughputController;
+import org.apache.hadoop.hbase.regionserver.throttle.TestCompactionWithThroughputControllerBase;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+
+@Category({ RegionServerTests.class, LargeTests.class })
+public class TestCompactionServerWithThroughputController
+    extends TestCompactionWithThroughputControllerBase {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestCompactionServerWithThroughputController.class);
+
+  private static final Logger LOG =
+      LoggerFactory.getLogger(TestCompactionServerWithThroughputController.class);
+
+  protected void setThroughputLimitConf(long throughputLimit) {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.setLong(CompactionOffloadManager.COMPACTION_SERVER_MAX_THROUGHPUT_HIGHER_BOUND,
+      throughputLimit);
+    conf.setLong(CompactionOffloadManager.COMPACTION_SERVER_MAX_THROUGHPUT_LOWER_BOUND,
+      throughputLimit);
+    conf.setLong(
+      PressureAwareCompactionThroughputController.HBASE_HSTORE_COMPACTION_MAX_THROUGHPUT_HIGHER_BOUND,
+      throughputLimit);
+    conf.setLong(
+      PressureAwareCompactionThroughputController.HBASE_HSTORE_COMPACTION_MAX_THROUGHPUT_LOWER_BOUND,
+      throughputLimit);
+  }
+
+  protected void startMiniCluster() throws Exception {
+    TEST_UTIL.startMiniCluster(StartMiniClusterOption.builder().numCompactionServers(1).build());
+    TEST_UTIL.getAdmin().switchCompactionOffload(true);
+  }
+
+  protected void shutdownMiniCluster() throws Exception {
+    HCompactionServer compactionServer =
+        TEST_UTIL.getMiniHBaseCluster().getCompactionServerThreads().get(0).getCompactionServer();
+    Assert.assertTrue(compactionServer.requestCount.sum() > 0);
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  protected Table createTable() throws IOException {
+    TableDescriptor tableDescriptor =
+        TableDescriptorBuilder.newBuilder(tableName).setCompactionOffloadEnabled(true).build();
+    return TEST_UTIL.createTable(tableDescriptor, Bytes.toByteArrays(family),
+      TEST_UTIL.getConfiguration());
+  }
+
+  @Test
+  public void testCompaction() throws Exception {
+    long limitTime = testCompactionWithThroughputLimit();
+    long noLimitTime = testCompactionWithoutThroughputLimit();
+    LOG.info("With 1M/s limit, compaction use " + limitTime + "ms; without limit, compaction use "
+        + noLimitTime + "ms");
+    // usually the throughput of a compaction without limitation is about 40MB/sec at least, so this
+    // is a very weak assumption.
+    assertTrue(limitTime > noLimitTime * 2);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/compactionserver/TestUpdateCompactionServerTotalThroughput.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/compactionserver/TestUpdateCompactionServerTotalThroughput.java
@@ -1,0 +1,114 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.compactionserver;
+
+import java.io.IOException;
+import java.util.Map;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.StartMiniClusterOption;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.regionserver.throttle.PressureAwareCompactionThroughputController;
+import org.apache.hadoop.hbase.testclassification.CompactionServerTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.junit.After;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+
+@Category({ MediumTests.class, CompactionServerTests.class })
+public class TestUpdateCompactionServerTotalThroughput {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestUpdateCompactionServerTotalThroughput.class);
+  private static HBaseTestingUtility TEST_UTIL;
+  private static Configuration conf = HBaseConfiguration.create();
+  private static Connection connection;
+  private static Admin admin;
+  private static int COMPACTION_SERVER_NUM = 2;
+
+  @Before
+  public void setUp() throws Exception {
+    TEST_UTIL = new HBaseTestingUtility(conf);
+    TEST_UTIL.startMiniCluster(
+      StartMiniClusterOption.builder().numCompactionServers(COMPACTION_SERVER_NUM).build());
+    admin = TEST_UTIL.getAdmin();
+    connection = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (admin != null) {
+      admin.close();
+    }
+    if (connection != null) {
+      connection.close();
+    }
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  private void checkThroughPut(long upperBound, long lowBound, long offPeak) {
+    TEST_UTIL.getHBaseCluster().getCompactionServerThreads().forEach(cs -> {
+      PressureAwareCompactionThroughputController throughputController =
+          (PressureAwareCompactionThroughputController) cs
+              .getCompactionServer().compactionThreadManager.getCompactionThroughputController();
+      TEST_UTIL.waitFor(60000,
+        () -> throughputController.getMaxThroughputUpperBound() == upperBound
+            && throughputController.getMaxThroughputLowerBound() == lowBound
+            && throughputController.getMaxThroughputOffPeak() == offPeak);
+    });
+  }
+
+  private void checkUpdateThroughPutResult(Map<String, Long> result, long upperBound, long lowBound,
+      long offPeak) {
+    Assert.assertEquals(upperBound, result.get("UpperBound").longValue());
+    Assert.assertEquals(lowBound, result.get("LowerBound").longValue());
+    Assert.assertEquals(offPeak, result.get("OffPeak").longValue());
+  }
+
+  @Test
+  public void testUpdateCompactionServerTotalThroughput() throws IOException {
+    Admin admin = TEST_UTIL.getAdmin();
+
+    Map<String, Long> result = admin.updateCompactionServerTotalThroughput(200L, 100L, 400L);
+    checkThroughPut(200 / COMPACTION_SERVER_NUM, 100 / COMPACTION_SERVER_NUM,
+      400 / COMPACTION_SERVER_NUM);
+    checkUpdateThroughPutResult(result, 200, 100, 400);
+
+    result = admin.updateCompactionServerTotalThroughput(0L, 0L, 0L);
+    // set TotalThroughput to 0 will not take effect
+    checkUpdateThroughPutResult(result, 200, 100, 400);
+
+    result = admin.updateCompactionServerTotalThroughput(-100L, -100L, -100L);
+    // set TotalThroughput to negative will not take effect
+    checkUpdateThroughPutResult(result, 200, 100, 400);
+
+    result = admin.updateCompactionServerTotalThroughput(2000L, 500L, 10000L);
+    checkThroughPut(2000 / COMPACTION_SERVER_NUM, 500 / COMPACTION_SERVER_NUM,
+      10000 / COMPACTION_SERVER_NUM);
+    checkUpdateThroughPutResult(result, 2000, 500, 10000);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/throttle/TestCompactionWithThroughputControllerBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/throttle/TestCompactionWithThroughputControllerBase.java
@@ -1,0 +1,163 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver.throttle;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.concurrent.ThreadLocalRandom;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.MiniHBaseCluster;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.regionserver.DefaultStoreEngine;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.regionserver.HStore;
+import org.apache.hadoop.hbase.regionserver.Region;
+import org.apache.hadoop.hbase.regionserver.StoreEngine;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionConfiguration;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.JVMClusterUtil;
+
+
+public class TestCompactionWithThroughputControllerBase {
+  protected static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  protected static final double EPSILON = 1E-6;
+
+  protected final TableName tableName = TableName.valueOf(getClass().getSimpleName());
+
+  protected final byte[] family = Bytes.toBytes("f");
+
+  protected final byte[] qualifier = Bytes.toBytes("q");
+
+  protected HStore getStoreWithName(TableName tableName) {
+    MiniHBaseCluster cluster = TEST_UTIL.getMiniHBaseCluster();
+    List<JVMClusterUtil.RegionServerThread> rsts = cluster.getRegionServerThreads();
+    for (int i = 0; i < cluster.getRegionServerThreads().size(); i++) {
+      HRegionServer hrs = rsts.get(i).getRegionServer();
+      for (Region region : hrs.getRegions(tableName)) {
+        return ((HRegion) region).getStores().iterator().next();
+      }
+    }
+    return null;
+  }
+
+  protected Table createTable() throws IOException {
+    return TEST_UTIL.createTable(tableName, family);
+  }
+
+  protected HStore prepareData() throws IOException {
+    Admin admin = TEST_UTIL.getAdmin();
+    if (admin.tableExists(tableName)) {
+      admin.disableTable(tableName);
+      admin.deleteTable(tableName);
+    }
+    Table table = createTable();
+    for (int i = 0; i < 10; i++) {
+      for (int j = 0; j < 10; j++) {
+        byte[] value = new byte[128 * 1024];
+        ThreadLocalRandom.current().nextBytes(value);
+        table.put(new Put(Bytes.toBytes(i * 10 + j)).addColumn(family, qualifier, value));
+      }
+      admin.flush(tableName);
+    }
+    return getStoreWithName(tableName);
+  }
+
+  protected void startMiniCluster() throws Exception{
+    TEST_UTIL.startMiniCluster(1);
+  }
+
+  protected void shutdownMiniCluster() throws Exception{
+    TEST_UTIL.shutdownMiniCluster();
+  }
+  protected void setThroughputLimitConf(long throughputLimit){
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.setLong(
+      PressureAwareCompactionThroughputController
+        .HBASE_HSTORE_COMPACTION_MAX_THROUGHPUT_HIGHER_BOUND,
+      throughputLimit);
+    conf.setLong(
+      PressureAwareCompactionThroughputController
+        .HBASE_HSTORE_COMPACTION_MAX_THROUGHPUT_LOWER_BOUND,
+      throughputLimit);
+  }
+
+  protected long testCompactionWithThroughputLimit() throws Exception {
+    long throughputLimit = 1024L * 1024;
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.set(StoreEngine.STORE_ENGINE_CLASS_KEY, DefaultStoreEngine.class.getName());
+    conf.setInt(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MIN_KEY, 100);
+    conf.setInt(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MAX_KEY, 200);
+    conf.setInt(HStore.BLOCKING_STOREFILES_KEY, 10000);
+    setThroughputLimitConf(throughputLimit);
+    conf.set(CompactionThroughputControllerFactory.HBASE_THROUGHPUT_CONTROLLER_KEY,
+      PressureAwareCompactionThroughputController.class.getName());
+    startMiniCluster();
+    try {
+      HStore store = prepareData();
+      assertEquals(10, store.getStorefilesCount());
+      long startTime = System.currentTimeMillis();
+      TEST_UTIL.getAdmin().majorCompact(tableName);
+      while (store.getStorefilesCount() != 1) {
+        Thread.sleep(20);
+      }
+      long duration = System.currentTimeMillis() - startTime;
+      double throughput = (double) store.getStorefilesSize() / duration * 1000;
+      // confirm that the speed limit work properly(not too fast, and also not too slow)
+      // 20% is the max acceptable error rate.
+      assertTrue(throughput < throughputLimit * 1.2);
+      assertTrue(throughput > throughputLimit * 0.8);
+      return System.currentTimeMillis() - startTime;
+    } finally {
+      shutdownMiniCluster();
+    }
+  }
+
+
+  protected long testCompactionWithoutThroughputLimit() throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.set(StoreEngine.STORE_ENGINE_CLASS_KEY, DefaultStoreEngine.class.getName());
+    conf.setInt(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MIN_KEY, 100);
+    conf.setInt(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MAX_KEY, 200);
+    conf.setInt(HStore.BLOCKING_STOREFILES_KEY, 10000);
+    conf.set(CompactionThroughputControllerFactory.HBASE_THROUGHPUT_CONTROLLER_KEY,
+      NoLimitThroughputController.class.getName());
+    startMiniCluster();
+    try {
+      HStore store = prepareData();
+      assertEquals(10, store.getStorefilesCount());
+      long startTime = System.currentTimeMillis();
+      TEST_UTIL.getAdmin().majorCompact(tableName);
+      while (store.getStorefilesCount() != 1) {
+        Thread.sleep(20);
+      }
+      return System.currentTimeMillis() - startTime;
+    } finally {
+      shutdownMiniCluster();
+    }
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
@@ -728,6 +728,11 @@ public class VerifyingRSGroupAdmin implements Admin, Closeable {
     return admin.switchCompactionOffload(enable);
   }
 
+  public Map<String, Long> updateCompactionServerTotalThroughput(Long upperBound, Long lowerBound,
+      Long offPeak) throws IOException {
+    return admin.updateCompactionServerTotalThroughput(upperBound, lowerBound, offPeak);
+  }
+
   public boolean isCompactionOffloadEnabled() throws IOException {
     return admin.isCompactionOffloadEnabled();
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
@@ -728,8 +728,8 @@ public class VerifyingRSGroupAdmin implements Admin, Closeable {
     return admin.switchCompactionOffload(enable);
   }
 
-  public Map<String, Long> updateCompactionServerTotalThroughput(Long upperBound, Long lowerBound,
-      Long offPeak) throws IOException {
+  public Map<String, Long> updateCompactionServerTotalThroughput(long upperBound, long lowerBound,
+      long offPeak) throws IOException {
     return admin.updateCompactionServerTotalThroughput(upperBound, lowerBound, offPeak);
   }
 

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -121,6 +121,13 @@ module Hbase
       @admin.compactionSwitch(java.lang.Boolean.valueOf(on_or_off), servers)
     end
 
+    # update compaction server total throughput bound
+    def update_compaction_server_total_throughput(upper_bound, lower_bound, offpeak)
+      @admin.updateCompactionServerTotalThroughput(java.lang.Long.value_of(upper_bound),
+                                                   java.lang.Long.value_of(lower_bound),
+                                                   java.lang.Long.value_of(offpeak))
+    end
+
     #----------------------------------------------------------------------------------------------
     # Gets compaction state for specified table
     def getCompactionState(table_name)

--- a/hbase-shell/src/main/ruby/shell.rb
+++ b/hbase-shell/src/main/ruby/shell.rb
@@ -489,6 +489,9 @@ Shell.load_command_group(
     list_decommissioned_regionservers
     decommission_regionservers
     recommission_regionserver
+    set_compaction_server_throughput_lower_bound
+    set_compaction_server_throughput_upper_bound
+    set_compaction_server_throughput_offpeak
   ],
   # TODO: remove older hlog_roll command
   aliases: {

--- a/hbase-shell/src/main/ruby/shell/commands/set_compaction_server_throughput_lower_bound.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/set_compaction_server_throughput_lower_bound.rb
@@ -1,0 +1,43 @@
+#
+# Copyright The Apache Software Foundation
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Shell
+  module Commands
+    class SetCompactionServerThroughputLowerBound < Command
+      def help
+        <<-EOF
+Set the compaction server total throughput lower bound.
+
+Examples:
+
+  # set bandwidth=2MB for total throughput lower bound.
+  hbase> set_compaction_server_throughput_lower_bound 2097152
+
+        EOF
+      end
+
+      def command(bandwidth = 0)
+        formatter.header(%w(['BOUND' 'BANDWIDTH']))
+        throughtput = admin.update_compaction_server_total_throughput(0, bandwidth, 0)
+        throughtput.each { |k, v| formatter.row([k, java.lang.String.valueOf(v)]) }
+      end
+    end
+  end
+end

--- a/hbase-shell/src/main/ruby/shell/commands/set_compaction_server_throughput_offpeak.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/set_compaction_server_throughput_offpeak.rb
@@ -1,0 +1,43 @@
+#
+# Copyright The Apache Software Foundation
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Shell
+  module Commands
+    class SetCompactionServerThroughputOffpeak < Command
+      def help
+        <<-EOF
+Set the compaction server total throughput offpeak.
+
+Examples:
+
+  # set bandwidth=2MB for total throughput offpeak.
+  hbase> set_compaction_server_throughput_offpeak 2097152
+
+        EOF
+      end
+
+      def command(bandwidth = 0)
+        formatter.header(%w(['BOUND' 'BANDWIDTH']))
+        throughtput = admin.update_compaction_server_total_throughput(0, 0, bandwidth)
+        throughtput.each { |k, v| formatter.row([k, java.lang.String.valueOf(v)]) }
+      end
+    end
+  end
+end

--- a/hbase-shell/src/main/ruby/shell/commands/set_compaction_server_throughput_upper_bound.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/set_compaction_server_throughput_upper_bound.rb
@@ -1,0 +1,43 @@
+#
+# Copyright The Apache Software Foundation
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Shell
+  module Commands
+    class SetCompactionServerThroughputUpperBound < Command
+      def help
+        <<-EOF
+Set the compaction server total throughput upper bound.
+
+Examples:
+
+  # set bandwidth=2MB for total throughput upper bound.
+  hbase> set_compaction_server_throughput_upper_bound 2097152
+
+        EOF
+      end
+
+      def command(bandwidth = 0)
+        formatter.header(%w(['BOUND' 'BANDWIDTH']))
+        throughtput = admin.update_compaction_server_total_throughput(bandwidth, 0, 0)
+        throughtput.each { |k, v| formatter.row([k, java.lang.String.valueOf(v)]) }
+      end
+    end
+  end
+end

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -512,6 +512,24 @@ module Hbase
 
     #-------------------------------------------------------------------------------
 
+    define_test 'set compaction server throughput lower bound' do
+      output = capture_stdout { command(:set_compaction_server_throughput_lower_bound, 500)}
+      assert(output.include?("LowerBound 500"))
+      output = capture_stdout { command(:set_compaction_server_throughput_lower_bound, 1500)}
+      assert(output.include?("LowerBound 1500"))
+    end
+    define_test 'set compaction server throughput upper bound' do
+      output = capture_stdout { command(:set_compaction_server_throughput_upper_bound, 5000)}
+      assert(output.include?("UpperBound 5000"))
+      output = capture_stdout { command(:set_compaction_server_throughput_upper_bound, 15000)}
+      assert(output.include?("UpperBound 15000"))
+    end
+    define_test 'set compaction server throughput offPeak' do
+      output = capture_stdout { command(:set_compaction_server_throughput_offpeak, 5000)}
+      assert(output.include?("OffPeak 5000"))
+      output = capture_stdout { command(:set_compaction_server_throughput_offpeak, 15000)}
+      assert(output.include?("OffPeak 15000"))
+    end
     define_test "describe should fail for non-existent tables" do
       assert_raise(ArgumentError) do
         admin.describe('NOT.EXISTS')

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
@@ -459,8 +459,8 @@ public class ThriftAdmin implements Admin {
   }
 
   @Override
-  public Map<String, Long> updateCompactionServerTotalThroughput(Long upperBound, Long lowerBound,
-      Long offPeak) throws IOException {
+  public Map<String, Long> updateCompactionServerTotalThroughput(long upperBound, long lowerBound,
+      long offPeak) throws IOException {
     throw new NotImplementedException(
         "updateCompactionServerTotalThroughput by pattern not supported in ThriftAdmin");
   }

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
@@ -459,6 +459,13 @@ public class ThriftAdmin implements Admin {
   }
 
   @Override
+  public Map<String, Long> updateCompactionServerTotalThroughput(Long upperBound, Long lowerBound,
+      Long offPeak) throws IOException {
+    throw new NotImplementedException(
+        "updateCompactionServerTotalThroughput by pattern not supported in ThriftAdmin");
+  }
+
+  @Override
   public boolean isCompactionOffloadEnabled() throws IOException {
     throw new NotImplementedException(
       "isCompactionOffloadEnabled by pattern not supported in ThriftAdmin");


### PR DESCRIPTION
Compaction servers report compaction tasks to  master via heartbeat report. 
The report response has throughput control message and compaction server use this message to adjust compaction throughtput.
We can set total throughtput of all compaction servers via hbase shell commands.