### PR TITLE
HBASE-26541 hbase-protocol-shaded not buildable on M1 MacOSX

### DIFF
--- a/hbase-protocol-shaded/pom.xml
+++ b/hbase-protocol-shaded/pom.xml
@@ -33,8 +33,8 @@
     <maven.javadoc.skip>true</maven.javadoc.skip>
     <!--Version of protobuf that hbase uses internally (we shade our pb)
          Must match what is out in hbase-thirdparty include.
-           -->
-    <internal.protobuf.version>3.11.4</internal.protobuf.version>
+    -->
+    <internal.protobuf.version>3.17.3</internal.protobuf.version>
   </properties>
   <build>
     <plugins>


### PR DESCRIPTION
I needed to make some changes to get hbase-protocol-shaded building on an M1 mac.

- Upgrade internal.protobuf.version to 3.17.3.
