### PR TITLE
[HBASE-26114][master]when “hbase.mob.compaction.threads.max” is set t…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobUtils.java
@@ -863,7 +863,7 @@ public final class MobUtils {
   public static ExecutorService createMobCompactorThreadPool(Configuration conf) {
     int maxThreads = conf.getInt(MobConstants.MOB_COMPACTION_THREADS_MAX,
         MobConstants.DEFAULT_MOB_COMPACTION_THREADS_MAX);
-    if (maxThreads == 0) {
+    if (maxThreads <= 0) {
       maxThreads = 1;
     }
     final SynchronousQueue<Runnable> queue = new SynchronousQueue<>();


### PR DESCRIPTION
[https://issues.apache.org/jira/projects/HBASE/issues/HBASE-26114]
**Description of PR**
fix bug HBASE-26114

When the value is set to a negative number, such as -1, Hmaster cannot start normally. When MOB_COMPACTION_THREADS_MAX is set to 0, mobUtil will set it to 1. But the program does not take into account that it is set to a negative number. 

**changge**
 modified 
    if (maxThreads == 0) {
to 
    if (maxThreads <= 0) {
to improve the handling mechanism for the user to set hbase.mob.compaction.threads.max as an abnormal value.
