### PR TITLE
HBASE-26361 Enable OpenTelemetry to be used from developer sandbox

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -487,8 +487,16 @@ add_jdk11_deps_to_classpath() {
   done
 }
 
-enable_trace() {
-  agent_jar=$(find lib/trace -type f -name "opentelemetry-javaagent-*")
+add_opentelemetry_agent() {
+  if ! agent_jar=$(find lib/trace -type f -name "opentelemetry-javaagent-*" 2>/dev/null); then
+    # must be dev environment
+    f="${HBASE_HOME}/hbase-build-configuration/target/cached_classpath.txt"
+    if [ ! -f "${f}" ]; then
+      echo "As this is a development environment, we need ${f} to be generated from maven (command: mvn install -DskipTests)"
+      exit 1
+    fi
+    agent_jar=$(tr ':' '\n' < "${f}" | grep opentelemetry-javaagent)
+  fi
   HBASE_OPTS="$HBASE_OPTS -javaagent:$agent_jar $HBASE_TRACE_OPTS"
 }
 
@@ -770,8 +778,10 @@ elif [ "${DEBUG}" = "true" ]; then
 fi
 
 if [[ -n "${HBASE_TRACE_OPTS}" ]]; then
-  echo "Attach opentelemetry agent to enable trace"
-  enable_trace
+  if [ "${DEBUG}" = "true" ]; then
+    echo "Attaching opentelemetry agent"
+  fi
+  add_opentelemetry_agent
 fi
 
 # Have JVM dump heap if we run out of memory.  Files will be 'launch directory'

--- a/conf/hbase-env.sh
+++ b/conf/hbase-env.sh
@@ -142,10 +142,10 @@
 # export GREP="${GREP-grep}"
 # export SED="${SED-sed}"
 
-# Additional argments passed to jshell invocation
-# export HBASE_JSHELL_ARGS="--startup DEFAULT --startup PRINTING --startup hbase_startup.jsh"
-
 # Uncomment to enable trace, you can change the options to use other exporters such as jaeger or
 # zipkin. See https://github.com/open-telemetry/opentelemetry-java-instrumentation on how to
 # configure exporters and other components through system properties.
-# export HBASE_TRACE_OPTS="-Dotel.resource.attributes=service.name=HBase -Dotel.traces.exporter=logging otel.metrics.exporter=none"
+# export HBASE_TRACE_OPTS="-Dotel.resource.attributes=service.name=HBase -Dotel.traces.exporter=logging -Dotel.metrics.exporter=none"
+
+# Additional argments passed to jshell invocation
+# export HBASE_JSHELL_ARGS="--startup DEFAULT --startup PRINTING --startup hbase_startup.jsh"


### PR DESCRIPTION
A small change to enable tracing in a dev's built environment.