### PR TITLE
Tracing Spans of RPCs should follow otel semantic conventions

### DIFF
--- a/hbase-client/pom.xml
+++ b/hbase-client/pom.xml
@@ -194,6 +194,11 @@
       <scope>test</scope>
     </dependency>
     <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
       <groupId>org.apache.commons</groupId>
       <artifactId>commons-crypto</artifactId>
       <exclusions>

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AbstractRpcBasedConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AbstractRpcBasedConnectionRegistry.java
@@ -272,6 +272,11 @@ abstract class AbstractRpcBasedConnectionRegistry implements ConnectionRegistry 
   }
 
   @Override
+  public String getConnectionString() {
+    return "unimplemented";
+  }
+
+  @Override
   public void close() {
     trace(() -> {
       if (registryEndpointRefresher != null) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
@@ -74,7 +74,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.MasterServ
  * The implementation of AsyncConnection.
  */
 @InterfaceAudience.Private
-class AsyncConnectionImpl implements AsyncConnection {
+public class AsyncConnectionImpl implements AsyncConnection {
 
   private static final Logger LOG = LoggerFactory.getLogger(AsyncConnectionImpl.class);
 
@@ -196,6 +196,14 @@ class AsyncConnectionImpl implements AsyncConnection {
       choreService = new ChoreService("AsyncConn Chore Service");
     }
     return choreService;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public ConnectionRegistry getConnectionRegistry() {
+    return registry;
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -25,6 +25,7 @@ import static org.apache.hadoop.hbase.client.ConnectionUtils.NO_NONCE_GENERATOR;
 import static org.apache.hadoop.hbase.client.ConnectionUtils.getStubKey;
 import static org.apache.hadoop.hbase.client.MetricsConnection.CLIENT_SIDE_METRICS_ENABLED_KEY;
 import static org.apache.hadoop.hbase.client.NonceGenerator.CLIENT_NONCES_ENABLED_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.SERVER_NAME_KEY;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
 import io.opentelemetry.api.trace.Span;
@@ -410,7 +411,7 @@ class AsyncConnectionImpl implements AsyncConnection {
   }
 
   private Hbck getHbckInternal(ServerName masterServer) {
-    Span.current().setAttribute(TraceUtil.SERVER_NAME_KEY, masterServer.getServerName());
+    Span.current().setAttribute(SERVER_NAME_KEY, masterServer.getServerName());
     // we will not create a new connection when creating a new protobuf stub, and for hbck there
     // will be no performance consideration, so for simplification we will create a new stub every
     // time instead of caching the stub here.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocator.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocator.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -20,24 +20,27 @@ package org.apache.hadoop.hbase.client;
 import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.REGION_NAMES_KEY;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.SERVER_NAME_KEY;
-import static org.apache.hadoop.hbase.trace.TraceUtil.createSpan;
-import static org.apache.hadoop.hbase.trace.TraceUtil.createTableSpan;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Scope;
-import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.trace.ConnectionSpanBuilder;
+import org.apache.hadoop.hbase.client.trace.TableSpanBuilder;
 import org.apache.hadoop.hbase.exceptions.TimeoutIOException;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -96,9 +99,12 @@ class AsyncRegionLocator {
     return TableName.isMetaTableName(tableName);
   }
 
-  private <T> CompletableFuture<T> tracedLocationFuture(Supplier<CompletableFuture<T>> action,
-    Function<T, List<String>> getRegionNames, TableName tableName, String methodName) {
-    Span span = createTableSpan("AsyncRegionLocator." + methodName, tableName);
+  private <T> CompletableFuture<T> tracedLocationFuture(
+    Supplier<CompletableFuture<T>> action,
+    Function<T, List<String>> getRegionNames,
+    Supplier<Span> spanSupplier
+  ) {
+    final Span span = spanSupplier.get();
     try (Scope scope = span.makeCurrent()) {
       CompletableFuture<T> future = action.get();
       FutureUtils.addListener(future, (resp, error) -> {
@@ -117,18 +123,29 @@ class AsyncRegionLocator {
     }
   }
 
-  private List<String> getRegionName(RegionLocations locs) {
-    List<String> names = new ArrayList<>();
-    for (HRegionLocation loc : locs.getRegionLocations()) {
-      if (loc != null) {
-        names.add(loc.getRegion().getRegionNameAsString());
-      }
-    }
-    return names;
+  private static List<String> getRegionNames(RegionLocations locs) {
+    if (locs == null) { return Collections.emptyList(); }
+    if (locs.getRegionLocations() == null) { return Collections.emptyList(); }
+    return Arrays.stream(locs.getRegionLocations())
+      .filter(Objects::nonNull)
+      .map(HRegionLocation::getRegion)
+      .map(RegionInfo::getRegionNameAsString)
+      .collect(Collectors.toList());
+  }
+
+  private static List<String> getRegionNames(HRegionLocation location) {
+    return Optional.ofNullable(location)
+      .map(HRegionLocation::getRegion)
+      .map(RegionInfo::getRegionNameAsString)
+      .map(Collections::singletonList)
+      .orElseGet(Collections::emptyList);
   }
 
   CompletableFuture<RegionLocations> getRegionLocations(TableName tableName, byte[] row,
     RegionLocateType type, boolean reload, long timeoutNs) {
+    final Supplier<Span> supplier = new TableSpanBuilder<>(conn)
+      .setName("AsyncRegionLocator.getRegionLocations")
+      .setTableName(tableName);
     return tracedLocationFuture(() -> {
       CompletableFuture<RegionLocations> future = isMeta(tableName) ?
         metaRegionLocator.getRegionLocations(RegionReplicaUtil.DEFAULT_REPLICA_ID, reload) :
@@ -138,11 +155,14 @@ class AsyncRegionLocator {
         () -> "Timeout(" + TimeUnit.NANOSECONDS.toMillis(timeoutNs) +
           "ms) waiting for region locations for " + tableName + ", row='" +
           Bytes.toStringBinary(row) + "'");
-    }, this::getRegionName, tableName, "getRegionLocations");
+    }, AsyncRegionLocator::getRegionNames, supplier);
   }
 
   CompletableFuture<HRegionLocation> getRegionLocation(TableName tableName, byte[] row,
     int replicaId, RegionLocateType type, boolean reload, long timeoutNs) {
+    final Supplier<Span> supplier = new TableSpanBuilder<>(conn)
+      .setName("AsyncRegionLocator.getRegionLocation")
+      .setTableName(tableName);
     return tracedLocationFuture(() -> {
       // meta region can not be split right now so we always call the same method.
       // Change it later if the meta table can have more than one regions.
@@ -173,8 +193,7 @@ class AsyncRegionLocator {
         () -> "Timeout(" + TimeUnit.NANOSECONDS.toMillis(timeoutNs) +
           "ms) waiting for region location for " + tableName + ", row='" +
           Bytes.toStringBinary(row) + "', replicaId=" + replicaId);
-    }, loc -> Arrays.asList(loc.getRegion().getRegionNameAsString()), tableName,
-      "getRegionLocation");
+    }, AsyncRegionLocator::getRegionNames, supplier);
   }
 
   CompletableFuture<HRegionLocation> getRegionLocation(TableName tableName, byte[] row,
@@ -202,6 +221,9 @@ class AsyncRegionLocator {
   }
 
   void clearCache(TableName tableName) {
+    Supplier<Span> supplier = new TableSpanBuilder<>(conn)
+      .setName("AsyncRegionLocator.clearCache")
+      .setTableName(tableName);
     TraceUtil.trace(() -> {
       LOG.debug("Clear meta cache for {}", tableName);
       if (tableName.equals(META_TABLE_NAME)) {
@@ -209,24 +231,28 @@ class AsyncRegionLocator {
       } else {
         nonMetaRegionLocator.clearCache(tableName);
       }
-    }, () -> createTableSpan("AsyncRegionLocator.clearCache", tableName));
+    }, supplier);
   }
 
   void clearCache(ServerName serverName) {
+    Supplier<Span> supplier = new ConnectionSpanBuilder<>(conn)
+      .setName("AsyncRegionLocator.clearCache")
+      .addAttribute(SERVER_NAME_KEY, serverName.getServerName());
     TraceUtil.trace(() -> {
       LOG.debug("Clear meta cache for {}", serverName);
       metaRegionLocator.clearCache(serverName);
       nonMetaRegionLocator.clearCache(serverName);
       conn.getConnectionMetrics().ifPresent(MetricsConnection::incrMetaCacheNumClearServer);
-    }, () -> createSpan("AsyncRegionLocator.clearCache").setAttribute(SERVER_NAME_KEY,
-      serverName.getServerName()));
+    }, supplier);
   }
 
   void clearCache() {
+    Supplier<Span> supplier = new ConnectionSpanBuilder<>(conn)
+      .setName("AsyncRegionLocator.clearCache");
     TraceUtil.trace(() -> {
       metaRegionLocator.clearCache();
       nonMetaRegionLocator.clearCache();
-    }, "AsyncRegionLocator.clearCache");
+    }, supplier);
   }
 
   AsyncNonMetaRegionLocator getNonMetaRegionLocator() {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocator.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocator.java
@@ -18,8 +18,8 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
-import static org.apache.hadoop.hbase.trace.TraceUtil.REGION_NAMES_KEY;
-import static org.apache.hadoop.hbase.trace.TraceUtil.SERVER_NAME_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.REGION_NAMES_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.SERVER_NAME_KEY;
 import static org.apache.hadoop.hbase.trace.TraceUtil.createSpan;
 import static org.apache.hadoop.hbase.trace.TraceUtil.createTableSpan;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionRegistry.java
@@ -29,7 +29,7 @@ import org.apache.yetus.audience.InterfaceAudience;
  * Internal use only.
  */
 @InterfaceAudience.Private
-interface ConnectionRegistry extends Closeable {
+public interface ConnectionRegistry extends Closeable {
 
   /**
    * Get the location of meta region(s).
@@ -47,6 +47,11 @@ interface ConnectionRegistry extends Closeable {
    * Get the address of active HMaster.
    */
   CompletableFuture<ServerName> getActiveMaster();
+
+  /**
+   * Return the connection string associated with this registry instance.
+   */
+  String getConnectionString();
 
   /**
    * Closes this instance and releases any system resources associated with it

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MasterRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MasterRegistry.java
@@ -87,9 +87,12 @@ public class MasterRegistry extends AbstractRpcBasedConnectionRegistry {
     return masterAddrs;
   }
 
+  private final String connectionString;
+
   MasterRegistry(Configuration conf) throws IOException {
     super(conf, MASTER_REGISTRY_HEDGED_REQS_FANOUT_KEY, MASTER_REGISTRY_INITIAL_REFRESH_DELAY_SECS,
       MASTER_REGISTRY_PERIODIC_REFRESH_INTERVAL_SECS, MASTER_REGISTRY_MIN_SECS_BETWEEN_REFRESHES);
+    connectionString = getConnectionString(conf);
   }
 
   @Override
@@ -100,6 +103,15 @@ public class MasterRegistry extends AbstractRpcBasedConnectionRegistry {
   @Override
   protected CompletableFuture<Set<ServerName>> fetchEndpoints() {
     return getMasters();
+  }
+
+  @Override
+  public String getConnectionString() {
+    return connectionString;
+  }
+
+  static String getConnectionString(Configuration conf) throws UnknownHostException {
+    return getMasterAddr(conf);
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
@@ -350,7 +350,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
       preCheck();
       final Supplier<Span> supplier = new TableOperationSpanBuilder()
         .setTableName(tableName)
-        .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE);
+        .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE)
+        .setContainerOperations(put);
       return tracedFuture(
         () -> RawAsyncTableImpl.this.<Boolean> newCaller(row, put.getPriority(), rpcTimeoutNs)
           .action((controller, loc, stub) -> RawAsyncTableImpl.mutate(controller, loc, stub, put,
@@ -366,7 +367,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
       preCheck();
       final Supplier<Span> supplier = new TableOperationSpanBuilder()
         .setTableName(tableName)
-        .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE);
+        .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE)
+        .setContainerOperations(delete);
       return tracedFuture(
         () -> RawAsyncTableImpl.this.<Boolean> newCaller(row, delete.getPriority(), rpcTimeoutNs)
           .action((controller, loc, stub) -> RawAsyncTableImpl.mutate(controller, loc, stub, delete,
@@ -383,7 +385,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
       validatePutsInRowMutations(mutations, conn.connConf.getMaxKeyValueSize());
       final Supplier<Span> supplier = new TableOperationSpanBuilder()
         .setTableName(tableName)
-        .setOperation(HBaseSemanticAttributes.Operation.BATCH);
+        .setOperation(HBaseSemanticAttributes.Operation.BATCH)
+        .setContainerOperations(mutations);
       return tracedFuture(
         () -> RawAsyncTableImpl.this
           .<Boolean> newCaller(row, mutations.getMaxPriority(), rpcTimeoutNs)
@@ -427,7 +430,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
       validatePut(put, conn.connConf.getMaxKeyValueSize());
       final Supplier<Span> supplier = new TableOperationSpanBuilder()
         .setTableName(tableName)
-        .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE);
+        .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE)
+        .setContainerOperations(put);
       return tracedFuture(
         () -> RawAsyncTableImpl.this.<Boolean> newCaller(row, put.getPriority(), rpcTimeoutNs)
         .action((controller, loc, stub) -> RawAsyncTableImpl.mutate(controller, loc,
@@ -443,7 +447,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     public CompletableFuture<Boolean> thenDelete(Delete delete) {
       final Supplier<Span> supplier = new TableOperationSpanBuilder()
         .setTableName(tableName)
-        .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE);
+        .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE)
+        .setContainerOperations(delete);
       return tracedFuture(
         () -> RawAsyncTableImpl.this.<Boolean> newCaller(row, delete.getPriority(), rpcTimeoutNs)
           .action((controller, loc, stub) -> RawAsyncTableImpl.mutate(controller, loc, stub, delete,
@@ -459,7 +464,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
       validatePutsInRowMutations(mutations, conn.connConf.getMaxKeyValueSize());
       final Supplier<Span> supplier = new TableOperationSpanBuilder()
         .setTableName(tableName)
-        .setOperation(HBaseSemanticAttributes.Operation.BATCH);
+        .setOperation(HBaseSemanticAttributes.Operation.BATCH)
+        .setContainerOperations(mutations);
       return tracedFuture(
         () -> RawAsyncTableImpl.this
           .<Boolean> newCaller(row, mutations.getMaxPriority(), rpcTimeoutNs)
@@ -482,7 +488,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   public CompletableFuture<CheckAndMutateResult> checkAndMutate(CheckAndMutate checkAndMutate) {
     final Supplier<Span> supplier = new TableOperationSpanBuilder()
       .setTableName(tableName)
-      .setOperation(checkAndMutate);
+      .setOperation(checkAndMutate)
+      .setContainerOperations(checkAndMutate.getAction());
     return tracedFuture(() -> {
       if (checkAndMutate.getAction() instanceof Put ||
         checkAndMutate.getAction() instanceof Delete ||
@@ -536,7 +543,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     checkAndMutate(List<CheckAndMutate> checkAndMutates) {
     final Supplier<Span> supplier = new TableOperationSpanBuilder()
       .setTableName(tableName)
-      .setOperation(HBaseSemanticAttributes.Operation.BATCH);
+      .setOperation(HBaseSemanticAttributes.Operation.BATCH)
+      .setContainerOperations(checkAndMutates);
     return tracedFutures(
       () -> batch(checkAndMutates, rpcTimeoutNs).stream()
         .map(f -> f.thenApply(r -> (CheckAndMutateResult) r)).collect(toList()),
@@ -593,7 +601,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     long nonce = conn.getNonceGenerator().newNonce();
     final Supplier<Span> supplier = new TableOperationSpanBuilder()
       .setTableName(tableName)
-      .setOperation(HBaseSemanticAttributes.Operation.BATCH);
+      .setOperation(HBaseSemanticAttributes.Operation.BATCH)
+      .setContainerOperations(mutations);
     return tracedFuture(
       () -> this
         .<Result> newCaller(mutations.getRow(), mutations.getMaxPriority(), writeRpcTimeoutNs)
@@ -668,7 +677,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   public List<CompletableFuture<Result>> get(List<Get> gets) {
     final Supplier<Span> supplier = new TableOperationSpanBuilder()
       .setTableName(tableName)
-      .setOperation(HBaseSemanticAttributes.Operation.BATCH);
+      .setOperation(HBaseSemanticAttributes.Operation.BATCH)
+      .setContainerOperations(HBaseSemanticAttributes.Operation.GET);
     return tracedFutures(() -> batch(gets, readRpcTimeoutNs), supplier);
   }
 
@@ -676,7 +686,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   public List<CompletableFuture<Void>> put(List<Put> puts) {
     final Supplier<Span> supplier = new TableOperationSpanBuilder()
       .setTableName(tableName)
-      .setOperation(HBaseSemanticAttributes.Operation.BATCH);
+      .setOperation(HBaseSemanticAttributes.Operation.BATCH)
+      .setContainerOperations(HBaseSemanticAttributes.Operation.PUT);
     return tracedFutures(() -> voidMutate(puts), supplier);
   }
 
@@ -684,7 +695,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   public List<CompletableFuture<Void>> delete(List<Delete> deletes) {
     final Supplier<Span> supplier = new TableOperationSpanBuilder()
       .setTableName(tableName)
-      .setOperation(HBaseSemanticAttributes.Operation.BATCH);
+      .setOperation(HBaseSemanticAttributes.Operation.BATCH)
+      .setContainerOperations(HBaseSemanticAttributes.Operation.DELETE);
     return tracedFutures(() -> voidMutate(deletes), supplier);
   }
 
@@ -692,7 +704,8 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   public <T> List<CompletableFuture<T>> batch(List<? extends Row> actions) {
     final Supplier<Span> supplier = new TableOperationSpanBuilder()
       .setTableName(tableName)
-      .setOperation(HBaseSemanticAttributes.Operation.BATCH);
+      .setOperation(HBaseSemanticAttributes.Operation.BATCH)
+      .setContainerOperations(actions);
     return tracedFutures(() -> batch(actions, rpcTimeoutNs), supplier);
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
@@ -224,7 +224,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
   @Override
   public CompletableFuture<Result> get(Get get) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(get);
     return tracedFuture(
@@ -237,7 +237,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   @Override
   public CompletableFuture<Void> put(Put put) {
     validatePut(put, conn.connConf.getMaxKeyValueSize());
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(put);
     return tracedFuture(() -> this.<Void, Put> newCaller(put, writeRpcTimeoutNs)
@@ -248,7 +248,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
   @Override
   public CompletableFuture<Void> delete(Delete delete) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(delete);
     return tracedFuture(
@@ -262,7 +262,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   @Override
   public CompletableFuture<Result> append(Append append) {
     checkHasFamilies(append);
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(append);
     return tracedFuture(() -> {
@@ -279,7 +279,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   @Override
   public CompletableFuture<Result> increment(Increment increment) {
     checkHasFamilies(increment);
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(increment);
     return tracedFuture(() -> {
@@ -348,7 +348,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     public CompletableFuture<Boolean> thenPut(Put put) {
       validatePut(put, conn.connConf.getMaxKeyValueSize());
       preCheck();
-      final Supplier<Span> supplier = new TableOperationSpanBuilder()
+      final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
         .setTableName(tableName)
         .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE)
         .setContainerOperations(put);
@@ -365,7 +365,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     @Override
     public CompletableFuture<Boolean> thenDelete(Delete delete) {
       preCheck();
-      final Supplier<Span> supplier = new TableOperationSpanBuilder()
+      final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
         .setTableName(tableName)
         .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE)
         .setContainerOperations(delete);
@@ -383,7 +383,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     public CompletableFuture<Boolean> thenMutate(RowMutations mutations) {
       preCheck();
       validatePutsInRowMutations(mutations, conn.connConf.getMaxKeyValueSize());
-      final Supplier<Span> supplier = new TableOperationSpanBuilder()
+      final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
         .setTableName(tableName)
         .setOperation(HBaseSemanticAttributes.Operation.BATCH)
         .setContainerOperations(mutations);
@@ -428,7 +428,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     @Override
     public CompletableFuture<Boolean> thenPut(Put put) {
       validatePut(put, conn.connConf.getMaxKeyValueSize());
-      final Supplier<Span> supplier = new TableOperationSpanBuilder()
+      final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
         .setTableName(tableName)
         .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE)
         .setContainerOperations(put);
@@ -445,7 +445,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
     @Override
     public CompletableFuture<Boolean> thenDelete(Delete delete) {
-      final Supplier<Span> supplier = new TableOperationSpanBuilder()
+      final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
         .setTableName(tableName)
         .setOperation(HBaseSemanticAttributes.Operation.CHECK_AND_MUTATE)
         .setContainerOperations(delete);
@@ -462,7 +462,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     @Override
     public CompletableFuture<Boolean> thenMutate(RowMutations mutations) {
       validatePutsInRowMutations(mutations, conn.connConf.getMaxKeyValueSize());
-      final Supplier<Span> supplier = new TableOperationSpanBuilder()
+      final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
         .setTableName(tableName)
         .setOperation(HBaseSemanticAttributes.Operation.BATCH)
         .setContainerOperations(mutations);
@@ -486,7 +486,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
   @Override
   public CompletableFuture<CheckAndMutateResult> checkAndMutate(CheckAndMutate checkAndMutate) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(checkAndMutate)
       .setContainerOperations(checkAndMutate.getAction());
@@ -541,7 +541,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   @Override
   public List<CompletableFuture<CheckAndMutateResult>>
     checkAndMutate(List<CheckAndMutate> checkAndMutates) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(HBaseSemanticAttributes.Operation.BATCH)
       .setContainerOperations(checkAndMutates);
@@ -599,7 +599,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     validatePutsInRowMutations(mutations, conn.connConf.getMaxKeyValueSize());
     long nonceGroup = conn.getNonceGenerator().getNonceGroup();
     long nonce = conn.getNonceGenerator().newNonce();
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(HBaseSemanticAttributes.Operation.BATCH)
       .setContainerOperations(mutations);
@@ -646,7 +646,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
   @Override
   public CompletableFuture<List<Result>> scanAll(Scan scan) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(scan);
     return tracedFuture(() -> {
@@ -675,7 +675,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
   @Override
   public List<CompletableFuture<Result>> get(List<Get> gets) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(HBaseSemanticAttributes.Operation.BATCH)
       .setContainerOperations(HBaseSemanticAttributes.Operation.GET);
@@ -684,7 +684,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
   @Override
   public List<CompletableFuture<Void>> put(List<Put> puts) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(HBaseSemanticAttributes.Operation.BATCH)
       .setContainerOperations(HBaseSemanticAttributes.Operation.PUT);
@@ -693,7 +693,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
   @Override
   public List<CompletableFuture<Void>> delete(List<Delete> deletes) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(HBaseSemanticAttributes.Operation.BATCH)
       .setContainerOperations(HBaseSemanticAttributes.Operation.DELETE);
@@ -702,7 +702,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
 
   @Override
   public <T> List<CompletableFuture<T>> batch(List<? extends Row> actions) {
-    final Supplier<Span> supplier = new TableOperationSpanBuilder()
+    final Supplier<Span> supplier = new TableOperationSpanBuilder<>(conn)
       .setTableName(tableName)
       .setOperation(HBaseSemanticAttributes.Operation.BATCH)
       .setContainerOperations(actions);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ZKConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ZKConnectionRegistry.java
@@ -236,6 +236,13 @@ class ZKConnectionRegistry implements ConnectionRegistry {
   }
 
   @Override
+  public String getConnectionString() {
+    final String serverList = zk.getConnectString();
+    final String baseZNode = znodePaths.baseZNode;
+    return serverList + ":" + baseZNode;
+  }
+
+  @Override
   public void close() {
     zk.close();
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/ConnectionSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/ConnectionSpanBuilder.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.client.trace;
+
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_CONNECTION_STRING;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_SYSTEM;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_SYSTEM_VALUE;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_USER;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
+import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Construct {@link Span} instances originating from the client side of a connection.
+ */
+@InterfaceAudience.Private
+public class ConnectionSpanBuilder<B extends ConnectionSpanBuilder<B>>
+  extends HBaseSpanBuilder<ConnectionSpanBuilder<B>>
+  implements Supplier<Span> {
+
+  protected String name;
+  protected final Map<AttributeKey<?>, Object> attributes = new HashMap<>();
+
+  @Override
+  public Span get() {
+    return build();
+  }
+
+  public ConnectionSpanBuilder(final AsyncConnectionImpl conn) {
+    addAttribute(DB_SYSTEM, DB_SYSTEM_VALUE);
+    addAttribute(DB_CONNECTION_STRING, conn.getConnectionRegistry().getConnectionString());
+    addAttribute(DB_USER, Optional.ofNullable(conn.getUser()).map(Object::toString).orElse(null));
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public B self() {
+    return (B) this;
+  }
+
+  public B setName(final String name) {
+    this.name = name;
+    return self();
+  }
+
+  public <T> B addAttribute(final AttributeKey<T> key, T value) {
+    attributes.put(key, value);
+    return self();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Span build() {
+    final SpanBuilder builder = TraceUtil.getGlobalTracer()
+      .spanBuilder(name)
+      // TODO: what about clients embedded in Master/RegionServer/Gateways/&c?
+      .setSpanKind(SpanKind.CLIENT);
+    attributes.forEach((k, v) -> builder.setAttribute((AttributeKey<? super Object>) k, v));
+    return builder.startSpan();
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/HBaseSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/HBaseSpanBuilder.java
@@ -1,0 +1,30 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.client.trace;
+
+import io.opentelemetry.api.trace.Span;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public abstract class HBaseSpanBuilder<B extends HBaseSpanBuilder<B>> {
+
+  public abstract Span build();
+
+  public abstract B self();
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableOperationSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableOperationSpanBuilder.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.client.trace;
+
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_NAME;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_OPERATION;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.CheckAndMutate;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionCoprocessorServiceExec;
+import org.apache.hadoop.hbase.client.Row;
+import org.apache.hadoop.hbase.client.RowMutations;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.Operation;
+import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Construct {@link io.opentelemetry.api.trace.Span} instances originating from
+ * "table operations" -- the verbs in our public API that interact with data in tables.
+ */
+@InterfaceAudience.Private
+public class TableOperationSpanBuilder implements Supplier<Span> {
+
+  // n.b. The results of this class are tested implicitly by way of the likes of
+  // `TestAsyncTableTracing` and friends.
+
+  private static final String unknown = "UNKNOWN";
+
+  private TableName tableName;
+  private final Map<AttributeKey<?>, Object> attributes = new HashMap<>();
+
+  @Override public Span get() {
+    return build();
+  }
+
+  public TableOperationSpanBuilder setOperation(final Scan scan) {
+    return setOperation(valueFrom(scan));
+  }
+
+  public TableOperationSpanBuilder setOperation(final Row row) {
+    return setOperation(valueFrom(row));
+  }
+
+  public TableOperationSpanBuilder setOperation(final Operation operation) {
+    attributes.put(DB_OPERATION, operation.name());
+    return this;
+  }
+
+  public TableOperationSpanBuilder setTableName(final TableName tableName) {
+    this.tableName = tableName;
+    attributes.put(NAMESPACE_KEY, tableName.getNamespaceAsString());
+    attributes.put(DB_NAME, tableName.getNamespaceAsString());
+    attributes.put(TABLE_KEY, tableName.getNameAsString());
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Span build() {
+    final String name = attributes.getOrDefault(DB_OPERATION, unknown)
+        + " "
+        + (tableName != null ? tableName.getNameWithNamespaceInclAsString() : unknown);
+    final SpanBuilder builder = TraceUtil.getGlobalTracer()
+      .spanBuilder(name)
+      // TODO: what about clients embedded in Master/RegionServer/Gateways/&c?
+      .setSpanKind(SpanKind.CLIENT);
+    attributes.forEach((k, v) -> builder.setAttribute((AttributeKey<? super Object>) k, v));
+    return builder.startSpan();
+  }
+
+  private static Operation valueFrom(final Scan scan) {
+    if (scan == null) { return null; }
+    return Operation.SCAN;
+  }
+
+  private static Operation valueFrom(final Row row) {
+    if (row == null) { return null; }
+    if (row instanceof Append) { return Operation.APPEND; }
+    if (row instanceof CheckAndMutate) { return Operation.CHECK_AND_MUTATE; }
+    if (row instanceof Delete) { return Operation.DELETE; }
+    if (row instanceof Get) { return Operation.GET; }
+    if (row instanceof Increment) { return Operation.INCREMENT; }
+    if (row instanceof Put) { return Operation.PUT; }
+    if (row instanceof RegionCoprocessorServiceExec) {
+      return Operation.COPROC_EXEC;
+    }
+    if (row instanceof RowMutations) { return Operation.BATCH; }
+    return null;
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableOperationSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableOperationSpanBuilder.java
@@ -18,6 +18,7 @@
 
 package org.apache.hadoop.hbase.client.trace;
 
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.CONTAINER_DB_OPERATIONS_KEY;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_NAME;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_OPERATION;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
@@ -26,9 +27,16 @@ import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
 import io.opentelemetry.api.trace.SpanKind;
+import java.util.Arrays;
+import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.function.Supplier;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.CheckAndMutate;
@@ -73,6 +81,72 @@ public class TableOperationSpanBuilder implements Supplier<Span> {
 
   public TableOperationSpanBuilder setOperation(final Operation operation) {
     attributes.put(DB_OPERATION, operation.name());
+    return this;
+  }
+
+  // `setContainerOperations` perform a recursive descent expansion of all the operations
+  // contained within the provided "batch" object.
+
+  public TableOperationSpanBuilder setContainerOperations(final RowMutations mutations) {
+    final Operation[] ops = mutations.getMutations()
+      .stream()
+      .flatMap(row -> Stream.concat(Stream.of(valueFrom(row)), unpackRowOperations(row).stream()))
+      .toArray(Operation[]::new);
+    return setContainerOperations(ops);
+  }
+
+  public TableOperationSpanBuilder setContainerOperations(final Row row) {
+    final Operation[] ops =
+      Stream.concat(Stream.of(valueFrom(row)), unpackRowOperations(row).stream())
+      .toArray(Operation[]::new);
+    return setContainerOperations(ops);
+  }
+
+  public TableOperationSpanBuilder setContainerOperations(
+    final Collection<? extends Row> operations
+  ) {
+    final Operation[] ops = operations.stream()
+      .flatMap(row -> Stream.concat(Stream.of(valueFrom(row)), unpackRowOperations(row).stream()))
+      .toArray(Operation[]::new);
+    return setContainerOperations(ops);
+  }
+
+  private static Set<Operation> unpackRowOperations(final Row row) {
+    final Set<Operation> ops = new HashSet<>();
+    if (row instanceof CheckAndMutate) {
+      final CheckAndMutate cam = (CheckAndMutate) row;
+      ops.addAll(unpackRowOperations(cam));
+    }
+    if (row instanceof RowMutations) {
+      final RowMutations mutations = (RowMutations) row;
+      ops.addAll(unpackRowOperations(mutations));
+    }
+    return ops;
+  }
+
+  private static Set<Operation> unpackRowOperations(final CheckAndMutate cam) {
+    final Set<Operation> ops = new HashSet<>();
+    final Operation op = valueFrom(cam.getAction());
+    switch (op) {
+      case BATCH:
+      case CHECK_AND_MUTATE:
+        ops.addAll(unpackRowOperations(cam.getAction()));
+        break;
+      default:
+        ops.add(op);
+    }
+    return ops;
+  }
+
+  public TableOperationSpanBuilder setContainerOperations(
+    final Operation... operations
+  ) {
+    final List<String> ops = Arrays.stream(operations)
+      .map(op -> op == null ? unknown : op.name())
+      .sorted()
+      .distinct()
+      .collect(Collectors.toList());
+    attributes.put(CONTAINER_DB_OPERATIONS_KEY, ops);
     return this;
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableSpanBuilder.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.client.trace;
+
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_NAME;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Construct {@link Span} instances involving data tables.
+ */
+@InterfaceAudience.Private
+public class TableSpanBuilder<B extends TableSpanBuilder<B>> extends ConnectionSpanBuilder<B> {
+
+  protected TableName tableName;
+
+  public TableSpanBuilder(AsyncConnectionImpl conn) {
+    super(conn);
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public B self() {
+    return (B) this;
+  }
+
+  public B setTableName(final TableName tableName) {
+    this.tableName = tableName;
+    attributes.put(NAMESPACE_KEY, tableName.getNamespaceAsString());
+    attributes.put(DB_NAME, tableName.getNamespaceAsString());
+    attributes.put(TABLE_KEY, tableName.getNameAsString());
+    return self();
+  }
+
+  @Override
+  @SuppressWarnings("unchecked")
+  public Span build() {
+    final Span span = super.build();
+    attributes.forEach((k, v) -> span.setAttribute((AttributeKey<? super Object>) k, v));
+    return span;
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
@@ -20,6 +20,10 @@ package org.apache.hadoop.hbase.ipc;
 
 import static org.apache.hadoop.hbase.ipc.IPCUtil.toIOE;
 import static org.apache.hadoop.hbase.ipc.IPCUtil.wrapException;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.REMOTE_HOST_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.REMOTE_PORT_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.RPC_METHOD_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.RPC_SERVICE_KEY;
 
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
@@ -41,6 +45,7 @@ import org.apache.hadoop.hbase.codec.KeyValueCodec;
 import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.UserProvider;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.PoolMap;
@@ -396,10 +401,10 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
     final Message param, Message returnType, final User ticket, final Address addr,
     final RpcCallback<Message> callback) {
     Span span = TraceUtil.createClientSpan("RpcClient.callMethod")
-      .setAttribute(TraceUtil.RPC_SERVICE_KEY, md.getService().getName())
-      .setAttribute(TraceUtil.RPC_METHOD_KEY, md.getName())
-      .setAttribute(TraceUtil.REMOTE_HOST_KEY, addr.getHostName())
-      .setAttribute(TraceUtil.REMOTE_PORT_KEY, addr.getPort());
+      .setAttribute(RPC_SERVICE_KEY, md.getService().getName())
+      .setAttribute(RPC_METHOD_KEY, md.getName())
+      .setAttribute(REMOTE_HOST_KEY, addr.getHostName())
+      .setAttribute(REMOTE_PORT_KEY, addr.getPort());
     try (Scope scope = span.makeCurrent()) {
       final MetricsConnection.CallStats cs = MetricsConnection.newCallStats();
       cs.setStartTime(EnvironmentEdgeManager.currentTime());

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/DoNothingConnectionRegistry.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/DoNothingConnectionRegistry.java
@@ -48,6 +48,11 @@ class DoNothingConnectionRegistry implements ConnectionRegistry {
   }
 
   @Override
+  public String getConnectionString() {
+    return "nothing";
+  }
+
+  @Override
   public void close() {
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncConnectionTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncConnectionTracing.java
@@ -33,7 +33,7 @@ import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
-import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.junit.After;
 import org.junit.Before;
@@ -89,7 +89,7 @@ public class TestAsyncConnectionTracing {
     assertEquals(StatusCode.OK, data.getStatus().getStatusCode());
     if (serverName != null) {
       assertEquals(serverName.getServerName(),
-        data.getAttributes().get(TraceUtil.SERVER_NAME_KEY));
+        data.getAttributes().get(HBaseSemanticAttributes.SERVER_NAME_KEY));
     }
   }
 

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocatorTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocatorTracing.java
@@ -38,7 +38,7 @@ import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
-import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.junit.After;
 import org.junit.Before;
@@ -109,7 +109,7 @@ public class TestAsyncRegionLocatorTracing {
     conn.getLocator().clearCache(sn);
     SpanData span = waitSpan("AsyncRegionLocator.clearCache");
     assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(sn.toString(), span.getAttributes().get(TraceUtil.SERVER_NAME_KEY));
+    assertEquals(sn.toString(), span.getAttributes().get(HBaseSemanticAttributes.SERVER_NAME_KEY));
   }
 
   @Test
@@ -118,9 +118,9 @@ public class TestAsyncRegionLocatorTracing {
     SpanData span = waitSpan("AsyncRegionLocator.clearCache");
     assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
     assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(TraceUtil.NAMESPACE_KEY));
+      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
     assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(TraceUtil.TABLE_KEY));
+      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
   }
 
   @Test
@@ -130,10 +130,10 @@ public class TestAsyncRegionLocatorTracing {
     SpanData span = waitSpan("AsyncRegionLocator.getRegionLocation");
     assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
     assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(TraceUtil.NAMESPACE_KEY));
+      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
     assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(TraceUtil.TABLE_KEY));
-    List<String> regionNames = span.getAttributes().get(TraceUtil.REGION_NAMES_KEY);
+      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
+    List<String> regionNames = span.getAttributes().get(HBaseSemanticAttributes.REGION_NAMES_KEY);
     assertEquals(1, regionNames.size());
     assertEquals(locs.getDefaultRegionLocation().getRegion().getRegionNameAsString(),
       regionNames.get(0));
@@ -146,10 +146,10 @@ public class TestAsyncRegionLocatorTracing {
     SpanData span = waitSpan("AsyncRegionLocator.getRegionLocations");
     assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
     assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(TraceUtil.NAMESPACE_KEY));
+      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
     assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(TraceUtil.TABLE_KEY));
-    List<String> regionNames = span.getAttributes().get(TraceUtil.REGION_NAMES_KEY);
+      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
+    List<String> regionNames = span.getAttributes().get(HBaseSemanticAttributes.REGION_NAMES_KEY);
     assertEquals(3, regionNames.size());
     for (int i = 0; i < 3; i++) {
       assertEquals(locs.getRegionLocation(i).getRegion().getRegionNameAsString(),

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocatorTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocatorTracing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,13 +17,25 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import static org.junit.Assert.assertEquals;
-
+import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntry;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntryWithStringValuesOf;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasAttributes;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasKind;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildConnectionAttributesMatcher;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildTableAttributesMatcher;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
-import java.util.List;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
@@ -31,6 +43,7 @@ import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.MatcherPredicate;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
@@ -38,15 +51,14 @@ import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
-import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
 import org.apache.hbase.thirdparty.com.google.common.io.Closeables;
 
 @Category({ ClientTests.class, MediumTests.class })
@@ -56,7 +68,7 @@ public class TestAsyncRegionLocatorTracing {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestAsyncRegionLocatorTracing.class);
 
-  private static Configuration CONF = HBaseConfiguration.create();
+  private static final Configuration CONF = HBaseConfiguration.create();
 
   private AsyncConnectionImpl conn;
 
@@ -90,16 +102,33 @@ public class TestAsyncRegionLocatorTracing {
   }
 
   private SpanData waitSpan(String name) {
-    Waiter.waitFor(CONF, 1000,
-      () -> traceRule.getSpans().stream().map(SpanData::getName).anyMatch(s -> s.equals(name)));
-    return traceRule.getSpans().stream().filter(s -> s.getName().equals(name)).findFirst().get();
+    return waitSpan(hasName(name));
+  }
+
+  private SpanData waitSpan(Matcher<SpanData> matcher) {
+    Matcher<SpanData> spanLocator = allOf(matcher, hasEnded());
+    try {
+      Waiter.waitFor(CONF, 1000, new MatcherPredicate<>(
+        "waiting for span",
+        () -> traceRule.getSpans(), hasItem(spanLocator)));
+    } catch (AssertionError e) {
+      traceRule.getSpans().forEach(System.err::println);
+    }
+    return traceRule.getSpans()
+      .stream()
+      .filter(spanLocator::matches)
+      .findFirst()
+      .orElseThrow(AssertionError::new);
   }
 
   @Test
   public void testClearCache() {
     conn.getLocator().clearCache();
     SpanData span = waitSpan("AsyncRegionLocator.clearCache");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn)));
   }
 
   @Test
@@ -108,19 +137,22 @@ public class TestAsyncRegionLocatorTracing {
       EnvironmentEdgeManager.currentTime());
     conn.getLocator().clearCache(sn);
     SpanData span = waitSpan("AsyncRegionLocator.clearCache");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(sn.toString(), span.getAttributes().get(HBaseSemanticAttributes.SERVER_NAME_KEY));
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn),
+      hasAttributes(containsEntry("db.hbase.server.name", sn.getServerName()))));
   }
 
   @Test
   public void testClearCacheTableName() {
     conn.getLocator().clearCache(TableName.META_TABLE_NAME);
     SpanData span = waitSpan("AsyncRegionLocator.clearCache");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
-    assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn),
+      buildTableAttributesMatcher(TableName.META_TABLE_NAME)));
   }
 
   @Test
@@ -128,15 +160,14 @@ public class TestAsyncRegionLocatorTracing {
     conn.getLocator().getRegionLocation(TableName.META_TABLE_NAME, HConstants.EMPTY_START_ROW,
       RegionLocateType.CURRENT, TimeUnit.SECONDS.toNanos(1)).join();
     SpanData span = waitSpan("AsyncRegionLocator.getRegionLocation");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
-    assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
-    List<String> regionNames = span.getAttributes().get(HBaseSemanticAttributes.REGION_NAMES_KEY);
-    assertEquals(1, regionNames.size());
-    assertEquals(locs.getDefaultRegionLocation().getRegion().getRegionNameAsString(),
-      regionNames.get(0));
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn),
+      buildTableAttributesMatcher(TableName.META_TABLE_NAME),
+      hasAttributes(
+        containsEntryWithStringValuesOf("db.hbase.regions",
+          locs.getDefaultRegionLocation().getRegion().getRegionNameAsString()))));
   }
 
   @Test
@@ -144,16 +175,16 @@ public class TestAsyncRegionLocatorTracing {
     conn.getLocator().getRegionLocations(TableName.META_TABLE_NAME, HConstants.EMPTY_START_ROW,
       RegionLocateType.CURRENT, false, TimeUnit.SECONDS.toNanos(1)).join();
     SpanData span = waitSpan("AsyncRegionLocator.getRegionLocations");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
-    assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
-    List<String> regionNames = span.getAttributes().get(HBaseSemanticAttributes.REGION_NAMES_KEY);
-    assertEquals(3, regionNames.size());
-    for (int i = 0; i < 3; i++) {
-      assertEquals(locs.getRegionLocation(i).getRegion().getRegionNameAsString(),
-        regionNames.get(i));
-    }
+    String[] expectedRegions = Arrays.stream(locs.getRegionLocations())
+      .map(HRegionLocation::getRegion)
+      .map(RegionInfo::getRegionNameAsString)
+      .toArray(String[]::new);
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn),
+      buildTableAttributesMatcher(TableName.META_TABLE_NAME),
+      hasAttributes(
+        containsEntryWithStringValuesOf("db.hbase.regions", containsInAnyOrder(expectedRegions)))));
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
 import static org.junit.Assert.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -48,7 +50,7 @@ import org.apache.hadoop.hbase.ipc.HBaseRpcController;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
-import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.After;
 import org.junit.Before;
@@ -227,9 +229,8 @@ public class TestAsyncTableTracing {
       .filter(s -> s.getName().equals("AsyncTable." + methodName)).findFirst().get();
     assertEquals(StatusCode.OK, data.getStatus().getStatusCode());
     TableName tableName = table.getName();
-    assertEquals(tableName.getNamespaceAsString(),
-      data.getAttributes().get(TraceUtil.NAMESPACE_KEY));
-    assertEquals(tableName.getNameAsString(), data.getAttributes().get(TraceUtil.TABLE_KEY));
+    assertEquals(tableName.getNamespaceAsString(), data.getAttributes().get(NAMESPACE_KEY));
+    assertEquals(tableName.getNameAsString(), data.getAttributes().get(TABLE_KEY));
   }
 
   @Test

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client.trace.hamcrest;
+
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.hasProperty;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.common.Attributes;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Helper methods for matching against instances of {@link io.opentelemetry.api.common.Attributes}.
+ */
+public final class AttributesMatchers {
+
+  private AttributesMatchers() { }
+
+  public static <T> Matcher<Attributes> containsEntry(
+    Matcher<AttributeKey<? super T>> keyMatcher,
+    Matcher<? super T> valueMatcher
+  ) {
+    return new IsAttributesContaining<>(keyMatcher, valueMatcher);
+  }
+
+  public static <T> Matcher<Attributes> containsEntry(AttributeKey<T> key, T value) {
+    return containsEntry(equalTo(key), equalTo(value));
+  }
+
+  public static Matcher<Attributes> containsEntry(String key, String value) {
+    return containsEntry(AttributeKey.stringKey(key), value);
+  }
+
+  private static final class IsAttributesContaining<T> extends TypeSafeMatcher<Attributes> {
+    private final Matcher<AttributeKey<? super T>> keyMatcher;
+    private final Matcher<? super T> valueMatcher;
+
+    private IsAttributesContaining(
+      final Matcher<AttributeKey<? super T>> keyMatcher,
+      final Matcher<? super T> valueMatcher
+    ) {
+      this.keyMatcher = keyMatcher;
+      this.valueMatcher = valueMatcher;
+    }
+
+    @Override
+    protected boolean matchesSafely(Attributes item) {
+      return item.asMap().entrySet().stream().anyMatch(e -> allOf(
+          hasProperty("key", keyMatcher),
+          hasProperty("value", valueMatcher))
+        .matches(e));
+    }
+
+    @Override
+    public void describeMismatchSafely(Attributes item, Description mismatchDescription) {
+      mismatchDescription
+        .appendText("Attributes was ")
+        .appendValueList("[", ", ", "]", item.asMap().entrySet());
+    }
+
+    @Override
+    public void describeTo(Description description) {
+      description
+        .appendText("Attributes containing [")
+        .appendDescriptionOf(keyMatcher)
+        .appendText("->")
+        .appendDescriptionOf(valueMatcher)
+        .appendText("]");
+    }
+  }
+}

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import java.util.Arrays;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -46,6 +47,10 @@ public final class AttributesMatchers {
 
   public static Matcher<Attributes> containsEntry(String key, String value) {
     return containsEntry(AttributeKey.stringKey(key), value);
+  }
+
+  public static Matcher<Attributes> containsEntryWithStringValuesOf(String key, String... values) {
+    return containsEntry(AttributeKey.stringArrayKey(key), Arrays.asList(values));
   }
 
   private static final class IsAttributesContaining<T> extends TypeSafeMatcher<Attributes> {

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
@@ -53,6 +53,13 @@ public final class AttributesMatchers {
     return containsEntry(AttributeKey.stringArrayKey(key), Arrays.asList(values));
   }
 
+  public static Matcher<Attributes> containsEntryWithStringValuesOf(
+    String key,
+    Matcher<Iterable<? extends String>> matcher
+  ) {
+    return new IsAttributesContaining<>(equalTo(AttributeKey.stringArrayKey(key)), matcher);
+  }
+
   private static final class IsAttributesContaining<T> extends TypeSafeMatcher<Attributes> {
     private final Matcher<AttributeKey<? super T>> keyMatcher;
     private final Matcher<? super T> valueMatcher;

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/SpanDataMatchers.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/SpanDataMatchers.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client.trace.hamcrest;
+
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.trace.SpanKind;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.sdk.trace.data.StatusData;
+import java.util.Objects;
+import org.hamcrest.Description;
+import org.hamcrest.Matcher;
+import org.hamcrest.TypeSafeMatcher;
+
+/**
+ * Helper methods for matching against instances of {@link SpanData}.
+ */
+public final class SpanDataMatchers {
+
+  private SpanDataMatchers() { }
+
+  public static Matcher<SpanData> hasAttributes(Matcher<Attributes> matcher) {
+    return new TypeSafeMatcher<SpanData>() {
+      @Override protected boolean matchesSafely(SpanData item) {
+        final Attributes attributes = item.getAttributes();
+        return attributes != null && matcher.matches(attributes);
+      }
+      @Override public void describeTo(Description description) {
+        description.appendText("SpanData having ").appendDescriptionOf(matcher);
+      }
+    };
+  }
+
+  public static Matcher<SpanData> hasEnded() {
+    return new TypeSafeMatcher<SpanData>() {
+      @Override protected boolean matchesSafely(SpanData item) {
+        return item.hasEnded();
+      }
+      @Override public void describeTo(Description description) {
+        description.appendText("SpanData that hasEnded");
+      }
+    };
+  }
+
+  public static Matcher<SpanData> hasKind(SpanKind kind) {
+    return new TypeSafeMatcher<SpanData>() {
+      @Override protected boolean matchesSafely(SpanData item) {
+        return Objects.equals(item.getKind(), kind);
+      }
+      @Override public void describeTo(Description description) {
+        description.appendText("SpanData with kind of ").appendValue(kind);
+      }
+    };
+  }
+
+  public static Matcher<SpanData> hasName(String name) {
+    return hasName(equalTo(name));
+  }
+
+  public static Matcher<SpanData> hasName(Matcher<String> matcher) {
+    return new TypeSafeMatcher<SpanData>() {
+      @Override protected boolean matchesSafely(SpanData item) {
+        final String name = item.getName();
+        return name != null && matcher.matches(name);
+      }
+      @Override public void describeTo(Description description) {
+        description.appendText("SpanData with a name that ").appendDescriptionOf(matcher);
+      }
+    };
+  }
+
+  public static Matcher<SpanData> hasStatusWithCode(StatusCode statusCode) {
+    final Matcher<StatusCode> matcher = is(equalTo(statusCode));
+    return new TypeSafeMatcher<SpanData>() {
+      @Override protected boolean matchesSafely(SpanData item) {
+        final StatusData statusData = item.getStatus();
+        return statusData != null
+          && statusData.getStatusCode() != null
+          && matcher.matches(statusData.getStatusCode());
+      }
+      @Override public void describeTo(Description description) {
+        description.appendText("SpanData with StatusCode that ").appendDescriptionOf(matcher);
+      }
+    };
+  }
+}

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.client.trace.hamcrest;
+
+import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntry;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasAttributes;
+import static org.hamcrest.Matchers.allOf;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
+import org.hamcrest.Matcher;
+
+public final class TraceTestUtil {
+
+  private TraceTestUtil() { }
+
+  /**
+   * All {@link Span}s involving {@code conn} should include these attributes.
+   */
+  public static Matcher<SpanData> buildConnectionAttributesMatcher(AsyncConnectionImpl conn) {
+    return hasAttributes(allOf(
+      containsEntry("db.system", "hbase"),
+      containsEntry("db.connection_string", "nothing"),
+      containsEntry("db.user", conn.getUser().toString())));
+  }
+
+  /**
+   * All {@link Span}s involving {@code tableName} should include these attributes.
+   */
+  public static Matcher<SpanData> buildTableAttributesMatcher(TableName tableName) {
+    return hasAttributes(allOf(
+      containsEntry("db.name", tableName.getNamespaceAsString()),
+      containsEntry("db.hbase.namespace", tableName.getNamespaceAsString()),
+      containsEntry("db.hbase.table", tableName.getNameAsString())));
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
@@ -28,6 +28,11 @@ import org.apache.yetus.audience.InterfaceAudience;
 */
 @InterfaceAudience.Private
 public final class HBaseSemanticAttributes {
+  public static final AttributeKey<String> DB_SYSTEM = SemanticAttributes.DB_SYSTEM;
+  public static final String DB_SYSTEM_VALUE = SemanticAttributes.DbSystemValues.HBASE;
+  public static final AttributeKey<String> DB_CONNECTION_STRING =
+    SemanticAttributes.DB_CONNECTION_STRING;
+  public static final AttributeKey<String> DB_USER = SemanticAttributes.DB_USER;
   public static final AttributeKey<String> DB_NAME = SemanticAttributes.DB_NAME;
   public static final AttributeKey<String> NAMESPACE_KEY = SemanticAttributes.DB_HBASE_NAMESPACE;
   public static final AttributeKey<String> DB_OPERATION = SemanticAttributes.DB_OPERATION;

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
@@ -32,6 +32,12 @@ public final class HBaseSemanticAttributes {
   public static final AttributeKey<String> NAMESPACE_KEY = SemanticAttributes.DB_HBASE_NAMESPACE;
   public static final AttributeKey<String> DB_OPERATION = SemanticAttributes.DB_OPERATION;
   public static final AttributeKey<String> TABLE_KEY = AttributeKey.stringKey("db.hbase.table");
+  /**
+   * For operations that themselves ship one or more operations, such as
+   * {@link Operation#BATCH} and {@link Operation#CHECK_AND_MUTATE}.
+   */
+  public static final AttributeKey<List<String>> CONTAINER_DB_OPERATIONS_KEY =
+    AttributeKey.stringArrayKey("db.hbase.container_operations");
   public static final AttributeKey<List<String>> REGION_NAMES_KEY =
     AttributeKey.stringArrayKey("db.hbase.regions");
   public static final AttributeKey<String> RPC_SERVICE_KEY =

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
@@ -28,7 +28,9 @@ import org.apache.yetus.audience.InterfaceAudience;
 */
 @InterfaceAudience.Private
 public final class HBaseSemanticAttributes {
+  public static final AttributeKey<String> DB_NAME = SemanticAttributes.DB_NAME;
   public static final AttributeKey<String> NAMESPACE_KEY = SemanticAttributes.DB_HBASE_NAMESPACE;
+  public static final AttributeKey<String> DB_OPERATION = SemanticAttributes.DB_OPERATION;
   public static final AttributeKey<String> TABLE_KEY = AttributeKey.stringKey("db.hbase.table");
   public static final AttributeKey<List<String>> REGION_NAMES_KEY =
     AttributeKey.stringArrayKey("db.hbase.regions");
@@ -43,6 +45,24 @@ public final class HBaseSemanticAttributes {
   public static final AttributeKey<Boolean> ROW_LOCK_READ_LOCK_KEY =
     AttributeKey.booleanKey("db.hbase.rowlock.readlock");
   public static final AttributeKey<String> WAL_IMPL = AttributeKey.stringKey("db.hbase.wal.impl");
+
+  /**
+   * These are values used with {@link #DB_OPERATION}. They correspond with the implementations of
+   * {@code org.apache.hadoop.hbase.client.Operation}, as well as
+   * {@code org.apache.hadoop.hbase.client.CheckAndMutate}, and "MULTI", meaning a batch of multiple
+   * operations.
+   */
+  public enum Operation {
+    APPEND,
+    BATCH,
+    CHECK_AND_MUTATE,
+    COPROC_EXEC,
+    DELETE,
+    GET,
+    INCREMENT,
+    PUT,
+    SCAN,
+  }
 
   private HBaseSemanticAttributes() { }
 }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.trace;
+
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.util.List;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * The constants in this class correspond with the guidance outlined by the OpenTelemetry
+ * <a href="https://github.com/open-telemetry/opentelemetry-specification/tree/main/specification/trace/semantic_conventions">Semantic Conventions</a>.
+*/
+@InterfaceAudience.Private
+public final class HBaseSemanticAttributes {
+  public static final AttributeKey<String> NAMESPACE_KEY = SemanticAttributes.DB_HBASE_NAMESPACE;
+  public static final AttributeKey<String> TABLE_KEY = AttributeKey.stringKey("db.hbase.table");
+  public static final AttributeKey<List<String>> REGION_NAMES_KEY =
+    AttributeKey.stringArrayKey("db.hbase.regions");
+  public static final AttributeKey<String> RPC_SERVICE_KEY =
+    AttributeKey.stringKey("db.hbase.rpc.service");
+  public static final AttributeKey<String> RPC_METHOD_KEY =
+    AttributeKey.stringKey("db.hbase.rpc.method");
+  public static final AttributeKey<String> SERVER_NAME_KEY =
+    AttributeKey.stringKey("db.hbase.server.name");
+  public static final AttributeKey<String> REMOTE_HOST_KEY = SemanticAttributes.NET_PEER_NAME;
+  public static final AttributeKey<Long> REMOTE_PORT_KEY = SemanticAttributes.NET_PEER_PORT;
+  public static final AttributeKey<Boolean> ROW_LOCK_READ_LOCK_KEY =
+    AttributeKey.booleanKey("db.hbase.rowlock.readlock");
+  public static final AttributeKey<String> WAL_IMPL = AttributeKey.stringKey("db.hbase.wal.impl");
+
+  private HBaseSemanticAttributes() { }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/TraceUtil.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/TraceUtil.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hbase.trace;
 
-import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
-import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -30,7 +28,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.Version;
 import org.apache.hadoop.hbase.util.FutureUtils;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -50,15 +47,6 @@ public final class TraceUtil {
    */
   public static Span createSpan(String name) {
     return createSpan(name, SpanKind.INTERNAL);
-  }
-
-  /**
-   * Create a {@link SpanKind#INTERNAL} span and set table related attributes.
-   */
-  public static Span createTableSpan(String spanName, TableName tableName) {
-    return createSpan(spanName)
-      .setAttribute(NAMESPACE_KEY, tableName.getNamespaceAsString())
-      .setAttribute(TABLE_KEY, tableName.getNameAsString());
   }
 
   /**

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/TraceUtil.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/TraceUtil.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,15 +17,15 @@
  */
 package org.apache.hadoop.hbase.trace;
 
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
 import io.opentelemetry.api.GlobalOpenTelemetry;
-import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.api.trace.Tracer;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -37,31 +37,6 @@ import org.apache.yetus.audience.InterfaceAudience;
 
 @InterfaceAudience.Private
 public final class TraceUtil {
-
-  public static final AttributeKey<String> NAMESPACE_KEY = SemanticAttributes.DB_HBASE_NAMESPACE;
-
-  public static final AttributeKey<String> TABLE_KEY = AttributeKey.stringKey("db.hbase.table");
-
-  public static final AttributeKey<List<String>> REGION_NAMES_KEY =
-    AttributeKey.stringArrayKey("db.hbase.regions");
-
-  public static final AttributeKey<String> RPC_SERVICE_KEY =
-    AttributeKey.stringKey("db.hbase.rpc.service");
-
-  public static final AttributeKey<String> RPC_METHOD_KEY =
-    AttributeKey.stringKey("db.hbase.rpc.method");
-
-  public static final AttributeKey<String> SERVER_NAME_KEY =
-    AttributeKey.stringKey("db.hbase.server.name");
-
-  public static final AttributeKey<String> REMOTE_HOST_KEY = SemanticAttributes.NET_PEER_NAME;
-
-  public static final AttributeKey<Long> REMOTE_PORT_KEY = SemanticAttributes.NET_PEER_PORT;
-
-  public static final AttributeKey<Boolean> ROW_LOCK_READ_LOCK_KEY =
-    AttributeKey.booleanKey("db.hbase.rowlock.readlock");
-
-  public static final AttributeKey<String> WAL_IMPL = AttributeKey.stringKey("db.hbase.wal.impl");
 
   private TraceUtil() {
   }
@@ -81,7 +56,8 @@ public final class TraceUtil {
    * Create a {@link SpanKind#INTERNAL} span and set table related attributes.
    */
   public static Span createTableSpan(String spanName, TableName tableName) {
-    return createSpan(spanName).setAttribute(NAMESPACE_KEY, tableName.getNamespaceAsString())
+    return createSpan(spanName)
+      .setAttribute(NAMESPACE_KEY, tableName.getNamespaceAsString())
       .setAttribute(TABLE_KEY, tableName.getNameAsString());
   }
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/TraceUtil.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/TraceUtil.java
@@ -91,9 +91,11 @@ public final class TraceUtil {
   /**
    * Trace an asynchronous operation for a table.
    */
-  public static <T> CompletableFuture<T> tracedFuture(Supplier<CompletableFuture<T>> action,
-    String spanName, TableName tableName) {
-    Span span = createTableSpan(spanName, tableName);
+  public static <T> CompletableFuture<T> tracedFuture(
+    Supplier<CompletableFuture<T>> action,
+    Supplier<Span> spanSupplier
+  ) {
+    Span span = spanSupplier.get();
     try (Scope scope = span.makeCurrent()) {
       CompletableFuture<T> future = action.get();
       endSpan(future, span);
@@ -119,8 +121,10 @@ public final class TraceUtil {
    * {@code futures} are completed.
    */
   public static <T> List<CompletableFuture<T>> tracedFutures(
-    Supplier<List<CompletableFuture<T>>> action, String spanName, TableName tableName) {
-    Span span = createTableSpan(spanName, tableName);
+    Supplier<List<CompletableFuture<T>>> action,
+    Supplier<Span> spanSupplier
+  ) {
+    Span span = spanSupplier.get();
     try (Scope scope = span.makeCurrent()) {
       List<CompletableFuture<T>> futures = action.get();
       endSpan(CompletableFuture.allOf(futures.toArray(new CompletableFuture[0])), span);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ShortCircuitConnectionRegistry.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ShortCircuitConnectionRegistry.java
@@ -69,6 +69,11 @@ class ShortCircuitConnectionRegistry implements ConnectionRegistry {
   }
 
   @Override
+  public String getConnectionString() {
+    return "localhost";
+  }
+
+  @Override
   public void close() {
     // nothing
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/CallRunner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/CallRunner.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.ipc;
 
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.RPC_METHOD_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.RPC_SERVICE_KEY;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Context;
@@ -30,6 +32,7 @@ import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.exceptions.TimeoutIOException;
 import org.apache.hadoop.hbase.monitoring.MonitoredRPCHandler;
 import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.Pair;
@@ -124,8 +127,8 @@ public class CallRunner {
       String methodName = getMethodName();
       Span span = TraceUtil.getGlobalTracer().spanBuilder("RpcServer.callMethod")
         .setParent(Context.current().with(((ServerCall<?>) call).getSpan())).startSpan()
-        .setAttribute(TraceUtil.RPC_SERVICE_KEY, serviceName)
-        .setAttribute(TraceUtil.RPC_METHOD_KEY, methodName);
+        .setAttribute(RPC_SERVICE_KEY, serviceName)
+        .setAttribute(RPC_METHOD_KEY, methodName);
       try (Scope traceScope = span.makeCurrent()) {
         if (!this.rpcServer.isStarted()) {
           InetSocketAddress address = rpcServer.getListenerAddress();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hbase.regionserver;
 
 import static org.apache.hadoop.hbase.HConstants.REPLICATION_SCOPE_LOCAL;
 import static org.apache.hadoop.hbase.regionserver.HStoreFile.MAJOR_COMPACTION_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.REGION_NAMES_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.ROW_LOCK_READ_LOCK_KEY;
 import static org.apache.hadoop.hbase.util.ConcurrentMapUtils.computeIfAbsent;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import io.opentelemetry.api.trace.Span;
@@ -153,6 +155,7 @@ import org.apache.hadoop.hbase.replication.regionserver.ReplicationObserver;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.SnapshotManifest;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CancelableProgressable;
@@ -6588,8 +6591,8 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
   }
 
   Span createRegionSpan(String name) {
-    return TraceUtil.createSpan(name).setAttribute(TraceUtil.REGION_NAMES_KEY,
-      Arrays.asList(getRegionInfo().getRegionNameAsString()));
+    return TraceUtil.createSpan(name).setAttribute(REGION_NAMES_KEY,
+      Collections.singletonList(getRegionInfo().getRegionNameAsString()));
   }
 
   // will be override in tests
@@ -6676,7 +6679,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
   private RowLock getRowLock(byte[] row, boolean readLock, final RowLock prevRowLock)
     throws IOException {
     return TraceUtil.trace(() -> getRowLockInternal(row, readLock, prevRowLock),
-      () -> createRegionSpan("Region.getRowLock").setAttribute(TraceUtil.ROW_LOCK_READ_LOCK_KEY,
+      () -> createRegionSpan("Region.getRowLock").setAttribute(ROW_LOCK_READ_LOCK_KEY,
         readLock));
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.regionserver.wal;
 import static org.apache.hadoop.hbase.regionserver.wal.WALActionsListener.RollRequestReason.ERROR;
 import static org.apache.hadoop.hbase.regionserver.wal.WALActionsListener.RollRequestReason.LOW_REPLICATION;
 import static org.apache.hadoop.hbase.regionserver.wal.WALActionsListener.RollRequestReason.SLOW_SYNC;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.WAL_IMPL;
 import static org.apache.hadoop.hbase.wal.AbstractFSWALProvider.WAL_FILE_NAME_DELIMITER;
 import static org.apache.hbase.thirdparty.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.hbase.thirdparty.com.google.common.base.Preconditions.checkNotNull;
@@ -69,6 +70,7 @@ import org.apache.hadoop.hbase.ipc.ServerCall;
 import org.apache.hadoop.hbase.log.HBaseMarkers;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.MultiVersionConcurrencyControl;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
@@ -841,7 +843,7 @@ public abstract class AbstractFSWAL<W extends WriterBase> implements WAL {
   }
 
   private Span createSpan(String name) {
-    return TraceUtil.createSpan(name).setAttribute(TraceUtil.WAL_IMPL, implClassName);
+    return TraceUtil.createSpan(name).setAttribute(WAL_IMPL, implClassName);
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyConnectionRegistry.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyConnectionRegistry.java
@@ -47,6 +47,11 @@ public class DummyConnectionRegistry implements ConnectionRegistry {
   }
 
   @Override
+  public String getConnectionString() {
+    return null;
+  }
+
+  @Override
   public void close() {
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/AbstractTestIPC.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/AbstractTestIPC.java
@@ -53,7 +53,7 @@ import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.Server;
 import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.ipc.RpcServer.BlockingServiceAndInterface;
-import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.io.compress.GzipCodec;
 import org.apache.hadoop.util.StringUtils;
@@ -459,11 +459,11 @@ public abstract class AbstractTestIPC {
   private void assertRpcAttribute(SpanData data, String methodName, InetSocketAddress addr,
     SpanKind kind) {
     assertEquals(SERVICE.getDescriptorForType().getName(),
-      data.getAttributes().get(TraceUtil.RPC_SERVICE_KEY));
-    assertEquals(methodName, data.getAttributes().get(TraceUtil.RPC_METHOD_KEY));
+      data.getAttributes().get(HBaseSemanticAttributes.RPC_SERVICE_KEY));
+    assertEquals(methodName, data.getAttributes().get(HBaseSemanticAttributes.RPC_METHOD_KEY));
     if (addr != null) {
-      assertEquals(addr.getHostName(), data.getAttributes().get(TraceUtil.REMOTE_HOST_KEY));
-      assertEquals(addr.getPort(), data.getAttributes().get(TraceUtil.REMOTE_PORT_KEY).intValue());
+      assertEquals(addr.getHostName(), data.getAttributes().get(HBaseSemanticAttributes.REMOTE_HOST_KEY));
+      assertEquals(addr.getPort(), data.getAttributes().get(HBaseSemanticAttributes.REMOTE_PORT_KEY).intValue());
     }
     assertEquals(kind, data.getKind());
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegionTracing.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegionTracing.java
@@ -43,7 +43,7 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
-import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.wal.WAL;
 import org.junit.After;
@@ -115,7 +115,7 @@ public class TestHRegionTracing {
       if (!span.getName().equals(spanName)) {
         return false;
       }
-      List<String> regionNames = span.getAttributes().get(TraceUtil.REGION_NAMES_KEY);
+      List<String> regionNames = span.getAttributes().get(HBaseSemanticAttributes.REGION_NAMES_KEY);
       return regionNames != null && regionNames.size() == 1 &&
         regionNames.get(0).equals(region.getRegionInfo().getRegionNameAsString());
     }));


### PR DESCRIPTION
A first set of patches to bring our implementation around to the conventions as described. Focuses primarily on spans from HTable and a couple other connection-level methods. Applicable reference is https://github.com/open-telemetry/opentelemetry-specification/blob/3e380e2/specification/trace/semantic_conventions/database.md