### PR TITLE
HBASE-26667 Integrate user-experience for hbase-client

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionFactory.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionFactory.java
@@ -73,6 +73,9 @@ public class ConnectionFactory {
   public static final String HBASE_CLIENT_ASYNC_CONNECTION_IMPL =
     "hbase.client.async.connection.impl";
 
+  /** Environment variable for OAuth Bearer token */
+  public static final String ENV_OAUTHBEARER_TOKEN = "HADOOP_JWT";
+
   /** No public c.tors */
   protected ConnectionFactory() {
   }
@@ -216,7 +219,9 @@ public class ConnectionFactory {
   public static Connection createConnection(Configuration conf, ExecutorService pool,
       final User user) throws IOException {
 
-    OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user);
+    if (System.getenv().containsKey(ENV_OAUTHBEARER_TOKEN)) {
+      OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user, System.getenv(ENV_OAUTHBEARER_TOKEN));
+    }
 
     Class<?> clazz = conf.getClass(ConnectionUtils.HBASE_CLIENT_CONNECTION_IMPL,
       ConnectionOverAsyncConnection.class, Connection.class);
@@ -298,7 +303,9 @@ public class ConnectionFactory {
           return;
         }
 
-        OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user);
+        if (System.getenv().containsKey(ENV_OAUTHBEARER_TOKEN)) {
+          OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user, System.getenv(ENV_OAUTHBEARER_TOKEN));
+        }
 
         Class<? extends AsyncConnection> clazz = conf.getClass(HBASE_CLIENT_ASYNC_CONNECTION_IMPL,
           AsyncConnectionImpl.class, AsyncConnection.class);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionFactory.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionFactory.java
@@ -74,7 +74,7 @@ public class ConnectionFactory {
     "hbase.client.async.connection.impl";
 
   /** Environment variable for OAuth Bearer token */
-  public static final String ENV_OAUTHBEARER_TOKEN = "HADOOP_JWT";
+  public static final String ENV_OAUTHBEARER_TOKEN = "HBASE_JWT";
 
   /** No public c.tors */
   protected ConnectionFactory() {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/OAuthBearerSaslAuthenticationProvider.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/OAuthBearerSaslAuthenticationProvider.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hbase.security.provider;
 
-import static org.apache.hadoop.hbase.security.token.OAuthBearerTokenUtil.TOKEN_KIND;
+import static org.apache.hadoop.hbase.security.oauthbearer.OAuthBearerUtils.TOKEN_KIND;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.yetus.audience.InterfaceAudience;
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/OAuthBearerSaslProviderSelector.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/OAuthBearerSaslProviderSelector.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hbase.security.provider;
 
-import static org.apache.hadoop.hbase.security.token.OAuthBearerTokenUtil.TOKEN_KIND;
+import static org.apache.hadoop.hbase.security.oauthbearer.OAuthBearerUtils.TOKEN_KIND;
 import java.util.Collection;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
@@ -35,8 +35,7 @@ public class OAuthBearerSaslProviderSelector extends BuiltInProviderSelector {
 
   private static final Logger LOG = LoggerFactory.getLogger(OAuthBearerSaslProviderSelector.class);
 
-  private final Text OAUTHBEARER_TOKEN_KIND_TEXT =
-    new Text(TOKEN_KIND);
+  private final Text OAUTHBEARER_TOKEN_KIND_TEXT = new Text(TOKEN_KIND);
   private OAuthBearerSaslClientAuthenticationProvider oauthbearer;
 
   @Override public void configure(Configuration conf,

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/OAuthBearerTokenUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/OAuthBearerTokenUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.hbase.security.token;
 
+import static org.apache.hadoop.hbase.client.ConnectionFactory.ENV_OAUTHBEARER_TOKEN;
 import static org.apache.hadoop.hbase.security.oauthbearer.OAuthBearerUtils.TOKEN_KIND;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
@@ -84,7 +85,7 @@ public final class OAuthBearerTokenUtil {
   }
 
   /**
-   * Check whether an OAuth Beaerer token is provided in environment variable HADOOP_JWT.
+   * Check whether an OAuth Beaerer token is provided in environment variable HBASE_JWT.
    * Parse and add it to user private credentials, but only if another token is not already present.
    */
   public static void addTokenFromEnvironmentVar(User user, String token) {
@@ -93,6 +94,8 @@ public final class OAuthBearerTokenUtil {
       .findFirst();
 
     if (oauthBearerToken.isPresent()) {
+      LOG.warn("Ignoring OAuth Bearer token in " + ENV_OAUTHBEARER_TOKEN + " environment "
+        + "variable, because another token is already present");
       return;
     }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/OAuthBearerTokenUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/OAuthBearerTokenUtil.java
@@ -109,10 +109,10 @@ public final class OAuthBearerTokenUtil {
         ZonedDateTime lifetime = ZonedDateTime.parse(tokens[1]);
         lifetimeMs = lifetime.toInstant().toEpochMilli();
       } catch (DateTimeParseException e) {
-        LOG.warn("Unable to parse JWT expiry: {}", tokens[1]);
+        throw new RuntimeException("Unable to parse JWT expiry: " + tokens[1], e);
       }
     } else {
-      LOG.warn("Expiry information of JWT is missing");
+      throw new RuntimeException("Expiry information of JWT is missing");
     }
 
     addTokenForUser(user, tokens[0], lifetimeMs);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/OAuthBearerTokenUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/OAuthBearerTokenUtil.java
@@ -18,6 +18,7 @@
  */
 package org.apache.hadoop.hbase.security.token;
 
+import static org.apache.hadoop.hbase.security.oauthbearer.OAuthBearerUtils.TOKEN_KIND;
 import java.security.AccessController;
 import java.security.PrivilegedAction;
 import javax.security.auth.Subject;
@@ -36,7 +37,6 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Public
 public final class OAuthBearerTokenUtil {
   private static final Logger LOG = LoggerFactory.getLogger(OAuthBearerTokenUtil.class);
-  public static final String TOKEN_KIND = "JWT_AUTH_TOKEN";
 
   static {
     OAuthBearerSaslClientProvider.initialize(); // not part of public API
@@ -68,6 +68,8 @@ public final class OAuthBearerTokenUtil {
           }
         };
         subject.getPrivateCredentials().add(jwt);
+        LOG.debug("OAuth Bearer token has been added to user credentials with expiry {}",
+          lifetimeMs);
         return null;
       }
     });

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestOAuthBearerTokenUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestOAuthBearerTokenUtil.java
@@ -64,7 +64,7 @@ public class TestOAuthBearerTokenUtil {
     });
   }
 
-  @Test
+  @Test(expected = RuntimeException.class)
   public void testAddTokenEnvVarWithoutExpiry() {
     // Arrange
     User user = User.createUserForTesting(new HBaseConfiguration(), "testuser", new String[] {});
@@ -74,24 +74,9 @@ public class TestOAuthBearerTokenUtil {
     OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user, testToken);
 
     // Assert
-    Optional<Token<?>> oauthBearerToken = user.getTokens().stream()
-      .filter((t) -> new Text(TOKEN_KIND).equals(t.getKind()))
-      .findFirst();
-    assertTrue("Token cannot be found in user tokens", oauthBearerToken.isPresent());
-    user.runAs(new PrivilegedAction<Object>() {
-      @Override public Object run() {
-        Subject subject = Subject.getSubject(AccessController.getContext());
-        Set<OAuthBearerToken> tokens = subject.getPrivateCredentials(OAuthBearerToken.class);
-        assertFalse("Token cannot be found in subject's private credentials", tokens.isEmpty());
-        OAuthBearerToken jwt = tokens.iterator().next();
-        assertEquals("Invalid encoded JWT value", "some_base64_encoded_stuff", jwt.value());
-        assertEquals("Invalid JWT expiry", 0, jwt.lifetimeMs());
-        return null;
-      }
-    });
   }
 
-  @Test
+  @Test(expected = RuntimeException.class)
   public void testAddTokenEnvVarWithInvalidExpiry() {
     // Arrange
     User user = User.createUserForTesting(new HBaseConfiguration(), "testuser", new String[] {});
@@ -101,21 +86,6 @@ public class TestOAuthBearerTokenUtil {
     OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user, testToken);
 
     // Assert
-    Optional<Token<?>> oauthBearerToken = user.getTokens().stream()
-      .filter((t) -> new Text(TOKEN_KIND).equals(t.getKind()))
-      .findFirst();
-    assertTrue("Token cannot be found in user tokens", oauthBearerToken.isPresent());
-    user.runAs(new PrivilegedAction<Object>() {
-      @Override public Object run() {
-        Subject subject = Subject.getSubject(AccessController.getContext());
-        Set<OAuthBearerToken> tokens = subject.getPrivateCredentials(OAuthBearerToken.class);
-        assertFalse("Token cannot be found in subject's private credentials", tokens.isEmpty());
-        OAuthBearerToken jwt = tokens.iterator().next();
-        assertEquals("Invalid encoded JWT value", "some_base64_encoded_stuff", jwt.value());
-        assertEquals("Invalid JWT expiry", 0, jwt.lifetimeMs());
-        return null;
-      }
-    });
   }
 
   @Test

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestOAuthBearerTokenUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestOAuthBearerTokenUtil.java
@@ -1,0 +1,145 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.token;
+
+import static org.apache.hadoop.hbase.security.oauthbearer.OAuthBearerUtils.TOKEN_KIND;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import java.security.AccessController;
+import java.security.PrivilegedAction;
+import java.time.Instant;
+import java.util.Optional;
+import java.util.Set;
+import javax.security.auth.Subject;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.security.oauthbearer.OAuthBearerToken;
+import org.apache.hadoop.io.Text;
+import org.apache.hadoop.security.token.Token;
+import org.junit.Test;
+
+public class TestOAuthBearerTokenUtil {
+
+  @Test
+  public void testAddTokenFromEnvVar() {
+    // Arrange
+    User user = User.createUserForTesting(new HBaseConfiguration(), "testuser", new String[] {});
+    String testToken = "some_base64_encoded_stuff,2022-01-25T16:59:48.614000+00:00";
+
+    // Act
+    OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user, testToken);
+
+    // Assert
+    Optional<Token<?>> oauthBearerToken = user.getTokens().stream()
+      .filter((t) -> new Text(TOKEN_KIND).equals(t.getKind()))
+      .findFirst();
+    assertTrue("Token cannot be found in user tokens", oauthBearerToken.isPresent());
+    user.runAs(new PrivilegedAction<Object>() {
+      @Override public Object run() {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+        Set<OAuthBearerToken> tokens = subject.getPrivateCredentials(OAuthBearerToken.class);
+        assertFalse("Token cannot be found in subject's private credentials", tokens.isEmpty());
+        OAuthBearerToken jwt = tokens.iterator().next();
+        assertEquals("Invalid encoded JWT value", "some_base64_encoded_stuff", jwt.value());
+        assertEquals("Invalid JWT expiry", "2022-01-25T16:59:48.614Z",
+          Instant.ofEpochMilli(jwt.lifetimeMs()).toString());
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testAddTokenEnvVarWithoutExpiry() {
+    // Arrange
+    User user = User.createUserForTesting(new HBaseConfiguration(), "testuser", new String[] {});
+    String testToken = "some_base64_encoded_stuff";
+
+    // Act
+    OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user, testToken);
+
+    // Assert
+    Optional<Token<?>> oauthBearerToken = user.getTokens().stream()
+      .filter((t) -> new Text(TOKEN_KIND).equals(t.getKind()))
+      .findFirst();
+    assertTrue("Token cannot be found in user tokens", oauthBearerToken.isPresent());
+    user.runAs(new PrivilegedAction<Object>() {
+      @Override public Object run() {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+        Set<OAuthBearerToken> tokens = subject.getPrivateCredentials(OAuthBearerToken.class);
+        assertFalse("Token cannot be found in subject's private credentials", tokens.isEmpty());
+        OAuthBearerToken jwt = tokens.iterator().next();
+        assertEquals("Invalid encoded JWT value", "some_base64_encoded_stuff", jwt.value());
+        assertEquals("Invalid JWT expiry", 0, jwt.lifetimeMs());
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testAddTokenEnvVarWithInvalidExpiry() {
+    // Arrange
+    User user = User.createUserForTesting(new HBaseConfiguration(), "testuser", new String[] {});
+    String testToken = "some_base64_encoded_stuff,foobarblahblah328742";
+
+    // Act
+    OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user, testToken);
+
+    // Assert
+    Optional<Token<?>> oauthBearerToken = user.getTokens().stream()
+      .filter((t) -> new Text(TOKEN_KIND).equals(t.getKind()))
+      .findFirst();
+    assertTrue("Token cannot be found in user tokens", oauthBearerToken.isPresent());
+    user.runAs(new PrivilegedAction<Object>() {
+      @Override public Object run() {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+        Set<OAuthBearerToken> tokens = subject.getPrivateCredentials(OAuthBearerToken.class);
+        assertFalse("Token cannot be found in subject's private credentials", tokens.isEmpty());
+        OAuthBearerToken jwt = tokens.iterator().next();
+        assertEquals("Invalid encoded JWT value", "some_base64_encoded_stuff", jwt.value());
+        assertEquals("Invalid JWT expiry", 0, jwt.lifetimeMs());
+        return null;
+      }
+    });
+  }
+
+  @Test
+  public void testAddTokenEnvVarTokenAlreadyPresent() {
+    // Arrange
+    User user = User.createUserForTesting(new HBaseConfiguration(), "testuser", new String[] {});
+    user.addToken(new Token<>(null, null, new Text(TOKEN_KIND), null));
+    String testToken = "some_base64_encoded_stuff,foobarblahblah328742";
+
+    // Act
+    OAuthBearerTokenUtil.addTokenFromEnvironmentVar(user, testToken);
+
+    // Assert
+    long numberOfTokens = user.getTokens().stream()
+      .filter((t) -> new Text(TOKEN_KIND).equals(t.getKind()))
+      .count();
+    assertEquals("Invalid number of tokens on User",1, numberOfTokens);
+    user.runAs(new PrivilegedAction<Object>() {
+      @Override public Object run() {
+        Subject subject = Subject.getSubject(AccessController.getContext());
+        Set<OAuthBearerToken> tokens = subject.getPrivateCredentials(OAuthBearerToken.class);
+        assertTrue("Token should not have been added to subject's credentials", tokens.isEmpty());
+        return null;
+      }
+    });
+  }
+}

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestOAuthBearerTokenUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/security/token/TestOAuthBearerTokenUtil.java
@@ -39,7 +39,7 @@ public class TestOAuthBearerTokenUtil {
   @Test
   public void testAddTokenFromEnvVar() {
     // Arrange
-    User user = User.createUserForTesting(new HBaseConfiguration(), "testuser", new String[] {});
+    User user = User.createUserForTesting(HBaseConfiguration.create(), "testuser", new String[] {});
     String testToken = "some_base64_encoded_stuff,2022-01-25T16:59:48.614000+00:00";
 
     // Act
@@ -132,7 +132,7 @@ public class TestOAuthBearerTokenUtil {
     long numberOfTokens = user.getTokens().stream()
       .filter((t) -> new Text(TOKEN_KIND).equals(t.getKind()))
       .count();
-    assertEquals("Invalid number of tokens on User",1, numberOfTokens);
+    assertEquals("Invalid number of tokens on User", 1, numberOfTokens);
     user.runAs(new PrivilegedAction<Object>() {
       @Override public Object run() {
         Subject subject = Subject.getSubject(AccessController.getContext());

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/security/oauthbearer/OAuthBearerUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/security/oauthbearer/OAuthBearerUtils.java
@@ -25,7 +25,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 @InterfaceAudience.Private
 public final class OAuthBearerUtils {
   public static final String OAUTHBEARER_MECHANISM = "OAUTHBEARER";
-  public static final String TOKEN_KIND = "OAUTHBEARER_AUTH_TOKEN";
+  public static final String TOKEN_KIND = "HBASE_JWT_TOKEN";
 
   /**
    * Verifies configuration for OAuth Bearer authentication mechanism.

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/security/oauthbearer/OAuthBearerUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/security/oauthbearer/OAuthBearerUtils.java
@@ -25,6 +25,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 @InterfaceAudience.Private
 public final class OAuthBearerUtils {
   public static final String OAUTHBEARER_MECHANISM = "OAUTHBEARER";
+  public static final String TOKEN_KIND = "OAUTHBEARER_AUTH_TOKEN";
 
   /**
    * Verifies configuration for OAuth Bearer authentication mechanism.


### PR DESCRIPTION
Implemented the environment variable based approach for detecting available JWT tokens. `ConnectionFactory` will check for the presence of "HADOOP_JWT" environment variable and adds it to user's credentials. Format of value is 
`<base64_encoded_jwt>,<expiry in DateTimeFormatter.ISO_ZONED_DATE_TIME format>`

Expiry info is optional.

```
export HADOOP_JWT="Tm90aGluZyBpcyB0cnVlOyBldmVyeXRoaW5nIGlzIHBlcm1pdHRlZAo=,2022-01-25T16:59:48.614000+00:00"
```