### PR TITLE
HBASE-25955 Setting NAMESPACES when adding a replication peer still requires scope definition at CF level

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/replication/ReplicationPeerConfigUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/replication/ReplicationPeerConfigUtil.java
@@ -290,12 +290,14 @@ public final class ReplicationPeerConfigUtil {
       peer.getTableCfsList().toArray(new ReplicationProtos.TableCF[peer.getTableCfsCount()]));
     if (tableCFsMap != null) {
       builder.setTableCFsMap(tableCFsMap);
+      builder.setChainedFiltersOperation(peer.getChainOperator());
     }
 
     List<ByteString> namespacesList = peer.getNamespacesList();
     if (namespacesList != null && namespacesList.size() != 0) {
       builder.setNamespaces(
         namespacesList.stream().map(ByteString::toStringUtf8).collect(Collectors.toSet()));
+      builder.setChainedFiltersOperation(peer.getChainOperator());
     }
 
     if (peer.hasBandwidth()) {
@@ -357,11 +359,18 @@ public final class ReplicationPeerConfigUtil {
       for (int i = 0; i < tableCFs.length; i++) {
         builder.addTableCfs(tableCFs[i]);
       }
+      if (peerConfig.getChainedFiltersOperator() != null) {
+        builder.setChainOperator(peerConfig.getChainedFiltersOperator());
+      }
+
     }
     Set<String> namespaces = peerConfig.getNamespaces();
     if (namespaces != null) {
       for (String namespace : namespaces) {
         builder.addNamespaces(ByteString.copyFromUtf8(namespace));
+      }
+      if (peerConfig.getChainedFiltersOperator() != null) {
+        builder.setChainOperator(peerConfig.getChainedFiltersOperator());
       }
     }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfig.java
@@ -51,6 +51,7 @@ public class ReplicationPeerConfig {
   private final boolean serial;
   // Used by synchronous replication
   private String remoteWALDir;
+  private String chainedFiltersOperator;
 
   private ReplicationPeerConfig(ReplicationPeerConfigBuilderImpl builder) {
     this.clusterKey = builder.clusterKey;
@@ -71,6 +72,7 @@ public class ReplicationPeerConfig {
     this.bandwidth = builder.bandwidth;
     this.serial = builder.serial;
     this.remoteWALDir = builder.remoteWALDir;
+    this.chainedFiltersOperator = builder.chainedFilterOperatorName;
   }
 
   private Map<TableName, List<String>>
@@ -140,6 +142,10 @@ public class ReplicationPeerConfig {
     return serial;
   }
 
+  public String getChainedFiltersOperator() {
+    return chainedFiltersOperator;
+  }
+
   public static ReplicationPeerConfigBuilder newBuilder(ReplicationPeerConfig peerConfig) {
     ReplicationPeerConfigBuilderImpl builder = new ReplicationPeerConfigBuilderImpl();
     builder.setClusterKey(peerConfig.getClusterKey())
@@ -150,7 +156,8 @@ public class ReplicationPeerConfig {
       .setExcludeTableCFsMap(peerConfig.getExcludeTableCFsMap())
       .setExcludeNamespaces(peerConfig.getExcludeNamespaces())
       .setBandwidth(peerConfig.getBandwidth()).setSerial(peerConfig.isSerial())
-      .setRemoteWALDir(peerConfig.getRemoteWALDir());
+      .setRemoteWALDir(peerConfig.getRemoteWALDir())
+      .setChainedFiltersOperation(peerConfig.getChainedFiltersOperator());
     return builder;
   }
 
@@ -180,6 +187,8 @@ public class ReplicationPeerConfig {
     private boolean serial = false;
 
     private String remoteWALDir = null;
+
+    private String chainedFilterOperatorName;
 
     @Override
     public ReplicationPeerConfigBuilder setClusterKey(String clusterKey) {
@@ -258,6 +267,12 @@ public class ReplicationPeerConfig {
     @Override
     public ReplicationPeerConfigBuilder setRemoteWALDir(String dir) {
       this.remoteWALDir = dir;
+      return this;
+    }
+
+    @Override public ReplicationPeerConfigBuilder setChainedFiltersOperation(
+      String chainedFilterOperation) {
+      this.chainedFilterOperatorName = chainedFilterOperation;
       return this;
     }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfigBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/replication/ReplicationPeerConfigBuilder.java
@@ -166,6 +166,14 @@ public interface ReplicationPeerConfigBuilder {
   ReplicationPeerConfigBuilder setRemoteWALDir(String dir);
 
   /**
+   * Specifies the boolean operator for the chain of WALEntry filters. The "AND" value enforces all
+   * filters on a given entry. The "OR" value needs only one filter to be valid.
+   * @param chainedFiltersOperation the ChainWALEntryFilter operator name.
+   * @return {@code this}
+   */
+  ReplicationPeerConfigBuilder setChainedFiltersOperation(String chainedFiltersOperation);
+
+  /**
    * Builds the configuration object from the current state of {@code this}.
    * @return A {@link ReplicationPeerConfig} instance.
    */

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/Replication.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/Replication.proto
@@ -50,6 +50,7 @@ message ReplicationPeer {
   repeated bytes exclude_namespaces = 10;
   optional bool serial = 11;
   optional string remoteWALDir = 12;
+  optional string chain_operator = 13;
 }
 
 /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/BaseReplicationEndpoint.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/BaseReplicationEndpoint.java
@@ -91,7 +91,8 @@ public abstract class BaseReplicationEndpoint extends AbstractService
         }
       }
     }
-    return filters.isEmpty() ? null : new ChainWALEntryFilter(filters);
+    return filters.isEmpty() ? null :
+      new ChainWALEntryFilter(filters, ctx.getPeerConfig().getChainedFiltersOperator());
   }
 
   /** Returns a WALEntryFilter for checking the scope. Subclasses can

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/NamespaceTableCfWALEntryFilter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/NamespaceTableCfWALEntryFilter.java
@@ -56,8 +56,9 @@ public class NamespaceTableCfWALEntryFilter implements WALEntryFilter, WALCellFi
     if (CellUtil.matchingColumn(cell, WALEdit.METAFAMILY, WALEdit.BULK_LOAD)) {
       // If the cell is about BULKLOAD event, unpack and filter it by BulkLoadCellFilter.
       return bulkLoadFilter.filterCell(cell, fam -> !peerConfig.needToReplicate(tableName, fam));
-    } else {
+    } else if ((!CellUtil.matchingFamily(cell, WALEdit.METAFAMILY))){
       return peerConfig.needToReplicate(tableName, CellUtil.cloneFamily(cell)) ? cell : null;
     }
+    return null;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
@@ -333,7 +333,8 @@ public class ReplicationSource implements ReplicationSourceInterface {
       filters.add(filterFromEndpoint);
     }
     filters.add(new ClusterMarkingEntryFilter(clusterId, peerClusterId, replicationEndpoint));
-    this.walEntryFilter = new ChainWALEntryFilter(filters);
+    this.walEntryFilter = new ChainWALEntryFilter(filters,
+      getPeer().getPeerConfig().getChainedFiltersOperator());
   }
 
   private void tryStartNewShipper(String walGroupId) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWALEntryFilters.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWALEntryFilters.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hbase.testclassification.ReplicationTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.wal.WAL.Entry;
 import org.apache.hadoop.hbase.wal.WALEdit;
 import org.apache.hadoop.hbase.wal.WALKeyImpl;
@@ -273,6 +274,49 @@ public class TestReplicationWALEntryFilters {
   }
 
   @Test
+  public void testChainWALEntryFilterOROperator() {
+    Entry userEntry = createEntry(null, a, b, c);
+    assertEquals(userEntry, testChainOperator(userEntry, "OR"));
+  }
+
+  @Test
+  public void testChainWALEntryFilterANDOperator() {
+    Entry userEntry = createEntry(null, a, b, c);
+    assertEquals(null, testChainOperator(userEntry, "AND"));
+  }
+
+  @Test
+  public void testChainWALEntryFilterNullOperator() {
+    Entry userEntry = createEntry(null, a, b, c);
+    assertEquals(null, testChainOperator(userEntry, null));
+  }
+
+  @Test
+  public void testChainWALEntryFilterEmptyOperator() {
+    Entry userEntry = createEntry(null, a, b, c);
+    assertEquals(null, testChainOperator(userEntry, ""));
+  }
+
+  @Test
+  public void testChainWALEntryFilterNoOperator() {
+    Entry userEntry = createEntry(null, a, b, c);
+    List<WALEntryFilter> filters = new ArrayList<>();
+    filters.add(passFilter);
+    filters.add(nullFilter);
+    ChainWALEntryFilter filter = new ChainWALEntryFilter(filters);
+    assertEquals(null, filter.filter(userEntry));
+  }
+
+
+  private WAL.Entry testChainOperator(Entry userEntry, String operatorName){
+    List<WALEntryFilter> filters = new ArrayList<>();
+    filters.add(passFilter);
+    filters.add(nullFilter);
+    ChainWALEntryFilter filter = new ChainWALEntryFilter(filters, operatorName);
+    return filter.filter(userEntry);
+  }
+
+  @Test
   public void testNamespaceTableCfWALEntryFilter() {
     ReplicationPeer peer = mock(ReplicationPeer.class);
     ReplicationPeerConfigBuilder peerConfigBuilder = ReplicationPeerConfig.newBuilder();
@@ -350,7 +394,7 @@ public class TestReplicationWALEntryFilters {
     assertEquals(null, filter.filter(userEntry));
 
     // 4. replicate_all flag is false, and config namespaces and table-cfs both
-    // Namespaces config should not confict with table-cfs config
+    // Namespaces config should not conflict with table-cfs config
     namespaces = new HashSet<>();
     tableCfs = new HashMap<>();
     namespaces.add("ns1");

--- a/hbase-shell/src/main/ruby/hbase/replication_admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/replication_admin.rb
@@ -67,6 +67,7 @@ module Hbase
         peer_state = args.fetch(STATE, nil)
         remote_wal_dir = args.fetch(REMOTE_WAL_DIR, nil)
         serial = args.fetch(SERIAL, nil)
+        chain_operator = args.fetch(OPERATOR, nil)
 
         # Create and populate a ReplicationPeerConfig
         builder = ReplicationPeerConfig.newBuilder()
@@ -112,6 +113,14 @@ module Hbase
           end
           builder.setReplicateAllUserTables(false)
           builder.set_table_cfs_map(map)
+        end
+
+        unless chain_operator.nil?
+          if 'AND'.eql?(chain_operator) || 'OR'.eql?(chain_operator)
+            builder.setChainedFiltersOperation(chain_operator)
+          else
+            raise(ArgumentError, 'OPERATOR valid values: [AND|OR]')
+          end
         end
 
         enabled = true

--- a/hbase-shell/src/main/ruby/hbase_constants.rb
+++ b/hbase-shell/src/main/ruby/hbase_constants.rb
@@ -72,6 +72,7 @@ module HBaseConstants
   NAMESPACES = 'NAMESPACES'.freeze
   NONE = 'NONE'.freeze
   NUMREGIONS = 'NUMREGIONS'.freeze
+  OPERATOR = 'OPERATOR'.freeze
   POLICY = 'POLICY'.freeze
   PRIORITY = 'PRIORITY'.freeze
   PROPERTIES = 'PROPERTIES'.freeze

--- a/hbase-shell/src/main/ruby/shell/commands/add_peer.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/add_peer.rb
@@ -34,11 +34,14 @@ An optional parameter for namespaces identifies which namespace's tables will be
 to the peer cluster.
 An optional parameter for table column families identifies which tables and/or column families
 will be replicated to the peer cluster.
+An optional parameter for the boolean operator to be applied over different WAL Entry filters. If
+omitted, conjunction (AND) is applied.
 An optional parameter for serial flag identifies whether or not the replication peer is a serial
 replication peer. The default serial flag is false.
 
 Note: Set a namespace in the peer config means that all tables in this namespace
-will be replicated to the peer cluster. So if you already have set a namespace in peer config,
+will be replicated to the peer cluster (If the 'OR' operator has been defined).
+So if you already have set a namespace in peer config,
 then you can't set this namespace's tables in the peer config again.
 
 Examples:
@@ -50,6 +53,8 @@ Examples:
     TABLE_CFS => { "table1" => [], "table2" => ["cf1"], "table3" => ["cf1", "cf2"] }
   hbase> add_peer '2', CLUSTER_KEY => "zk1,zk2,zk3:2182:/hbase-prod",
     NAMESPACES => ["ns1", "ns2", "ns3"]
+  hbase> add_peer '2', CLUSTER_KEY => "zk1,zk2,zk3:2182:/hbase-prod",
+    NAMESPACES => ["ns1", "ns2", "ns3"], OPERATOR => "OR"
   hbase> add_peer '2', CLUSTER_KEY => "zk1,zk2,zk3:2182:/hbase-prod",
     NAMESPACES => ["ns1", "ns2"], TABLE_CFS => { "ns3:table1" => [], "ns3:table2" => ["cf1"] }
   hbase> add_peer '3', CLUSTER_KEY => "zk1,zk2,zk3:2182:/hbase-prod",

--- a/hbase-shell/src/test/ruby/hbase/replication_admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/replication_admin_test.rb
@@ -791,6 +791,39 @@ module Hbase
       command(:remove_peer, @peer_id)
     end
 
+    define_test "add_peer: 'OR' operator" do
+      cluster_key = "server1.cie.com:2181:/hbase"
+
+      args = {CLUSTER_KEY => cluster_key, ENDPOINT_CLASSNAME => @dummy_endpoint, OPERATOR => "OR"}
+      command(:add_peer, @peer_id, args)
+
+      assert_equal(1, command(:list_peers).length)
+
+      # cleanup for future tests
+      command(:remove_peer, @peer_id)
+    end
+
+    define_test "add_peer: 'AND' operator" do
+      cluster_key = "server1.cie.com:2181:/hbase"
+
+      args = {CLUSTER_KEY => cluster_key, ENDPOINT_CLASSNAME => @dummy_endpoint, OPERATOR => "AND"}
+      command(:add_peer, @peer_id, args)
+
+      assert_equal(1, command(:list_peers).length)
+
+      # cleanup for future tests
+      command(:remove_peer, @peer_id)
+    end
+
+    define_test "add_peer: should fail when invalid operator" do
+      cluster_key = "server1.cie.com:2181:/hbase"
+
+      args = {CLUSTER_KEY => cluster_key, ENDPOINT_CLASSNAME => @dummy_endpoint, OPERATOR => "NAND"}
+      assert_raise(ArgumentError) do
+        command(:add_peer, @peer_id, args)
+      end
+    end
+
     # assert_raise fails on native exceptions - https://jira.codehaus.org/browse/JRUBY-5279
     # Can't catch native Java exception with assert_raise in JRuby 1.6.8 as in the test below.
     # define_test "add_peer: adding a second peer with same id should error" do


### PR DESCRIPTION
As mentioned on the jira description, setting either NAMESPACES or TABLECFs when calling add_peer still doesn't suffice to allow entries for the related namespaces/tables to be replicated, if those don't have replication scope set to '1' in the CF descriptor. 
The above happens because ChainWalEntryFilter, currently, applies conjunction (AND) to all its chained filters. Following suggestions from @anoopsjohn on an previous [PR](https://github.com/apache/hbase/pull/3347), rather than changing this behaviour completely, this PR introduces an option to define between conjunction (AND) or disjunction (OR) logic for ChainWalEntryFilter, keeping current logic (AND) the default one, if not specified.