### PR TITLE
HBASE-26122: Implement an optional maximum size for Gets, after which a partial result is returned

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Get.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Get.java
@@ -75,6 +75,7 @@ public class Get extends Query implements Row {
   private TimeRange tr = TimeRange.allTime();
   private boolean checkExistenceOnly = false;
   private Map<byte [], NavigableSet<byte []>> familyMap = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+  private long maxResultSize = -1;
 
   /**
    * Create a Get operation for the specified row.
@@ -281,6 +282,21 @@ public class Get extends Query implements Row {
     return this;
   }
 
+  /**
+   * Set the maximum result size. The default is -1; this means that no specific
+   * maximum result size will be set for this Get.
+   *
+   * If set to a value greater than zero, the server may respond with a Result where
+   * {@link Result#mayHaveMoreCellsInRow()} is true. The user is required to handle
+   * this case.
+   *
+   * @param maxResultSize The maximum result size in bytes
+   */
+  public Get setMaxResultSize(long maxResultSize) {
+    this.maxResultSize = maxResultSize;
+    return this;
+  }
+
   /* Accessors */
 
   /**
@@ -398,6 +414,13 @@ public class Get extends Query implements Row {
       families.add(Bytes.toStringBinary(entry.getKey()));
     }
     return map;
+  }
+
+  /**
+   * @return the maximum result size in bytes. See {@link #setMaxResultSize(long)}
+   */
+  public long getMaxResultSize() {
+    return maxResultSize;
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -640,6 +640,9 @@ public final class ProtobufUtil {
     if (proto.hasLoadColumnFamiliesOnDemand()) {
       get.setLoadColumnFamiliesOnDemand(proto.getLoadColumnFamiliesOnDemand());
     }
+    if (proto.hasMaxResultSize()) {
+      get.setMaxResultSize(proto.getMaxResultSize());
+    }
     return get;
   }
 
@@ -1296,6 +1299,9 @@ public final class ProtobufUtil {
     if (loadColumnFamiliesOnDemand != null) {
       builder.setLoadColumnFamiliesOnDemand(loadColumnFamiliesOnDemand);
     }
+    if (get.getMaxResultSize() > 0) {
+      builder.setMaxResultSize(get.getMaxResultSize());
+    }
     return builder.build();
   }
 
@@ -1497,6 +1503,7 @@ public final class ProtobufUtil {
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
     builder.setAssociatedCellCount(size);
     builder.setStale(result.isStale());
+    builder.setPartial(result.mayHaveMoreCellsInRow());
     return builder.build();
   }
 
@@ -1587,7 +1594,7 @@ public final class ProtobufUtil {
 
     return (cells == null || cells.isEmpty())
         ? (proto.getStale() ? EMPTY_RESULT_STALE : EMPTY_RESULT)
-        : Result.create(cells, null, proto.getStale());
+        : Result.create(cells, null, proto.getStale(), proto.getPartial());
   }
 
 

--- a/hbase-protocol-shaded/src/main/protobuf/client/Client.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/client/Client.proto
@@ -90,6 +90,8 @@ message Get {
   optional Consistency consistency = 12 [default = STRONG];
   repeated ColumnFamilyTimeRange cf_time_range = 13;
   optional bool load_column_families_on_demand = 14; /* DO NOT add defaults to load_column_families_on_demand. */
+
+  optional uint64 max_result_size = 15;
 }
 
 message Result {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -142,6 +142,7 @@ import org.apache.hadoop.hbase.regionserver.MultiVersionConcurrencyControl.Write
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionContext;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionLifeCycleTracker;
 import org.apache.hadoop.hbase.regionserver.compactions.ForbidMajorCompactionChecker;
+import org.apache.hadoop.hbase.regionserver.ScannerContext.LimitScope;
 import org.apache.hadoop.hbase.regionserver.throttle.CompactionThroughputControllerFactory;
 import org.apache.hadoop.hbase.regionserver.throttle.NoLimitThroughputController;
 import org.apache.hadoop.hbase.regionserver.throttle.StoreHotnessProtector;
@@ -3871,8 +3872,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
             Result result;
             if (returnResults) {
               // convert duplicate increment/append to get
-              List<Cell> results = region.get(toGet(mutation), false, nonceGroup, nonce);
-              result = Result.create(results);
+              result = region.get(toGet(mutation), false, nonceGroup, nonce);
             } else {
               result = Result.EMPTY_RESULT;
             }
@@ -7524,9 +7524,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
   @Override
   public Result get(final Get get) throws IOException {
     prepareGet(get);
-    List<Cell> results = get(get, true);
-    boolean stale = this.getRegionInfo().getReplicaId() != 0;
-    return Result.create(results, get.isCheckExistenceOnly() ? !results.isEmpty() : null, stale);
+    return get(get, true, HConstants.NO_NONCE, HConstants.NO_NONCE);
   }
 
   void prepareGet(final Get get) throws IOException {
@@ -7545,17 +7543,37 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
 
   @Override
   public List<Cell> get(Get get, boolean withCoprocessor) throws IOException {
-    return get(get, withCoprocessor, HConstants.NO_NONCE, HConstants.NO_NONCE);
+    return get(get, null, withCoprocessor, HConstants.NO_NONCE, HConstants.NO_NONCE);
   }
 
-  private List<Cell> get(Get get, boolean withCoprocessor, long nonceGroup, long nonce)
+  private Result get(Get get, boolean withCoprocessor, long nonceGroup, long nonce)
     throws IOException {
-    return TraceUtil.trace(() -> getInternal(get, withCoprocessor, nonceGroup, nonce),
+
+    ScannerContext scannerContext = get.getMaxResultSize() > 0
+      ? ScannerContext.newBuilder()
+          .setSizeLimit(LimitScope.BETWEEN_CELLS, get.getMaxResultSize(), get.getMaxResultSize())
+          .build()
+      : null;
+
+    List<Cell> result = get(get, scannerContext, withCoprocessor, nonceGroup, nonce);
+    boolean stale = this.getRegionInfo().getReplicaId() != 0;
+
+    return Result.create(
+      result,
+      get.isCheckExistenceOnly() ? !result.isEmpty() : null,
+      stale,
+      scannerContext != null && scannerContext.mayHaveMoreCellsInRow());
+  }
+
+  private List<Cell> get(Get get, ScannerContext scannerContext, boolean withCoprocessor,
+    long nonceGroup, long nonce) throws IOException {
+    return TraceUtil.trace(
+      () -> getInternal(get, scannerContext, withCoprocessor, nonceGroup, nonce),
       () -> createRegionSpan("Region.get"));
   }
 
-  private List<Cell> getInternal(Get get, boolean withCoprocessor, long nonceGroup, long nonce)
-    throws IOException {
+  private List<Cell> getInternal(Get get, ScannerContext scannerContext, boolean withCoprocessor,
+    long nonceGroup, long nonce) throws IOException {
     List<Cell> results = new ArrayList<>();
     long before = EnvironmentEdgeManager.currentTime();
 
@@ -7572,7 +7590,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
     }
     try (RegionScanner scanner = getScanner(scan, null, nonceGroup, nonce)) {
       List<Cell> tmp = new ArrayList<>();
-      scanner.next(tmp);
+      scanner.next(tmp, scannerContext);
       // Copy EC to heap, then close the scanner.
       // This can be an EXPENSIVE call. It may make an extra copy from offheap to onheap buffers.
       // See more details in HBASE-26036.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
@@ -241,6 +241,9 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
     }
     region.startRegionOperation(Operation.SCAN);
     try {
+      if (scannerContext == null) {
+        scannerContext = defaultScannerContext;
+      }
       return nextRaw(outResults, scannerContext);
     } finally {
       region.closeRegionOperation(Operation.SCAN);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
@@ -7879,4 +7879,89 @@ public class TestHRegion {
     assertFalse("Region lock holder should not have been interrupted", holderInterrupted.get());
   }
 
+  @Test
+  public void testOversizedGetsReturnPartialResult() throws IOException {
+    HRegion region = initHRegion(tableName, name.getMethodName(), CONF, fam1);
+
+    Put p = new Put(row)
+      .addColumn(fam1, qual1, value1)
+      .addColumn(fam1, qual2, value2);
+
+    region.put(p);
+
+    Get get = new Get(row)
+      .addColumn(fam1, qual1)
+      .addColumn(fam1, qual2)
+      .setMaxResultSize(1); // 0 doesn't count as a limit, according to HBase
+
+    Result r = region.get(get);
+
+    assertTrue("Expected partial result, but result was not marked as partial", r.mayHaveMoreCellsInRow());
+  }
+
+  @Test
+  public void testGetsWithoutResultSizeLimitAreNotPartial() throws IOException {
+    HRegion region = initHRegion(tableName, name.getMethodName(), CONF, fam1);
+
+    Put p = new Put(row)
+      .addColumn(fam1, qual1, value1)
+      .addColumn(fam1, qual2, value2);
+
+    region.put(p);
+
+    Get get = new Get(row)
+      .addColumn(fam1, qual1)
+      .addColumn(fam1, qual2);
+
+    Result r = region.get(get);
+
+    assertFalse("Expected full result, but it was marked as partial", r.mayHaveMoreCellsInRow());
+    assertTrue(Bytes.equals(value1, r.getValue(fam1, qual1)));
+    assertTrue(Bytes.equals(value2, r.getValue(fam1, qual2)));
+  }
+
+  @Test
+  public void testGetsWithinResultSizeLimitAreNotPartial() throws IOException {
+    HRegion region = initHRegion(tableName, name.getMethodName(), CONF, fam1);
+
+    Put p = new Put(row)
+      .addColumn(fam1, qual1, value1)
+      .addColumn(fam1, qual2, value2);
+
+    region.put(p);
+
+    Get get = new Get(row)
+      .addColumn(fam1, qual1)
+      .addColumn(fam1, qual2)
+      .setMaxResultSize(Long.MAX_VALUE);
+
+    Result r = region.get(get);
+
+    assertFalse("Expected full result, but it was marked as partial", r.mayHaveMoreCellsInRow());
+    assertTrue(Bytes.equals(value1, r.getValue(fam1, qual1)));
+    assertTrue(Bytes.equals(value2, r.getValue(fam1, qual2)));
+  }
+
+  @Test
+  public void testGetsWithResultSizeLimitReturnPartialResults() throws IOException {
+    HRegion region = initHRegion(tableName, name.getMethodName(), CONF, fam1);
+
+    Put p = new Put(row)
+      .addColumn(fam1, qual1, value1)
+      .addColumn(fam1, qual2, value2);
+
+    region.put(p);
+
+    Get get = new Get(row)
+      .addColumn(fam1, qual1)
+      .addColumn(fam1, qual2)
+      .setMaxResultSize(10);
+
+    Result r = region.get(get);
+
+    assertTrue("Expected partial result, but it was marked as complete", r.mayHaveMoreCellsInRow());
+    assertTrue(Bytes.equals(value1, r.getValue(fam1, qual1)));
+    assertEquals("Got more results than expected", 1, r.size());
+  }
+
 }


### PR DESCRIPTION
This is a version of https://github.com/apache/hbase/pull/3532 which applies against master branch. When I created the previous PR I didn't realize the convention of doing master first. That PR did not cleanly apply to master due to changes in hbase-protocol vs hbase-protocol-shaded and minor differences in HRegion.