### PR TITLE
HBASE-26406 Can not add peer replicating to non-HBase

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestNonHBaseReplicationEndpoint.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestNonHBaseReplicationEndpoint.java
@@ -1,0 +1,205 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.replication;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.ReplicationTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Threads;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ MediumTests.class, ReplicationTests.class })
+public class TestNonHBaseReplicationEndpoint {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestNonHBaseReplicationEndpoint.class);
+
+  private static final HBaseTestingUtil UTIL = new HBaseTestingUtil();
+
+  private static Admin ADMIN;
+
+  private static final TableName tableName = TableName.valueOf("test");
+  private static final byte[] famName = Bytes.toBytes("f");
+
+  private static final AtomicBoolean REPLICATED = new AtomicBoolean();
+
+  @BeforeClass
+  public static void setupBeforeClass() throws Exception {
+    UTIL.startMiniCluster();
+    ADMIN = UTIL.getAdmin();
+  }
+
+  @AfterClass
+  public static void teardownAfterClass() throws Exception {
+    UTIL.shutdownMiniCluster();
+  }
+
+  @Before
+  public void setup() {
+    REPLICATED.set(false);
+  }
+
+  @Test
+  public void test() throws IOException {
+    TableDescriptor td = TableDescriptorBuilder.newBuilder(tableName)
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(famName)
+        .setScope(HConstants.REPLICATION_SCOPE_GLOBAL).build())
+      .build();
+    Table table = UTIL.createTable(td, HBaseTestingUtil.KEYS_FOR_HBA_CREATE_TABLE);
+
+    ReplicationPeerConfig peerConfig = ReplicationPeerConfig.newBuilder()
+      .setReplicationEndpointImpl(NonHBaseReplicationEndpoint.class.getName())
+      .setReplicateAllUserTables(false)
+      .setTableCFsMap(new HashMap<TableName, List<String>>() {{
+          put(tableName, new ArrayList<>());
+        }
+      }).build();
+
+    ADMIN.addReplicationPeer("1", peerConfig);
+    loadData(table);
+
+    UTIL.waitFor(10000L, () -> REPLICATED.get());
+  }
+
+  protected static void loadData(Table table) throws IOException {
+    for (int i = 0; i < 100; i++) {
+      Put put = new Put(Bytes.toBytes(Integer.toString(i)));
+      put.addColumn(famName, famName, Bytes.toBytes(i));
+      table.put(put);
+    }
+  }
+
+  public static class NonHBaseReplicationEndpoint implements ReplicationEndpoint {
+
+    private boolean running = false;
+
+    @Override
+    public void init(Context context) throws IOException {
+    }
+
+    @Override
+    public boolean canReplicateToSameCluster() {
+      return false;
+    }
+
+    @Override
+    public UUID getPeerUUID() {
+      return UUID.randomUUID();
+    }
+
+    @Override
+    public WALEntryFilter getWALEntryfilter() {
+      return null;
+    }
+
+    @Override
+    public boolean replicate(ReplicateContext replicateContext) {
+      REPLICATED.set(true);
+      return true;
+    }
+
+    @Override
+    public boolean isRunning() {
+      return running;
+    }
+
+    @Override
+    public boolean isStarting() {
+      return false;
+    }
+
+    @Override
+    public void start() {
+      running = true;
+    }
+
+    @Override
+    public void awaitRunning() {
+      long interval = 100L;
+      while (!running) {
+        Threads.sleep(interval);
+      }
+    }
+
+    @Override
+    public void awaitRunning(long timeout, TimeUnit unit) {
+      long start = System.currentTimeMillis();
+      long end = start + unit.toMillis(timeout);
+      long interval = 100L;
+      while (!running && System.currentTimeMillis() < end) {
+        Threads.sleep(interval);
+      }
+    }
+
+    @Override
+    public void stop() {
+      running = false;
+    }
+
+    @Override
+    public void awaitTerminated() {
+      long interval = 100L;
+      while (running) {
+        Threads.sleep(interval);
+      }
+    }
+
+    @Override
+    public void awaitTerminated(long timeout, TimeUnit unit) {
+      long start = System.currentTimeMillis();
+      long end = start + unit.toMillis(timeout);
+      long interval = 100L;
+      while (running && System.currentTimeMillis() < end) {
+        Threads.sleep(interval);
+      }
+    }
+
+    @Override
+    public Throwable failureCause() {
+      return null;
+    }
+
+    @Override
+    public void peerConfigUpdated(ReplicationPeerConfig rpc) {
+    }
+  }
+}


### PR DESCRIPTION
Failed to add a peer replicating to non-HBase(like MQ) by implementing custom ReplicationEndpoint,  got exception like this in my UT: 
```
2021-10-29T15:14:47,632 INFO  [RPCClient-NioEventLoopGroup-5-3] client.RawAsyncHBaseAdmin$ReplicationProcedureBiConsumer(2761): Operation: ADD_REPLICATION_PEER, peerId: 1 failed with Invalid cluster key: , should not replicate to itself for HBaseInterClusterReplicationEndpoint2021-10-29T15:14:47,632 INFO  [RPCClient-NioEventLoopGroup-5-3] client.RawAsyncHBaseAdmin$ReplicationProcedureBiConsumer(2761): Operation: ADD_REPLICATION_PEER, peerId: 1 failed with Invalid cluster key: , should not replicate to itself for HBaseInterClusterReplicationEndpoint
org.apache.hadoop.hbase.DoNotRetryIOException: Invalid cluster key: , should not replicate to itself for HBaseInterClusterReplicationEndpoint
 at java.lang.Thread.getStackTrace(Thread.java:1559)
 at org.apache.hadoop.hbase.util.FutureUtils.setStackTrace(FutureUtils.java:130)
 at org.apache.hadoop.hbase.util.FutureUtils.rethrow(FutureUtils.java:149)
 at org.apache.hadoop.hbase.util.FutureUtils.get(FutureUtils.java:186)
 at org.apache.hadoop.hbase.client.Admin.addReplicationPeer(Admin.java:1948)
 at org.apache.hadoop.hbase.client.Admin.addReplicationPeer(Admin.java:1936)
 at org.apache.hadoop.hbase.replication.TestNonHBaseReplicationEndpoint.test(TestNonHBaseReplicationEndpoint.java:97)
 at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
 at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
 at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
 at java.lang.reflect.Method.invoke(Method.java:498)
 at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
 at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
 at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
 at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
 at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
 at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
 at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
 at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
 at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
 at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
 at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
 at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
 at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
 at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
 at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
 at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
 at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
 at org.apache.hadoop.hbase.SystemExitRule$1.evaluate(SystemExitRule.java:38)
 at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:288)
 at org.junit.internal.runners.statements.FailOnTimeout$CallableStatement.call(FailOnTimeout.java:282)
 at java.util.concurrent.FutureTask.run(FutureTask.java:266)
 at java.lang.Thread.run(Thread.java:748)
 at --------Future.get--------(Unknown Source)
 at org.apache.hadoop.hbase.master.replication.ReplicationPeerManager.checkClusterId(ReplicationPeerManager.java:527)
 at org.apache.hadoop.hbase.master.replication.ReplicationPeerManager.checkPeerConfig(ReplicationPeerManager.java:367)
 at org.apache.hadoop.hbase.master.replication.ReplicationPeerManager.preAddPeer(ReplicationPeerManager.java:123)
 at org.apache.hadoop.hbase.master.replication.AddPeerProcedure.prePeerModification(AddPeerProcedure.java:101)
 at org.apache.hadoop.hbase.master.replication.ModifyPeerProcedure.executeFromState(ModifyPeerProcedure.java:162)
 at org.apache.hadoop.hbase.master.replication.ModifyPeerProcedure.executeFromState(ModifyPeerProcedure.java:43)
 at org.apache.hadoop.hbase.procedure2.StateMachineProcedure.execute(StateMachineProcedure.java:190)
 at org.apache.hadoop.hbase.procedure2.Procedure.doExecute(Procedure.java:953)
 at org.apache.hadoop.hbase.procedure2.ProcedureExecutor.execProcedure(ProcedureExecutor.java:1667)
 at org.apache.hadoop.hbase.procedure2.ProcedureExecutor.executeProcedure(ProcedureExecutor.java:1414)
 at org.apache.hadoop.hbase.procedure2.ProcedureExecutor.access$1100(ProcedureExecutor.java:78)
 at org.apache.hadoop.hbase.procedure2.ProcedureExecutor$WorkerThread.run(ProcedureExecutor.java:1981)
```
HBASE-24743 ignored this situation and introduced this bug.