### PR TITLE
HBASE-26169 Fix MapReduceBackupCopyJob.BackupDistCp.getKey() concatenates strings

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceBackupCopyJob.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceBackupCopyJob.java
@@ -331,12 +331,12 @@ public class MapReduceBackupCopyJob implements BackupCopyJob {
     private Text getKey(Path path) {
       int level = conf.getInt(NUMBER_OF_LEVELS_TO_PRESERVE_KEY, 1);
       int count = 0;
-      String relPath = "";
+      StringBuilder relPath = new StringBuilder();
       while (count++ < level) {
-        relPath = Path.SEPARATOR + path.getName() + relPath;
+        relPath.insert(0, Path.SEPARATOR + path.getName());
         path = path.getParent();
       }
-      return new Text(relPath);
+      return new Text(relPath.toString());
     }
 
     private List<Path> getSourceFiles() throws NoSuchFieldException, SecurityException,


### PR DESCRIPTION
`MapReduceBackupCopyJob.BackupDistCp.getKey()` concatenates strings in a loop, you should consider using `StringBuilder` to concatenate strings, thanks