### PR TITLE
HBASE-26027 The calling of HTable.batch blocked at AsyncRequestFutureImpl.waitUntilDone caused by ArrayStoreException

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRequestFutureImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRequestFutureImpl.java
@@ -1132,8 +1132,15 @@ class AsyncRequestFutureImpl<CResult> implements AsyncRequestFuture {
   @Override
   public void waitUntilDone() throws InterruptedIOException {
     try {
-      long cutoff = (EnvironmentEdgeManager.currentTime() + this.operationTimeout) * 1000L;
-      waitUntilDone(cutoff);
+      if (this.operationTimeout > 0) {
+        // the worker thread maybe over by some exception without decrement the actionsInProgress,
+        // then the guarantee of operationTimeout will be broken, so we should set cutoff to avoid
+        // stuck here forever
+        long cutoff = (EnvironmentEdgeManager.currentTime() + this.operationTimeout) * 1000L;
+        waitUntilDone(cutoff);
+      } else {
+        waitUntilDone(Long.MAX_VALUE);
+      }
     } catch (InterruptedException iex) {
       throw new InterruptedIOException(iex.getMessage());
     } finally {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRequestFutureImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRequestFutureImpl.java
@@ -1132,7 +1132,8 @@ class AsyncRequestFutureImpl<CResult> implements AsyncRequestFuture {
   @Override
   public void waitUntilDone() throws InterruptedIOException {
     try {
-      waitUntilDone(Long.MAX_VALUE);
+      long cutoff = (EnvironmentEdgeManager.currentTime() + this.operationTimeout) * 1000L;
+      waitUntilDone(cutoff);
     } catch (InterruptedException iex) {
       throw new InterruptedIOException(iex.getMessage());
     } finally {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientOperationTimeout.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientOperationTimeout.java
@@ -158,7 +158,7 @@ public class TestClientOperationTimeout {
   }
 
   /**
-   * Tests that a batch mutate on a table throws {@link RetriesExhaustedException} when the
+   * Tests that a batch mutate on a table throws {@link SocketTimeoutException} when the
    * operation takes longer than 'hbase.client.operation.timeout'.
    */
   @Test
@@ -175,7 +175,7 @@ public class TestClientOperationTimeout {
       TABLE.batch(puts, new Object[2]);
       Assert.fail("should not reach here");
     } catch (Exception e) {
-      Assert.assertTrue(e instanceof RetriesExhaustedWithDetailsException);
+      Assert.assertTrue(e instanceof SocketTimeoutException);
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientOperationTimeout.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientOperationTimeout.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.RetriesExhaustedException;
-import org.apache.hadoop.hbase.client.RetriesExhaustedWithDetailsException;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;


### PR DESCRIPTION
This is a new pr instead of #3419.