### PR TITLE
HBASE-26650 Create module hbase-client-test-support

### DIFF
--- a/hbase-client-test-support/pom.xml
+++ b/hbase-client-test-support/pom.xml
@@ -1,0 +1,61 @@
+<?xml version="1.0"?>
+<project xmlns="https://maven.apache.org/POM/4.0.0" xmlns:xsi="https://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://maven.apache.org/POM/4.0.0 https://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+  /**
+   * Licensed to the Apache Software Foundation (ASF) under one
+   * or more contributor license agreements.  See the NOTICE file
+   * distributed with this work for additional information
+   * regarding copyright ownership.  The ASF licenses this file
+   * to you under the Apache License, Version 2.0 (the
+   * "License"); you may not use this file except in compliance
+   * with the License.  You may obtain a copy of the License at
+   *
+   *     http://www.apache.org/licenses/LICENSE-2.0
+   *
+   * Unless required by applicable law or agreed to in writing, software
+   * distributed under the License is distributed on an "AS IS" BASIS,
+   * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   * See the License for the specific language governing permissions and
+   * limitations under the License.
+   */
+  -->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <artifactId>hbase-build-configuration</artifactId>
+    <groupId>org.apache.hbase</groupId>
+    <version>3.0.0-alpha-3-SNAPSHOT</version>
+    <relativePath>../hbase-build-configuration</relativePath>
+  </parent>
+
+  <artifactId>hbase-client-test-support</artifactId>
+  <name>Apache HBase - Client Test Support</name>
+  <description>Test support for code found in the Client module</description>
+
+  <build>
+    <plugins>
+      <plugin>
+        <!--Make it so assembly:single does nothing in here-->
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <skipAssembly>true</skipAssembly>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-common</artifactId>
+    </dependency>
+    <!-- tracing Dependencies -->
+    <dependency>
+      <artifactId>opentelemetry-sdk-trace</artifactId>
+      <groupId>io.opentelemetry</groupId>
+    </dependency>
+    <dependency>
+      <groupId>org.hamcrest</groupId>
+      <artifactId>hamcrest-library</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/hbase-client-test-support/src/main/java/org/apache/hadoop/hbase/trace/hamcrest/AttributesMatchers.java
+++ b/hbase-client-test-support/src/main/java/org/apache/hadoop/hbase/trace/hamcrest/AttributesMatchers.java
@@ -15,7 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hbase.client.trace.hamcrest;
+
+package org.apache.hadoop.hbase.trace.hamcrest;
 
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;

--- a/hbase-client-test-support/src/main/java/org/apache/hadoop/hbase/trace/hamcrest/SpanDataMatchers.java
+++ b/hbase-client-test-support/src/main/java/org/apache/hadoop/hbase/trace/hamcrest/SpanDataMatchers.java
@@ -15,7 +15,8 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.hadoop.hbase.client.trace.hamcrest;
+
+package org.apache.hadoop.hbase.trace.hamcrest;
 
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;

--- a/hbase-client/pom.xml
+++ b/hbase-client/pom.xml
@@ -95,6 +95,11 @@
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-client-test-support</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-protocol-shaded</artifactId>
     </dependency>
     <!-- General dependencies -->

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocatorTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocatorTracing.java
@@ -17,15 +17,15 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntry;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntryWithStringValuesOf;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasAttributes;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasKind;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildConnectionAttributesMatcher;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildTableAttributesMatcher;
+import static org.apache.hadoop.hbase.trace.hamcrest.AttributesMatchers.containsEntry;
+import static org.apache.hadoop.hbase.trace.hamcrest.AttributesMatchers.containsEntryWithStringValuesOf;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasAttributes;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasEnded;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasKind;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasName;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsInAnyOrder;

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasKind;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildConnectionAttributesMatcher;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.TraceTestUtil.buildTableAttributesMatcher;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasEnded;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasKind;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasName;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
@@ -18,8 +18,8 @@
 
 package org.apache.hadoop.hbase.client.trace.hamcrest;
 
-import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntry;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasAttributes;
+import static org.apache.hadoop.hbase.trace.hamcrest.AttributesMatchers.containsEntry;
+import static org.apache.hadoop.hbase.trace.hamcrest.SpanDataMatchers.hasAttributes;
 import static org.hamcrest.Matchers.allOf;
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.sdk.trace.data.SpanData;

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,7 @@
     <module>hbase-asyncfs</module>
     <module>hbase-logging</module>
     <module>hbase-compression</module>
+    <module>hbase-client-test-support</module>
   </modules>
   <scm>
     <connection>scm:git:git://gitbox.apache.org/repos/asf/hbase.git</connection>
@@ -1930,6 +1931,12 @@
         <artifactId>hbase-common</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-client-test-support</artifactId>
+        <version>${project.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>


### PR DESCRIPTION
Move `SpanData` matcher support classes to new module. Probably there are others, but start with these for now.

This is a prerequisite for further progress with the otel effort.