### PR TITLE
Clean shared state pollution to avoid flaky tests.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/TaskMonitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/TaskMonitor.java
@@ -243,6 +243,11 @@ public class TaskMonitor {
     }
   }
 
+  public synchronized void purgeAllTasks() {
+    tasks.clear();
+    rpcTasks.clear();
+  }
+
   /**
    * This class encapsulates an object as well as a weak reference to a proxy
    * that passes through calls to that object. In art form:

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -142,6 +142,7 @@ public class TestTaskMonitor {
     }
     assertEquals("RPC Tasks have been purged!", RPCTaskNums, remainRPCTask);
     tm.shutdown();
+    tm.purgeAllTasks();
   }
 
   @Test


### PR DESCRIPTION
## What is the purpose of this PR
- This PR cleans the state polluted by `org.apache.hadoop.hbase.monitoring.TestTaskMonitor.testDoNotPurgeRPCTask`.

- It may be better to clean state pollutions so that some other tests won't fail in the future due to the shared state pollution.
## Reproduce the test failure
- Run the test twice in the same JVM. 
## Expected  result:
- The tests should run successfully when multiple tests that use this state are run in the same JVM.
## Actual result:
- We get the failure:
`[ERROR] Failures: 
[ERROR] testDoNotPurgeRPCTask:144 RPC Tasks have been purged! expected:<10> but was:<20>`
## Why the test fails
- Each time this test runs,10 RPCtasks are created and added to the ArrayList `rpcTasks`, but `rpcTasks` is not completely purged when the test ends. So next time the test starts, the remaining RPC tasks lead to an assertion failure.
## Fix
- Clean all tasks when the test ends.
- Another solution is to create a new `TaskMonitor` each time to avoid pollution similar to the other tests (e.g., `testTaskMonitorBasics`, `testTasksGetAbortedOnLeak`) in `TestTaskMonitor`. https://github.com/LALAYANG/hbase/pull/1

Please let me know which fix you think is better. Thanks!