### PR TITLE
HBASE-26215 The backup master status page should use ActiveMasterManager instead of MasterAddressTracker

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/BackupMasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/BackupMasterStatusTmpl.jamon
@@ -27,9 +27,9 @@ org.apache.hadoop.hbase.master.HMaster;
 </%import>
 <%if (!master.isActiveMaster()) %>
     <%java>
-    ServerName active_master = master.getActiveMaster().isPresent() ? master.getActiveMaster().get() : null;
+    ServerName active_master = master.getActiveMaster().orElse(null);
     assert active_master != null : "Failed to retrieve active master's ServerName!";
-    int activeInfoPort = master.getActiveMaster().isPresent() ? master.getActiveMasterInfoPort() : 0;
+    int activeInfoPort = active_master == null ? 0 : master.getActiveMasterInfoPort();
     </%java>
     <div class="row inner_header">
         <div class="page-header">

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/BackupMasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/BackupMasterStatusTmpl.jamon
@@ -24,25 +24,19 @@ java.util.*;
 org.apache.hadoop.hbase.ServerName;
 org.apache.hadoop.hbase.ClusterMetrics;
 org.apache.hadoop.hbase.master.HMaster;
-org.apache.hadoop.hbase.zookeeper.MasterAddressTracker;
 </%import>
-<%java>
-MasterAddressTracker masterAddressTracker = master.getMasterAddressTracker();
-</%java>
-
 <%if (!master.isActiveMaster()) %>
     <%java>
-    ServerName active_master =
-        (masterAddressTracker == null) ? null : masterAddressTracker.getMasterAddress();
-    assert active_master != null : "Failed to retrieve master's ServerName!";
-    int infoPort = (masterAddressTracker == null) ? 0 : masterAddressTracker.getMasterInfoPort();
+    ServerName active_master = master.getActiveMaster().isPresent() ? master.getActiveMaster().get() : null;
+    assert active_master != null : "Failed to retrieve active master's ServerName!";
+    int activeInfoPort = master.getActiveMaster().isPresent() ? master.getActiveMasterInfoPort() : 0;
     </%java>
     <div class="row inner_header">
         <div class="page-header">
             <h1>Backup Master <small><% master.getServerName().getHostname() %></small></h1>
         </div>
     </div>
-    <h4>Current Active Master: <a href="//<% active_master.getHostname() %>:<% infoPort %>/master-status"
+    <h4>Current Active Master: <a href="//<% active_master.getHostname() %>:<% activeInfoPort %>/master-status"
         target="_blank"><% active_master.getHostname() %></a><h4>
 <%else>
     <h2>Backup Masters</h2>
@@ -54,13 +48,11 @@ MasterAddressTracker masterAddressTracker = master.getMasterAddressTracker();
         <th>Start Time</th>
     </tr>
     <%java>
-    Collection<ServerName> backup_masters = master.getClusterMetricsWithoutCoprocessor(
-        EnumSet.of(ClusterMetrics.Option.BACKUP_MASTERS)).getBackupMasterNames();
+    Collection<ServerName> backup_masters = master.getBackupMasters();
     ServerName [] backupServerNames = backup_masters.toArray(new ServerName[backup_masters.size()]);
     Arrays.sort(backupServerNames);
     for (ServerName serverName : backupServerNames) {
-      int infoPort = (masterAddressTracker == null) ? 0 : masterAddressTracker
-          .getBackupMasterInfoPort(serverName);
+      int infoPort = master.getBackupMasterInfoPort(serverName);
     </%java>
     <tr>
         <td><a href="//<% serverName.getHostname() %>:<% infoPort %>/master-status"

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ActiveMasterManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ActiveMasterManager.java
@@ -158,6 +158,25 @@ public class ActiveMasterManager extends ZKListener {
     return Optional.ofNullable(activeMasterServerName);
   }
 
+
+  public int getActiveMasterInfoPort(){
+    try {
+      return MasterAddressTracker.getMasterInfoPort(watcher);
+    }catch (Exception e){
+      LOG.warn("Failed to get active master's info port.", e);
+      return 0;
+    }
+  }
+
+  public int getBackupMasterInfoPort(final ServerName sn){
+    try {
+      return MasterAddressTracker.getBackupMasterInfoPort(watcher, sn);
+    }catch (Exception e){
+      LOG.warn("Failed to get backup master: " + sn + "'s info port.", e);
+      return 0;
+    }
+  }
+
   /**
    * Handle a change in the master node.  Doesn't matter whether this was called
    * from a nodeCreated or nodeDeleted event because there are no guarantees

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ActiveMasterManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ActiveMasterManager.java
@@ -158,20 +158,19 @@ public class ActiveMasterManager extends ZKListener {
     return Optional.ofNullable(activeMasterServerName);
   }
 
-
-  public int getActiveMasterInfoPort(){
+  public int getActiveMasterInfoPort() {
     try {
       return MasterAddressTracker.getMasterInfoPort(watcher);
-    }catch (Exception e){
+    } catch (Exception e) {
       LOG.warn("Failed to get active master's info port.", e);
       return 0;
     }
   }
 
-  public int getBackupMasterInfoPort(final ServerName sn){
+  public int getBackupMasterInfoPort(final ServerName sn) {
     try {
       return MasterAddressTracker.getBackupMasterInfoPort(watcher, sn);
-    }catch (Exception e){
+    } catch (Exception e) {
       LOG.warn("Failed to get backup master: " + sn + "'s info port.", e);
       return 0;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -2710,6 +2710,22 @@ public class HMaster extends HRegionServer implements MasterServices {
     return activeMasterManager.getBackupMasters();
   }
 
+  /**
+   * @return info port of active master or 0 if any  exception occurs.
+   * */
+  public int getActiveMasterInfoPort() {
+    return activeMasterManager.getActiveMasterInfoPort();
+  }
+
+  /**
+   * @param sn is ServerName of the backup master
+   * @return info port of backup master or 0 if any  exception occurs.
+   * */
+  public int getBackupMasterInfoPort(final ServerName sn) {
+    return activeMasterManager.getBackupMasterInfoPort(sn);
+  }
+
+
   @Override
   public List<ServerName> getRegionServers() {
     return serverManager.getOnlineServersList();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -2711,20 +2711,19 @@ public class HMaster extends HRegionServer implements MasterServices {
   }
 
   /**
-   * @return info port of active master or 0 if any  exception occurs.
-   * */
+   * @return info port of active master or 0 if any exception occurs.
+   */
   public int getActiveMasterInfoPort() {
     return activeMasterManager.getActiveMasterInfoPort();
   }
 
   /**
    * @param sn is ServerName of the backup master
-   * @return info port of backup master or 0 if any  exception occurs.
-   * */
+   * @return info port of backup master or 0 if any exception occurs.
+   */
   public int getBackupMasterInfoPort(final ServerName sn) {
     return activeMasterManager.getBackupMasterInfoPort(sn);
   }
-
 
   @Override
   public List<ServerName> getRegionServers() {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/http/TestMasterStatusServlet.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/http/TestMasterStatusServlet.java
@@ -23,6 +23,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
@@ -115,6 +116,9 @@ public class TestMasterStatusServlet {
     MasterAddressTracker tracker = Mockito.mock(MasterAddressTracker.class);
     Mockito.doReturn(tracker).when(master).getMasterAddressTracker();
     Mockito.doReturn(FAKE_HOST).when(tracker).getMasterAddress();
+
+    // Fake ActiveMaster
+    Mockito.doReturn(Optional.of(FAKE_HOST)).when(master).getActiveMaster();
 
     MetricsRegionServer rms = Mockito.mock(MetricsRegionServer.class);
     Mockito.doReturn(new MetricsRegionServerWrapperStub()).when(rms).getRegionServerWrapper();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/http/TestMasterStatusServlet.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/http/TestMasterStatusServlet.java
@@ -27,14 +27,9 @@ import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseConfiguration;
-import org.apache.hadoop.hbase.HBaseTestingUtil;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
-import org.apache.hadoop.hbase.StartTestingClusterOption;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
-import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
-import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
@@ -51,7 +46,6 @@ import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.tmpl.master.MasterStatusTmpl;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hadoop.hbase.util.JVMClusterUtil;
 import org.apache.hadoop.hbase.zookeeper.MasterAddressTracker;
 import org.apache.hadoop.hbase.zookeeper.ZKWatcher;
 import org.apache.hadoop.hbase.zookeeper.ZNodePaths;
@@ -170,39 +164,4 @@ public class TestMasterStatusServlet {
       .setDeadServers(deadServers)
       .render(new StringWriter(), master);
   }
-
-
-  @Test
-  public void test() throws Exception{
-
-    Configuration conf = new Configuration();
-//    conf.set(HConstants.MASTER_INFO_PORT, "18010");
-    conf.setBoolean("hbase.snapshot.enabled",true);
-    conf.setBoolean(HConstants.SLOW_LOG_BUFFER_ENABLED_KEY, true);
-    conf.setInt("hbase.ipc.warn.response.time",50);
-    conf.setInt("hbase.ipc.warn.response.size",7000);
-    conf.set("hbase.namedqueue.provider.classes",
-      "org.apache.hadoop.hbase.namequeues.impl.SlowLogQueueService,org.apache.hadoop.hbase.namequeues.impl.BalancerDecisionQueueService,org.apache.hadoop.hbase.namequeues.impl.BalancerRejectionQueueService");
-    HBaseTestingUtil hBaseTestingUtil = new HBaseTestingUtil(conf);
-    hBaseTestingUtil.startMiniCluster(StartTestingClusterOption.builder().numRegionServers(2).numAlwaysStandByMasters(1)
-      .build());
-    List<JVMClusterUtil.MasterThread> a = hBaseTestingUtil.getHBaseCluster().getMasterThreads();
-    System.out.println(a.toString());
-    hBaseTestingUtil.getAdmin()
-      .createTable(TableDescriptorBuilder.newBuilder(TableName.valueOf("test1")).setColumnFamily(
-        ColumnFamilyDescriptorBuilder.of("CF".getBytes())).build(), "0".getBytes(),"999999".getBytes(), 3);
-    hBaseTestingUtil.getAdmin()
-      .createTable(TableDescriptorBuilder.newBuilder(TableName.valueOf("test2")).setColumnFamily(
-        ColumnFamilyDescriptorBuilder.of("CF".getBytes())).build(), "0".getBytes(),"999999".getBytes(), 3);
-    ServerName theFirstRS = hBaseTestingUtil.getAdmin().getRegionServers().iterator().next();
-    List<RegionInfo> regions = hBaseTestingUtil.getAdmin().getRegions(TableName.valueOf("test2"));
-    for (RegionInfo ri:regions){
-      hBaseTestingUtil.getAdmin().move(ri.getEncodedNameAsBytes(), theFirstRS);
-    }
-    hBaseTestingUtil.getAdmin().balance(true);
-    hBaseTestingUtil.getConnection().getTable(TableName.valueOf("test1"))
-      .put(new Put("11".getBytes()).addColumn("CF".getBytes(), "q".getBytes(), "value".getBytes()));
-    while(true){}
-  }
-
 }

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MasterAddressTracker.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MasterAddressTracker.java
@@ -230,7 +230,7 @@ public class MasterAddressTracker extends ZKNodeTracker {
    * @param zkw ZKWatcher to use
    * @param sn  ServerName of the backup master
    * @return backup master info port in the the master address znode or 0 if no
-   * znode present.
+   *         znode present.
    * @throws KeeperException if a ZooKeeper operation fails
    * @throws IOException     if the address of the ZooKeeper master cannot be retrieved
    */

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MasterAddressTracker.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MasterAddressTracker.java
@@ -226,12 +226,13 @@ public class MasterAddressTracker extends ZKNodeTracker {
    * Get backup master info port.
    * Use this instead of {@link #getBackupMasterInfoPort(ServerName)} if you do not have an
    * instance of this tracker in your context.
+   *
    * @param zkw ZKWatcher to use
-   * @param sn ServerName of the backup master
+   * @param sn  ServerName of the backup master
    * @return backup master info port in the the master address znode or 0 if no
-   *         znode present.
+   * znode present.
    * @throws KeeperException if a ZooKeeper operation fails
-   * @throws IOException if the address of the ZooKeeper master cannot be retrieved
+   * @throws IOException     if the address of the ZooKeeper master cannot be retrieved
    */
   public static int getBackupMasterInfoPort(ZKWatcher zkw, final ServerName sn)
     throws KeeperException, IOException {

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MasterAddressTracker.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MasterAddressTracker.java
@@ -223,6 +223,42 @@ public class MasterAddressTracker extends ZKNodeTracker {
   }
 
   /**
+   * Get backup master info port.
+   * Use this instead of {@link #getBackupMasterInfoPort(ServerName)} if you do not have an
+   * instance of this tracker in your context.
+   * @param zkw ZKWatcher to use
+   * @param sn ServerName of the backup master
+   * @return backup master info port in the the master address znode or 0 if no
+   *         znode present.
+   * @throws KeeperException if a ZooKeeper operation fails
+   * @throws IOException if the address of the ZooKeeper master cannot be retrieved
+   */
+  public static int getBackupMasterInfoPort(ZKWatcher zkw, final ServerName sn)
+    throws KeeperException, IOException {
+    byte[] data;
+    try {
+      data = ZKUtil.getData(zkw,
+        ZNodePaths.joinZNode(zkw.getZNodePaths().backupMasterAddressesZNode, sn.toString()));
+    } catch (InterruptedException e) {
+      throw new InterruptedIOException();
+    }
+    if (data == null) {
+      throw new IOException("Can't get backup master address from ZooKeeper; znode data == null");
+    }
+    try {
+      final ZooKeeperProtos.Master backup = parse(data);
+      if (backup == null) {
+        return 0;
+      }
+      return backup.getInfoPort();
+    } catch (DeserializationException e) {
+      KeeperException ke = new KeeperException.DataInconsistencyException();
+      ke.initCause(e);
+      throw ke;
+    }
+  }
+
+  /**
    * Set master address into the <code>master</code> znode or into the backup
    * subdirectory of backup masters; switch off the passed in <code>znode</code>
    * path.


### PR DESCRIPTION
Since the backup master status page will remove the MasterAddressTracker, and there is no direct method to obtain ActiveMasterManager (I saw that ActiveMasterManager is a private member of HMaster, and all values in ActiveMasterManager should be returned through HMaster’s public methods). I added some code to make the backup master status page easily retrieve the information it needs.