### PR TITLE
HBASE-26103 Deprecate BufferedMutatorParams#pool method

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/BufferedMutatorParams.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/BufferedMutatorParams.java
@@ -148,6 +148,7 @@ public class BufferedMutatorParams implements Cloneable {
    *  @deprecated Since 3.0.0-alpha-2, will be removed in 4.0.0. You can not set it anymore.
    *              BufferedMutator will use Connection's ExecutorService.
    */
+  @Deprecated
   public ExecutorService getPool() {
     return pool;
   }
@@ -158,6 +159,7 @@ public class BufferedMutatorParams implements Cloneable {
    * @deprecated Since 3.0.0-alpha-2, will be removed in 4.0.0. You can not set it anymore.
    *             BufferedMutator will use Connection's ExecutorService.
    */
+  @Deprecated
   public BufferedMutatorParams pool(ExecutorService pool) {
     this.pool = pool;
     return this;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/BufferedMutatorParams.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/BufferedMutatorParams.java
@@ -144,6 +144,10 @@ public class BufferedMutatorParams implements Cloneable {
     return this;
   }
 
+  /**
+   *  @deprecated Since 3.0.0-alpha-2, will be removed in 4.0.0. You can not set it anymore.
+   *              BufferedMutator will use Connection's ExecutorService.
+   */
   public ExecutorService getPool() {
     return pool;
   }
@@ -151,6 +155,8 @@ public class BufferedMutatorParams implements Cloneable {
   /**
    * Override the default executor pool defined by the {@code hbase.htable.threads.*}
    * configuration values.
+   * @deprecated Since 3.0.0-alpha-2, will be removed in 4.0.0. You can not set it anymore.
+   *             BufferedMutator will use Connection's ExecutorService.
    */
   public BufferedMutatorParams pool(ExecutorService pool) {
     this.pool = pool;


### PR DESCRIPTION
In [HBASE-26103#comment](https://issues.apache.org/jira/browse/HBASE-26103?focusedCommentId=17384541&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17384541), we discussed to remove BufferedMutatorParams#pool and BufferedMutatorParams#getPool methods.
But BufferedMutatorParams#InterfaceAudience is public and `BufferedMutatorParams#pool` and `BufferedMutatorParams#getPool` methods are both public so we can't remove them. We need to deprecate them for 1 version and remove in next.
@saintstack  Please review.