### PR TITLE
HBASE-25642 Fix or stop warning about already cached block

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheUtil.java
@@ -244,7 +244,7 @@ public class BlockCacheUtil {
             + "nextBlockOnDiskSize set, Keeping cached block.");
         return false;
       } else {
-        LOG.warn("Caching an already cached block: {}. This is harmless and can happen in rare "
+        LOG.debug("Caching an already cached block: {}. This is harmless and can happen in rare "
             + "cases (see HBASE-8547)",
           cacheKey);
         return false;


### PR DESCRIPTION
Our logs have as a fairly common occurrence: 2021-03-05 22:24:31,034 WARN
[StoreFileOpener-foo-1] hfile.BlockCacheUtil: Caching an already cached
block: blah.bub. This is harmless and can happen in rare cases (see HBASE-8547)

Because it is harmless, log at DEBUG level, not WARN.