### PR TITLE
HBASE-26363 OpenTelemetry configuration support for per-process servi…

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -493,7 +493,9 @@ add_jdk11_deps_to_classpath() {
 }
 
 add_opentelemetry_agent() {
-  if ! agent_jar=$(find lib/trace -type f -name "opentelemetry-javaagent-*" 2>/dev/null); then
+  if [ -e "${OPENTELEMETRY_JAVAAGENT_PATH}" ] ; then
+    agent_jar="${OPENTELEMETRY_JAVAAGENT_PATH}"
+  elif ! agent_jar=$(find -L "${HBASE_HOME}/lib/trace" -type f -name "opentelemetry-javaagent-*" 2>/dev/null); then
     # must be dev environment
     f="${HBASE_HOME}/hbase-build-configuration/target/cached_classpath.txt"
     if [ ! -f "${f}" ]; then
@@ -502,7 +504,7 @@ add_opentelemetry_agent() {
     fi
     agent_jar=$(tr ':' '\n' < "${f}" | grep opentelemetry-javaagent)
   fi
-  HBASE_OPTS="$HBASE_OPTS -javaagent:$agent_jar $HBASE_TRACE_OPTS"
+  HBASE_OPTS="$HBASE_OPTS -javaagent:$agent_jar"
 }
 
 #Add the development env class path stuff
@@ -565,6 +567,7 @@ elif [ "$COMMAND" = 'jshell' ] ; then
   CLASS='jdk.internal.jshell.tool.JShellToolProvider'
   # set default values for HBASE_JSHELL_ARGS
   read -r -a JSHELL_ARGS <<< "${HBASE_JSHELL_ARGS:-"--startup DEFAULT --startup PRINTING --startup ${HBASE_HOME}/bin/hbase_startup.jsh"}"
+  HBASE_OPTS="$HBASE_OPTS $HBASE_JSHELL_OPTS"
 elif [ "$COMMAND" = "hbck" ] ; then
   # Look for the -j /path/to/HBCK2.jar parameter. Else pass through to hbck.
   case "${1}" in

--- a/conf/hbase-env.sh
+++ b/conf/hbase-env.sh
@@ -143,10 +143,32 @@
 # export GREP="${GREP-grep}"
 # export SED="${SED-sed}"
 
-# Uncomment to enable trace, you can change the options to use other exporters such as jaeger or
-# zipkin. See https://github.com/open-telemetry/opentelemetry-java-instrumentation on how to
+# Tracing
+# Uncomment some combination of these lines to enable tracing. You should change the options to use
+# the exporters appropriate to your environment. See
+# https://github.com/open-telemetry/opentelemetry-java-instrumentation for details on how to
 # configure exporters and other components through system properties.
-# export HBASE_TRACE_OPTS="-Dotel.resource.attributes=service.name=HBase -Dotel.traces.exporter=logging -Dotel.metrics.exporter=none"
+#
+# The presence HBASE_TRACE_OPTS indicates that tracing should be enabled, and serves as site-wide
+# settings.
+# export HBASE_TRACE_OPTS="-Dotel.traces.exporter=none -Dotel.metrics.exporter=none"
+#
+# Per-process configuration variables allow for fine-grained configuration control.
+# export HBASE_SHELL_OPTS="${HBASE_SHELL_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-shell"
+# export HBASE_JSHELL_OPTS="${HBASE_JSHELL_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-jshell"
+# export HBASE_HBCK_OPTS="${HBASE_HBCK_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-hbck"
+# export HBASE_MASTER_OPTS="${HBASE_MASTER_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-master"
+# export HBASE_REGIONSERVER_OPTS="${HBASE_REGIONSERVER_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-regionserver"
+# export HBASE_THRIFT_OPTS="${HBASE_THRIFT_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-thrift"
+# export HBASE_REST_OPTS="${HBASE_REST_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-rest"
+# export HBASE_ZOOKEEPER_OPTS="${HBASE_ZOOKEEPER_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-zookeeper"
+# export HBASE_PE_OPTS="${HBASE_PE_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-performanceevaluation"
+# export HBASE_LTT_OPTS="${HBASE_LTT_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-loadtesttool"
+# export HBASE_CANARY_OPTS="${HBASE_CANARY_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-canary"
+# export HBASE_HBTOP_OPTS="${HBASE_HBTOP_OPTS} ${HBASE_TRACE_OPTS} -Dotel.resource.attributes=service.name=hbase-hbtop"
+#
+# Manually specify a value for OPENTELEMETRY_JAVAAGENT_PATH to override the autodiscovery mechanism
+# export OPENTELEMETRY_JAVAAGENT_PATH=""
 
 # Additional argments passed to jshell invocation
 # export HBASE_JSHELL_ARGS="--startup DEFAULT --startup PRINTING --startup hbase_startup.jsh"


### PR DESCRIPTION
…ce names

Exposes process-specific tracing arguments for most of the commands that we can launch from
`bin/hbase`. In addition to serving as an on/off flag, `HBASE_TRACE_OPTS` acts as the site-wide
configuration setting. Additional variables are provided for each applicable command, giving
operators fine-grain control over which processes participate in the tracing system, and to what
degree.