### PR TITLE
HBASE-26274 Create an option to reintroduce BlockCache to mapreduce job

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1049,6 +1049,11 @@ public final class HConstants {
 
   public static final float HFILE_BLOCK_CACHE_SIZE_DEFAULT = 0.4f;
 
+  public static final String HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY =
+    "hbase.client.scanner.block.cache.size";
+
+  public static final float HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT = 0.1f;
+
   /*
     * Minimum percentage of free heap necessary for a successful cluster startup.
     */

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1054,10 +1054,11 @@ public final class HConstants {
    * be explicitly set by user or only used within ClientSideRegionScanner. if it's set less than
    * current max on heap size, it overrides the max size of block cache
    */
-  public static final String HBASE_BLOCK_CACHE_FIXED_SIZE_KEY =
-    "hfile.block.cache.fixed.size";
-  public static final long HBASE_BLOCK_CACHE_FIXED_SIZE_DEFAULT = 0L;
-  public static final long HBASE_CLIENT_SCANNER_BLOCK_CACHE_FIXED_SIZE_DEFAULT = 32 * 1024 * 1024L;
+  public static final String HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_KEY =
+    "hfile.onheap.block.cache.fixed.size";
+  public static final long HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_DEFAULT = 0L;
+  public static final long HBASE_CLIENT_SCANNER_ONHEAP_BLOCK_CACHE_FIXED_SIZE_DEFAULT =
+    32 * 1024 * 1024L;
 
   /*
     * Minimum percentage of free heap necessary for a successful cluster startup.

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1049,10 +1049,15 @@ public final class HConstants {
 
   public static final float HFILE_BLOCK_CACHE_SIZE_DEFAULT = 0.4f;
 
-  public static final String HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY =
-    "hbase.client.scanner.block.cache.size";
-
-  public static final float HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT = 0.1f;
+  /**
+   * Configuration key for setting the fix size of the block size, default do nothing and it should
+   * be explicitly set by user or only used within ClientSideRegionScanner. if it's set less than
+   * current max on heap size, it overrides the max size of block cache
+   */
+  public static final String HBASE_BLOCK_CACHE_FIXED_SIZE_KEY =
+    "hfile.block.cache.fixed.size";
+  public static final long HBASE_BLOCK_CACHE_FIXED_SIZE_DEFAULT = 0L;
+  public static final long HBASE_CLIENT_SCANNER_BLOCK_CACHE_FIXED_SIZE_DEFAULT = 32 * 1024 * 1024L;
 
   /*
     * Minimum percentage of free heap necessary for a successful cluster startup.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
@@ -63,10 +63,11 @@ public class ClientSideRegionScanner extends AbstractClientScanner {
       conf, hri, htd, null);
     region.setRestoredRegion(true);
     // non RS process does not have a block cache, and this a client side scanner,
-    // create one for MapReduce jobs to cache the INDEX block
-    conf.setFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY,
-      conf.getFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY,
-        HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT));
+    // create one for MapReduce jobs to cache the INDEX block by setting to use
+    // IndexOnlyLruBlockCache and set a value to HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY
+    conf.set(BlockCacheFactory.BLOCKCACHE_POLICY_KEY, "IndexOnlyLru");
+    conf.setIfUnset(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY,
+        String.valueOf(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_FIXED_SIZE_DEFAULT));
     // don't allow L2 bucket cache for non RS process to avoid unexpected disk usage.
     conf.unset(HConstants.BUCKET_CACHE_IOENGINE_KEY);
     region.setBlockCache(BlockCacheFactory.createBlockCache(conf));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
@@ -25,8 +25,10 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.PrivateCellUtil;
 import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheFactory;
 import org.apache.hadoop.hbase.mob.MobFileCache;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
@@ -60,6 +62,14 @@ public class ClientSideRegionScanner extends AbstractClientScanner {
     region = HRegion.newHRegion(CommonFSUtils.getTableDir(rootDir, htd.getTableName()), null, fs,
       conf, hri, htd, null);
     region.setRestoredRegion(true);
+    // non RS process does not have a block cache, and this a client side scanner,
+    // create one for MapReduce jobs to cache the INDEX block
+    conf.setFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY,
+      conf.getFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY,
+        HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT));
+    // don't allow L2 bucket cache for non RS process to avoid unexpected disk usage.
+    conf.unset(HConstants.BUCKET_CACHE_IOENGINE_KEY);
+    region.setBlockCache(BlockCacheFactory.createBlockCache(conf));
     // we won't initialize the MobFileCache when not running in RS process. so provided an
     // initialized cache. Consider the case: an CF was set from an mob to non-mob. if we only
     // initialize cache for MOB region, NPE from HMobStore will still happen. So Initialize the
@@ -120,6 +130,10 @@ public class ClientSideRegionScanner extends AbstractClientScanner {
         LOG.warn("Exception while closing region", ex);
       }
     }
+  }
+
+  HRegion getRegion() {
+    return region;
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
@@ -65,9 +65,9 @@ public class ClientSideRegionScanner extends AbstractClientScanner {
     // non RS process does not have a block cache, and this a client side scanner,
     // create one for MapReduce jobs to cache the INDEX block by setting to use
     // IndexOnlyLruBlockCache and set a value to HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY
-    conf.set(BlockCacheFactory.BLOCKCACHE_POLICY_KEY, "IndexOnlyLru");
-    conf.setIfUnset(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY,
-        String.valueOf(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_FIXED_SIZE_DEFAULT));
+    conf.set(BlockCacheFactory.BLOCKCACHE_POLICY_KEY, "IndexOnlyLRU");
+    conf.setIfUnset(HConstants.HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_KEY,
+        String.valueOf(HConstants.HBASE_CLIENT_SCANNER_ONHEAP_BLOCK_CACHE_FIXED_SIZE_DEFAULT));
     // don't allow L2 bucket cache for non RS process to avoid unexpected disk usage.
     conf.unset(HConstants.BUCKET_CACHE_IOENGINE_KEY);
     region.setBlockCache(BlockCacheFactory.createBlockCache(conf));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCache.java
@@ -147,4 +147,13 @@ public interface BlockCache extends Iterable<CachedBlock> {
    * @return The list of sub blockcaches that make up this one; returns null if no sub caches.
    */
   BlockCache [] getBlockCaches();
+
+  /**
+   * Check if block type is meta or index block
+   * @param blockType block type of a given HFile block
+   * @return true if block type is non-data block
+   */
+  default boolean isMetaBlock(BlockType blockType) {
+    return blockType != null && blockType.getCategory() != BlockType.BlockCategory.DATA;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheFactory.java
@@ -43,7 +43,7 @@ public final class BlockCacheFactory {
    */
 
   /**
-   * Configuration key to cache block policy (Lru, TinyLfu, AdaptiveLRU, IndexOnlyLru).
+   * Configuration key to cache block policy (Lru, TinyLfu, AdaptiveLRU, IndexOnlyLRU).
    */
   public static final String BLOCKCACHE_POLICY_KEY = "hfile.block.cache.policy";
   public static final String BLOCKCACHE_POLICY_DEFAULT = "LRU";
@@ -129,7 +129,7 @@ public final class BlockCacheFactory {
         StringUtils.byteDesc(cacheSize) + ", blockSize=" + StringUtils.byteDesc(blockSize));
     if (policy.equalsIgnoreCase("LRU")) {
       return new LruBlockCache(cacheSize, blockSize, true, c);
-    } else if (policy.equalsIgnoreCase("IndexOnlyLru")) {
+    } else if (policy.equalsIgnoreCase("IndexOnlyLRU")) {
       return new IndexOnlyLruBlockCache(cacheSize, blockSize, true, c);
     } else if (policy.equalsIgnoreCase("TinyLFU")) {
       return new TinyLfuBlockCache(cacheSize, blockSize, ForkJoinPool.commonPool(), c);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheFactory.java
@@ -43,7 +43,7 @@ public final class BlockCacheFactory {
    */
 
   /**
-   * Configuration key to cache block policy (Lru, TinyLfu).
+   * Configuration key to cache block policy (Lru, TinyLfu, AdaptiveLRU, IndexOnlyLru).
    */
   public static final String BLOCKCACHE_POLICY_KEY = "hfile.block.cache.policy";
   public static final String BLOCKCACHE_POLICY_DEFAULT = "LRU";
@@ -129,6 +129,8 @@ public final class BlockCacheFactory {
         StringUtils.byteDesc(cacheSize) + ", blockSize=" + StringUtils.byteDesc(blockSize));
     if (policy.equalsIgnoreCase("LRU")) {
       return new LruBlockCache(cacheSize, blockSize, true, c);
+    } else if (policy.equalsIgnoreCase("IndexOnlyLru")) {
+      return new IndexOnlyLruBlockCache(cacheSize, blockSize, true, c);
     } else if (policy.equalsIgnoreCase("TinyLFU")) {
       return new TinyLfuBlockCache(cacheSize, blockSize, ForkJoinPool.commonPool(), c);
     } else if (policy.equalsIgnoreCase("AdaptiveLRU")) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CombinedBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CombinedBlockCache.java
@@ -71,10 +71,6 @@ public class CombinedBlockCache implements ResizableBlockCache, HeapSize {
     cacheBlock(cacheKey, buf, false);
   }
 
-  private boolean isMetaBlock(BlockType blockType) {
-    return blockType.getCategory() != BlockCategory.DATA;
-  }
-
   @Override
   public Cacheable getBlock(BlockCacheKey cacheKey, boolean caching,
       boolean repeat, boolean updateCacheMetrics) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CombinedBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CombinedBlockCache.java
@@ -22,7 +22,6 @@ import java.util.Iterator;
 
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.hadoop.hbase.io.HeapSize;
-import org.apache.hadoop.hbase.io.hfile.BlockType.BlockCategory;
 import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
 
 /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/IndexOnlyLruBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/IndexOnlyLruBlockCache.java
@@ -42,8 +42,7 @@ public class IndexOnlyLruBlockCache extends LruBlockCache {
    */
   @Override
   public void cacheBlock(BlockCacheKey cacheKey, Cacheable buf, boolean inMemory) {
-    boolean isIndexBlock = buf.getBlockType().getCategory() != BlockType.BlockCategory.DATA;
-    if (isIndexBlock) {
+    if (isMetaBlock(buf.getBlockType())) {
       super.cacheBlock(cacheKey, buf, inMemory);
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/IndexOnlyLruBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/IndexOnlyLruBlockCache.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * An on heap block cache implementation extended LruBlockCache and only cache index block.
+ * This block cache should be only used by
+ * {@link org.apache.hadoop.hbase.client.ClientSideRegionScanner} that normally considers to be
+ * used by client resides out of the region server, e.g. a container of a map reduce job.
+ **/
+@InterfaceAudience.Private
+public class IndexOnlyLruBlockCache extends LruBlockCache {
+
+  public IndexOnlyLruBlockCache(long maxSize, long blockSize, boolean evictionThread,
+    Configuration conf) {
+    super(maxSize, blockSize, evictionThread, conf);
+  }
+
+  /**
+   * Cache only index block with the specified name and buffer
+   * @param cacheKey block's cache key
+   * @param buf      block buffer
+   * @param inMemory if block is in-memory
+   */
+  @Override
+  public void cacheBlock(BlockCacheKey cacheKey, Cacheable buf, boolean inMemory) {
+    boolean isIndexBlock = buf.getBlockType().getCategory() != BlockType.BlockCategory.DATA;
+    if (isIndexBlock) {
+      super.cacheBlock(cacheKey, buf, inMemory);
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/ResizableBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/ResizableBlockCache.java
@@ -31,13 +31,4 @@ public interface ResizableBlockCache extends BlockCache {
    * @param size The max heap size.
    */
   void setMaxSize(long size);
-
-  /**
-   * Check if block type is meta or index block
-   * @param blockType block type of a given HFile block
-   * @return true if block type is non-data block
-   */
-  default boolean isMetaBlock(BlockType blockType) {
-    return blockType.getCategory() != BlockType.BlockCategory.DATA;
-  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/ResizableBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/ResizableBlockCache.java
@@ -31,4 +31,13 @@ public interface ResizableBlockCache extends BlockCache {
    * @param size The max heap size.
    */
   void setMaxSize(long size);
+
+  /**
+   * Check if block type is meta or index block
+   * @param blockType block type of a given HFile block
+   * @return true if block type is non-data block
+   */
+  default boolean isMetaBlock(BlockType blockType) {
+    return blockType.getCategory() != BlockType.BlockCategory.DATA;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/util/MemorySizeUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/util/MemorySizeUtil.java
@@ -216,9 +216,6 @@ public class MemorySizeUtil {
   public static long getOnHeapCacheSize(final Configuration conf) {
     float cachePercentage = conf.getFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY,
       HConstants.HFILE_BLOCK_CACHE_SIZE_DEFAULT);
-    // only uses when it's ClientSideRegionScanner or user explicitly sets it
-    long fixedCacheSize = conf.getLong(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY,
-        HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_DEFAULT);
     if (cachePercentage <= 0.0001f) {
       return -1;
     }
@@ -231,10 +228,13 @@ public class MemorySizeUtil {
     if (usage != null) {
       max = usage.getMax();
     }
-
+    float onHeapCacheFixedSize = (float) conf
+      .getLong(HConstants.HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_KEY,
+        HConstants.HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_DEFAULT) / max;
     // Calculate the amount of heap to give the heap.
-    return (fixedCacheSize > 0L && fixedCacheSize < max) ?
-      fixedCacheSize : (long) (max * cachePercentage);
+    return (onHeapCacheFixedSize > 0 && onHeapCacheFixedSize < cachePercentage) ?
+      (long) (max * onHeapCacheFixedSize) :
+      (long) (max * cachePercentage);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/util/MemorySizeUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/util/MemorySizeUtil.java
@@ -216,6 +216,9 @@ public class MemorySizeUtil {
   public static long getOnHeapCacheSize(final Configuration conf) {
     float cachePercentage = conf.getFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY,
       HConstants.HFILE_BLOCK_CACHE_SIZE_DEFAULT);
+    // only uses when it's ClientSideRegionScanner or user explicitly sets it
+    long fixedCacheSize = conf.getLong(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY,
+        HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_DEFAULT);
     if (cachePercentage <= 0.0001f) {
       return -1;
     }
@@ -230,7 +233,8 @@ public class MemorySizeUtil {
     }
 
     // Calculate the amount of heap to give the heap.
-    return (long) (max * cachePercentage);
+    return (fixedCacheSize > 0L && fixedCacheSize < max) ?
+      fixedCacheSize : (long) (max * cachePercentage);
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientSideRegionScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientSideRegionScanner.java
@@ -85,8 +85,10 @@ public class TestClientSideRegionScanner {
     assertTrue(blockCache instanceof LruBlockCache);
 
     float actualBlockCacheRatio = copyConf
-      .getFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY,
-        HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT);
+      .getFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY,
+        copyConf.getFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY,
+          HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT));
+
     assertTrue(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT == actualBlockCacheRatio);
   }
 
@@ -103,8 +105,9 @@ public class TestClientSideRegionScanner {
     assertTrue(blockCache instanceof LruBlockCache);
 
     float actualBlockCacheRatio = copyConf
-      .getFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY,
-        HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT);
+      .getFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY,
+        copyConf.getFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY,
+          HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT));
     assertTrue(blockCacheRatio == actualBlockCacheRatio);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientSideRegionScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientSideRegionScanner.java
@@ -83,8 +83,8 @@ public class TestClientSideRegionScanner {
     BlockCache blockCache = clientSideRegionScanner.getRegion().getBlockCache();
     assertNotNull(blockCache);
     assertTrue(blockCache instanceof IndexOnlyLruBlockCache);
-    assertTrue(
-      HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_FIXED_SIZE_DEFAULT == blockCache.getMaxSize());
+    assertTrue(HConstants.HBASE_CLIENT_SCANNER_ONHEAP_BLOCK_CACHE_FIXED_SIZE_DEFAULT == blockCache
+      .getMaxSize());
   }
 
   @Test
@@ -92,7 +92,7 @@ public class TestClientSideRegionScanner {
     Configuration copyConf = new Configuration(conf);
     // tiny 1MB fixed cache size
     long blockCacheFixedSize = 1024 * 1024L;
-    copyConf.setLong(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY, blockCacheFixedSize);
+    copyConf.setLong(HConstants.HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_KEY, blockCacheFixedSize);
     ClientSideRegionScanner clientSideRegionScanner =
       new ClientSideRegionScanner(copyConf, fs, rootDir, htd, hri, scan, null);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientSideRegionScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientSideRegionScanner.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.io.hfile.BlockCache;
+import org.apache.hadoop.hbase.io.hfile.LruBlockCache;
+import org.apache.hadoop.hbase.testclassification.ClientTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ SmallTests.class, ClientTests.class })
+public class TestClientSideRegionScanner {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestClientSideRegionScanner.class);
+
+  private final static HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+
+  private Configuration conf;
+  private Path rootDir;
+  private FileSystem fs;
+  private TableDescriptor htd;
+  private RegionInfo hri;
+  private Scan scan;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    TEST_UTIL.startMiniCluster(1);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Before
+  public void setup() throws IOException {
+    conf = TEST_UTIL.getConfiguration();
+    rootDir = TEST_UTIL.getDefaultRootDirPath();
+    fs = TEST_UTIL.getTestFileSystem();
+    htd = TEST_UTIL.getAdmin().getDescriptor(TableName.META_TABLE_NAME);
+    hri = TEST_UTIL.getAdmin().getRegions(TableName.META_TABLE_NAME).get(0);
+    scan = new Scan();
+  }
+
+  @Test
+  public void testDefaultBlockCache() throws IOException {
+    Configuration copyConf = new Configuration(conf);
+    ClientSideRegionScanner clientSideRegionScanner =
+      new ClientSideRegionScanner(copyConf, fs, rootDir, htd, hri, scan, null);
+
+    BlockCache blockCache = clientSideRegionScanner.getRegion().getBlockCache();
+    assertNotNull(blockCache);
+    assertTrue(blockCache instanceof LruBlockCache);
+
+    float actualBlockCacheRatio = copyConf
+      .getFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY,
+        HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT);
+    assertTrue(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT == actualBlockCacheRatio);
+  }
+
+  @Test
+  public void testConfiguredBlockCache() throws IOException {
+    Configuration copyConf = new Configuration(conf);
+    float blockCacheRatio = 0.05f;
+    copyConf.setFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY, blockCacheRatio);
+    ClientSideRegionScanner clientSideRegionScanner =
+      new ClientSideRegionScanner(copyConf, fs, rootDir, htd, hri, scan, null);
+
+    BlockCache blockCache = clientSideRegionScanner.getRegion().getBlockCache();
+    assertNotNull(blockCache);
+    assertTrue(blockCache instanceof LruBlockCache);
+
+    float actualBlockCacheRatio = copyConf
+      .getFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY,
+        HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_DEFAULT);
+    assertTrue(blockCacheRatio == actualBlockCacheRatio);
+  }
+
+  @Test
+  public void testNoBlockCache() throws IOException {
+    Configuration copyConf = new Configuration(conf);
+    float blockCacheRatio = 0.0f;
+    copyConf.setFloat(HConstants.HBASE_CLIENT_SCANNER_BLOCK_CACHE_SIZE_KEY, blockCacheRatio);
+    ClientSideRegionScanner clientSideRegionScanner =
+      new ClientSideRegionScanner(copyConf, fs, rootDir, htd, hri, scan, null);
+
+    BlockCache blockCache = clientSideRegionScanner.getRegion().getBlockCache();
+    assertNull(blockCache);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
@@ -398,7 +398,7 @@ public class TestCacheConfig {
     long fixedSize = 1024 * 1024L;
     long onHeapCacheSize = MemorySizeUtil.getOnHeapCacheSize(copyConf);
     assertEquals(null, copyConf.get(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY));
-    assertTrue(onHeapCacheSize > 0 && onHeapCacheSize != fixedSize );
+    assertTrue(onHeapCacheSize > 0 && onHeapCacheSize != fixedSize);
     // when HBASE_BLOCK_CACHE_FIXED_SIZE_KEY is set, it will be a fixed size
     copyConf.setLong(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY, fixedSize);
     onHeapCacheSize = MemorySizeUtil.getOnHeapCacheSize(copyConf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
@@ -374,4 +374,34 @@ public class TestCacheConfig {
     } catch (IllegalArgumentException e) {
     }
   }
+
+  @Test
+  public void testIndexOnlyLruBlockCache() {
+    CacheConfig cc = new CacheConfig(this.conf);
+    conf.set(BlockCacheFactory.BLOCKCACHE_POLICY_KEY, "IndexOnlyLru");
+    BlockCache blockCache = BlockCacheFactory.createBlockCache(this.conf);
+    assertTrue(blockCache instanceof IndexOnlyLruBlockCache);
+    // reject data block
+    long initialBlockCount = blockCache.getBlockCount();
+    BlockCacheKey bck = new BlockCacheKey("bck", 0);
+    Cacheable c = new DataCacheEntry();
+    blockCache.cacheBlock(bck, c, true);
+    // accept index block
+    Cacheable indexCacheEntry = new IndexCacheEntry();
+    blockCache.cacheBlock(bck, indexCacheEntry, true);
+    assertEquals(initialBlockCount + 1, blockCache.getBlockCount());
+  }
+
+  @Test
+  public void testGetOnHeapCacheSize() {
+    Configuration copyConf = new Configuration(conf);
+    long fixedSize = 1024 * 1024L;
+    long onHeapCacheSize = MemorySizeUtil.getOnHeapCacheSize(copyConf);
+    assertEquals(null, copyConf.get(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY));
+    assertTrue(onHeapCacheSize > 0 && onHeapCacheSize != fixedSize );
+    // when HBASE_BLOCK_CACHE_FIXED_SIZE_KEY is set, it will be a fixed size
+    copyConf.setLong(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY, fixedSize);
+    onHeapCacheSize = MemorySizeUtil.getOnHeapCacheSize(copyConf);
+    assertEquals(fixedSize, onHeapCacheSize);
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
@@ -378,7 +378,7 @@ public class TestCacheConfig {
   @Test
   public void testIndexOnlyLruBlockCache() {
     CacheConfig cc = new CacheConfig(this.conf);
-    conf.set(BlockCacheFactory.BLOCKCACHE_POLICY_KEY, "IndexOnlyLru");
+    conf.set(BlockCacheFactory.BLOCKCACHE_POLICY_KEY, "IndexOnlyLRU");
     BlockCache blockCache = BlockCacheFactory.createBlockCache(this.conf);
     assertTrue(blockCache instanceof IndexOnlyLruBlockCache);
     // reject data block
@@ -397,10 +397,10 @@ public class TestCacheConfig {
     Configuration copyConf = new Configuration(conf);
     long fixedSize = 1024 * 1024L;
     long onHeapCacheSize = MemorySizeUtil.getOnHeapCacheSize(copyConf);
-    assertEquals(null, copyConf.get(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY));
+    assertEquals(null, copyConf.get(HConstants.HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_KEY));
     assertTrue(onHeapCacheSize > 0 && onHeapCacheSize != fixedSize);
     // when HBASE_BLOCK_CACHE_FIXED_SIZE_KEY is set, it will be a fixed size
-    copyConf.setLong(HConstants.HBASE_BLOCK_CACHE_FIXED_SIZE_KEY, fixedSize);
+    copyConf.setLong(HConstants.HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_KEY, fixedSize);
     onHeapCacheSize = MemorySizeUtil.getOnHeapCacheSize(copyConf);
     assertEquals(fixedSize, onHeapCacheSize);
   }


### PR DESCRIPTION
Introduce `hbase.client.scanner.block.cache.size`
and default to 0.1f of over heap size that should
be good enough for caching LEAF_INDEX when a client,
e.g. snapshot scanner, scans the entire HFile
and does not need to seek/reseek to LEAF_INDEX
multiple times.