### PR TITLE
HBASE-26726 Allow disable of region warmup before graceful move

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -414,6 +414,9 @@ public class HMaster extends HRegionServer implements MasterServices {
   // Cached clusterId on stand by masters to serve clusterID requests from clients.
   private final CachedClusterId cachedClusterId;
 
+  public static final String WARMUP_BEFORE_MOVE = "hbase.master.warmup.before.move";
+  private static final boolean DEFAULT_WARMUP_BEFORE_MOVE = true;
+
   /**
    * Initializes the HMaster. The steps are as follows:
    * <p>
@@ -2171,10 +2174,14 @@ public class HMaster extends HRegionServer implements MasterServices {
 
       TransitRegionStateProcedure proc =
           this.assignmentManager.createMoveRegionProcedure(rp.getRegionInfo(), rp.getDestination());
-      // Warmup the region on the destination before initiating the move. this call
-      // is synchronous and takes some time. doing it before the source region gets
-      // closed
-      serverManager.sendRegionWarmup(rp.getDestination(), hri);
+      if (conf.getBoolean(WARMUP_BEFORE_MOVE, DEFAULT_WARMUP_BEFORE_MOVE)) {
+        // Warmup the region on the destination before initiating the move. this call
+        // is synchronous and takes some time. doing it before the source region gets
+        // closed
+        LOG.info(getClientIdAuditPrefix() + " move " + rp + ", warming up region on " +
+          rp.getDestination());
+        serverManager.sendRegionWarmup(rp.getDestination(), hri);
+      }
       LOG.info(getClientIdAuditPrefix() + " move " + rp + ", running balancer");
       Future<byte[]> future = ProcedureSyncWait.submitProcedure(this.procedureExecutor, proc);
       try {


### PR DESCRIPTION
We have encountered two issues with region warmup before the assignment manager gracefully moves a region from one regionserver to another.

The first instance is HBASE-26722. Part of the failure chain is temporary double assignment like conditions where both the source and destination regionservers think they have exclusive rights to storefile management (as they should) but warmup opens a region before it is closed and then both regionservers take compaction related actions. While this can be remediated with more care to this case, it is unclear if warmup affords significant advantage. The motivation of the original commit in 2015 introducing this feature was avoidance of blockcache misses once region ownership transfer was advertised to clients. Depending on use case and additional default-false schema options (like preload) this could be valuable. Or not.

The second instance is in place upgrade from HBase 1 to HBase 2. In a scenario where regionservers have been replaced by HBase 2 versions, but the master is still HBase 1, the region warmup RPC request fails. This is not particularly harmful but indicates it will not be useful during the transition period.

We think it would be good to allow for warmup before move to be optionally disabled by a site configuration setting. In particular there have been many unrelated changes committed since 2015 and expectations of invariants in the contribution of the warmup-on-move feature have been invalidated. HBASE-26722 may be the only case, or it might not. This is a fairly trivial change.