### PR TITLE
Backport "HBASE-26542 Apply a `package` to test protobuf files (addendum)" to branch-2.5

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcServerSlowConnectionSetup.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcServerSlowConnectionSetup.java
@@ -114,7 +114,7 @@ public class TestRpcServerSlowConnectionSetup {
     socket.getOutputStream().flush();
 
     ConnectionHeader header = ConnectionHeader.newBuilder()
-        .setServiceName(TestRpcServiceProtos.TestProtobufRpcProto.getDescriptor().getFullName())
+        .setServiceName(TestRpcServiceProtos.TestProtobufRpcProto.getDescriptor().getName())
         .setVersionInfo(ProtobufUtil.getVersionInfo()).build();
     DataOutputStream dos = new DataOutputStream(socket.getOutputStream());
     dos.writeInt(header.getSerializedSize());


### PR DESCRIPTION
RpcServer identifies the services it hosts by unqualified service name. Thus, use `getName()`
instead of `getFullName()`. See also HBASE-26589.

Signed-off-by: Peter Somogyi <psomogyi@apache.org>