### PR TITLE
HBASE-26557 Correct export to set log4j2.formatMsgNoLookups in HBASE_…

### DIFF
--- a/bin/hbase-config.sh
+++ b/bin/hbase-config.sh
@@ -164,7 +164,7 @@ export MALLOC_ARENA_MAX=${MALLOC_ARENA_MAX:-4}
 
 # Disable the JNDI. This feature has critical REC vulnerability
 # when 2.x <= log4j.version <= 2.14.1
-export HBASE_OPTS = "$HBASE_OPTS -Dlog4j2.formatMsgNoLookups=true"
+export HBASE_OPTS="$HBASE_OPTS -Dlog4j2.formatMsgNoLookups=true"
 
 # Now having JAVA_HOME defined is required 
 if [ -z "$JAVA_HOME" ]; then


### PR DESCRIPTION
…OPTS

Tagging folks who reviewed the first time. The original change is ineffective and does not result in adding the property to the HBASE_OPTS environment variable
```
$ ./bin/start-hbase.sh
/Users/jelser/hbase300alpha2rc0/hbase300/hbase-3.0.0-alpha-2/bin/hbase-config.sh: line 167: export: `=': not a valid identifier
/Users/jelser/hbase300alpha2rc0/hbase300/hbase-3.0.0-alpha-2/bin/hbase-config.sh: line 167: export: ` -Dlog4j2.formatMsgNoLookups=true': not a valid identifier
/Users/jelser/hbase300alpha2rc0/hbase300/hbase-3.0.0-alpha-2/bin/hbase-config.sh: line 167: export: `=': not a valid identifier
/Users/jelser/hbase300alpha2rc0/hbase300/hbase-3.0.0-alpha-2/bin/hbase-config.sh: line 167: export: ` -Dlog4j2.formatMsgNoLookups=true': not a valid identifier 
```