### PR TITLE
HBASE-26546: hbase-shaded-client missing required thirdparty classes under hadoop 3.3.1

### DIFF
--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -525,8 +525,6 @@
                       <!-- We already concat NOTICE, safe to drop individual ones -->
                       <exclude>LICENSE</exclude>
                       <exclude>NOTICE</exclude>
-                      <!-- Remove the shaded guava added in hadoop-3.3.1+-->
-                      <exclude>org/apache/hadoop/thirdparty/**/*</exclude>
                     </excludes>
                   </filter>
                   <filter>


### PR DESCRIPTION
I expected there would be more to this, but this ended up working locally without needing to modify our invariants checks. I'm continuing to look into why, but wanted to get the full build started.