### PR TITLE
HBASE-26271: Cleanup the broken store files under data directory

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/DirectHFileCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/DirectHFileCleaner.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.ScheduledChore;
+import org.apache.hadoop.hbase.Stoppable;
+import org.apache.hadoop.hbase.io.HFileLink;
+import org.apache.hadoop.hbase.regionserver.compactions.DirectStoreCompactor;
+import org.apache.hadoop.ipc.RemoteException;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicLong;
+
+/**
+ * This Chore, every time it runs, will clear the unsused  direct HFiles in the data
+ * folder that are deletable for each HFile cleaner in the chain.
+ */
+@InterfaceAudience.Private public class DirectHFileCleaner extends ScheduledChore {
+  private static final Logger LOG = LoggerFactory.getLogger(DirectHFileCleaner.class);
+  public static final String DIRECT_HFILE_CLEANER_ENABLED =
+      "hbase.region.direct.hfilecleaner.enabled";
+  public static final boolean DEFAULT_DIRECT_HFILE_CLEANER_ENABLED = false;
+  public static final String DIRECT_HFILE_CLEANER_TTL =
+      "hbase.region.direct.hfilecleaner.ttl";
+  public static final long DEFAULT_DIRECT_HFILE_CLEANER_TTL = 1000 * 60 * 60 * 12; //12h
+  public static final String DIRECT_HFILE_CLEANER_DELAY =
+      "hbase.region.direct.hfilecleaner.delay";
+  public static final int DEFAULT_DIRECT_HFILE_CLEANER_DELAY = 1000 * 60 * 60 * 2; //2h
+  public static final String DIRECT_HFILE_CLEANER_DELAY_JITTER =
+      "hbase.region.direct.hfilecleaner.delay.jitter";
+  public static final double DEFAULT_DIRECT_HFILE_CLEANER_DELAY_JITTER = 0.25D;
+  public static final String DIRECT_HFILE_CLEANER_PERIOD =
+      "hbase.region.direct.hfilecleaner.period";
+  public static final int DEFAULT_DIRECT_HFILE_CLEANER_PERIOD = 1000 * 60 * 60 * 6; //6h
+
+  private HRegionServer regionServer;
+  private final AtomicBoolean enabled = new AtomicBoolean(true);
+  private AtomicLong deletedFiles = new AtomicLong();
+  private long ttl;
+
+  public DirectHFileCleaner(final int delay, final int period, final Stoppable stopper, Configuration conf,
+      HRegionServer regionServer) {
+    super("DirectHFileCleaner", stopper, period, delay);
+    this.regionServer = regionServer;
+    setEnabled(conf.getBoolean(DIRECT_HFILE_CLEANER_ENABLED, DEFAULT_DIRECT_HFILE_CLEANER_ENABLED));
+    ttl = conf.getLong(DIRECT_HFILE_CLEANER_TTL, DEFAULT_DIRECT_HFILE_CLEANER_TTL);
+  }
+
+  public boolean setEnabled(final boolean enabled) {
+    return this.enabled.getAndSet(enabled);
+  }
+
+  public boolean getEnabled() {
+    return this.enabled.get();
+  }
+
+  @Override protected void chore() {
+    if (getEnabled()) {
+      for (HRegion region : regionServer.getRegions()) {
+        for (HStore store : region.getStores()) {
+          if (!(store.getStoreEngine() instanceof PersistedStoreEngine)) {
+            continue;
+          }
+          Path storePath =
+              new Path(region.getRegionFileSystem().getRegionDir(), store.getColumnFamilyName());
+          List<FileStatus> fsStoreFiles = new ArrayList<>();
+          try {
+            fsStoreFiles = Arrays.asList(region.getRegionFileSystem().fs.listStatus(storePath));
+          } catch (IOException e) {
+            LOG.warn("Failed to list files in {}, cleanup is skipped there",storePath);
+            continue;
+          }
+
+          fsStoreFiles.forEach(file -> cleanFileIfNeeded(file, store));
+
+        }
+      }
+
+    } else {
+      LOG.trace("Direct Hfile Cleaner chore disabled! Not cleaning.");
+    }
+  }
+
+  private void cleanFileIfNeeded(FileStatus file, HStore store) {
+    if(!validate(file.getPath())){
+      LOG.trace("Invalid file {}, skip cleanup", file.getPath());
+      return;
+    }
+
+    if(!isOldEnough(file)){
+      LOG.trace("Fresh file {}, skip cleanup", file.getPath());
+      return;
+    }
+
+    if(isActiveStorefile(file, store)){
+      LOG.trace("Actively used storefile file {}, skip cleanup", file.getPath());
+      return;
+    }
+
+    if(isCompactedFile(file, store)){
+      LOG.trace("Cleanup is done by a different chore for file {}, skip cleanup", file.getPath());
+      return;
+    }
+
+    if(isCompactingFile(file, store)){
+      LOG.trace("The file is the result of an ongoing compaction {}, skip cleanup", file.getPath());
+      return;
+    }
+
+    deleteFile(file, store);
+  }
+
+  private boolean isCompactingFile(FileStatus file, HStore store) {
+    if (!(store.getStoreEngine().getCompactor() instanceof DirectStoreCompactor)){
+      return true; //skip examining current compaction targets if the data is not available
+    }
+    DirectStoreCompactor dsc = (DirectStoreCompactor) store.getStoreEngine().getCompactor();
+    return dsc.getCompactionPaths().contains(file.getPath());
+  }
+
+  private boolean isCompactedFile(FileStatus file, HStore store) {
+    return store.getStoreEngine().getStoreFileManager().getCompactedfiles().stream().anyMatch(sf -> sf.getPath().equals(file.getPath()));
+  }
+
+  private boolean isActiveStorefile(FileStatus file, HStore store) {
+    return store.getStoreEngine().getStoreFileManager().getStorefiles().stream().anyMatch(sf -> sf.getPath().equals(file.getPath()));
+  }
+
+  boolean validate(Path file) {
+    if (HFileLink.isBackReferencesDir(file) || HFileLink.isBackReferencesDir(file.getParent())) {
+      return true;
+    }
+    return StoreFileInfo.validateStoreFileName(file.getName());
+  }
+
+  boolean isOldEnough(FileStatus file){
+    return file.getModificationTime() + ttl < System.currentTimeMillis();
+  }
+
+  private void deleteFile(FileStatus file, HStore store) {
+    Path filePath = file.getPath();
+    LOG.debug("Removing {} from store", filePath);
+    try {
+      boolean success = store.getFileSystem().delete(filePath, false);
+      if (!success) {
+        LOG.warn("Attempted to delete:" + filePath
+            + ", but couldn't. Attempt to delete on next pass.");
+      }
+    } catch (IOException e) {
+      e = e instanceof RemoteException ?
+          ((RemoteException)e).unwrapRemoteException() : e;
+      LOG.warn("Error while deleting: " + filePath, e);
+    }
+  }
+
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -1569,6 +1569,9 @@ public class HStore implements Store, HeapSize, StoreConfigInformation,
         filesCompacting.removeAll(compactedFiles);
       }
 
+      this.getStoreEngine().getCompactor()
+        .filesDone(result.stream().map(sf -> sf.getPath()).collect(Collectors.toList()));
+
       // These may be null when the RS is shutting down. The space quota Chores will fix the Region
       // sizes later so it's not super-critical if we miss these.
       RegionServerServices rsServices = region.getRegionServerServices();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
@@ -108,8 +108,6 @@ public abstract class Compactor<T extends CellSink> {
     this.dropCacheMinor = conf.getBoolean(MINOR_COMPACTION_DROP_CACHE, true);
   }
 
-
-
   protected interface CellSinkFactory<S> {
     S createWriter(InternalScanner scanner, FileDetails fd, boolean shouldDropBehind, boolean major)
         throws IOException;
@@ -609,5 +607,9 @@ public abstract class Compactor<T extends CellSink> {
   @FunctionalInterface
   public interface StoreFileProvider {
     HStoreFile createFile(Path path) throws IOException;
+  }
+
+  public void filesDone(Collection<Path> result) {
+    //only used for DirectStoreCompactor
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/DefaultCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/DefaultCompactor.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.regionserver.compactions;
 
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.List;
 
@@ -104,6 +105,9 @@ public class DefaultCompactor extends Compactor<StoreFileWriter> {
       LOG.warn(
         "Failed to delete the leftover file " + leftoverFile + " after an unfinished compaction.",
         e);
+    }
+    finally {
+      filesDone(Arrays.asList(leftoverFile));
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDirectHFileCleaner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDirectHFileCleaner.java
@@ -1,0 +1,181 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import java.io.IOException;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+@Category({ MediumTests.class, RegionServerTests.class })
+public class TestDirectHFileCleaner {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+      HBaseClassTestRule.forClass(TestDirectHFileCleaner.class);
+
+  private final HBaseTestingUtility testUtil = new HBaseTestingUtility();
+  private final static byte[] fam = Bytes.toBytes("cf_1");
+  private final static byte[] qual1 = Bytes.toBytes("qf_1");
+  private final static byte[] val = Bytes.toBytes("val");
+  private final static  String junkFileName = "409fad9a751c4e8c86d7f32581bdc156";
+  TableName tableName;
+
+
+  @Before
+  public void setUp() throws Exception {
+    testUtil.getConfiguration().set(HConstants.STOREFILE_TRACKING_PERSIST_ENABLED, "true");
+    testUtil.getConfiguration().set(StoreEngine.STORE_ENGINE_CLASS_KEY, "org.apache.hadoop.hbase.regionserver.PersistedStoreEngine");
+    testUtil.getConfiguration().set(DefaultStoreEngine.DEFAULT_COMPACTOR_CLASS_KEY, "org.apache.hadoop.hbase.regionserver.compactions.DirectStoreCompactor");
+    testUtil.getConfiguration().set(DirectHFileCleaner.DIRECT_HFILE_CLEANER_ENABLED, "true");
+    testUtil.getConfiguration().set(DirectHFileCleaner.DIRECT_HFILE_CLEANER_TTL, "0");
+    testUtil.getConfiguration().set(DirectHFileCleaner.DIRECT_HFILE_CLEANER_PERIOD, "15000000");
+    testUtil.getConfiguration().set(DirectHFileCleaner.DIRECT_HFILE_CLEANER_DELAY, "0");
+    testUtil.startMiniCluster(1);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    testUtil.deleteTable(tableName);
+    testUtil.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testDeletingJunkFile() throws Exception {
+    tableName = TableName.valueOf(getClass().getSimpleName() + "testDeletingJunkFile");
+    createTableWithData(tableName);
+
+    HRegion region = testUtil.getMiniHBaseCluster().getRegions(tableName).get(0);
+    ServerName sn = testUtil.getMiniHBaseCluster().getServerHoldingRegion(tableName, region.getRegionInfo().getRegionName());
+    HRegionServer rs = testUtil.getMiniHBaseCluster().getRegionServer(sn);
+    DirectHFileCleaner cleaner = rs.getDirectHFileCleaner();
+
+    //create junk file
+    HStore store = region.getStore(fam);
+    Path cfPath = store.getRegionFileSystem().getStoreDir(store.getColumnFamilyName());
+    Path junkFilePath = new Path(cfPath, junkFileName);
+
+    FSDataOutputStream junkFileOS = store.getFileSystem().create(junkFilePath);
+    junkFileOS.writeUTF("hello");
+    junkFileOS.close();
+
+    int storeFiles =  store.getStorefilesCount();
+    assertTrue(storeFiles > 0);
+
+    //verify the file exist before the chore and missing afterwards
+    assertTrue(store.getFileSystem().exists(junkFilePath));
+    cleaner.chore();
+    assertFalse(store.getFileSystem().exists(junkFilePath));
+
+    //verify no storefile got deleted
+    int currentStoreFiles =  store.getStorefilesCount();
+    assertEquals(currentStoreFiles, storeFiles);
+
+  }
+
+  @Test
+  public void testSkippningCompactedFiles() throws Exception {
+    tableName = TableName.valueOf(getClass().getSimpleName() + "testSkippningCompactedFiles");
+    createTableWithData(tableName);
+
+    HRegion region = testUtil.getMiniHBaseCluster().getRegions(tableName).get(0);
+
+    ServerName sn = testUtil.getMiniHBaseCluster().getServerHoldingRegion(tableName, region.getRegionInfo().getRegionName());
+    HRegionServer rs = testUtil.getMiniHBaseCluster().getRegionServer(sn);
+    DirectHFileCleaner cleaner = rs.getDirectHFileCleaner();
+
+    //run major compaction to generate compaced files
+    region.compact(true);
+
+    //make sure there are compacted files
+    HStore store = region.getStore(fam);
+    int compactedFiles =  store.getCompactedFilesCount();
+    assertTrue(compactedFiles > 0);
+
+    cleaner.chore();
+
+    //verify none of the compacted files wee deleted
+    int existingCompactedFiles =  store.getCompactedFilesCount();
+    assertEquals(compactedFiles, existingCompactedFiles);
+
+    //verify adding a junk file does not break anything
+    Path cfPath = store.getRegionFileSystem().getStoreDir(store.getColumnFamilyName());
+    Path junkFilePath = new Path(cfPath, junkFileName);
+
+    FSDataOutputStream junkFileOS = store.getFileSystem().create(junkFilePath);
+    junkFileOS.writeUTF("hello");
+    junkFileOS.close();
+
+    assertTrue(store.getFileSystem().exists(junkFilePath));
+    cleaner.setEnabled(true);
+    cleaner.chore();
+    assertFalse(store.getFileSystem().exists(junkFilePath));
+
+    //verify compacted files are still intact
+    existingCompactedFiles =  store.getCompactedFilesCount();
+    assertEquals(compactedFiles, existingCompactedFiles);
+  }
+
+  private Table createTableWithData(TableName tableName) throws IOException {
+    Table table = testUtil.createTable(tableName, fam);
+    try {
+      for (int i = 1; i < 10; i++) {
+        Put p = new Put(Bytes.toBytes("row" + i));
+        p.addColumn(fam, qual1, val);
+        table.put(p);
+      }
+      // flush them
+      testUtil.getAdmin().flush(tableName);
+      for (int i = 11; i < 20; i++) {
+        Put p = new Put(Bytes.toBytes("row" + i));
+        p.addColumn(fam, qual1, val);
+        table.put(p);
+      }
+      // flush them
+      testUtil.getAdmin().flush(tableName);
+      for (int i = 21; i < 30; i++) {
+        Put p = new Put(Bytes.toBytes("row" + i));
+        p.addColumn(fam, qual1, val);
+        table.put(p);
+      }
+      // flush them
+      testUtil.getAdmin().flush(tableName);
+    } catch (IOException e) {
+      table.close();
+      throw e;
+    }
+    return table;
+  }
+}


### PR DESCRIPTION
Add new chore to delete lefotver directly stored hfiles
Allow DirectStoreCompactor to list current compaction target paths for
easier validation