### PR TITLE
HBASE-26590 Hbase-client Meta lookup performance regression between h…

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
@@ -912,7 +912,7 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
     byte[] metaStopKey =
       RegionInfo.createRegionName(tableName, HConstants.EMPTY_START_ROW, "", false);
     Scan s = new Scan().withStartRow(metaStartKey).withStopRow(metaStopKey, true)
-      .addFamily(HConstants.CATALOG_FAMILY).setReversed(true).setCaching(5)
+      .addFamily(HConstants.CATALOG_FAMILY).setReversed(true).setCaching(1)
       .setReadType(ReadType.PREAD);
 
     switch (this.metaReplicaMode) {


### PR DESCRIPTION
…base-1 and hbase-2

Change scan caching back to 1 to avoid extra work at Region Server side. For most cases, the extra 4 results
fetched are wasted at the client side.