### PR TITLE
HBASE-26309 Balancer tends to move regions to the server at the end o…

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
@@ -287,6 +287,7 @@ class BalancerClusterState {
       serversPerHost[i] = new int[serversPerHostList.get(i).size()];
       for (int j = 0; j < serversPerHost[i].length; j++) {
         serversPerHost[i][j] = serversPerHostList.get(i).get(j);
+        LOG.debug("server {} is on host {}",serversPerHostList.get(i).get(j), i);
       }
       if (serversPerHost[i].length > 1) {
         multiServersPerHost = true;
@@ -297,6 +298,7 @@ class BalancerClusterState {
       serversPerRack[i] = new int[serversPerRackList.get(i).size()];
       for (int j = 0; j < serversPerRack[i].length; j++) {
         serversPerRack[i][j] = serversPerRackList.get(i).get(j);
+        LOG.info("server {} is on rack {}",serversPerRackList.get(i).get(j), i);
       }
     }
 

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
@@ -179,6 +179,7 @@ class BalancerClusterState {
       serversPerHostList.get(hostIndex).add(serverIndex);
 
       String rack = this.rackManager.getRack(sn);
+
       if (!racksToIndex.containsKey(rack)) {
         racksToIndex.put(rack, numRacks++);
         serversPerRackList.add(new ArrayList<>());
@@ -187,6 +188,7 @@ class BalancerClusterState {
       serversPerRackList.get(rackIndex).add(serverIndex);
     }
 
+    LOG.debug("Hosts are {} racks are {}", hostsToIndex, racksToIndex);
     // Count how many regions there are.
     for (Map.Entry<ServerName, List<RegionInfo>> entry : clusterState.entrySet()) {
       numRegions += entry.getValue().size();
@@ -790,7 +792,7 @@ class BalancerClusterState {
     return Arrays.binarySearch(arr, val) >= 0;
   }
 
-  private Comparator<Integer> numRegionsComparator = Comparator.comparingInt(this::getNumRegions);
+  public Comparator<Integer> numRegionsComparator = Comparator.comparingInt(this::getNumRegions);
 
   int getLowestLocalityRegionOnServer(int serverIndex) {
     if (regionFinder != null) {

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BalancerClusterState.java
@@ -792,7 +792,11 @@ class BalancerClusterState {
     return Arrays.binarySearch(arr, val) >= 0;
   }
 
-  public Comparator<Integer> numRegionsComparator = Comparator.comparingInt(this::getNumRegions);
+  private Comparator<Integer> numRegionsComparator = Comparator.comparingInt(this::getNumRegions);
+
+  public Comparator<Integer> getNumRegionsComparator() {
+    return numRegionsComparator;
+  }
 
   int getLowestLocalityRegionOnServer(int serverIndex) {
     if (regionFinder != null) {

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
@@ -18,6 +18,8 @@
 
 package org.apache.hadoop.hbase.master.balancer;
 
+import java.util.Arrays;
+import java.util.concurrent.ThreadLocalRandom;
 import org.apache.yetus.audience.InterfaceAudience;
 
 @InterfaceAudience.Private
@@ -34,27 +36,52 @@ class LoadCandidateGenerator extends CandidateGenerator {
   private int pickLeastLoadedServer(final BalancerClusterState cluster, int thisServer) {
     Integer[] servers = cluster.serverIndicesSortedByRegionCount;
 
-    int index = 0;
-    while (servers[index] == null || servers[index] == thisServer) {
-      index++;
-      if (index == servers.length) {
-        return -1;
+    int selectedIndex = -1;
+    double currentLargestRandom = -1;
+    for (int i = 0; i < servers.length; i++){
+      if (servers[i] == null || servers[i] == thisServer) {
+        continue;
+      }
+      if (selectedIndex != -1 &&cluster.numRegionsComparator.compare(servers[i],
+        servers[selectedIndex]) != 0) {
+        // Exhausted servers of the same region count
+        break;
+      }
+      // we don't know how many servers have the same region count, we will randomly select one
+      // using reservoir sampling (http://gregable.com/2007/10/reservoir-sampling.html)
+      double currentRandom = ThreadLocalRandom.current().nextDouble();
+      if (currentRandom > currentLargestRandom) {
+        if(selectedIndex != -1) {
+        selectedIndex = i;
+        currentLargestRandom = currentRandom;
       }
     }
-    return servers[index];
+    return selectedIndex == -1? -1 : servers[selectedIndex];
   }
 
   private int pickMostLoadedServer(final BalancerClusterState cluster, int thisServer) {
     Integer[] servers = cluster.serverIndicesSortedByRegionCount;
 
-    int index = servers.length - 1;
-    while (servers[index] == null || servers[index] == thisServer) {
-      index--;
-      if (index < 0) {
-        return -1;
+    int selectedIndex = -1;
+    double currentLargestRandom = -1;
+    for (int i = servers.length - 1; i >= 0; i--) {
+      if (servers[i] == null || servers[i] == thisServer) {
+        continue;
+      }
+      if (selectedIndex != -1 && cluster.numRegionsComparator.compare(servers[i],
+        servers[selectedIndex]) != 0) {
+        // Exhausted servers of the same region count
+        break;
+      }
+      // we don't know how many servers have the same region count, we will randomly select one
+      // using reservoir sampling (http://gregable.com/2007/10/reservoir-sampling.html)
+      double currentRandom = ThreadLocalRandom.current().nextDouble();
+      if (currentRandom > currentLargestRandom) {
+        selectedIndex = i;
+        currentLargestRandom = currentRandom;
       }
     }
-    return servers[index];
+    return selectedIndex == -1? -1 : servers[selectedIndex];
   }
 
 }

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
@@ -18,7 +18,6 @@
 
 package org.apache.hadoop.hbase.master.balancer;
 
-import java.util.Arrays;
 import java.util.concurrent.ThreadLocalRandom;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -43,7 +42,7 @@ class LoadCandidateGenerator extends CandidateGenerator {
         continue;
       }
       if (selectedIndex != -1
-        && cluster.numRegionsComparator.compare(servers[i], servers[selectedIndex]) != 0) {
+        && cluster.getNumRegionsComparator().compare(servers[i], servers[selectedIndex]) != 0) {
         // Exhausted servers of the same region count
         break;
       }
@@ -67,7 +66,7 @@ class LoadCandidateGenerator extends CandidateGenerator {
       if (servers[i] == null || servers[i] == thisServer) {
         continue;
       }
-      if (selectedIndex != -1 && cluster.numRegionsComparator.compare(servers[i],
+      if (selectedIndex != -1 && cluster.getNumRegionsComparator().compare(servers[i],
         servers[selectedIndex]) != 0) {
         // Exhausted servers of the same region count
         break;

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
@@ -51,13 +51,11 @@ class LoadCandidateGenerator extends CandidateGenerator {
       // using reservoir sampling (http://gregable.com/2007/10/reservoir-sampling.html)
       double currentRandom = ThreadLocalRandom.current().nextDouble();
       if (currentRandom > currentLargestRandom) {
-        if (selectedIndex != -1) {
-          selectedIndex = i;
-          currentLargestRandom = currentRandom;
-        }
+        selectedIndex = i;
+        currentLargestRandom = currentRandom;
       }
-      return selectedIndex == -1 ? -1 : servers[selectedIndex];
     }
+    return selectedIndex == -1 ? -1 : servers[selectedIndex];
   }
 
   private int pickMostLoadedServer(final BalancerClusterState cluster, int thisServer) {

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
@@ -47,7 +47,8 @@ class LoadCandidateGenerator extends CandidateGenerator {
         break;
       }
       // we don't know how many servers have the same region count, we will randomly select one
-      // using reservoir sampling (http://gregable.com/2007/10/reservoir-sampling.html)
+      // using a simplified inline reservoir sampling by assignmening a random number to  stream
+      // data and choose the greatest one. (http://gregable.com/2007/10/reservoir-sampling.html)
       double currentRandom = ThreadLocalRandom.current().nextDouble();
       if (currentRandom > currentLargestRandom) {
         selectedIndex = i;
@@ -72,7 +73,8 @@ class LoadCandidateGenerator extends CandidateGenerator {
         break;
       }
       // we don't know how many servers have the same region count, we will randomly select one
-      // using reservoir sampling (http://gregable.com/2007/10/reservoir-sampling.html)
+      // using a simplified inline reservoir sampling by assignmening a random number to  stream
+      // data and choose the greatest one. (http://gregable.com/2007/10/reservoir-sampling.html)
       double currentRandom = ThreadLocalRandom.current().nextDouble();
       if (currentRandom > currentLargestRandom) {
         selectedIndex = i;

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/LoadCandidateGenerator.java
@@ -38,12 +38,12 @@ class LoadCandidateGenerator extends CandidateGenerator {
 
     int selectedIndex = -1;
     double currentLargestRandom = -1;
-    for (int i = 0; i < servers.length; i++){
+    for (int i = 0; i < servers.length; i++) {
       if (servers[i] == null || servers[i] == thisServer) {
         continue;
       }
-      if (selectedIndex != -1 &&cluster.numRegionsComparator.compare(servers[i],
-        servers[selectedIndex]) != 0) {
+      if (selectedIndex != -1
+        && cluster.numRegionsComparator.compare(servers[i], servers[selectedIndex]) != 0) {
         // Exhausted servers of the same region count
         break;
       }
@@ -51,12 +51,13 @@ class LoadCandidateGenerator extends CandidateGenerator {
       // using reservoir sampling (http://gregable.com/2007/10/reservoir-sampling.html)
       double currentRandom = ThreadLocalRandom.current().nextDouble();
       if (currentRandom > currentLargestRandom) {
-        if(selectedIndex != -1) {
-        selectedIndex = i;
-        currentLargestRandom = currentRandom;
+        if (selectedIndex != -1) {
+          selectedIndex = i;
+          currentLargestRandom = currentRandom;
+        }
       }
+      return selectedIndex == -1 ? -1 : servers[selectedIndex];
     }
-    return selectedIndex == -1? -1 : servers[selectedIndex];
   }
 
   private int pickMostLoadedServer(final BalancerClusterState cluster, int thisServer) {

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -345,8 +345,6 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     }
 
     if (idleRegionServerExist(cluster)){
-      LOG.info("Running balancer because at least one server hosts replicas of the same region." +
-        "regionReplicaRackCostFunction={}", regionReplicaRackCostFunction.cost());
       LOG.info("Running balancer because cluster has idle server(s)."+
         " function cost={}", functionCost());
       return true;
@@ -510,9 +508,9 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
       LOG.info("Finished computing new moving plan. Computation took {} ms" +
           " to try {} different iterations.  Found a solution that moves " +
           "{} regions; Going from a computed imbalance of {}" +
-          " to a new imbalance of {}. ",
+          " to a new imbalance of {}. funtionCost={}",
         endTime - startTime, step, plans.size(),
-        initCost / sumMultiplier, currentCost / sumMultiplier);
+        initCost / sumMultiplier, currentCost / sumMultiplier, functionCost());
       sendRegionPlansToRingBuffer(plans, currentCost, initCost, initFunctionTotalCosts, step);
       return plans;
     }

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/StochasticBalancerTestBase.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/StochasticBalancerTestBase.java
@@ -80,7 +80,7 @@ public class StochasticBalancerTestBase extends BalancerTestBase {
       List<ServerAndLoad> balancedCluster = reconcile(list, plans, serverMap);
 
       // Print out the cluster loads to make debugging easier.
-      LOG.info("Mock Balance : " + printMock(balancedCluster));
+      LOG.info("Mock after Balance : " + printMock(balancedCluster));
 
       if (assertFullyBalanced) {
         assertClusterAsBalanced(balancedCluster);
@@ -93,6 +93,42 @@ public class StochasticBalancerTestBase extends BalancerTestBase {
       if (assertFullyBalancedForReplicas) {
         assertRegionReplicaPlacement(serverMap, rackManager);
       }
+    }
+  }
+
+  protected void testWithClusterWithIteration(Map<ServerName, List<RegionInfo>> serverMap,
+    RackManager rackManager, boolean assertFullyBalanced, boolean assertFullyBalancedForReplicas) {
+    List<ServerAndLoad> list = convertToList(serverMap);
+    LOG.info("Mock Cluster : " + printMock(list) + " " + printStats(list));
+
+    loadBalancer.setRackManager(rackManager);
+    // Run the balancer.
+    Map<TableName, Map<ServerName, List<RegionInfo>>> LoadOfAllTable = (Map) mockClusterServersWithTables(serverMap);
+    List<RegionPlan> plans = loadBalancer.balanceCluster(LoadOfAllTable);
+    assertNotNull("Initial cluster balance should produce plans.", plans);
+
+    List<ServerAndLoad> balancedCluster = null;
+    // Run through iteration until done. Otherwise will be killed as test time out
+    while (plans != null && (assertFullyBalanced || assertFullyBalancedForReplicas)) {
+      // Apply the plan to the mock cluster.
+      balancedCluster = reconcile(list, plans, serverMap);
+
+      // Print out the cluster loads to make debugging easier.
+      LOG.info("Mock after balance: " + printMock(balancedCluster));
+
+      LoadOfAllTable = (Map) mockClusterServersWithTables(serverMap);
+      plans = loadBalancer.balanceCluster(LoadOfAllTable);
+    }
+
+    // Print out the cluster loads to make debugging easier.
+    LOG.info("Mock Final balance: " + printMock(balancedCluster));
+
+    if (assertFullyBalanced) {
+      assertNull("Given a requirement to be fully balanced, second attempt at plans should " +
+        "produce none.", plans);
+    }
+    if (assertFullyBalancedForReplicas) {
+      assertRegionReplicaPlacement(serverMap, rackManager);
     }
   }
 }

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerRegionReplicaWithRacks.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerRegionReplicaWithRacks.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.master.balancer;
 
 import java.util.List;
+import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.ServerName;
@@ -37,7 +38,10 @@ public class TestStochasticLoadBalancerRegionReplicaWithRacks extends Stochastic
       HBaseClassTestRule.forClass(TestStochasticLoadBalancerRegionReplicaWithRacks.class);
 
   private static class ForTestRackManager extends RackManager {
+
     int numRacks;
+    Map<String, Integer> serverIndexes = new HashMap<String, Integer>();
+    int numServers = 0;
 
     public ForTestRackManager(int numRacks) {
       this.numRacks = numRacks;
@@ -45,7 +49,11 @@ public class TestStochasticLoadBalancerRegionReplicaWithRacks extends Stochastic
 
     @Override
     public String getRack(ServerName server) {
-      return "rack_" + (server.hashCode() % numRacks);
+      String key = server.getServerName();
+      if (!serverIndexes.containsKey(key)) {
+        serverIndexes.put(key, numServers++);
+      }
+      return "rack_" + serverIndexes.get(key) % numRacks;
     }
   }
 

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerRegionReplicaWithRacks.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancerRegionReplicaWithRacks.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hbase.master.balancer;
 
-import java.util.List;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.ServerName;


### PR DESCRIPTION
…f list

There is a reason for the bias of the server pick. LoadCandidate generator always pick the first server of the same region count. For large cluster, it often gets stuck and also causes drifting. This fix will use reservoir sampling (http://gregable.com/2007/10/reservoir-sampling.html) to randomize the pick.