### PR TITLE
HBASE-26196 Support configuration override for remote cluster of HFileOutputFormat locality sensitive

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -32,6 +32,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.Set;
 import java.util.TreeMap;
 import java.util.TreeSet;
@@ -163,12 +164,14 @@ public class HFileOutputFormat2
   static final String MULTI_TABLE_HFILEOUTPUTFORMAT_CONF_KEY =
           "hbase.mapreduce.use.multi.table.hfileoutputformat";
 
+  public static final String REMOTE_CLUSTER_CONF_PREFIX =
+    "hbase.hfileoutputformat.remote.cluster.";
   public static final String REMOTE_CLUSTER_ZOOKEEPER_QUORUM_CONF_KEY =
-    "hbase.hfileoutputformat.remote.cluster.zookeeper.quorum";
+    REMOTE_CLUSTER_CONF_PREFIX + "zookeeper.quorum";
   public static final String REMOTE_CLUSTER_ZOOKEEPER_CLIENT_PORT_CONF_KEY =
-    "hbase.hfileoutputformat.remote.cluster.zookeeper." + HConstants.CLIENT_PORT_STR;
+    REMOTE_CLUSTER_CONF_PREFIX + "zookeeper." + HConstants.CLIENT_PORT_STR;
   public static final String REMOTE_CLUSTER_ZOOKEEPER_ZNODE_PARENT_CONF_KEY =
-    "hbase.hfileoutputformat.remote.cluster." + HConstants.ZOOKEEPER_ZNODE_PARENT;
+    REMOTE_CLUSTER_CONF_PREFIX + HConstants.ZOOKEEPER_ZNODE_PARENT;
 
   public static final String STORAGE_POLICY_PROPERTY = HStore.BLOCK_STORAGE_POLICY_KEY;
   public static final String STORAGE_POLICY_PROPERTY_CF_PREFIX = STORAGE_POLICY_PROPERTY + ".";
@@ -359,6 +362,23 @@ public class HFileOutputFormat2
           newConf.set(HConstants.ZOOKEEPER_QUORUM, quorum);
           newConf.setInt(HConstants.ZOOKEEPER_CLIENT_PORT, Integer.parseInt(clientPort));
           newConf.set(HConstants.ZOOKEEPER_ZNODE_PARENT, parent);
+        }
+
+        for (Entry<String, String> entry : conf) {
+          String key = entry.getKey();
+          if (REMOTE_CLUSTER_ZOOKEEPER_QUORUM_CONF_KEY.equals(key) ||
+              REMOTE_CLUSTER_ZOOKEEPER_CLIENT_PORT_CONF_KEY.equals(key) ||
+              REMOTE_CLUSTER_ZOOKEEPER_ZNODE_PARENT_CONF_KEY.equals(key)) {
+            // Handled them above
+            continue;
+          }
+
+          if (entry.getKey().startsWith(REMOTE_CLUSTER_CONF_PREFIX)) {
+            String originalKey = entry.getKey().substring(REMOTE_CLUSTER_CONF_PREFIX.length());
+            if (!originalKey.isEmpty()) {
+              newConf.set(originalKey, entry.getValue());
+            }
+          }
         }
 
         return newConf;

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
@@ -102,6 +102,7 @@ import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HStore;
 import org.apache.hadoop.hbase.regionserver.TestHRegionFileSystem;
 import org.apache.hadoop.hbase.regionserver.TimeRangeTracker;
+import org.apache.hadoop.hbase.security.SecurityConstants;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.VerySlowMapReduceTests;
@@ -1693,6 +1694,11 @@ public class TestHFileOutputFormat2  {
       assertEquals(confB.get(HConstants.ZOOKEEPER_ZNODE_PARENT),
         jobConf.get(HFileOutputFormat2.REMOTE_CLUSTER_ZOOKEEPER_ZNODE_PARENT_CONF_KEY));
 
+      String bSpecificConfigKey = "my.override.config.for.b";
+      String bSpecificConfigValue = "b-specific-value";
+      jobConf.set(HFileOutputFormat2.REMOTE_CLUSTER_CONF_PREFIX + bSpecificConfigKey,
+        bSpecificConfigValue);
+
       FileOutputFormat.setOutputPath(job, testDir);
 
       assertFalse(util.getTestFileSystem().exists(testDir));
@@ -1710,6 +1716,9 @@ public class TestHFileOutputFormat2  {
           config.get(HConstants.ZOOKEEPER_CLIENT_PORT));
         assertEquals(confB.get(HConstants.ZOOKEEPER_ZNODE_PARENT),
           config.get(HConstants.ZOOKEEPER_ZNODE_PARENT));
+
+        assertEquals(bSpecificConfigValue,
+          config.get(bSpecificConfigKey));
       }
     } finally {
       utilB.deleteTable(tableName);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-26196

Usecase:
```
        TableName tableName = TableName.valueOf("table");
        Configuration conf = job.getConfiguration();

        // assume cluster B is secure
        Configuration clusterB = HBaseConfiguration.createClusterConf(
                conf,  "hbase-b-1.example.com,hbase-b-2.example.com,hbase-b-3.example.com:2181:/hbase-b");
        clusterB.set(User.HBASE_SECURITY_CONF_KEY, "kerberos");
        // configure others too like MASTER_KRB_PRINCIPAL, REGIONSERVER_KRB_PRINCIPAL and so on

        // hack. TableMapReduceUtil.initCredentialsForCluster create UserProvider using job's configuration
        // Thus if User.HBASE_SECURITY_CONF_KEY is simple, token isn't obtained
        conf.set(User.HBASE_SECURITY_CONF_KEY, "kerberos");

        TableMapReduceUtil.initCredentialsForCluster(job, clusterB);

        // assume cluster A isn't secure
        conf.set(HConstants.ZOOKEEPER_QUORUM, "hbase-a-1.example.com,hbase-a-2.example.com,hbase-a-3.example.com");
        conf.setInt(HConstants.ZOOKEEPER_CLIENT_PORT, 2181);
        conf.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/hbase-a");
        conf.set(User.HBASE_SECURITY_CONF_KEY, "simple");

        TableMapReduceUtil.initTableMapperJob(tableName, scanner, Mapper.class, ImmutableBytesWritable.class, Put.class, job);

        try (Connection con = ConnectionFactory.createConnection(clusterB);
             Table table = con.getTable(tableName);
             RegionLocator regionLocator = con.getRegionLocator(tableName)) {
            HFileOutputFormat2.configureIncrementalLoad(job, table, regionLocator);
            conf.set(HFileOutputFormat2.REMOTE_CLUSTER_CONF_PREFIX + User.HBASE_SECURITY_CONF_KEY, "kerberos");
        }


        return job.waitForCompletion(true) ? 0 : 1;
```