### PR TITLE
HBASE-26122: Only create ScannerContext for Gets with setMaxResultSize > 0  (ADDENDUM)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -2669,9 +2669,11 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
       scan.setLoadColumnFamiliesOnDemand(region.isLoadingCfsOnDemandDefault());
     }
 
-    ScannerContext scannerContext = ScannerContext.newBuilder()
+    ScannerContext scannerContext = get.getMaxResultSize() > 0
+      ? ScannerContext.newBuilder()
       .setSizeLimit(LimitScope.BETWEEN_CELLS, get.getMaxResultSize(), get.getMaxResultSize())
-      .build();
+      .build()
+      : null;
 
     RegionScannerImpl scanner = null;
     try {
@@ -2702,7 +2704,7 @@ public class RSRpcServices implements HBaseRPCErrorHandler,
     region.metricsUpdateForGet(results, before);
 
     return Result.create(results, get.isCheckExistenceOnly() ? !results.isEmpty() : null, stale,
-      scannerContext.mayHaveMoreCellsInRow());
+      scannerContext != null && scannerContext.mayHaveMoreCellsInRow());
   }
 
   private void checkBatchSizeAndLogLargeSize(MultiRequest request) throws ServiceException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
@@ -240,6 +240,9 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
     }
     region.startRegionOperation(Operation.SCAN);
     try {
+      if (scannerContext == null) {
+        scannerContext = defaultScannerContext;
+      }
       return nextRaw(outResults, scannerContext);
     } finally {
       region.closeRegionOperation(Operation.SCAN);


### PR DESCRIPTION
@saintstack After your suggestion in https://github.com/apache/hbase/pull/3532 I had meant to also apply the change to RSRpcServices, but got pulled away and didn't submit before you merged.

This small patch applies that same change to RSRpcServices. I'll include this in the master branch PR