### PR TITLE
Backport "HBASE-26474 Implement connection-level attributes" to branch-2

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AbstractRpcBasedConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AbstractRpcBasedConnectionRegistry.java
@@ -273,6 +273,11 @@ abstract class AbstractRpcBasedConnectionRegistry implements ConnectionRegistry 
   }
 
   @Override
+  public String getConnectionString() {
+    return "unimplemented";
+  }
+
+  @Override
   public void close() {
     trace(() -> {
       if (registryEndpointRefresher != null) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
@@ -71,7 +71,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.MasterServ
  * The implementation of AsyncConnection.
  */
 @InterfaceAudience.Private
-class AsyncConnectionImpl implements AsyncConnection {
+public class AsyncConnectionImpl implements AsyncConnection {
 
   private static final Logger LOG = LoggerFactory.getLogger(AsyncConnectionImpl.class);
 
@@ -189,6 +189,14 @@ class AsyncConnectionImpl implements AsyncConnection {
       choreService = new ChoreService("AsyncConn Chore Service");
     }
     return choreService;
+  }
+
+  public User getUser() {
+    return user;
+  }
+
+  public ConnectionRegistry getConnectionRegistry() {
+    return registry;
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ClusterConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ClusterConnection.java
@@ -337,7 +337,7 @@ public interface ClusterConnection extends Connection {
   List<ServerName> getAllBootstrapNodes(ServerName regionServer) throws IOException;
 
   /**
-   * Get the {@link User} associated with this connection. Maybe be {@code null}.
+   * Get the {@link User} associated with this connection. May be {@code null}.
    */
   User getUser();
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ClusterConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ClusterConnection.java
@@ -31,6 +31,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.ZooKeeperConnectionException;
 import org.apache.hadoop.hbase.client.backoff.ClientBackoffPolicy;
 import org.apache.hadoop.hbase.ipc.RpcControllerFactory;
+import org.apache.hadoop.hbase.security.User;
 import org.apache.yetus.audience.InterfaceAudience;
 
 import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.AdminService;
@@ -175,8 +176,7 @@ public interface ClusterConnection extends Connection {
    *   question
    * @throws IOException if a remote or network exception occurs
    */
-  HRegionLocation locateRegion(final byte[] regionName)
-  throws IOException;
+  HRegionLocation locateRegion(final byte[] regionName) throws IOException;
 
   /**
    * Gets the locations of all regions in the specified table, <i>tableName</i>.
@@ -335,4 +335,14 @@ public interface ClusterConnection extends Connection {
    * Get the bootstrap node list of another region server.
    */
   List<ServerName> getAllBootstrapNodes(ServerName regionServer) throws IOException;
+
+  /**
+   * Get the {@link User} associated with this connection. Maybe be {@code null}.
+   */
+  User getUser();
+
+  /**
+   * Get the {@link ConnectionRegistry} used to orient this cluster.
+   */
+  ConnectionRegistry getConnectionRegistry();
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionImplementation.java
@@ -166,7 +166,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.ReplicationProtos.Updat
     value="AT_OPERATION_SEQUENCE_ON_CONCURRENT_ABSTRACTION",
     justification="Access to the conncurrent hash map is under a lock so should be fine.")
 @InterfaceAudience.Private
-class ConnectionImplementation implements ClusterConnection, Closeable {
+public class ConnectionImplementation implements ClusterConnection, Closeable {
   public static final String RETRIES_BY_SERVER_KEY = "hbase.client.retries.by.server";
   private static final Logger LOG = LoggerFactory.getLogger(ConnectionImplementation.class);
 
@@ -511,6 +511,16 @@ class ConnectionImplementation implements ClusterConnection, Closeable {
   @Override
   public MetricsConnection getConnectionMetrics() {
     return this.metrics;
+  }
+
+  @Override
+  public User getUser() {
+    return user;
+  }
+
+  @Override
+  public ConnectionRegistry getConnectionRegistry() {
+    return registry;
   }
 
   private ThreadPoolExecutor getBatchPool() {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionRegistry.java
@@ -29,7 +29,7 @@ import org.apache.yetus.audience.InterfaceAudience;
  * Internal use only.
  */
 @InterfaceAudience.Private
-interface ConnectionRegistry extends Closeable {
+public interface ConnectionRegistry extends Closeable {
 
   /**
    * Get the location of meta region(s).
@@ -47,6 +47,13 @@ interface ConnectionRegistry extends Closeable {
    * Get the address of active HMaster.
    */
   CompletableFuture<ServerName> getActiveMaster();
+
+  /**
+   * Return the connection string associated with this registry instance. This value is
+   * informational, used for annotating traces. Values returned may not be valid for establishing a
+   * working cluster connection.
+   */
+  String getConnectionString();
 
   /**
    * Closes this instance and releases any system resources associated with it

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HRegionLocator.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HRegionLocator.java
@@ -18,18 +18,26 @@
 */
 package org.apache.hadoop.hbase.client;
 
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.REGION_NAMES_KEY;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.StatusCode;
+import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
 import java.util.List;
+import java.util.Objects;
+import java.util.function.Function;
+import java.util.function.Supplier;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.trace.TableSpanBuilder;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.hbase.thirdparty.org.apache.commons.collections4.CollectionUtils;
 
 /**
  * An implementation of {@link RegionLocator}. Used to view region location information for a single
@@ -62,41 +70,47 @@ public class HRegionLocator implements RegionLocator {
   @Override
   public HRegionLocation getRegionLocation(byte[] row, int replicaId, boolean reload)
     throws IOException {
-    return TraceUtil.trace(() -> connection.locateRegion(tableName, row, !reload, true, replicaId)
-      .getRegionLocation(replicaId), () -> TraceUtil
-      .createTableSpan(getClass().getSimpleName() + ".getRegionLocation", tableName));
+    final Supplier<Span> supplier = new TableSpanBuilder(connection)
+      .setName("HRegionLocator.getRegionLocation")
+      .setTableName(tableName);
+    return tracedLocationFuture(
+      () -> connection.locateRegion(tableName, row, !reload, true, replicaId)
+        .getRegionLocation(replicaId),
+      AsyncRegionLocator::getRegionNames,
+      supplier);
   }
 
   @Override
   public List<HRegionLocation> getRegionLocations(byte[] row, boolean reload) throws IOException {
-    return TraceUtil.trace(() -> {
-      RegionLocations locs =
-        connection.locateRegion(tableName, row, !reload, true, RegionInfo.DEFAULT_REPLICA_ID);
-      return Arrays.asList(locs.getRegionLocations());
-    }, () -> TraceUtil
-      .createTableSpan(getClass().getSimpleName() + ".getRegionLocations", tableName));
+    final Supplier<Span> supplier = new TableSpanBuilder(connection)
+      .setName("HRegionLocator.getRegionLocations")
+      .setTableName(tableName);
+    final RegionLocations locs = tracedLocationFuture(
+      () -> connection.locateRegion(tableName, row, !reload, true,
+        RegionInfo.DEFAULT_REPLICA_ID),
+      AsyncRegionLocator::getRegionNames, supplier);
+    return Arrays.asList(locs.getRegionLocations());
   }
 
   @Override
   public List<HRegionLocation> getAllRegionLocations() throws IOException {
-    return TraceUtil.trace(() -> {
-      ArrayList<HRegionLocation> regions = new ArrayList<>();
-      for (RegionLocations locations : listRegionLocations()) {
-        for (HRegionLocation location : locations.getRegionLocations()) {
-          regions.add(location);
-        }
-        connection.cacheLocation(tableName, locations);
-      }
-      return regions;
-    }, () -> TraceUtil
-      .createTableSpan(getClass().getSimpleName() + ".getAllRegionLocations", tableName));
+    final Supplier<Span> supplier = new TableSpanBuilder(connection)
+      .setName("HRegionLocator.getAllRegionLocations")
+      .setTableName(tableName);
+    final RegionLocations locs = tracedLocationFuture(() -> {
+      final RegionLocations rlocs = listRegionLocations();
+      connection.cacheLocation(tableName, rlocs);
+      return rlocs;
+    }, AsyncRegionLocator::getRegionNames, supplier);
+    return Arrays.asList(locs.getRegionLocations());
   }
 
   @Override
   public void clearRegionLocationCache() {
-    TraceUtil.trace(() ->
-      connection.clearRegionCache(tableName), () -> TraceUtil
-      .createTableSpan(this.getClass().getSimpleName() + ".clearRegionLocationCache", tableName));
+    final Supplier<Span> supplier = new TableSpanBuilder(connection)
+      .setName("HRegionLocator.clearRegionLocationCache")
+      .setTableName(tableName);
+    TraceUtil.trace(() -> connection.clearRegionCache(tableName), supplier);
   }
 
   @Override
@@ -104,10 +118,9 @@ public class HRegionLocator implements RegionLocator {
     return this.tableName;
   }
 
-  private List<RegionLocations> listRegionLocations() throws IOException {
+  private RegionLocations listRegionLocations() throws IOException {
     if (TableName.isMetaTableName(tableName)) {
-      return Collections
-        .singletonList(connection.locateRegion(tableName, HConstants.EMPTY_START_ROW, false, true));
+      return connection.locateRegion(tableName, HConstants.EMPTY_START_ROW, false, true);
     }
     final List<RegionLocations> regions = new ArrayList<>();
     MetaTableAccessor.Visitor visitor = new MetaTableAccessor.TableVisitorBase(tableName) {
@@ -122,6 +135,37 @@ public class HRegionLocator implements RegionLocator {
       }
     };
     MetaTableAccessor.scanMetaForTableRegions(connection, visitor, tableName);
-    return regions;
+    return consolidate(regions);
+  }
+
+  private static RegionLocations consolidate(final List<RegionLocations> locations) {
+    final HRegionLocation[] consolidated = locations.stream()
+      .filter(Objects::nonNull)
+      .flatMap(locs -> Arrays.stream(locs.getRegionLocations()))
+      .filter(Objects::nonNull)
+      .toArray(HRegionLocation[]::new);
+    return new RegionLocations(consolidated);
+  }
+
+  private <T> T tracedLocationFuture(
+    TraceUtil.IOExceptionCallable<T> action,
+    Function<T, List<String>> getRegionNames,
+    Supplier<Span> spanSupplier
+  ) throws IOException {
+    final Span span = spanSupplier.get();
+    try (Scope ignored = span.makeCurrent()) {
+      final T result = action.call();
+      final List<String> regionNames = getRegionNames.apply(result);
+      if (!CollectionUtils.isEmpty(regionNames)) {
+        span.setAttribute(REGION_NAMES_KEY, regionNames);
+      }
+      span.setStatus(StatusCode.OK);
+      span.end();
+      return result;
+    } catch (IOException e) {
+      TraceUtil.setError(span, e);
+      span.end();
+      throw e;
+    }
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MasterRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MasterRegistry.java
@@ -87,9 +87,12 @@ public class MasterRegistry extends AbstractRpcBasedConnectionRegistry {
     return masterAddrs;
   }
 
+  private final String connectionString;
+
   MasterRegistry(Configuration conf) throws IOException {
     super(conf, MASTER_REGISTRY_HEDGED_REQS_FANOUT_KEY, MASTER_REGISTRY_INITIAL_REFRESH_DELAY_SECS,
       MASTER_REGISTRY_PERIODIC_REFRESH_INTERVAL_SECS, MASTER_REGISTRY_MIN_SECS_BETWEEN_REFRESHES);
+    connectionString = getConnectionString(conf);
   }
 
   @Override
@@ -100,6 +103,15 @@ public class MasterRegistry extends AbstractRpcBasedConnectionRegistry {
   @Override
   protected CompletableFuture<Set<ServerName>> fetchEndpoints() {
     return getMasters();
+  }
+
+  @Override
+  public String getConnectionString() {
+    return connectionString;
+  }
+
+  static String getConnectionString(Configuration conf) throws UnknownHostException {
+    return getMasterAddr(conf);
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
@@ -261,7 +261,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
   }
 
   private TableOperationSpanBuilder newTableOperationSpanBuilder() {
-    return new TableOperationSpanBuilder().setTableName(tableName);
+    return new TableOperationSpanBuilder(conn).setTableName(tableName);
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ZKConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ZKConnectionRegistry.java
@@ -248,6 +248,13 @@ class ZKConnectionRegistry implements ConnectionRegistry {
   }
 
   @Override
+  public String getConnectionString() {
+    final String serverList = zk.getConnectString();
+    final String baseZNode = znodePaths.baseZNode;
+    return serverList + ":" + baseZNode;
+  }
+
+  @Override
   public void close() {
     zk.close();
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/ConnectionSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/ConnectionSpanBuilder.java
@@ -1,0 +1,107 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.client.trace;
+
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_CONNECTION_STRING;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_SYSTEM;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_SYSTEM_VALUE;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_USER;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+import java.util.function.Supplier;
+import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
+import org.apache.hadoop.hbase.client.ClusterConnection;
+import org.apache.hadoop.hbase.client.ConnectionImplementation;
+import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Construct {@link Span} instances originating from the client side of a connection.
+ */
+@InterfaceAudience.Private
+public class ConnectionSpanBuilder implements Supplier<Span> {
+
+  private String name;
+  private final Map<AttributeKey<?>, Object> attributes = new HashMap<>();
+
+  public ConnectionSpanBuilder(final AsyncConnectionImpl conn) {
+    populateConnectionAttributes(attributes, conn);
+  }
+
+  @Override
+  public Span get() {
+    return build();
+  }
+
+  public ConnectionSpanBuilder setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public <T> ConnectionSpanBuilder addAttribute(final AttributeKey<T> key, T value) {
+    attributes.put(key, value);
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Span build() {
+    final SpanBuilder builder = TraceUtil.getGlobalTracer()
+      .spanBuilder(name)
+      // TODO: what about clients embedded in Master/RegionServer/Gateways/&c?
+      .setSpanKind(SpanKind.CLIENT);
+    attributes.forEach((k, v) -> builder.setAttribute((AttributeKey<? super Object>) k, v));
+    return builder.startSpan();
+  }
+
+  /**
+   * @see #populateConnectionAttributes(Map, AsyncConnectionImpl)
+   */
+  static void populateConnectionAttributes(
+    final Map<AttributeKey<?>, Object> attributes,
+    final ClusterConnection conn
+  ) {
+    attributes.put(DB_SYSTEM, DB_SYSTEM_VALUE);
+    attributes.put(DB_CONNECTION_STRING, conn.getConnectionRegistry().getConnectionString());
+    attributes.put(DB_USER, Optional.ofNullable(conn.getUser())
+      .map(Object::toString)
+      .orElse(null));
+  }
+
+  /**
+   * Static utility method that performs the primary logic of this builder. It is visible to other
+   * classes in this package so that other builders can use this functionality as a mix-in.
+   * @param attributes the attributes map to be populated.
+   * @param conn the source of attribute values.
+   */
+  static void populateConnectionAttributes(
+    final Map<AttributeKey<?>, Object> attributes,
+    final AsyncConnectionImpl conn
+  ) {
+    attributes.put(DB_SYSTEM, DB_SYSTEM_VALUE);
+    attributes.put(DB_CONNECTION_STRING, conn.getConnectionRegistry().getConnectionString());
+    attributes.put(DB_USER, Optional.ofNullable(conn.getUser())
+      .map(Object::toString)
+      .orElse(null));
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/ConnectionSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/ConnectionSpanBuilder.java
@@ -32,7 +32,6 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
 import org.apache.hadoop.hbase.client.ClusterConnection;
-import org.apache.hadoop.hbase.client.ConnectionImplementation;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.yetus.audience.InterfaceAudience;
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableOperationSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableOperationSpanBuilder.java
@@ -18,10 +18,7 @@
 
 package org.apache.hadoop.hbase.client.trace;
 
-import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_NAME;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_OPERATION;
-import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
-import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanBuilder;
@@ -32,7 +29,10 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
 import org.apache.hadoop.hbase.client.CheckAndMutate;
+import org.apache.hadoop.hbase.client.ClusterConnection;
+import org.apache.hadoop.hbase.client.ConnectionImplementation;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Increment;
@@ -46,8 +46,8 @@ import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
- * Construct {@link io.opentelemetry.api.trace.Span} instances originating from
- * "table operations" -- the verbs in our public API that interact with data in tables.
+ * Construct {@link Span} instances originating from "table operations" -- the verbs in our public
+ * API that interact with data in tables.
  */
 @InterfaceAudience.Private
 public class TableOperationSpanBuilder implements Supplier<Span> {
@@ -60,7 +60,16 @@ public class TableOperationSpanBuilder implements Supplier<Span> {
   private TableName tableName;
   private final Map<AttributeKey<?>, Object> attributes = new HashMap<>();
 
-  @Override public Span get() {
+  public TableOperationSpanBuilder(final ClusterConnection conn) {
+    ConnectionSpanBuilder.populateConnectionAttributes(attributes, conn);
+  }
+
+  public TableOperationSpanBuilder(final AsyncConnectionImpl conn) {
+    ConnectionSpanBuilder.populateConnectionAttributes(attributes, conn);
+  }
+
+  @Override
+  public Span get() {
     return build();
   }
 
@@ -84,9 +93,7 @@ public class TableOperationSpanBuilder implements Supplier<Span> {
 
   public TableOperationSpanBuilder setTableName(final TableName tableName) {
     this.tableName = tableName;
-    attributes.put(NAMESPACE_KEY, tableName.getNamespaceAsString());
-    attributes.put(DB_NAME, tableName.getNamespaceAsString());
-    attributes.put(TABLE_KEY, tableName.getNameAsString());
+    TableSpanBuilder.populateTableNameAttributes(attributes, tableName);
     return this;
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableOperationSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableOperationSpanBuilder.java
@@ -32,7 +32,6 @@ import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
 import org.apache.hadoop.hbase.client.CheckAndMutate;
 import org.apache.hadoop.hbase.client.ClusterConnection;
-import org.apache.hadoop.hbase.client.ConnectionImplementation;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Increment;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableSpanBuilder.java
@@ -1,0 +1,99 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.client.trace;
+
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_NAME;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
+import io.opentelemetry.api.common.AttributeKey;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.api.trace.SpanBuilder;
+import io.opentelemetry.api.trace.SpanKind;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.function.Supplier;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
+import org.apache.hadoop.hbase.client.ClusterConnection;
+import org.apache.hadoop.hbase.trace.TraceUtil;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Construct {@link Span} instances involving data tables.
+ */
+@InterfaceAudience.Private
+public class TableSpanBuilder implements Supplier<Span> {
+
+  private String name;
+  private SpanKind spanKind = SpanKind.CLIENT;
+  private final Map<AttributeKey<?>, Object> attributes = new HashMap<>();
+
+  public TableSpanBuilder(ClusterConnection conn) {
+    ConnectionSpanBuilder.populateConnectionAttributes(attributes, conn);
+  }
+
+  public TableSpanBuilder(AsyncConnectionImpl conn) {
+    ConnectionSpanBuilder.populateConnectionAttributes(attributes, conn);
+  }
+
+  @Override
+  public Span get() {
+    return build();
+  }
+
+  public TableSpanBuilder setName(final String name) {
+    this.name = name;
+    return this;
+  }
+
+  public TableSpanBuilder setSpanKind(final SpanKind spanKind) {
+    this.spanKind = spanKind;
+    return this;
+  }
+
+  public TableSpanBuilder setTableName(final TableName tableName) {
+    populateTableNameAttributes(attributes, tableName);
+    return this;
+  }
+
+  @SuppressWarnings("unchecked")
+  public Span build() {
+    final SpanBuilder builder = TraceUtil.getGlobalTracer()
+      .spanBuilder(name)
+      // TODO: what about clients embedded in Master/RegionServer/Gateways/&c?
+      .setSpanKind(spanKind);
+    attributes.forEach((k, v) -> builder.setAttribute((AttributeKey<? super Object>) k, v));
+    return builder.startSpan();
+  }
+
+  /**
+   * Static utility method that performs the primary logic of this builder. It is visible to other
+   * classes in this package so that other builders can use this functionality as a mix-in.
+   * @param attributes the attributes map to be populated.
+   * @param tableName the source of attribute values.
+   */
+  static void populateTableNameAttributes(
+    final Map<AttributeKey<?>, Object> attributes,
+    final TableName tableName
+  ) {
+    attributes.put(NAMESPACE_KEY, tableName.getNamespaceAsString());
+    attributes.put(DB_NAME, tableName.getNamespaceAsString());
+    attributes.put(TABLE_KEY, tableName.getNameAsString());
+  }
+}

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/DoNothingConnectionRegistry.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/DoNothingConnectionRegistry.java
@@ -48,6 +48,11 @@ class DoNothingConnectionRegistry implements ConnectionRegistry {
   }
 
   @Override
+  public String getConnectionString() {
+    return "nothing";
+  }
+
+  @Override
   public void close() {
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocatorTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocatorTracing.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -17,13 +17,25 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import static org.junit.Assert.assertEquals;
-
+import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntry;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntryWithStringValuesOf;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasAttributes;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasKind;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildConnectionAttributesMatcher;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildTableAttributesMatcher;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.Matchers.hasItem;
+import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
-import java.util.List;
+import java.util.Arrays;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
@@ -31,6 +43,7 @@ import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.MatcherPredicate;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
@@ -38,24 +51,26 @@ import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
-import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
+import org.hamcrest.Matcher;
 import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.apache.hbase.thirdparty.com.google.common.io.Closeables;
 
 @Category({ ClientTests.class, MediumTests.class })
 public class TestAsyncRegionLocatorTracing {
+  private static final Logger LOG = LoggerFactory.getLogger(TestAsyncRegionLocatorTracing.class);
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestAsyncRegionLocatorTracing.class);
 
-  private static Configuration CONF = HBaseConfiguration.create();
+  private static final Configuration CONF = HBaseConfiguration.create();
 
   private AsyncConnectionImpl conn;
 
@@ -89,16 +104,35 @@ public class TestAsyncRegionLocatorTracing {
   }
 
   private SpanData waitSpan(String name) {
-    Waiter.waitFor(CONF, 1000,
-      () -> traceRule.getSpans().stream().map(SpanData::getName).anyMatch(s -> s.equals(name)));
-    return traceRule.getSpans().stream().filter(s -> s.getName().equals(name)).findFirst().get();
+    return waitSpan(hasName(name));
+  }
+
+  private SpanData waitSpan(Matcher<SpanData> matcher) {
+    Matcher<SpanData> spanLocator = allOf(matcher, hasEnded());
+    try {
+      Waiter.waitFor(CONF, 1000, new MatcherPredicate<>(
+        "waiting for span",
+        () -> traceRule.getSpans(), hasItem(spanLocator)));
+    } catch (AssertionError e) {
+      LOG.error("AssertionError while waiting for matching span. Span reservoir contains: {}",
+        traceRule.getSpans());
+      throw e;
+    }
+    return traceRule.getSpans()
+      .stream()
+      .filter(spanLocator::matches)
+      .findFirst()
+      .orElseThrow(AssertionError::new);
   }
 
   @Test
   public void testClearCache() {
     conn.getLocator().clearCache();
     SpanData span = waitSpan("AsyncRegionLocator.clearCache");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn)));
   }
 
   @Test
@@ -106,19 +140,22 @@ public class TestAsyncRegionLocatorTracing {
     ServerName sn = ServerName.valueOf("127.0.0.1", 12345, System.currentTimeMillis());
     conn.getLocator().clearCache(sn);
     SpanData span = waitSpan("AsyncRegionLocator.clearCache");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(sn.toString(), span.getAttributes().get(HBaseSemanticAttributes.SERVER_NAME_KEY));
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn),
+      hasAttributes(containsEntry("db.hbase.server.name", sn.getServerName()))));
   }
 
   @Test
   public void testClearCacheTableName() {
     conn.getLocator().clearCache(TableName.META_TABLE_NAME);
     SpanData span = waitSpan("AsyncRegionLocator.clearCache");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
-    assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn),
+      buildTableAttributesMatcher(TableName.META_TABLE_NAME)));
   }
 
   @Test
@@ -126,15 +163,14 @@ public class TestAsyncRegionLocatorTracing {
     conn.getLocator().getRegionLocation(TableName.META_TABLE_NAME, HConstants.EMPTY_START_ROW,
       RegionLocateType.CURRENT, TimeUnit.SECONDS.toNanos(1)).join();
     SpanData span = waitSpan("AsyncRegionLocator.getRegionLocation");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
-    assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
-    List<String> regionNames = span.getAttributes().get(HBaseSemanticAttributes.REGION_NAMES_KEY);
-    assertEquals(1, regionNames.size());
-    assertEquals(locs.getDefaultRegionLocation().getRegion().getRegionNameAsString(),
-      regionNames.get(0));
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn),
+      buildTableAttributesMatcher(TableName.META_TABLE_NAME),
+      hasAttributes(
+        containsEntryWithStringValuesOf("db.hbase.regions",
+          locs.getDefaultRegionLocation().getRegion().getRegionNameAsString()))));
   }
 
   @Test
@@ -142,16 +178,16 @@ public class TestAsyncRegionLocatorTracing {
     conn.getLocator().getRegionLocations(TableName.META_TABLE_NAME, HConstants.EMPTY_START_ROW,
       RegionLocateType.CURRENT, false, TimeUnit.SECONDS.toNanos(1)).join();
     SpanData span = waitSpan("AsyncRegionLocator.getRegionLocations");
-    assertEquals(StatusCode.OK, span.getStatus().getStatusCode());
-    assertEquals(TableName.META_TABLE_NAME.getNamespaceAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
-    assertEquals(TableName.META_TABLE_NAME.getNameAsString(),
-      span.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
-    List<String> regionNames = span.getAttributes().get(HBaseSemanticAttributes.REGION_NAMES_KEY);
-    assertEquals(3, regionNames.size());
-    for (int i = 0; i < 3; i++) {
-      assertEquals(locs.getRegionLocation(i).getRegion().getRegionNameAsString(),
-        regionNames.get(i));
-    }
+    String[] expectedRegions = Arrays.stream(locs.getRegionLocations())
+      .map(HRegionLocation::getRegion)
+      .map(RegionInfo::getRegionNameAsString)
+      .toArray(String[]::new);
+    assertThat(span, allOf(
+      hasStatusWithCode(StatusCode.OK),
+      hasKind(SpanKind.CLIENT),
+      buildConnectionAttributesMatcher(conn),
+      buildTableAttributesMatcher(TableName.META_TABLE_NAME),
+      hasAttributes(
+        containsEntryWithStringValuesOf("db.hbase.regions", containsInAnyOrder(expectedRegions)))));
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
@@ -23,11 +23,12 @@ import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.has
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasKind;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildConnectionAttributesMatcher;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildTableAttributesMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
-import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -57,6 +58,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.filter.PrefixFilter;
 import org.apache.hadoop.hbase.ipc.HBaseRpcController;
+import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
@@ -99,7 +101,7 @@ public class TestAsyncTableTracing {
 
   private ClientService.Interface stub;
 
-  private AsyncConnection conn;
+  private AsyncConnectionImpl conn;
 
   private AsyncTable<?> table;
 
@@ -197,8 +199,9 @@ public class TestAsyncTableTracing {
         return null;
       }
     }).when(stub).get(any(HBaseRpcController.class), any(GetRequest.class), any());
+    final User user = UserProvider.instantiate(CONF).getCurrent();
     conn = new AsyncConnectionImpl(CONF, new DoNothingConnectionRegistry(CONF), "test",
-      UserProvider.instantiate(CONF).getCurrent()) {
+      user) {
 
       @Override
       AsyncRegionLocator getLocator() {
@@ -236,22 +239,13 @@ public class TestAsyncTableTracing {
     Closeables.close(conn, true);
   }
 
-  /**
-   * All {@link Span}s generated from table data access operations over {@code tableName} should
-   * include these attributes.
-   */
-  static Matcher<SpanData> buildBaseAttributesMatcher(TableName tableName) {
-    return hasAttributes(allOf(
-      containsEntry("db.name", tableName.getNamespaceAsString()),
-      containsEntry("db.hbase.namespace", tableName.getNamespaceAsString()),
-      containsEntry("db.hbase.table", tableName.getNameAsString())));
-  }
-
   private void assertTrace(String tableOperation) {
     assertTrace(tableOperation, new IsAnything<>());
   }
 
   private void assertTrace(String tableOperation, Matcher<SpanData> matcher) {
+    // n.b. this method implementation must match the one of the same name found in
+    // TestHTableTracing
     final TableName tableName = table.getName();
     final Matcher<SpanData> spanLocator = allOf(
       hasName(containsString(tableOperation)), hasEnded());
@@ -269,7 +263,8 @@ public class TestAsyncTableTracing {
       hasName(expectedName),
       hasKind(SpanKind.CLIENT),
       hasStatusWithCode(StatusCode.OK),
-      buildBaseAttributesMatcher(tableName),
+      buildConnectionAttributesMatcher(conn),
+      buildTableAttributesMatcher(tableName),
       matcher));
   }
 
@@ -523,17 +518,5 @@ public class TestAsyncTableTracing {
   public void testBatchAll() {
     table.batchAll(Arrays.asList(new Delete(Bytes.toBytes(0)))).join();
     assertTrace("BATCH");
-  }
-
-  @Test
-  public void testConnClose() throws IOException {
-    conn.close();
-    Waiter.waitFor(CONF, 1000,
-      () -> traceRule.getSpans().stream()
-        .anyMatch(span -> span.getName().equals("AsyncConnection.close") &&
-          span.getKind() == SpanKind.INTERNAL && span.hasEnded()));
-    SpanData data = traceRule.getSpans().stream()
-      .filter(s -> s.getName().equals("AsyncConnection.close")).findFirst().get();
-    assertEquals(StatusCode.OK, data.getStatus().getStatusCode());
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntry;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasAttributes;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasKind;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
@@ -35,7 +33,6 @@ import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.doAnswer;
 import static org.mockito.Mockito.mock;
-import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestHTableTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestHTableTracing.java
@@ -17,11 +17,12 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import static org.apache.hadoop.hbase.client.TestAsyncTableTracing.buildBaseAttributesMatcher;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasKind;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildConnectionAttributesMatcher;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildTableAttributesMatcher;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
@@ -238,6 +239,8 @@ public class TestHTableTracing extends TestTracingBase {
   }
 
   private void assertTrace(String tableOperation, Matcher<SpanData> matcher) {
+    // n.b. this method implementation must match the one of the same name found in
+    // TestAsyncTableTracing
     final TableName tableName = table.getName();
     final Matcher<SpanData> spanLocator = allOf(
       hasName(containsString(tableOperation)), hasEnded());
@@ -255,7 +258,8 @@ public class TestHTableTracing extends TestTracingBase {
       hasName(expectedName),
       hasKind(SpanKind.CLIENT),
       hasStatusWithCode(StatusCode.OK),
-      buildBaseAttributesMatcher(tableName),
+      buildConnectionAttributesMatcher(conn),
+      buildTableAttributesMatcher(tableName),
       matcher));
   }
 

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
@@ -22,6 +22,7 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
+import java.util.Arrays;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -46,6 +47,17 @@ public final class AttributesMatchers {
 
   public static Matcher<Attributes> containsEntry(String key, String value) {
     return containsEntry(AttributeKey.stringKey(key), value);
+  }
+
+  public static Matcher<Attributes> containsEntryWithStringValuesOf(String key, String... values) {
+    return containsEntry(AttributeKey.stringArrayKey(key), Arrays.asList(values));
+  }
+
+  public static Matcher<Attributes> containsEntryWithStringValuesOf(
+    String key,
+    Matcher<Iterable<? extends String>> matcher
+  ) {
+    return new IsAttributesContaining<>(equalTo(AttributeKey.stringArrayKey(key)), matcher);
   }
 
   private static final class IsAttributesContaining<T> extends TypeSafeMatcher<Attributes> {

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
@@ -43,6 +43,7 @@ public final class TraceTestUtil {
   }
 
   /**
+   * All {@link Span}s involving {@code conn} should include these attributes.
    * @see #buildConnectionAttributesMatcher(AsyncConnectionImpl)
    */
   public static Matcher<SpanData> buildConnectionAttributesMatcher(ConnectionImplementation conn) {

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.client.trace.hamcrest;
+
+import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntry;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasAttributes;
+import static org.hamcrest.Matchers.allOf;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.sdk.trace.data.SpanData;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.AsyncConnectionImpl;
+import org.apache.hadoop.hbase.client.ConnectionImplementation;
+import org.hamcrest.Matcher;
+
+public final class TraceTestUtil {
+
+  private TraceTestUtil() { }
+
+  /**
+   * All {@link Span}s involving {@code conn} should include these attributes.
+   */
+  public static Matcher<SpanData> buildConnectionAttributesMatcher(AsyncConnectionImpl conn) {
+    return hasAttributes(allOf(
+      containsEntry("db.system", "hbase"),
+      containsEntry("db.connection_string", "nothing"),
+      containsEntry("db.user", conn.getUser().toString())));
+  }
+
+  /**
+   * @see #buildConnectionAttributesMatcher(AsyncConnectionImpl)
+   */
+  public static Matcher<SpanData> buildConnectionAttributesMatcher(ConnectionImplementation conn) {
+    return hasAttributes(allOf(
+      containsEntry("db.system", "hbase"),
+      containsEntry("db.connection_string", "nothing"),
+      containsEntry("db.user", conn.getUser().toString())));
+  }
+
+  /**
+   * All {@link Span}s involving {@code tableName} should include these attributes.
+   */
+  public static Matcher<SpanData> buildTableAttributesMatcher(TableName tableName) {
+    return hasAttributes(allOf(
+      containsEntry("db.name", tableName.getNamespaceAsString()),
+      containsEntry("db.hbase.namespace", tableName.getNamespaceAsString()),
+      containsEntry("db.hbase.table", tableName.getNameAsString())));
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
@@ -28,6 +28,11 @@ import org.apache.yetus.audience.InterfaceAudience;
 */
 @InterfaceAudience.Private
 public final class HBaseSemanticAttributes {
+  public static final AttributeKey<String> DB_SYSTEM = SemanticAttributes.DB_SYSTEM;
+  public static final String DB_SYSTEM_VALUE = SemanticAttributes.DbSystemValues.HBASE;
+  public static final AttributeKey<String> DB_CONNECTION_STRING =
+    SemanticAttributes.DB_CONNECTION_STRING;
+  public static final AttributeKey<String> DB_USER = SemanticAttributes.DB_USER;
   public static final AttributeKey<String> DB_NAME = SemanticAttributes.DB_NAME;
   public static final AttributeKey<String> NAMESPACE_KEY = SemanticAttributes.DB_HBASE_NAMESPACE;
   public static final AttributeKey<String> DB_OPERATION = SemanticAttributes.DB_OPERATION;

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/TraceUtil.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/TraceUtil.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hbase.trace;
 
-import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
-import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
 import io.opentelemetry.api.GlobalOpenTelemetry;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.SpanKind;
@@ -30,7 +28,6 @@ import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.Version;
 import org.apache.hadoop.hbase.util.FutureUtils;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -50,15 +47,6 @@ public final class TraceUtil {
    */
   public static Span createSpan(String name) {
     return createSpan(name, SpanKind.INTERNAL);
-  }
-
-  /**
-   * Create a {@link SpanKind#INTERNAL} span and set table related attributes.
-   */
-  public static Span createTableSpan(String spanName, TableName tableName) {
-    return createSpan(spanName)
-      .setAttribute(NAMESPACE_KEY, tableName.getNamespaceAsString())
-      .setAttribute(TABLE_KEY, tableName.getNameAsString());
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/RegionServerRegistry.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/RegionServerRegistry.java
@@ -75,6 +75,11 @@ public class RegionServerRegistry implements ConnectionRegistry {
   }
 
   @Override
+  public String getConnectionString() {
+    return "short-circuit";
+  }
+
+  @Override
   public void close() {
     // nothing
   }


### PR DESCRIPTION
Add support for `db.system`, `db.connection_string`, `db.user`.

This is a non-trivial backport of #3952 to branch-2. It's non-trivial because it implements these tracing features on the non-async implementation of HRegionLocator. Please take a look at those changed with a critical reviewer's eye. A diff of the diffs might be useful for reviewers... I don't now if GitHub can produce such a thing.