### PR TITLE
HBASE-26479: Print too slow/big scan's operation_id in region server log

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -74,6 +74,7 @@ import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.OperationWithAttributes;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionReplicaUtil;
@@ -1278,6 +1279,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
     StringBuilder builder = new StringBuilder();
     builder.append("table: ").append(scanner.getRegionInfo().getTable().getNameAsString());
     builder.append(" region: ").append(scanner.getRegionInfo().getRegionNameAsString());
+    builder.append(" operation_id: ").append(scanner.getOperationId());
     return builder.toString();
   }
 
@@ -1290,6 +1292,12 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
       StringBuilder builder = new StringBuilder();
       builder.append("table: ").append(region.getRegionInfo().getTable().getNameAsString());
       builder.append(" region: ").append(region.getRegionInfo().getRegionNameAsString());
+      for (NameBytesPair pair : request.getScan().getAttributeList()) {
+        if (OperationWithAttributes.ID_ATRIBUTE.equals(pair.getName())) {
+          builder.append(" operation_id: ").append(Bytes.toString(pair.getValue().toByteArray()));
+          break;
+        }
+      }
       return builder.toString();
     } catch (IOException ignored) {
       return null;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScanner.java
@@ -75,7 +75,7 @@ public interface RegionScanner extends InternalScanner {
 
   /**
    * @return The Scanner's {@link org.apache.hadoop.hbase.client.Scan#ID_ATRIBUTE} value,
-   * or null if not set.
+   *         or null if not set.
    */
   default String getOperationId() {
     return null;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScanner.java
@@ -74,6 +74,14 @@ public interface RegionScanner extends InternalScanner {
   int getBatch();
 
   /**
+   * @return The Scanner's {@link org.apache.hadoop.hbase.client.Scan#ID_ATRIBUTE} value,
+   * or null if not set.
+   */
+  default String getOperationId() {
+    return null;
+  }
+
+  /**
    * Grab the next row's worth of values. This is a special internal method to be called from
    * coprocessor hooks to avoid expensive setup. Caller must set the thread's readpoint, start and
    * close a region operation, an synchronize on the scanner object. Caller should maintain and

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
@@ -89,6 +89,7 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
   private final long maxResultSize;
   private final ScannerContext defaultScannerContext;
   private final FilterWrapper filter;
+  private final String operationId;
 
   private RegionServerServices rsServices;
 
@@ -121,6 +122,7 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
     defaultScannerContext = ScannerContext.newBuilder().setBatchLimit(scan.getBatch()).build();
     this.stopRow = scan.getStopRow();
     this.includeStopRow = scan.includeStopRow();
+    this.operationId = scan.getId();
 
     // synchronize on scannerReadPoints so that nobody calculates
     // getSmallestReadPoint, before scannerReadPoints is updated.
@@ -213,6 +215,11 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
   @Override
   public int getBatch() {
     return this.defaultScannerContext.getBatchLimit();
+  }
+
+  @Override
+  public String getOperationId() {
+    return operationId;
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
@@ -4446,6 +4446,23 @@ public class TestHRegion {
     }
   }
 
+  @Test
+  public void testScannerOperationId() throws IOException {
+    region = initHRegion(tableName, method, CONF, COLUMN_FAMILY_BYTES);
+    Scan scan = new Scan();
+    RegionScanner scanner = region.getScanner(scan);
+    assertNull(scanner.getOperationId());
+    scanner.close();
+
+    String operationId = "test_operation_id_0101";
+    scan = new Scan().setId(operationId);
+    scanner = region.getScanner(scan);
+    assertEquals(operationId, scanner.getOperationId());
+    scanner.close();
+
+    HBaseTestingUtil.closeRegionAndWAL(this.region);
+  }
+
   /**
    * Write an HFile block full with Cells whose qualifier that are identical between
    * 0 and Short.MAX_VALUE. See HBASE-13329.


### PR DESCRIPTION
Tracing is very important in large-scale distributed systems.

The attribute `_operation.attributes.id`  of a scan request can be used as trace id between hbase client and region server.

We should print operation id in region server's log if the scan request is too slow or too big.

It will be very helpful for finding problematic requests.

