### PR TITLE
Backport "HBASE-26520 Remove use of `db.hbase.namespance` tracing attribute (#4015)" to branch-2.5

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableSpanBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/trace/TableSpanBuilder.java
@@ -19,7 +19,6 @@
 package org.apache.hadoop.hbase.client.trace;
 
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DB_NAME;
-import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.NAMESPACE_KEY;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.TABLE_KEY;
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.trace.Span;
@@ -92,7 +91,6 @@ public class TableSpanBuilder implements Supplier<Span> {
     final Map<AttributeKey<?>, Object> attributes,
     final TableName tableName
   ) {
-    attributes.put(NAMESPACE_KEY, tableName.getNamespaceAsString());
     attributes.put(DB_NAME, tableName.getNamespaceAsString());
     attributes.put(TABLE_KEY, tableName.getNameAsString());
   }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestTracingBase.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestTracingBase.java
@@ -89,7 +89,7 @@ public class TestTracingBase {
 
     if (tableName != null) {
       assertEquals(tableName.getNamespaceAsString(),
-        data.getAttributes().get(HBaseSemanticAttributes.NAMESPACE_KEY));
+        data.getAttributes().get(HBaseSemanticAttributes.DB_NAME));
       assertEquals(tableName.getNameAsString(),
         data.getAttributes().get(HBaseSemanticAttributes.TABLE_KEY));
     }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/TraceTestUtil.java
@@ -59,7 +59,6 @@ public final class TraceTestUtil {
   public static Matcher<SpanData> buildTableAttributesMatcher(TableName tableName) {
     return hasAttributes(allOf(
       containsEntry("db.name", tableName.getNamespaceAsString()),
-      containsEntry("db.hbase.namespace", tableName.getNamespaceAsString()),
       containsEntry("db.hbase.table", tableName.getNameAsString())));
   }
 }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
@@ -34,7 +34,6 @@ public final class HBaseSemanticAttributes {
     SemanticAttributes.DB_CONNECTION_STRING;
   public static final AttributeKey<String> DB_USER = SemanticAttributes.DB_USER;
   public static final AttributeKey<String> DB_NAME = SemanticAttributes.DB_NAME;
-  public static final AttributeKey<String> NAMESPACE_KEY = SemanticAttributes.DB_HBASE_NAMESPACE;
   public static final AttributeKey<String> DB_OPERATION = SemanticAttributes.DB_OPERATION;
   public static final AttributeKey<String> TABLE_KEY = AttributeKey.stringKey("db.hbase.table");
   public static final AttributeKey<List<String>> REGION_NAMES_KEY =


### PR DESCRIPTION
The HBase-specific attribute `db.hbase.namespace` has been deprecated in favor of the generic
`db.name`. See also https://github.com/open-telemetry/opentelemetry-specification/issues/1760

Signed-off-by: Duo Zhang <zhangduo@apache.org>
Signed-off-by: Tak Lon (Stephen) Wu <taklwu@apache.org>