### PR TITLE
HBASE-26252: Add option to reload balancer configs when invoking the balancer

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/LoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/LoadBalancer.java
@@ -147,4 +147,9 @@ public interface LoadBalancer extends Stoppable, ConfigurationObserver {
 
   /*Updates balancer status tag reported to JMX*/
   void updateBalancerStatus(boolean status);
+
+  /**
+   * Forces a reload of the underlying Configuration for the balancer
+   */
+  void reloadConfiguration();
 }

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BaseLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BaseLoadBalancer.java
@@ -402,7 +402,7 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
     } else {
       regionFinder = null;
     }
-    this.isByTable = conf.getBoolean(HConstants.HBASE_MASTER_LOADBALANCE_BYTABLE, isByTable);
+    this.isByTable = conf.getBoolean(HConstants.HBASE_MASTER_LOADBALANCE_BYTABLE, HConstants.DEFAULT_HBASE_MASTER_LOADBALANCE_BYTABLE);
     // Print out base configs. Don't print overallSlop since it for simple balancer exclusively.
     LOG.info("slop={}", this.slop);
   }
@@ -616,5 +616,15 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
   @Override
   public void onConfigurationChange(Configuration conf) {
     loadConf(conf);
+  }
+
+  @Override
+  public void reloadConfiguration() {
+    LOG.info("Reloading balancer configs");
+    // We clone and reload the clone because the original conf may be used in other
+    // non-balancer contexts. We only want to reload configs for the balancer.
+    Configuration conf = new Configuration(getConf());
+    conf.reloadConfiguration();
+    onConfigurationChange(conf);
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/BalanceRequest.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/BalanceRequest.java
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import org.apache.hadoop.hbase.ServerName;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -34,6 +35,7 @@ public final class BalanceRequest {
   public final static class Builder {
     private boolean dryRun = false;
     private boolean ignoreRegionsInTransition = false;
+    private boolean reloadConfigs = false;
 
     private Builder() {}
 
@@ -66,10 +68,21 @@ public final class BalanceRequest {
     }
 
     /**
+     * Updates BalanceRequest to cause the balancer to reload configuration from
+     * disk before running. The newly loaded changes will remain in effect
+     * for the lifetime of the active HMaster or until reloaded again (through
+     * {@link #setReloadConfigs(boolean)} or {@link Admin#updateConfiguration(ServerName)}).
+     */
+    public Builder setReloadConfigs(boolean reloadConfigs) {
+      this.reloadConfigs = reloadConfigs;
+      return this;
+    }
+
+    /**
      * Build the {@link BalanceRequest}
      */
     public BalanceRequest build() {
-      return new BalanceRequest(dryRun, ignoreRegionsInTransition);
+      return new BalanceRequest(dryRun, ignoreRegionsInTransition, reloadConfigs);
     }
   }
 
@@ -90,10 +103,12 @@ public final class BalanceRequest {
 
   private final boolean dryRun;
   private final boolean ignoreRegionsInTransition;
+  private final boolean reloadConfigs;
 
-  private BalanceRequest(boolean dryRun, boolean ignoreRegionsInTransition) {
+  private BalanceRequest(boolean dryRun, boolean ignoreRegionsInTransition, boolean reloadConfigs) {
     this.dryRun = dryRun;
     this.ignoreRegionsInTransition = ignoreRegionsInTransition;
+    this.reloadConfigs = reloadConfigs;
   }
 
   /**
@@ -110,5 +125,15 @@ public final class BalanceRequest {
    */
   public boolean isIgnoreRegionsInTransition() {
     return ignoreRegionsInTransition;
+  }
+
+  /**
+   * Returns true if the balancer should reload configuration from hbase-site.xml before running.
+   * The newly loaded changes will remain in effect  for the lifetime of the active HMaster or
+   * until reloaded again (through {@link Builder#setReloadConfigs(boolean)} or
+   * {@link Admin#updateConfiguration(ServerName)}).
+   */
+  public boolean isReloadConfigs() {
+    return reloadConfigs;
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -3630,6 +3630,7 @@ public final class ProtobufUtil {
       .setRSGroupName(groupName)
       .setDryRun(request.isDryRun())
       .setIgnoreRit(request.isIgnoreRegionsInTransition())
+      .setReloadConfigs(request.isReloadConfigs())
       .build();
   }
 
@@ -3637,6 +3638,7 @@ public final class ProtobufUtil {
     return BalanceRequest.newBuilder()
       .setDryRun(request.hasDryRun() && request.getDryRun())
       .setIgnoreRegionsInTransition(request.hasIgnoreRit() && request.getIgnoreRit())
+      .setReloadConfigs(request.hasReloadConfigs() && request.getReloadConfigs())
       .build();
   }
 
@@ -3872,6 +3874,7 @@ public final class ProtobufUtil {
     return MasterProtos.BalanceRequest.newBuilder()
       .setDryRun(request.isDryRun())
       .setIgnoreRit(request.isIgnoreRegionsInTransition())
+      .setReloadConfigs(request.isReloadConfigs())
       .build();
   }
 
@@ -3879,6 +3882,7 @@ public final class ProtobufUtil {
     return BalanceRequest.newBuilder()
       .setDryRun(request.hasDryRun() && request.getDryRun())
       .setIgnoreRegionsInTransition(request.hasIgnoreRit() && request.getIgnoreRit())
+      .setReloadConfigs(request.hasReloadConfigs() && request.getReloadConfigs())
       .build();
   }
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -139,6 +139,8 @@ public final class HConstants {
   /** Config for balancing the cluster by table */
   public static final String HBASE_MASTER_LOADBALANCE_BYTABLE = "hbase.master.loadbalance.bytable";
 
+  public static final boolean DEFAULT_HBASE_MASTER_LOADBALANCE_BYTABLE = false;
+
   /** Config for the max percent of regions in transition */
   public static final String HBASE_MASTER_BALANCER_MAX_RIT_PERCENT =
       "hbase.master.balancer.maxRitPercent";

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/Master.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/Master.proto
@@ -295,6 +295,7 @@ message IsInMaintenanceModeResponse {
 message BalanceRequest {
   optional bool ignore_rit = 1;
   optional bool dry_run = 2;
+  optional bool reload_configs = 4;
 }
 
 message BalanceResponse {

--- a/hbase-protocol-shaded/src/main/protobuf/server/rsgroup/RSGroupAdmin.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/rsgroup/RSGroupAdmin.proto
@@ -87,6 +87,7 @@ message BalanceRSGroupRequest {
   required string r_s_group_name = 1;
   optional bool ignore_rit = 2;
   optional bool dry_run = 3;
+  optional bool reload_configs = 4;
 }
 
 message BalanceRSGroupResponse {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1867,6 +1867,10 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         serverMap.keySet().removeAll(this.serverManager.getDrainingServersList());
       }
 
+      if (request.isReloadConfigs()) {
+        this.balancer.reloadConfiguration();
+      }
+
       //Give the balancer the current cluster state.
       this.balancer.updateClusterMetrics(getClusterMetricsWithoutCoprocessor());
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/MaintenanceLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/MaintenanceLoadBalancer.java
@@ -121,4 +121,9 @@ public class MaintenanceLoadBalancer implements LoadBalancer {
   @Override
   public void updateBalancerStatus(boolean status) {
   }
+
+  @Override
+  public void reloadConfiguration() {
+
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupBasedLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupBasedLoadBalancer.java
@@ -402,6 +402,11 @@ public class RSGroupBasedLoadBalancer implements LoadBalancer {
   }
 
   @Override
+  public void reloadConfiguration() {
+    internalBalancer.reloadConfiguration();
+  }
+
+  @Override
   public void stop(String why) {
     internalBalancer.stop(why);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupInfoManagerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupInfoManagerImpl.java
@@ -1192,6 +1192,10 @@ final class RSGroupInfoManagerImpl implements RSGroupInfoManager {
         return responseBuilder.build();
       }
 
+      if (request.isReloadConfigs()) {
+        balancer.reloadConfiguration();
+      }
+
       // We balance per group instead of per table
       Map<TableName, Map<ServerName, List<RegionInfo>>> assignmentsByTable =
           getRSGroupAssignmentsByTable(masterServices.getTableStateManager(), groupName);

--- a/hbase-shell/src/main/ruby/hbase/balancer_utils.rb
+++ b/hbase-shell/src/main/ruby/hbase/balancer_utils.rb
@@ -27,7 +27,7 @@ module Hbase
       args = args.first if args.first.is_a?(Array) and args.size == 1
       if args.nil? or args.empty?
         return BalanceRequest.defaultInstance()
-      elsif args.size > 2
+      elsif args.size > 3
         raise ArgumentError, "Illegal arguments #{args}. Expected between 0 and 2 arguments, but got #{args.size}."
       end
 
@@ -44,8 +44,10 @@ module Hbase
           builder.setIgnoreRegionsInTransition(true)
         when 'dry_run'
           builder.setDryRun(true)
+        when 'reload_configs'
+          builder.setReloadConfigs(true)
         else
-          raise ArgumentError, "Illegal argument in index #{index}: #{arg}. Unknown option #{arg}, expected 'force', 'ignore_rit', or 'dry_run'."
+          raise ArgumentError, "Illegal argument in index #{index}: #{arg}. Unknown option #{arg}, expected 'force', 'ignore_rit', 'dry_run', or 'reload_configs'."
         end
 
         index += 1

--- a/hbase-shell/src/main/ruby/shell/commands/balance_rsgroup.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/balance_rsgroup.rb
@@ -27,13 +27,17 @@ Parameter can be "force" or "dry_run":
    This is useful for testing out new balance configurations. See the active HMaster logs for the results of the dry_run.
  - "ignore_rit" tells master whether we should force the balancer to run even if there is region in transition.
    WARNING: For experts only. Forcing a balance may do more damage than repair when assignment is confused
+ - "reload_configs" tells master to reload balancer configs from disk before running the balance.
+
+Multiple parameters can be added, in any order, by separating them by commas.
 
 Example:
 
   hbase> balance_rsgroup 'my_group'
   hbase> balance_rsgroup 'my_group', 'ignore_rit'
   hbase> balance_rsgroup 'my_group', 'dry_run'
-  hbase> balance_rsgroup 'my_group', 'dry_run', 'ignore_rit'
+  hbase> balance_rsgroup 'my_group', 'reload_configs'
+  hbase> balance_rsgroup 'my_group', 'dry_run', 'ignore_rit', 'reload_configs'
 
 EOF
       end

--- a/hbase-shell/src/main/ruby/shell/commands/balancer.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/balancer.rb
@@ -24,18 +24,22 @@ module Shell
         <<-EOF
 Trigger the cluster balancer. Returns true if balancer ran, otherwise false (Will not run if regions in transition).
 
-Parameter can be "force" or "dry_run":
+Parameter can be "force", "dry_run", or "reload_configs":
  - "dry_run" will run the balancer to generate a plan, but will not actually execute that plan.
    This is useful for testing out new balance configurations. See the active HMaster logs for the results of the dry_run.
  - "ignore_rit" tells master whether we should force the balancer to run even if there is region in transition.
    WARNING: For experts only. Forcing a balance may do more damage than repair when assignment is confused
+ - "reload_configs" tells master to reload balancer configs from disk before running the balance.
+
+Multiple parameters can be added, in any order, by separating them by commas.
 
 Examples:
 
   hbase> balancer
   hbase> balancer "ignore_rit"
   hbase> balancer "dry_run"
-  hbase> balancer "dry_run", "ignore_rit"
+  hbase> balancer "reload_configs"
+  hbase> balancer "dry_run", "ignore_rit", "reload_configs"
 EOF
       end
 

--- a/hbase-shell/src/test/ruby/hbase/balancer_utils_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/balancer_utils_test.rb
@@ -49,30 +49,42 @@ module Hbase
       request = create_balance_request()
       assert(!request.isDryRun())
       assert(!request.isIgnoreRegionsInTransition())
+      assert(!request.isReloadConfigs())
     end
 
     define_test "should parse 'force' string" do
       request = create_balance_request('force')
       assert(!request.isDryRun())
       assert(request.isIgnoreRegionsInTransition())
+      assert(!request.isReloadConfigs())
     end
     
     define_test "should parse 'ignore_rit' string" do
       request = create_balance_request('ignore_rit')
       assert(!request.isDryRun())
       assert(request.isIgnoreRegionsInTransition())
+      assert(!request.isReloadConfigs())
     end
 
     define_test "should parse 'dry_run' string" do
       request = create_balance_request('dry_run')
       assert(request.isDryRun())
       assert(!request.isIgnoreRegionsInTransition())
+      assert(!request.isReloadConfigs())
+    end
+
+    define_test "should parse 'reload_configs' string" do
+      request = create_balance_request('reload_configs')
+      assert(!request.isDryRun())
+      assert(!request.isIgnoreRegionsInTransition())
+      assert(request.isReloadConfigs())
     end
 
     define_test "should parse multiple string args" do
-      request = create_balance_request('dry_run', 'ignore_rit')
+      request = create_balance_request('dry_run', 'ignore_rit', 'reload_configs')
       assert(request.isDryRun())
       assert(request.isIgnoreRegionsInTransition())
+      assert(request.isReloadConfigs())
     end
   end
 end


### PR DESCRIPTION
I made one important design decision in this implementation: This new option _only_ reloads the _balancer's_ config, not any other observers. It would be easy to simply call configurationManager.notifyObservers instead, but I felt like even with docs it would be too unexpected to have a balancer-specific option reload all configurations for the entire HMaster. If there are strong opposing opinions, perhaps we could name the option `setReloadAllMasterConfigs` or something. This would probably be safe,r but just feels like scope creep for the balancer command.

I added a test for this new feature and it exposed an existing bug with reloading configs for the balancer. I will call out the fix with a line-item comment below.

I also noticed and fixed another small logging bug which you'll see in StochasticLoadBalancer.