### PR TITLE
HBASE-26212 Expose configuration to enable/disable AuthUtil

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
@@ -180,7 +180,7 @@ class AsyncConnectionImpl implements AsyncConnection {
 
   private void spawnRenewalChore(final UserGroupInformation user) {
     ChoreService service = getChoreService();
-    service.scheduleChore(AuthUtil.getAuthRenewalChore(user));
+    service.scheduleChore(AuthUtil.getAuthRenewalChore(user, conf));
   }
 
   /**


### PR DESCRIPTION
In some situations, a caller may know that it is properly managing the
Kerberos ticket to talk to HBase. In these situations, it's possible
that AuthUtil still tries to do renewals, but just fails repeatedly to
do so. Give a configuration flag for such clients to be able to tell
AuthUtil to simply stop trying.