### PR TITLE
HBASE-26564 Retire the method visitLogEntryBeforeWrite without RegionInfo in WALActionListner

### DIFF
--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportExport.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportExport.java
@@ -810,7 +810,7 @@ public class TestImportExport {
     }
 
     @Override
-    public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) {
+    public void visitLogEntryBeforeWrite(RegionInfo info, WALKey logKey, WALEdit logEdit) {
       if (logKey.getTableName().getNameAsString().equalsIgnoreCase(
           this.regionInfo.getTable().getNameAsString()) && (!logEdit.isMetaEdit())) {
         isVisited = true;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
@@ -1129,7 +1129,7 @@ public abstract class AbstractFSWAL<W extends WriterBase> implements WAL {
     coprocessorHost.preWALWrite(entry.getRegionInfo(), entry.getKey(), entry.getEdit());
     if (!listeners.isEmpty()) {
       for (WALActionsListener i : listeners) {
-        i.visitLogEntryBeforeWrite(entry.getKey(), entry.getEdit());
+        i.visitLogEntryBeforeWrite(entry.getRegionInfo(), entry.getKey(), entry.getEdit());
       }
     }
     doAppend(writer, entry);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/WALActionsListener.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/WALActionsListener.java
@@ -90,16 +90,6 @@ public interface WALActionsListener {
   default void visitLogEntryBeforeWrite(RegionInfo info, WALKey logKey, WALEdit logEdit) {}
 
   /**
-   * @param logKey
-   * @param logEdit TODO: Retire this in favor of
-   *          {@link #visitLogEntryBeforeWrite(RegionInfo, WALKey, WALEdit)} It only exists to get
-   *          scope when replicating. Scope should be in the WALKey and not need us passing in a
-   *          <code>htd</code>.
-   * @throws IOException If failed to parse the WALEdit
-   */
-  default void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) throws IOException {}
-
-  /**
    * For notification post append to the writer.  Used by metrics system at least.
    * TODO: Combine this with above.
    * @param entryLen approx length of cells in this append.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceWALActionListener.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSourceWALActionListener.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.replication.regionserver;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.regionserver.wal.WALActionsListener;
 import org.apache.hadoop.hbase.replication.ReplicationUtils;
 import org.apache.hadoop.hbase.wal.WALEdit;
@@ -53,7 +54,7 @@ class ReplicationSourceWALActionListener implements WALActionsListener {
   }
 
   @Override
-  public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) throws IOException {
+  public void visitLogEntryBeforeWrite(RegionInfo info, WALKey logKey, WALEdit logEdit) {
     scopeWALEdits(logKey, logEdit, conf);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegionServerBulkLoad.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegionServerBulkLoad.java
@@ -49,6 +49,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
@@ -407,7 +408,7 @@ public class TestHRegionServerBulkLoad {
     private boolean found = false;
 
     @Override
-    public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) {
+    public void visitLogEntryBeforeWrite(RegionInfo info, WALKey logKey, WALEdit logEdit) {
       for (Cell cell : logEdit.getCells()) {
         KeyValue kv = KeyValueUtil.ensureKeyValue(cell);
         for (Map.Entry entry : kv.toStringMap().entrySet()) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/AbstractTestFSWAL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/AbstractTestFSWAL.java
@@ -545,7 +545,7 @@ public abstract class AbstractTestFSWAL {
     wal.init();
     wal.registerWALActionsListener(new WALActionsListener() {
       @Override
-      public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) throws IOException {
+      public void visitLogEntryBeforeWrite(RegionInfo info, WALKey logKey, WALEdit logEdit) {
         if (startHoldingForAppend.get()) {
           try {
             holdAppend.await();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestFSHLog.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestFSHLog.java
@@ -240,8 +240,7 @@ public class TestFSHLog extends AbstractTestFSWAL {
       log.init();
       log.registerWALActionsListener(new WALActionsListener() {
         @Override
-        public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit)
-            throws IOException {
+        public void visitLogEntryBeforeWrite(RegionInfo info, WALKey logKey, WALEdit logEdit) {
           if (startHoldingForAppend.get()) {
             try {
               holdAppend.await();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALFactory.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALFactory.java
@@ -675,13 +675,6 @@ public class TestWALFactory {
     public void visitLogEntryBeforeWrite(RegionInfo info, WALKey logKey, WALEdit logEdit) {
       increments++;
     }
-
-//    @Override
-//    public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) {
-//      // To change body of implemented methods use File | Settings | File
-//      // Templates.
-//      increments++;
-//    }
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALFactory.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestWALFactory.java
@@ -676,12 +676,12 @@ public class TestWALFactory {
       increments++;
     }
 
-    @Override
-    public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) {
-      // To change body of implemented methods use File | Settings | File
-      // Templates.
-      increments++;
-    }
+//    @Override
+//    public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) {
+//      // To change body of implemented methods use File | Settings | File
+//      // Templates.
+//      increments++;
+//    }
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/WALPerformanceEvaluation.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/WALPerformanceEvaluation.java
@@ -471,7 +471,7 @@ public final class WALPerformanceEvaluation extends Configured implements Tool {
         private int appends = 0;
 
         @Override
-        public void visitLogEntryBeforeWrite(WALKey logKey, WALEdit logEdit) {
+        public void visitLogEntryBeforeWrite(RegionInfo info, WALKey logKey, WALEdit logEdit) {
           this.appends++;
           if (this.appends % whenToRoll == 0) {
             LOG.info("Rolling after " + appends + " edits");


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-26564