### PR TITLE
HBASE-26623 Report CallDroppedException in exception metrics

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSource.java
@@ -43,6 +43,7 @@ public interface ExceptionTrackingSource extends BaseSource {
   String EXCEPTIONS_CALL_QUEUE_TOO_BIG_DESC = "Call queue is full";
   String EXCEPTIONS_QUOTA_EXCEEDED = "exceptions.quotaExceeded";
   String EXCEPTIONS_RPC_THROTTLING = "exceptions.rpcThrottling";
+  String EXCEPTIONS_CALL_DROPPED = "exceptions.callDropped";
 
   void exception();
 
@@ -60,4 +61,5 @@ public interface ExceptionTrackingSource extends BaseSource {
   void callQueueTooBigException();
   void quotaExceededException();
   void rpcThrottlingException();
+  void callDroppedException();
 }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/metrics/ExceptionTrackingSourceImpl.java
@@ -40,6 +40,7 @@ public class ExceptionTrackingSourceImpl extends BaseSourceImpl
   protected MutableFastCounter exceptionsCallQueueTooBig;
   protected MutableFastCounter exceptionsQuotaExceeded;
   protected MutableFastCounter exceptionsRpcThrottling;
+  protected MutableFastCounter exceptionsCallDropped;
 
   public ExceptionTrackingSourceImpl(String metricsName, String metricsDescription,
                                      String metricsContext, String metricsJmxContext) {
@@ -72,6 +73,8 @@ public class ExceptionTrackingSourceImpl extends BaseSourceImpl
       .newCounter(EXCEPTIONS_QUOTA_EXCEEDED, EXCEPTIONS_TYPE_DESC, 0L);
     this.exceptionsRpcThrottling = this.getMetricsRegistry()
       .newCounter(EXCEPTIONS_RPC_THROTTLING, EXCEPTIONS_TYPE_DESC, 0L);
+    this.exceptionsCallDropped = this.getMetricsRegistry()
+      .newCounter(EXCEPTIONS_CALL_DROPPED, EXCEPTIONS_TYPE_DESC, 0L);
   }
 
   @Override
@@ -132,5 +135,10 @@ public class ExceptionTrackingSourceImpl extends BaseSourceImpl
   @Override
   public void rpcThrottlingException() {
     exceptionsRpcThrottling.incr();
+  }
+
+  @Override
+  public void callDroppedException() {
+    exceptionsCallDropped.incr();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
@@ -19,6 +19,7 @@
 
 package org.apache.hadoop.hbase.ipc;
 
+import org.apache.hadoop.hbase.CallDroppedException;
 import org.apache.hadoop.hbase.CallQueueTooBigException;
 import org.apache.hadoop.hbase.MultiActionResultTooLarge;
 import org.apache.hadoop.hbase.NotServingRegionException;
@@ -126,6 +127,8 @@ public class MetricsHBaseServer {
         source.quotaExceededException();
       } else if (throwable instanceof RpcThrottlingException) {
         source.rpcThrottlingException();
+      } else if (throwable instanceof CallDroppedException) {
+        source.callDroppedException();
       } else if (LOG.isDebugEnabled()) {
         LOG.debug("Unknown exception type", throwable);
       }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcMetrics.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
 
 import static org.junit.Assert.*;
 
+import org.apache.hadoop.hbase.CallDroppedException;
 import org.apache.hadoop.hbase.CompatibilityFactory;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.NotServingRegionException;
@@ -143,11 +144,13 @@ public class TestRpcMetrics {
     mrpc.exception(new RegionTooBusyException("Some region"));
     mrpc.exception(new OutOfOrderScannerNextException());
     mrpc.exception(new NotServingRegionException());
+    mrpc.exception(new CallDroppedException());
     HELPER.assertCounter("exceptions.RegionMovedException", 1, serverSource);
     HELPER.assertCounter("exceptions.RegionTooBusyException", 1, serverSource);
     HELPER.assertCounter("exceptions.OutOfOrderScannerNextException", 1, serverSource);
     HELPER.assertCounter("exceptions.NotServingRegionException", 1, serverSource);
-    HELPER.assertCounter("exceptions", 5, serverSource);
+    HELPER.assertCounter("exceptions.CallDroppedException", 1, serverSource);
+    HELPER.assertCounter("exceptions", 6, serverSource);
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcMetrics.java
@@ -149,7 +149,7 @@ public class TestRpcMetrics {
     HELPER.assertCounter("exceptions.RegionTooBusyException", 1, serverSource);
     HELPER.assertCounter("exceptions.OutOfOrderScannerNextException", 1, serverSource);
     HELPER.assertCounter("exceptions.NotServingRegionException", 1, serverSource);
-    HELPER.assertCounter("exceptions.CallDroppedException", 1, serverSource);
+    HELPER.assertCounter("exceptions.callDropped", 1, serverSource);
     HELPER.assertCounter("exceptions", 6, serverSource);
   }
 

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftMetrics.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftMetrics.java
@@ -20,6 +20,7 @@
 package org.apache.hadoop.hbase.thrift;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.CallDroppedException;
 import org.apache.hadoop.hbase.CallQueueTooBigException;
 import org.apache.hadoop.hbase.CompatibilitySingletonFactory;
 import org.apache.hadoop.hbase.MultiActionResultTooLarge;
@@ -154,6 +155,8 @@ public class ThriftMetrics  {
         source.quotaExceededException();
       } else if (throwable instanceof RpcThrottlingException) {
         source.rpcThrottlingException();
+      } else if (throwable instanceof CallDroppedException) {
+        source.callDroppedException();
       } else if (LOG.isDebugEnabled()) {
         LOG.debug("Unknown exception type", throwable);
       }

--- a/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift/ErrorThrowingGetObserver.java
+++ b/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift/ErrorThrowingGetObserver.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Optional;
 
+import org.apache.hadoop.hbase.CallDroppedException;
 import org.apache.hadoop.hbase.CallQueueTooBigException;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
@@ -85,6 +86,8 @@ public class ErrorThrowingGetObserver implements RegionCoprocessor, RegionObserv
           throw new QuotaExceededException("Failing for test");
         case RPC_THROTTLING:
           throw new RpcThrottlingException("Failing for test");
+        case CALL_DROPPED:
+          throw new CallDroppedException("Failing for test");
         default:
           throw new DoNotRetryIOException("Failing for test");
       }
@@ -102,7 +105,8 @@ public class ErrorThrowingGetObserver implements RegionCoprocessor, RegionObserv
     REGION_TOO_BUSY(ExceptionTrackingSource.EXCEPTIONS_BUSY_NAME),
     OUT_OF_ORDER_SCANNER_NEXT(ExceptionTrackingSource.EXCEPTIONS_OOO_NAME),
     QUOTA_EXCEEDED(ExceptionTrackingSource.EXCEPTIONS_QUOTA_EXCEEDED),
-    RPC_THROTTLING(ExceptionTrackingSource.EXCEPTIONS_RPC_THROTTLING);
+    RPC_THROTTLING(ExceptionTrackingSource.EXCEPTIONS_RPC_THROTTLING),
+    CALL_DROPPED(ExceptionTrackingSource.EXCEPTIONS_CALL_DROPPED);
 
     private final String metricName;
 


### PR DESCRIPTION
`CallDroppedException` can be thrown with `CallRunner.drop()` by queue implementations that decide to drop calls to groom the RPC call backlog. The LifoCoDel queue does this I believe and with Pluggable queue it's possible for 3rd party queue implementations to be using `drop()` for similar reasons. It would be nice for the server to be tracking these exceptions in metrics since otherwise you might have to do some extra lifting on the client side.

https://issues.apache.org/jira/browse/HBASE-26623