### PR TITLE
HBASE-26472 Adhere to semantic conventions regarding table data operations (addendum)

### DIFF
--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
@@ -29,6 +29,7 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
@@ -41,9 +42,11 @@ import io.opentelemetry.sdk.testing.junit4.OpenTelemetryRule;
 import io.opentelemetry.sdk.trace.data.SpanData;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.Cell.Type;
@@ -251,11 +254,12 @@ public class TestAsyncTableTracing {
     Waiter.waitFor(CONF, 1000, new MatcherPredicate<>(
       "waiting for span to emit",
       () -> traceRule.getSpans(), hasItem(spanLocator)));
-    SpanData data = traceRule.getSpans()
+    List<SpanData> candidateSpans = traceRule.getSpans()
       .stream()
       .filter(spanLocator::matches)
-      .findFirst()
-      .orElseThrow(AssertionError::new);
+      .collect(Collectors.toList());
+    assertThat(candidateSpans, hasSize(1));
+    SpanData data = candidateSpans.iterator().next();
     assertThat(data, allOf(
       hasName(expectedName),
       hasKind(SpanKind.CLIENT),


### PR DESCRIPTION
Ensure table data operations emit one and only one span.