### PR TITLE
Clean shared state pollution to avoid flaky tests.

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestDrainReplicationQueuesForStandBy.java
@@ -114,5 +114,7 @@ public class TestDrainReplicationQueuesForStandBy extends SyncReplicationTestBas
     for (int i = 0; i < 100; i++) {
       assertTrue(region2.get(new Get(Bytes.toBytes(i))).isEmpty());
     }
+    UTIL2.getAdmin().transitReplicationPeerSyncReplicationState(PEER_ID,
+      SyncReplicationState.DOWNGRADE_ACTIVE);
   }
 }


### PR DESCRIPTION
## What is the purpose of this PR
- This PR fixes a flaky test to avoid shared state pollution  `org.apache.hadoop.hbase.replication.regionserver.TestDrainReplicationQueuesForStandBy.test`
## Reproduce the test failure
- Run the test twice in the same JVM.
## Expected result:
- The test should run successfully when multiple tests that use this state are run in the same JVM.
## Actual result:
- We get the failure:
```
org.apache.hadoop.hbase.DoNotRetryIOException: Can not transit current cluster state from STANDBY to STANDBY for peer id=1
```
## Why the test fails
- When the test ends, current cluster for peer id=1 is STANDBY, it can not be transitted from STANDBY to STANDBY. 
## Fix
- Reset the state when test ends.