### PR TITLE
[HBASE-26243]Fix typo for file "hbase-server/src/main/java/org/apache…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsck.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsck.java
@@ -1820,7 +1820,7 @@ public class HBaseFsck extends Configured implements Closeable {
   }
 
   /**
-   * Check consistency of all regions using mulitple threads concurrently.
+   * Check consistency of all regions using multiple threads concurrently.
    */
   private void checkRegionConsistencyConcurrently(
     final List<CheckRegionConsistencyWorkItem> workItems)
@@ -3559,7 +3559,7 @@ public class HBaseFsck extends Configured implements Closeable {
     out.println("NOTE: Following options are NOT supported as of HBase version 2.0+.");
     out.println("");
     out.println("  UNSUPPORTED Metadata Repair options: (expert features, use with caution!)");
-    out.println("   -fix              Try to fix region assignments.  This is for backwards compatiblity");
+    out.println("   -fix              Try to fix region assignments.  This is for backwards compatibility");
     out.println("   -fixAssignments   Try to fix region assignments.  Replaces the old -fix");
     out.println("   -fixMeta          Try to fix meta problems.  This assumes HDFS region info is good.");
     out.println("   -fixHdfsHoles     Try to fix region holes in hdfs.");
@@ -3859,7 +3859,7 @@ public class HBaseFsck extends Configured implements Closeable {
       for (String arg : args) {
         if (unsupportedOptionsInV2.contains(arg)) {
           errors.reportError(ERROR_CODE.UNSUPPORTED_OPTION,
-              "option '" + arg + "' is not " + "supportted!");
+              "option '" + arg + "' is not " + "supported!");
           result = false;
           break;
         }


### PR DESCRIPTION


Fix typo for file 'hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsck.java'


```bash
hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsck.java:1823: mulitple ==> multiple
hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsck.java:3562: compatiblity ==> compatibility
hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsck.java:3864: supportted ==> supported

```

