### PR TITLE
HBASE-26429 HeapMemoryManager fails memstore flushes with NPE if enabled

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreFlusher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreFlusher.java
@@ -673,9 +673,9 @@ public class MemStoreFlusher implements FlushRequester {
     FlushType type = null;
     if (emergencyFlush) {
       type = isAboveHighWaterMark();
-      if (type == null) {
-        type = isAboveLowWaterMark();
-      }
+    }
+    if (type == null) {
+      type = isAboveLowWaterMark();
     }
     for (FlushRequestListener listener : flushRequestListeners) {
       listener.flushRequested(type, region);


### PR DESCRIPTION
NPE in HeapMemoryManager$HeapMemoryTunerChore.flushRequested because in MemStoreFlusher.notifyFlushRequest 'type' can be null. Seems like a long standing bug. I guess nobody uses this feature?