### PR TITLE
HBASE-26273 Force ReadType.STREAM when the user does not explicitly s…

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
@@ -130,10 +130,12 @@ public class TableSnapshotInputFormatImpl {
   public static final boolean SNAPSHOT_INPUTFORMAT_SCAN_METRICS_ENABLED_DEFAULT = true;
 
   /**
-   * The {@link ReadType} which should be set on the {@link Scan} to read the HBase Snapshot, default STREAM.
+   * The {@link ReadType} which should be set on the {@link Scan} to read the HBase Snapshot,
+   * default STREAM.
    */
-  public static final String SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE = "hbase.TableSnapshotinputFormat.scanner.readtype";
-  public static final ReadType SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE_DEFAULT = ReadType.STREAM; 
+  public static final String SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE =
+      "hbase.TableSnapshotInputFormat.scanner.readtype";
+  public static final ReadType SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE_DEFAULT = ReadType.STREAM;
 
   /**
    * Implementation class for InputSplit logic common between mapred and mapreduce.
@@ -391,7 +393,8 @@ public class TableSnapshotInputFormatImpl {
     }
 
     if (scan.getReadType() == ReadType.DEFAULT) {
-      LOG.info("Provided Scan has DEFAULT ReadType, updating STREAM for Snapshot-based InputFormat");
+      LOG.info("Provided Scan has DEFAULT ReadType,"
+          + " updating STREAM for Snapshot-based InputFormat");
       // Update the "DEFAULT" ReadType to be "STREAM" to try to improve the default case.
       scan.setReadType(conf.getEnum(SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE,
           SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE_DEFAULT));

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Scan.ReadType;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.regionserver.HRegion;
@@ -127,6 +128,12 @@ public class TableSnapshotInputFormatImpl {
     "hbase.TableSnapshotInputFormat.scan_metrics.enabled";
 
   public static final boolean SNAPSHOT_INPUTFORMAT_SCAN_METRICS_ENABLED_DEFAULT = true;
+
+  /**
+   * The {@link ReadType} which should be set on the {@link Scan} to read the HBase Snapshot, default STREAM.
+   */
+  public static final String SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE = "hbase.TableSnapshotinputFormat.scanner.readtype";
+  public static final ReadType SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE_DEFAULT = ReadType.STREAM; 
 
   /**
    * Implementation class for InputSplit logic common between mapred and mapreduce.
@@ -382,6 +389,14 @@ public class TableSnapshotInputFormatImpl {
     } else {
       throw new IllegalArgumentException("Unable to create scan");
     }
+
+    if (scan.getReadType() == ReadType.DEFAULT) {
+      LOG.info("Provided Scan has DEFAULT ReadType, updating STREAM for Snapshot-based InputFormat");
+      // Update the "DEFAULT" ReadType to be "STREAM" to try to improve the default case.
+      scan.setReadType(conf.getEnum(SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE,
+          SNAPSHOT_INPUTFORMAT_SCANNER_READTYPE_DEFAULT));
+    }
+
     return scan;
   }
 

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableSnapshotInputFormat.java
@@ -41,9 +41,9 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Scan.ReadType;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TestTableSnapshotScanner;
-import org.apache.hadoop.hbase.client.Scan.ReadType;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.mapreduce.TableSnapshotInputFormat.TableSnapshotRegionSplit;
 import org.apache.hadoop.hbase.snapshot.SnapshotTestingUtils;
@@ -417,7 +417,8 @@ public class TestTableSnapshotInputFormat extends TableSnapshotInputFormatTestBa
     for (ReadType readType : Arrays.asList(ReadType.PREAD, ReadType.STREAM)) {
       Scan scanWithReadType = new Scan();
       scanWithReadType.setReadType(readType);
-      assertEquals(scanWithReadType.getReadType(), serializeAndReturn(conf, scanWithReadType).getReadType());
+      assertEquals(scanWithReadType.getReadType(),
+          serializeAndReturn(conf, scanWithReadType).getReadType());
     }
     // We should only see the DEFAULT ReadType getting updated to STREAM.
     Scan scanWithoutReadType = new Scan();
@@ -431,7 +432,8 @@ public class TestTableSnapshotInputFormat extends TableSnapshotInputFormatTestBa
   }
 
   /**
-   * Serializes and deserializes the given scan in the same manner that TableSnapshotInputFormat does.
+   * Serializes and deserializes the given scan in the same manner that
+   * TableSnapshotInputFormat does.
    */
   private Scan serializeAndReturn(Configuration conf, Scan s) throws IOException {
     conf.set(TableInputFormat.SCAN, TableMapReduceUtil.convertScanToString(s));


### PR DESCRIPTION
…et a ReadType on the Scan for a Snapshot-based Job

HBase 2 moved over Scans to use PREAD by default instead of STREAM like
HBase 1. In the context of a MapReduce job, we can generally expect that
clients using the InputFormat (batch job) would be reading most of the
data for a job. Cater to them, but still give users who want PREAD the
ability to do so.