### PR TITLE
HBASE-26576

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
@@ -84,6 +84,8 @@ public abstract class RpcExecutor {
 
   public static final String PLUGGABLE_CALL_QUEUE_CLASS_NAME =
     "hbase.ipc.server.callqueue.pluggable.queue.class.name";
+  public static final String PLUGGABLE_CALL_QUEUE_WITH_FAST_PATH_ENABLED =
+    "hbase.ipc.server.callqueue.pluggable.queue.fast.path.enabled";
 
   private LongAdder numGeneralCallsDropped = new LongAdder();
   private LongAdder numLifoModeSwitches = new LongAdder();
@@ -380,6 +382,11 @@ public abstract class RpcExecutor {
 
   public static boolean isPluggableQueueType(String callQueueType) {
     return callQueueType.equals(CALL_QUEUE_TYPE_PLUGGABLE_CONF_VALUE);
+  }
+
+  public static boolean isPluggableQueueWithFastPath(String callQueueType, Configuration conf) {
+    return isPluggableQueueType(callQueueType) &&
+      conf.getBoolean(PLUGGABLE_CALL_QUEUE_WITH_FAST_PATH_ENABLED, false);
   }
 
   private Optional<Class<? extends BlockingQueue<CallRunner>>> getPluggableQueueClass() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleRpcScheduler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleRpcScheduler.java
@@ -91,7 +91,9 @@ public class SimpleRpcScheduler extends RpcScheduler implements ConfigurationObs
       callExecutor = new FastPathRWQueueRpcExecutor("default.FPRWQ", Math.max(2, handlerCount),
         maxQueueLength, priority, conf, server);
     } else {
-      if (RpcExecutor.isFifoQueueType(callQueueType) || RpcExecutor.isCodelQueueType(callQueueType)) {
+      if (RpcExecutor.isFifoQueueType(callQueueType) ||
+        RpcExecutor.isCodelQueueType(callQueueType) ||
+        RpcExecutor.isPluggableQueueWithFastPath(callQueueType, conf)) {
         callExecutor = new FastPathBalancedQueueRpcExecutor("default.FPBQ", handlerCount,
             maxQueueLength, priority, conf, server);
       } else {


### PR DESCRIPTION
Allow pluggable queue to be used with the fast path executor or normal balanced executor.

https://issues.apache.org/jira/browse/HBASE-26576