### PR TITLE
HBASE-26138 Backport HBASE-25733 "Upgrade opentelemetry to 1.0.1" to branch-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1482,8 +1482,8 @@
     <jruby.version>9.2.13.0</jruby.version>
     <junit.version>4.13</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <opentelemetry.version>1.0.0</opentelemetry.version>
-    <opentelemetry-javaagent.version>1.0.0</opentelemetry-javaagent.version>
+    <opentelemetry.version>1.0.1</opentelemetry.version>
+    <opentelemetry-javaagent.version>1.0.1</opentelemetry-javaagent.version>
     <log4j.version>1.2.17</log4j.version>
     <mockito-core.version>2.28.2</mockito-core.version>
     <!--Internally we use a different version of protobuf. See hbase-protocol-shaded-->


### PR DESCRIPTION
15/17 commits of HBASE-22120, original commit b71488998970a3353086a34736ed1edab527f673