### PR TITLE
Backport "HBASE-26542 Apply a `package` to test protobuf files" to branch-2.4

### DIFF
--- a/hbase-endpoint/src/main/protobuf/ColumnAggregationNullResponseProtocol.proto
+++ b/hbase-endpoint/src/main/protobuf/ColumnAggregationNullResponseProtocol.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 // Coprocessor test
 option java_package = "org.apache.hadoop.hbase.coprocessor.protobuf.generated";

--- a/hbase-endpoint/src/main/protobuf/ColumnAggregationProtocol.proto
+++ b/hbase-endpoint/src/main/protobuf/ColumnAggregationProtocol.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 // Coprocessor test
 option java_package = "org.apache.hadoop.hbase.coprocessor.protobuf.generated";

--- a/hbase-endpoint/src/main/protobuf/ColumnAggregationWithErrorsProtocol.proto
+++ b/hbase-endpoint/src/main/protobuf/ColumnAggregationWithErrorsProtocol.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 // Coprocessor test
 option java_package = "org.apache.hadoop.hbase.coprocessor.protobuf.generated";

--- a/hbase-endpoint/src/main/protobuf/IncrementCounterProcessor.proto
+++ b/hbase-endpoint/src/main/protobuf/IncrementCounterProcessor.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 option java_package = "org.apache.hadoop.hbase.coprocessor.protobuf.generated";
 option java_outer_classname = "IncrementCounterProcessorTestProtos";

--- a/hbase-endpoint/src/main/protobuf/ShellExecEndpoint.proto
+++ b/hbase-endpoint/src/main/protobuf/ShellExecEndpoint.proto
@@ -21,6 +21,7 @@
  */
 
 syntax = "proto2";
+package hbase.test.pb;
 option java_package = "org.apache.hadoop.hbase.coprocessor.protobuf.generated";
 option java_outer_classname = "ShellExecEndpoint";
 option java_generic_services = true;

--- a/hbase-protocol-shaded/src/main/protobuf/TestProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/TestProcedure.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 option java_package = "org.apache.hadoop.hbase.shaded.ipc.protobuf.generated";
 option java_outer_classname = "TestProcedureProtos";
 option java_generic_services = true;

--- a/hbase-protocol-shaded/src/main/protobuf/test.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 
 option java_package = "org.apache.hadoop.hbase.shaded.ipc.protobuf.generated";
 option java_outer_classname = "TestProtos";

--- a/hbase-protocol-shaded/src/main/protobuf/test_rpc_service.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/test_rpc_service.proto
@@ -16,6 +16,7 @@
  * limitations under the License.
  */
 syntax = "proto2";
+package hbase.test.pb;
 option java_package = "org.apache.hadoop.hbase.shaded.ipc.protobuf.generated";
 option java_outer_classname = "TestRpcServiceProtos";
 option java_generic_services = true;

--- a/hbase-protocol/src/main/protobuf/PingProtocol.proto
+++ b/hbase-protocol/src/main/protobuf/PingProtocol.proto
@@ -17,6 +17,7 @@
  */
 syntax = "proto2";
 
+package hbase.test.pb;
 // Coprocessor test
 option java_package = "org.apache.hadoop.hbase.coprocessor.protobuf.generated";
 option java_outer_classname = "PingProtos";


### PR DESCRIPTION
This is needed in a couple places in order to test that traces over the IPC layer carry correct
span names, and it's good hygiene anyway.

Signed-off-by: Duo Zhang <zhangduo@apache.org>