### PR TITLE
HBASE-26598 Fix excessive connections in MajorCompactor

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactionRequest.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactionRequest.java
@@ -22,13 +22,11 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
-import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
@@ -45,26 +43,26 @@ class MajorCompactionRequest {
 
   private static final Logger LOG = LoggerFactory.getLogger(MajorCompactionRequest.class);
 
-  protected final Configuration configuration;
+  protected final Connection connection;
   protected final RegionInfo region;
   private Set<String> stores;
 
-  MajorCompactionRequest(Configuration configuration, RegionInfo region) {
-    this.configuration = configuration;
+  MajorCompactionRequest(Connection connection, RegionInfo region) {
+    this.connection = connection;
     this.region = region;
   }
 
-  MajorCompactionRequest(Configuration configuration, RegionInfo region,
+  MajorCompactionRequest(Connection connection, RegionInfo region,
       Set<String> stores) {
-    this(configuration, region);
+    this(connection, region);
     this.stores = stores;
   }
 
-  static Optional<MajorCompactionRequest> newRequest(Configuration configuration, RegionInfo info,
+  static Optional<MajorCompactionRequest> newRequest(Connection connection, RegionInfo info,
       Set<String> stores, long timestamp) throws IOException {
     MajorCompactionRequest request =
-        new MajorCompactionRequest(configuration, info, stores);
-    return request.createRequest(configuration, stores, timestamp);
+        new MajorCompactionRequest(connection, info, stores);
+    return request.createRequest(connection, stores, timestamp);
   }
 
   RegionInfo getRegion() {
@@ -79,28 +77,26 @@ class MajorCompactionRequest {
     this.stores = stores;
   }
 
-  Optional<MajorCompactionRequest> createRequest(Configuration configuration,
+  Optional<MajorCompactionRequest> createRequest(Connection connection,
       Set<String> stores, long timestamp) throws IOException {
     Set<String> familiesToCompact = getStoresRequiringCompaction(stores, timestamp);
     MajorCompactionRequest request = null;
     if (!familiesToCompact.isEmpty()) {
-      request = new MajorCompactionRequest(configuration, region, familiesToCompact);
+      request = new MajorCompactionRequest(connection, region, familiesToCompact);
     }
     return Optional.ofNullable(request);
   }
 
   Set<String> getStoresRequiringCompaction(Set<String> requestedStores, long timestamp)
       throws IOException {
-    try(Connection connection = getConnection(configuration)) {
-      HRegionFileSystem fileSystem = getFileSystem(connection);
-      Set<String> familiesToCompact = Sets.newHashSet();
-      for (String family : requestedStores) {
-        if (shouldCFBeCompacted(fileSystem, family, timestamp)) {
-          familiesToCompact.add(family);
-        }
+    HRegionFileSystem fileSystem = getFileSystem();
+    Set<String> familiesToCompact = Sets.newHashSet();
+    for (String family : requestedStores) {
+      if (shouldCFBeCompacted(fileSystem, family, timestamp)) {
+        familiesToCompact.add(family);
       }
-      return familiesToCompact;
     }
+    return familiesToCompact;
   }
 
   boolean shouldCFBeCompacted(HRegionFileSystem fileSystem, String family, long ts)
@@ -142,10 +138,6 @@ class MajorCompactionRequest {
     return false;
   }
 
-  Connection getConnection(Configuration configuration) throws IOException {
-    return ConnectionFactory.createConnection(configuration);
-  }
-
   protected boolean familyHasReferenceFile(HRegionFileSystem fileSystem, String family, long ts)
       throws IOException {
     List<Path> referenceFiles =
@@ -167,12 +159,13 @@ class MajorCompactionRequest {
     return FSUtils.getReferenceFilePaths(fileSystem, familyDir);
   }
 
-  HRegionFileSystem getFileSystem(Connection connection) throws IOException {
-    Admin admin = connection.getAdmin();
-    return HRegionFileSystem.openRegionFromFileSystem(admin.getConfiguration(),
-      CommonFSUtils.getCurrentFileSystem(admin.getConfiguration()), CommonFSUtils.getTableDir(
-        CommonFSUtils.getRootDir(admin.getConfiguration()), region.getTable()),
-      region, true);
+  HRegionFileSystem getFileSystem() throws IOException {
+    try (Admin admin = connection.getAdmin()) {
+      return HRegionFileSystem.openRegionFromFileSystem(admin.getConfiguration(),
+        CommonFSUtils.getCurrentFileSystem(admin.getConfiguration()),
+        CommonFSUtils.getTableDir(CommonFSUtils.getRootDir(admin.getConfiguration()),
+          region.getTable()), region, true);
+    }
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactor.java
@@ -202,8 +202,7 @@ public class MajorCompactor extends Configured implements Tool {
 
   protected Optional<MajorCompactionRequest> getMajorCompactionRequest(RegionInfo hri)
       throws IOException {
-    return MajorCompactionRequest.newRequest(connection.getConfiguration(), hri, storesToCompact,
-            timestamp);
+    return MajorCompactionRequest.newRequest(connection, hri, storesToCompact, timestamp);
   }
 
   private Collection<ServerName> getServersToCompact(Set<ServerName> snSet) {
@@ -352,8 +351,7 @@ public class MajorCompactor extends Configured implements Tool {
       for (HRegionLocation location : locations) {
         if (location.getRegion().getRegionId() > timestamp) {
           Optional<MajorCompactionRequest> compactionRequest = MajorCompactionRequest
-              .newRequest(connection.getConfiguration(), location.getRegion(), storesToCompact,
-                  timestamp);
+              .newRequest(connection, location.getRegion(), storesToCompact, timestamp);
           compactionRequest.ifPresent(request -> clusterCompactionQueues
               .addToCompactionQueue(location.getServerName(), request));
         }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactorTTL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactorTTL.java
@@ -76,7 +76,7 @@ public class MajorCompactorTTL extends MajorCompactor {
   @Override
   protected Optional<MajorCompactionRequest> getMajorCompactionRequest(RegionInfo hri)
       throws IOException {
-    return MajorCompactionTTLRequest.newRequest(connection.getConfiguration(), hri, htd);
+    return MajorCompactionTTLRequest.newRequest(connection, hri, htd);
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/compaction/TestMajorCompactionTTLRequest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/compaction/TestMajorCompactionTTLRequest.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.hbase.util.compaction;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
-import static org.mockito.Matchers.eq;
-import static org.mockito.Matchers.isA;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -31,7 +29,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.TableName;
@@ -72,29 +69,28 @@ public class TestMajorCompactionTTLRequest extends TestMajorCompactionRequest {
     MajorCompactionTTLRequest request = makeMockRequest(storeFiles);
     // All files are <= 100, so region should not be compacted.
     Optional<MajorCompactionRequest> result =
-        request.createRequest(mock(Configuration.class), Sets.newHashSet(FAMILY), 10);
+        request.createRequest(mock(Connection.class), Sets.newHashSet(FAMILY), 10);
     assertFalse(result.isPresent());
 
     // All files are <= 100, so region should not be compacted yet.
-    result = request.createRequest(mock(Configuration.class), Sets.newHashSet(FAMILY), 100);
+    result = request.createRequest(mock(Connection.class), Sets.newHashSet(FAMILY), 100);
     assertFalse(result.isPresent());
 
     // All files are <= 100, so they should be considered for compaction
-    result = request.createRequest(mock(Configuration.class), Sets.newHashSet(FAMILY), 101);
+    result = request.createRequest(mock(Connection.class), Sets.newHashSet(FAMILY), 101);
     assertTrue(result.isPresent());
   }
 
   private MajorCompactionTTLRequest makeMockRequest(List<StoreFileInfo> storeFiles)
       throws IOException {
-    Configuration configuration = mock(Configuration.class);
+    Connection connection = mock(Connection.class);
     RegionInfo regionInfo = mock(RegionInfo.class);
     when(regionInfo.getEncodedName()).thenReturn("HBase");
     when(regionInfo.getTable()).thenReturn(TableName.valueOf("foo"));
-    MajorCompactionTTLRequest request = new MajorCompactionTTLRequest(configuration, regionInfo);
+    MajorCompactionTTLRequest request = new MajorCompactionTTLRequest(connection, regionInfo);
     MajorCompactionTTLRequest spy = spy(request);
     HRegionFileSystem fileSystem = mockFileSystem(regionInfo, false, storeFiles);
-    doReturn(fileSystem).when(spy).getFileSystem(isA(Connection.class));
-    doReturn(mock(Connection.class)).when(spy).getConnection(eq(configuration));
+    doReturn(fileSystem).when(spy).getFileSystem();
     return spy;
   }
 }


### PR DESCRIPTION
MajorCompactor creates excessive connections: once every time MajorCompactionRequest.getConnection is called. Can do better by using the Connection object created in MajorCompactor.

**Testing:**
Ran `mvn -D test="org.apache.hadoop.hbase.util.compaction.TestMajorCompactor" test -pl hbase-server -am`
Before:
```
% grep 'ipc.RpcConnection' hbase-server/target/surefire-reports/org.apache.hadoop.hbase.util.compaction.TestMajorCompactor-output.txt | grep -c 'ClientMeta'
17
```
After:
```
% grep 'ipc.RpcConnection' hbase-server/target/surefire-reports/org.apache.hadoop.hbase.util.compaction.TestMajorCompactor-output.txt | grep -c 'ClientMeta'
2
```