### PR TITLE
HBASE-26543 correct parsing of shell args with GetoptLong

### DIFF
--- a/hbase-shell/src/main/ruby/jar-bootstrap.rb
+++ b/hbase-shell/src/main/ruby/jar-bootstrap.rb
@@ -78,62 +78,61 @@ def add_to_configuration(c, arg)
   c
 end
 
+_configuration = nil
+
+# strip out any config definitions that won't work with GetoptLong
+D_ARG = '-D'.freeze
+ARGV.delete_if do |arg|
+  unless arg.start_with?(D_ARG) and arg.include?("=")
+    false
+  else
+    _configuration = add_to_configuration(_configuration, arg[2..-1])
+    true
+  end
+end
+
 opts = GetoptLong.new(
   [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
-  [ '--debug', '-d', GetoptLong::OPTIONAL_ARGUMENT ],
-  [ '--noninteractive', '-n', GetoptLong::OPTIONAL_ARGUMENT ],
-  [ '--top-level-defs', GetoptLong::OPTIONAL_ARGUMENT ],
-  [ '--Dkey=value', '-D', GetoptLong::NO_ARGUMENT ]
+  [ '--debug', '-d', GetoptLong::NO_ARGUMENT ],
+  [ '--noninteractive', '-n', GetoptLong::NO_ARGUMENT ],
+  [ '--top-level-defs', GetoptLong::NO_ARGUMENT ],
+  [ '-D', GetoptLong::REQUIRED_ARGUMENT ],
+  [ '--return-values', '-r', GetoptLong::NO_ARGUMENT ]
 )
+opts.ordering = GetoptLong::REQUIRE_ORDER
 
-found = []
 script2run = nil
 log_level = org.apache.log4j.Level::ERROR
 @shell_debug = false
 interactive = true
 top_level_definitions = false
-_configuration = nil
-D_ARG = '-D'.freeze
 
 opts.each do |opt, arg|
-  case opt || arg
-  when '--help' || '-h'
+  case opt
+  when '--help'
     puts cmdline_help
+    exit
   when D_ARG
-    argValue = ARGV.shift || (raise "#{D_ARG} takes a 'key=value' parameter")
-    _configuration = add_to_configuration(_configuration, argValue)
-    found.push(arg)
-    found.push(argValue)
-  when arg.start_with?(D_ARG)
-    _configuration = add_to_configuration(_configuration, arg[2..-1])
-    found.push(arg)
-  when '--debug'|| '-d'
+    _configuration = add_to_configuration(_configuration, arg)
+  when '--debug'
     log_level = org.apache.log4j.Level::DEBUG
     $fullBackTrace = true
     @shell_debug = true
-    found.push(arg)
     puts 'Setting DEBUG log level...'
-   when '--noninteractive'||  '-n'
-     interactive = false
-     found.push(arg)
-   when '--return-values' || 'r'
-     warn '[INFO] the -r | --return-values option is ignored. we always behave '\
+  when '--noninteractive'
+    interactive = false
+  when '--return-values'
+    warn '[INFO] the -r | --return-values option is ignored. we always behave '\
            'as though it was given.'
-     found.push(arg)
-   when '--top-level-defs'
-     top_level_definitions = true
-   else
-      # Presume it a script. Save it off for running later below
-      # after we've set up some environment.
-      script2run = arg
-      found.push(arg)
-      # Presume that any other args are meant for the script.
+  when '--top-level-defs'
+    top_level_definitions = true
   end
 end
 
+if ARGV.length > 0
+  script2run = ARGV.shift
+end
 
-# Delete all processed args
-found.each { |arg| ARGV.delete(arg) }
 # Make sure debug flag gets back to IRB
 ARGV.unshift('-d') if @shell_debug
 

--- a/hbase-shell/src/main/ruby/jar-bootstrap.rb
+++ b/hbase-shell/src/main/ruby/jar-bootstrap.rb
@@ -78,26 +78,26 @@ def add_to_configuration(c, arg)
   c
 end
 
-_configuration = nil
+conf_from_cli = nil
 
 # strip out any config definitions that won't work with GetoptLong
 D_ARG = '-D'.freeze
 ARGV.delete_if do |arg|
-  unless arg.start_with?(D_ARG) and arg.include?("=")
-    false
-  else
-    _configuration = add_to_configuration(_configuration, arg[2..-1])
+  if arg.start_with?(D_ARG) && arg.include?('=')
+    conf_from_cli = add_to_configuration(conf_from_cli, arg[2..-1])
     true
+  else
+    false
   end
 end
 
 opts = GetoptLong.new(
-  [ '--help', '-h', GetoptLong::NO_ARGUMENT ],
-  [ '--debug', '-d', GetoptLong::NO_ARGUMENT ],
-  [ '--noninteractive', '-n', GetoptLong::NO_ARGUMENT ],
-  [ '--top-level-defs', GetoptLong::NO_ARGUMENT ],
-  [ '-D', GetoptLong::REQUIRED_ARGUMENT ],
-  [ '--return-values', '-r', GetoptLong::NO_ARGUMENT ]
+  ['--help', '-h', GetoptLong::NO_ARGUMENT],
+  ['--debug', '-d', GetoptLong::NO_ARGUMENT],
+  ['--noninteractive', '-n', GetoptLong::NO_ARGUMENT],
+  ['--top-level-defs', GetoptLong::NO_ARGUMENT],
+  ['-D', GetoptLong::REQUIRED_ARGUMENT],
+  ['--return-values', '-r', GetoptLong::NO_ARGUMENT]
 )
 opts.ordering = GetoptLong::REQUIRE_ORDER
 
@@ -113,7 +113,7 @@ opts.each do |opt, arg|
     puts cmdline_help
     exit
   when D_ARG
-    _configuration = add_to_configuration(_configuration, arg)
+    conf_from_cli = add_to_configuration(conf_from_cli, arg)
   when '--debug'
     log_level = org.apache.log4j.Level::DEBUG
     $fullBackTrace = true
@@ -129,9 +129,7 @@ opts.each do |opt, arg|
   end
 end
 
-if ARGV.length > 0
-  script2run = ARGV.shift
-end
+script2run = ARGV.shift unless ARGV.empty?
 
 # Make sure debug flag gets back to IRB
 ARGV.unshift('-d') if @shell_debug
@@ -150,7 +148,7 @@ require 'hbase_shell'
 require 'shell/formatter'
 
 # Setup the HBase module.  Create a configuration.
-@hbase = _configuration.nil? ? Hbase::Hbase.new : Hbase::Hbase.new(_configuration)
+@hbase = conf_from_cli.nil? ? Hbase::Hbase.new : Hbase::Hbase.new(conf_from_cli)
 
 # Setup console
 @shell = Shell::Shell.new(@hbase, interactive)


### PR DESCRIPTION
Since Ruby's getoptlong library can't handle config definitions of the form `-Dkey=value`, we preprocess all args to pull out config definitions.

After that preprocessing, the remaining changes correct our use of the getoptlong library so we have the same cli handling as prior to using the getoptlong library.

Local testing, see HBASE-26543 for previous behavior:

```
(base) sbusbey@Seans-MacBook-Pro hbase-3.0.0-alpha-3-SNAPSHOT % cat ~/.irbrc 
puts "reading from ~/.irbrc"
(base) sbusbey@Seans-MacBook-Pro hbase-3.0.0-alpha-3-SNAPSHOT % cat ../tmp/rely_on_argv.rb 
if ARGV.length > 0
  puts "Pulled out cli option for use in script: #{ARGV.shift}"
end
(base) sbusbey@Seans-MacBook-Pro hbase-3.0.0-alpha-3-SNAPSHOT % ./bin/hbase shell ../tmp/rely_on_argv.rb foobar
2022-01-04T17:35:26,106 WARN  [main] util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Pulled out cli option for use in script: foobar

HBase Shell
Use "help" to get list of supported commands.
Use "exit" to quit this interactive shell.
For Reference, please visit: http://hbase.apache.org/book.html#shell
Version 3.0.0-alpha-3-SNAPSHOT, r898b1695e92e89d22d60da69f3c662555ec1eb0a, Mon Jan  3 19:56:35 CST 2022
Took 0.0010 seconds                                                                                                                                                                                                                             
reading from ~/.irbrc
hbase:001:0> exit
(base) sbusbey@Seans-MacBook-Pro hbase-3.0.0-alpha-3-SNAPSHOT % ./bin/hbase shell ../tmp/rely_on_argv.rb foobar -f
2022-01-04T17:36:06,137 WARN  [main] util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Pulled out cli option for use in script: foobar

HBase Shell
Use "help" to get list of supported commands.
Use "exit" to quit this interactive shell.
For Reference, please visit: http://hbase.apache.org/book.html#shell
Version 3.0.0-alpha-3-SNAPSHOT, r898b1695e92e89d22d60da69f3c662555ec1eb0a, Mon Jan  3 19:56:35 CST 2022
Took 0.0011 seconds                                                                                                                                                                                                                             
hbase:001:0> exit
(base) sbusbey@Seans-MacBook-Pro hbase-3.0.0-alpha-3-SNAPSHOT % ./bin/hbase shell -D cats=dee -Dfoo=bar  ../tmp/rely_on_argv.rb foobar -f 
2022-01-04T17:36:41,621 WARN  [main] util.NativeCodeLoader: Unable to load native-hadoop library for your platform... using builtin-java classes where applicable
Pulled out cli option for use in script: foobar

HBase Shell
Use "help" to get list of supported commands.
Use "exit" to quit this interactive shell.
For Reference, please visit: http://hbase.apache.org/book.html#shell
Version 3.0.0-alpha-3-SNAPSHOT, r898b1695e92e89d22d60da69f3c662555ec1eb0a, Mon Jan  3 19:56:35 CST 2022
Took 0.0009 seconds                                                                                                                                                                                                                             
hbase:001:0> p @hbase.configuration.get 'foo'
"bar"
=> "bar"
hbase:002:0> p @hbase.configuration.get 'cats'
"dee"
=> "dee"
hbase:003:0> exit
```