### PR TITLE
HBASE-26383 HBCK incorrectly reports inconsistencies for recently split regions following a master failover

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HbckChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HbckChore.java
@@ -223,7 +223,8 @@ public class HbckChore extends ScheduledChore {
           .isTableState(regionInfo.getTable(), TableState.State.DISABLED)) {
         disabledTableRegions.add(regionInfo.getRegionNameAsString());
       }
-      if (regionState.isSplit()) {
+      // Check both state and regioninfo for split status, see HBASE-26383
+      if (regionState.isSplit() || regionInfo.isSplit()) {
         splitParentRegions.add(regionInfo.getRegionNameAsString());
       }
       HbckRegionInfo.MetaEntry metaEntry =


### PR DESCRIPTION
A regression was introduced by HBASE-25847 which changed regionInfo#isParentSplit to regionState#isSplit. The region state after restart is CLOSED instead of SPLIT. We need to check both regionState and regionInfo for split status.