### PR TITLE
HBASE-26542 Apply a `package` to test protobuf files

### DIFF
--- a/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/ColumnAggregationNullResponseProtocol.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/ColumnAggregationNullResponseProtocol.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 // Coprocessor test
 option java_package = "org.apache.hadoop.hbase.shaded.coprocessor.protobuf.generated";

--- a/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/ColumnAggregationProtocol.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/ColumnAggregationProtocol.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 // Coprocessor test
 option java_package = "org.apache.hadoop.hbase.shaded.coprocessor.protobuf.generated";

--- a/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/ColumnAggregationWithErrorsProtocol.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/ColumnAggregationWithErrorsProtocol.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 // Coprocessor test
 option java_package = "org.apache.hadoop.hbase.shaded.coprocessor.protobuf.generated";

--- a/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/IncrementCounterProcessor.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/IncrementCounterProcessor.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 option java_package = "org.apache.hadoop.hbase.shaded.coprocessor.protobuf.generated";
 option java_outer_classname = "IncrementCounterProcessorTestProtos";

--- a/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/PingProtocol.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/PingProtocol.proto
@@ -17,6 +17,7 @@
  */
 // Coprocessor test
 syntax = "proto2";
+package hbase.test.pb;
 option java_package = "org.apache.hadoop.hbase.shaded.coprocessor.protobuf.generated";
 option java_outer_classname = "PingProtos";
 option java_generic_services = true;

--- a/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/ShellExecEndpoint.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/coprocessor/ShellExecEndpoint.proto
@@ -21,6 +21,7 @@
  */
 
 syntax = "proto2";
+package hbase.test.pb;
 option java_package = "org.apache.hadoop.hbase.coprocessor.protobuf.generated";
 option java_outer_classname = "ShellExecEndpoint";
 option java_generic_services = true;

--- a/hbase-protocol-shaded/src/main/protobuf/test/ipc/TestProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/ipc/TestProcedure.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 option java_package = "org.apache.hadoop.hbase.shaded.ipc.protobuf.generated";
 option java_outer_classname = "TestProcedureProtos";
 option java_generic_services = true;

--- a/hbase-protocol-shaded/src/main/protobuf/test/ipc/test.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/ipc/test.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 option java_package = "org.apache.hadoop.hbase.shaded.ipc.protobuf.generated";
 option java_outer_classname = "TestProtos";

--- a/hbase-protocol-shaded/src/main/protobuf/test/ipc/test_rpc_service.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test/ipc/test_rpc_service.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 option java_package = "org.apache.hadoop.hbase.shaded.ipc.protobuf.generated";
 option java_outer_classname = "TestRpcServiceProtos";
 option java_generic_services = true;


### PR DESCRIPTION
This is needed in a couple places in order to test that traces over the IPC layer carry correct
span names, and it's good hygiene anyway.