### PR TITLE
HBASE-26730 Extend hbase shell 'status' command to support an option 'tasks'

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ClusterMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ClusterMetrics.java
@@ -162,6 +162,12 @@ public interface ClusterMetrics {
   Map<TableName, RegionStatesCount> getTableRegionStatesCount();
 
   /**
+   * Provide the list of master tasks
+   */
+  @Nullable
+  List<ServerTask> getMasterTasks();
+
+  /**
    * Kinds of ClusterMetrics
    */
   enum Option {
@@ -213,5 +219,9 @@ public interface ClusterMetrics {
      * metrics about table to no of regions status count
      */
     TABLE_TO_REGIONS_COUNT,
+    /**
+     * metrics about monitored tasks
+     */
+    TASKS,
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerMetrics.java
@@ -124,4 +124,11 @@ public interface ServerMetrics {
    */
   long getLastReportTimestamp();
 
+  /**
+   * Called directly from clients such as the hbase shell
+   * @return the active monitored tasks
+   */
+  @Nullable
+  List<ServerTask> getTasks();
+
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerTask.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerTask.java
@@ -32,26 +32,31 @@ public interface ServerTask {
   }
 
   /**
+   * Get the task's description.
    * @return the task's description, typically a name
    */
   String getDescription();
 
   /**
+   * Get the current status of the task.
    * @return the task's current status
    */
   String getStatus();
 
   /**
+   * Get the current state of the task.
    * @return the task's current state
    */
   State getState();
 
   /**
+   * Get the task start time.
    * @return the time when the task started, or 0 if it has not started yet
    */
   long getStartTime();
 
   /**
+   * Get the task completion time.
    * @return the time when the task completed, or 0 if it has not completed yet
    */
   long getCompletionTime();

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerTask.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerTask.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/** Information about active monitored server tasks */
+@InterfaceAudience.Public
+public interface ServerTask {
+
+  /** Task state */
+  enum State {
+    RUNNING,
+    WAITING,
+    COMPLETE,
+    ABORTED;
+  }
+
+  /**
+   * @return the task's description, typically a name
+   */
+  String getDescription();
+
+  /**
+   * @return the task's current status
+   */
+  String getStatus();
+
+  /**
+   * @return the task's current state
+   */
+  State getState();
+
+  /**
+   * @return the time when the task started, or 0 if it has not started yet
+   */
+  long getStartTime();
+
+  /**
+   * @return the time when the task completed, or 0 if it has not completed yet
+   */
+  long getCompletionTime();
+
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerTaskBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerTaskBuilder.java
@@ -35,7 +35,7 @@ public final class ServerTaskBuilder {
 
   private ServerTaskBuilder() { }
 
-  private static class ServerTaskImpl implements ServerTask {
+  private static final class ServerTaskImpl implements ServerTask {
 
     private final String description;
     private final String status;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerTaskBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ServerTaskBuilder.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/** Builder for information about active monitored server tasks */
+@InterfaceAudience.Private
+public final class ServerTaskBuilder {
+
+  public static ServerTaskBuilder newBuilder() {
+    return new ServerTaskBuilder();
+  }
+
+  private String description = "";
+  private String status = "";
+  private ServerTask.State state = ServerTask.State.RUNNING;
+  private long startTime;
+  private long completionTime;
+
+  private ServerTaskBuilder() { }
+
+  private static class ServerTaskImpl implements ServerTask {
+
+    private final String description;
+    private final String status;
+    private final ServerTask.State state;
+    private final long startTime;
+    private final long completionTime;
+
+    private ServerTaskImpl(final String description, final String status,
+        final ServerTask.State state, final long startTime, final long completionTime) {
+      this.description = description;
+      this.status = status;
+      this.state = state;
+      this.startTime = startTime;
+      this.completionTime = completionTime;
+    }
+
+    @Override
+    public String getDescription() {
+      return description;
+    }
+
+    @Override
+    public String getStatus() {
+      return status;
+    }
+
+    @Override
+    public State getState() {
+      return state;
+    }
+
+    @Override
+    public long getStartTime() {
+      return startTime;
+    }
+
+    @Override
+    public long getCompletionTime() {
+      return completionTime;
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder(512);
+      sb.append(getDescription());
+      sb.append(": status=");
+      sb.append(getStatus());
+      sb.append(", state=");
+      sb.append(getState());
+      sb.append(", startTime=");
+      sb.append(getStartTime());
+      sb.append(", completionTime=");
+      sb.append(getCompletionTime());
+      return sb.toString();
+    }
+
+  }
+
+  public ServerTaskBuilder setDescription(final String description) {
+    this.description = description;
+    return this;
+  }
+
+  public ServerTaskBuilder setStatus(final String status) {
+    this.status = status;
+    return this;
+  }
+
+  public ServerTaskBuilder setState(final ServerTask.State state) {
+    this.state = state;
+    return this;
+  }
+
+  public ServerTaskBuilder setStartTime(final long startTime) {
+    this.startTime = startTime;
+    return this;
+  }
+
+  public ServerTaskBuilder setCompletionTime(final long completionTime) {
+    this.completionTime = completionTime;
+    return this;
+  }
+
+  public ServerTask build() {
+    return new ServerTaskImpl(description, status, state, startTime, completionTime);
+  }
+
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -67,6 +67,8 @@ import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.NamespaceDescriptor;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.ServerTask;
+import org.apache.hadoop.hbase.ServerTaskBuilder;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Append;
 import org.apache.hadoop.hbase.client.BalanceResponse;
@@ -3902,6 +3904,26 @@ public final class ProtobufUtil {
       .setBalancerRan(response.hasBalancerRan() && response.getBalancerRan())
       .setMovesCalculated(response.hasMovesCalculated() ? response.getMovesExecuted() : 0)
       .setMovesExecuted(response.hasMovesExecuted() ? response.getMovesExecuted() : 0)
+      .build();
+  }
+
+  public static ServerTask getServerTask(ClusterStatusProtos.ServerTask task) {
+    return ServerTaskBuilder.newBuilder()
+      .setDescription(task.getDescription())
+      .setStatus(task.getStatus())
+      .setState(ServerTask.State.valueOf(task.getState().name()))
+      .setStartTime(task.getStartTime())
+      .setCompletionTime(task.getCompletionTime())
+      .build();
+  }
+
+  public static ClusterStatusProtos.ServerTask toServerTask(ServerTask task) {
+    return ClusterStatusProtos.ServerTask.newBuilder()
+      .setDescription(task.getDescription())
+      .setStatus(task.getStatus())
+      .setState(ClusterStatusProtos.ServerTask.State.valueOf(task.getState().name()))
+      .setStartTime(task.getStartTime())
+      .setCompletionTime(task.getCompletionTime())
       .build();
   }
 

--- a/hbase-protocol-shaded/src/main/protobuf/server/ClusterStatus.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/ClusterStatus.proto
@@ -229,6 +229,21 @@ message ReplicationLoadSource {
   optional uint64 oPsShipped = 12;
 }
 
+message ServerTask {
+  required string description = 1;
+  required string status = 2;
+  required State state = 3;
+  optional uint64 startTime = 4;
+  optional uint64 completionTime = 5;
+
+  enum State {
+    RUNNING = 0;
+    WAITING = 1;
+    COMPLETE = 2;
+    ABORTED = 3;
+  }
+}
+
 message ServerLoad {
   /** Number of requests since last report. */
   optional uint64 number_of_requests = 1;
@@ -295,6 +310,11 @@ message ServerLoad {
    * The metrics for write requests on this region server
    */
   optional uint64 write_requests_count = 14;
+ 
+  /**
+   * The active monitored tasks
+   */
+  repeated ServerTask tasks = 15;
 }
 
 message LiveServerInfo {
@@ -328,6 +348,7 @@ message ClusterStatus {
   optional int32 master_info_port = 10 [default = -1];
   repeated ServerName servers_name = 11;
   repeated TableRegionStatesCount table_region_states_count = 12;
+  repeated ServerTask master_tasks = 13;
 }
 
 enum Option {
@@ -343,4 +364,5 @@ enum Option {
   MASTER_INFO_PORT = 9;
   SERVERS_NAME = 10;
   TABLE_TO_REGIONS_COUNT = 11;
+  TASKS = 12;
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -80,6 +80,8 @@ import org.apache.hadoop.hbase.RegionMetrics;
 import org.apache.hadoop.hbase.ReplicationPeerNotFoundException;
 import org.apache.hadoop.hbase.ServerMetrics;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.ServerTask;
+import org.apache.hadoop.hbase.ServerTaskBuilder;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotDisabledException;
 import org.apache.hadoop.hbase.TableNotFoundException;
@@ -1006,7 +1008,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     // initialize load balancer
     this.balancer.setMasterServices(this);
     this.balancer.initialize();
-    this.balancer.updateClusterMetrics(getClusterMetricsWithoutCoprocessor());
+    this.balancer.updateClusterMetrics(getClusterMetricsInternal());
 
     // start up all service threads.
     status.setStatus("Initializing master service threads");
@@ -1094,7 +1096,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     }
 
     // set cluster status again after user regions are assigned
-    this.balancer.updateClusterMetrics(getClusterMetricsWithoutCoprocessor());
+    this.balancer.updateClusterMetrics(getClusterMetricsInternal());
 
     // Start balancer and meta catalog janitor after meta and regions have been assigned.
     status.setStatus("Starting balancer and catalog janitor");
@@ -1916,7 +1918,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
       }
 
       //Give the balancer the current cluster state.
-      this.balancer.updateClusterMetrics(getClusterMetricsWithoutCoprocessor());
+      this.balancer.updateClusterMetrics(getClusterMetricsInternal());
 
       List<RegionPlan> plans = this.balancer.balanceCluster(assignments);
 
@@ -2724,11 +2726,11 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     }
   }
 
-  public ClusterMetrics getClusterMetricsWithoutCoprocessor() throws InterruptedIOException {
-    return getClusterMetricsWithoutCoprocessor(EnumSet.allOf(Option.class));
+  public ClusterMetrics getClusterMetricsInternal() throws InterruptedIOException {
+    return getClusterMetricsInternal(EnumSet.allOf(Option.class));
   }
 
-  public ClusterMetrics getClusterMetricsWithoutCoprocessor(EnumSet<Option> options)
+  public ClusterMetrics getClusterMetricsInternal(EnumSet<Option> options)
       throws InterruptedIOException {
     ClusterMetricsBuilder builder = ClusterMetricsBuilder.newBuilder();
     // given that hbase1 can't submit the request with Option,
@@ -2737,16 +2739,52 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
       options = EnumSet.allOf(Option.class);
     }
 
+    // TASKS and/or LIVE_SERVERS will populate this map, which will be given to the builder if
+    // not null after option processing completes.
+    Map<ServerName, ServerMetrics> serverMetricsMap = null;
+    boolean processedLiveServers = false;
+
     for (Option opt : options) {
       switch (opt) {
         case HBASE_VERSION: builder.setHBaseVersion(VersionInfo.getVersion()); break;
         case CLUSTER_ID: builder.setClusterId(getClusterId()); break;
         case MASTER: builder.setMasterName(getServerName()); break;
         case BACKUP_MASTERS: builder.setBackerMasterNames(getBackupMasters()); break;
+        case TASKS: {
+          // Master tasks
+          builder.setMasterTasks(TaskMonitor.get().getTasks().stream()
+            .map(task -> ServerTaskBuilder.newBuilder()
+              .setDescription(task.getDescription())
+              .setStatus(task.getStatus())
+              .setState(ServerTask.State.valueOf(task.getState().name()))
+              .setStartTime(task.getStartTime())
+              .setCompletionTime(task.getCompletionTimestamp())
+              .build())
+            .collect(Collectors.toList()));
+          // TASKS is also synonymous with LIVE_SERVERS for now because task information for
+          // regionservers is carried in ServerLoad.
+          // Add entries to serverMetricsMap for all live servers
+          if (serverManager != null && !processedLiveServers) {
+            if (serverMetricsMap == null) {
+              serverMetricsMap = new HashMap<>();
+            }
+            final Map<ServerName, ServerMetrics> map = serverMetricsMap;
+            serverManager.getOnlineServers().entrySet()
+              .forEach(e -> map.put(e.getKey(), e.getValue()));
+            processedLiveServers = true;
+          }
+          break;
+        }
         case LIVE_SERVERS: {
-          if (serverManager != null) {
-            builder.setLiveServerMetrics(serverManager.getOnlineServers().entrySet().stream()
-              .collect(Collectors.toMap(e -> e.getKey(), e -> e.getValue())));
+          // Add entries to serverMetricsMap for all live servers
+          if (serverManager != null && !processedLiveServers) {
+            if (serverMetricsMap == null) {
+              serverMetricsMap = new HashMap<>();
+            }
+            final Map<ServerName, ServerMetrics> map = serverMetricsMap;
+            serverManager.getOnlineServers().entrySet()
+              .forEach(e -> map.put(e.getKey(), e.getValue()));
+            processedLiveServers = true;
           }
           break;
         }
@@ -2808,6 +2846,11 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         }
       }
     }
+
+    if (serverMetricsMap != null) {
+      builder.setLiveServerMetrics(serverMetricsMap);
+    }
+
     return builder.build();
   }
 
@@ -2822,7 +2865,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     if (cpHost != null) {
       cpHost.preGetClusterMetrics();
     }
-    ClusterMetrics status = getClusterMetricsWithoutCoprocessor(options);
+    ClusterMetrics status = getClusterMetricsInternal(options);
     if (cpHost != null) {
       cpHost.postGetClusterMetrics(status);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/ClusterStatusChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/ClusterStatusChore.java
@@ -46,7 +46,7 @@ public class ClusterStatusChore extends ScheduledChore {
   @Override
   protected void chore() {
     try {
-      balancer.updateClusterMetrics(master.getClusterMetricsWithoutCoprocessor());
+      balancer.updateClusterMetrics(master.getClusterMetricsInternal());
     } catch (InterruptedIOException e) {
       LOG.warn("Ignoring interruption", e);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/ClusterStatusChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/ClusterStatusChore.java
@@ -46,7 +46,7 @@ public class ClusterStatusChore extends ScheduledChore {
   @Override
   protected void chore() {
     try {
-      balancer.updateClusterMetrics(master.getClusterMetricsInternal());
+      balancer.updateClusterMetrics(master.getClusterMetricsWithoutCoprocessor());
     } catch (InterruptedIOException e) {
       LOG.warn("Ignoring interruption", e);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -105,6 +105,8 @@ import org.apache.hadoop.hbase.ipc.ServerNotRunningYetException;
 import org.apache.hadoop.hbase.ipc.ServerRpcController;
 import org.apache.hadoop.hbase.log.HBaseMarkers;
 import org.apache.hadoop.hbase.mob.MobFileCache;
+import org.apache.hadoop.hbase.monitoring.MonitoredTask;
+import org.apache.hadoop.hbase.monitoring.TaskMonitor;
 import org.apache.hadoop.hbase.namequeues.NamedQueueRecorder;
 import org.apache.hadoop.hbase.namequeues.SlowLogTableOpsChore;
 import org.apache.hadoop.hbase.net.Address;
@@ -1194,6 +1196,15 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
         }
       }
     }
+
+    TaskMonitor.get().getTasks().forEach(task ->
+      serverLoad.addTasks(ClusterStatusProtos.ServerTask.newBuilder()
+        .setDescription(task.getDescription())
+        .setStatus(task.getStatus() != null ? task.getStatus() : "")
+        .setState(ClusterStatusProtos.ServerTask.State.valueOf(task.getState().name()))
+        .setStartTime(task.getStartTime())
+        .setCompletionTime(task.getCompletionTimestamp())
+        .build()));
 
     return serverLoad.build();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -105,7 +105,6 @@ import org.apache.hadoop.hbase.ipc.ServerNotRunningYetException;
 import org.apache.hadoop.hbase.ipc.ServerRpcController;
 import org.apache.hadoop.hbase.log.HBaseMarkers;
 import org.apache.hadoop.hbase.mob.MobFileCache;
-import org.apache.hadoop.hbase.monitoring.MonitoredTask;
 import org.apache.hadoop.hbase.monitoring.TaskMonitor;
 import org.apache.hadoop.hbase.namequeues.NamedQueueRecorder;
 import org.apache.hadoop.hbase.namequeues.SlowLogTableOpsChore;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientClusterMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientClusterMetrics.java
@@ -49,12 +49,14 @@ import org.apache.hadoop.hbase.coprocessor.MasterObserver;
 import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.filter.FilterAllFilter;
 import org.apache.hadoop.hbase.master.HMaster;
+import org.apache.hadoop.hbase.monitoring.TaskMonitor;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.regionserver.MetricsUserAggregateFactory;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.JVMClusterUtil.MasterThread;
 import org.apache.hadoop.hbase.util.JVMClusterUtil.RegionServerThread;
 import org.junit.AfterClass;
@@ -80,6 +82,18 @@ public class TestClientClusterMetrics {
   private static final TableName TABLE_NAME = TableName.valueOf("test");
   private static final byte[] CF = Bytes.toBytes("cf");
 
+  // We need to promote the visibility of tryRegionServerReport for this test
+  public static class MyRegionServer 
+      extends SingleProcessHBaseCluster.MiniHBaseClusterRegionServer {
+    public MyRegionServer(Configuration conf) throws IOException, InterruptedException {
+      super(conf);
+    }
+    @Override
+    public void tryRegionServerReport(long reportStartTime, long reportEndTime)
+        throws IOException {
+      super.tryRegionServerReport(reportStartTime, reportEndTime);
+    }
+  }
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
@@ -87,6 +101,7 @@ public class TestClientClusterMetrics {
     conf.set(CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY, MyObserver.class.getName());
     UTIL = new HBaseTestingUtil(conf);
     StartTestingClusterOption option = StartTestingClusterOption.builder()
+        .rsClass(TestClientClusterMetrics.MyRegionServer.class)
         .numMasters(MASTERS).numRegionServers(SLAVES).numDataNodes(SLAVES).build();
     UTIL.startMiniCluster(option);
     CLUSTER = UTIL.getHBaseCluster();
@@ -305,7 +320,8 @@ public class TestClientClusterMetrics {
     Assert.assertEquals(MASTERS - 1, metrics.getBackupMasterNames().size());
   }
 
-  @Test public void testUserMetrics() throws Exception {
+  @Test
+  public void testUserMetrics() throws Exception {
     Configuration conf = UTIL.getConfiguration();
     // If metrics for users is not enabled, this test doesn't  make sense.
     if (!conf.getBoolean(MetricsUserAggregateFactory.METRIC_USER_ENABLED_CONF,
@@ -391,6 +407,48 @@ public class TestClientClusterMetrics {
       }
     }
     UTIL.deleteTable(TABLE_NAME);
+  }
+
+  @Test
+  public void testServerTasks() throws Exception {
+    // TaskMonitor is a singleton per VM, so will be shared among all minicluster "servers",
+    // so we only need to look at the first live server's results to find it.
+    final String testTaskName = "TEST TASK";
+    TaskMonitor.get().createStatus(testTaskName).setStatus("Testing 1... 2... 3...");
+    // Of course, first we must trigger regionserver reports.
+    final long now = EnvironmentEdgeManager.currentTime();
+    final long last = now - 1000; // fake a period, or someone might div by zero
+    for (RegionServerThread rs: CLUSTER.getRegionServerThreads()) {
+      ((MyRegionServer)rs.getRegionServer()).tryRegionServerReport(last, now);
+    }
+    // Get status now
+    ClusterMetrics clusterMetrics = ADMIN.getClusterMetrics(EnumSet.of(Option.TASKS));
+    // The test task will be in the master metrics list
+    boolean found = false;
+    for (ServerTask task: clusterMetrics.getMasterTasks()) {
+      if (testTaskName.equals(task.getDescription())) {
+        // Found it
+        found = true;
+        break;
+      }
+    }
+    Assert.assertTrue("Expected task not found in master task list", found);
+    // Get the tasks information (carried in server metrics)
+    found = false;
+    for (ServerMetrics serverMetrics: clusterMetrics.getLiveServerMetrics().values()) {
+      if (serverMetrics.getTasks() != null) {
+        for (ServerTask task: serverMetrics.getTasks()) {
+          if (testTaskName.equals(task.getDescription())) {
+            // Found it
+            found = true;
+            break;
+          }
+        }
+      }
+    }
+    // We will fall through here if getClusterMetrics(TASKS) did not correctly process the
+    // task list.
+    Assert.assertTrue("Expected task not found in server load", found);
   }
 
   private RegionMetrics getMetaMetrics() throws IOException {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientClusterMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestClientClusterMetrics.java
@@ -83,7 +83,7 @@ public class TestClientClusterMetrics {
   private static final byte[] CF = Bytes.toBytes("cf");
 
   // We need to promote the visibility of tryRegionServerReport for this test
-  public static class MyRegionServer 
+  public static class MyRegionServer
       extends SingleProcessHBaseCluster.MiniHBaseClusterRegionServer {
     public MyRegionServer(Configuration conf) throws IOException, InterruptedException {
       super(conf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestRegionsRecoveryChore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestRegionsRecoveryChore.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.RegionMetrics;
 import org.apache.hadoop.hbase.ServerMetrics;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.ServerTask;
 import org.apache.hadoop.hbase.Size;
 import org.apache.hadoop.hbase.Stoppable;
 import org.apache.hadoop.hbase.TableName;
@@ -293,6 +294,11 @@ public class TestRegionsRecoveryChore {
         return null;
       }
 
+      @Override
+      public List<ServerTask> getMasterTasks() {
+        return null;
+      }
+
     };
     return clusterMetrics;
   }
@@ -385,6 +391,11 @@ public class TestRegionsRecoveryChore {
       @Override
       public long getLastReportTimestamp() {
         return 0;
+      }
+
+      @Override
+      public List<ServerTask> getTasks() {
+        return null;
       }
 
     };

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -923,15 +923,19 @@ module Hbase
         for v in cluster_metrics.getRegionStatesInTransition
           puts(format('    %s', v))
         end
-        master = cluster_metrics.getMasterName
-        puts(format('active master:  %s:%d %d', master.getHostname, master.getPort,
-                    master.getStartcode))
-        puts(format('%d backup masters', cluster_metrics.getBackupMasterNames.size))
-        for server in cluster_metrics.getBackupMasterNames
+        master = cluster_metrics.getMaster
+        unless master.nil?
+          puts(format('active master:  %s:%d %d', master.getHostname, master.getPort, master.getStartcode))
+          for task in cluster_metrics.getMasterTasks
+            next unless task.getState.name == 'RUNNING'
+            puts(format('    %s', task.toString))
+          end
+        end
+        puts(format('%d backup masters', cluster_metrics.getBackupMastersSize))
+        for server in cluster_metrics.getBackupMasters
           puts(format('    %s:%d %d', server.getHostname, server.getPort, server.getStartcode))
         end
-
-        master_coprocs = @admin.getMasterCoprocessorNames.toString
+        master_coprocs = java.util.Arrays.toString(@admin.getMasterCoprocessors)
         unless master_coprocs.nil?
           puts(format('master coprocessors: %s', master_coprocs))
         end
@@ -942,6 +946,10 @@ module Hbase
           for name, region in cluster_metrics.getLiveServerMetrics.get(server).getRegionMetrics
             puts(format('        %s', region.getNameAsString.dump))
             puts(format('            %s', region.toString))
+          end
+          for task in cluster_metrics.getLoad(server).getTasks
+            next unless task.getState.name == 'RUNNING'
+            puts(format('        %s', task.toString))
           end
         end
         puts(format('%d dead servers', cluster_metrics.getDeadServerNames.size))
@@ -980,6 +988,33 @@ module Hbase
           else
             puts(format('%<source>s', source: r_source_string))
             puts(format('%<sink>s', sink: r_sink_string))
+          end
+        end
+      elsif format == 'tasks'
+        master = cluster_metrics.getMaster
+        unless master.nil?
+          puts(format('active master:  %s:%d %d', master.getHostname, master.getPort, master.getStartcode))
+          printed = false
+          for task in cluster_metrics.getMasterTasks
+            next unless task.getState.name == 'RUNNING'
+            puts(format('    %s', task.toString))
+            printed = true
+          end
+          if !printed
+            puts('    no active tasks')
+          end
+        end
+        puts(format('%d live servers', cluster_metrics.getServersSize))
+        for server in cluster_metrics.getServers
+          puts(format('    %s:%d %d', server.getHostname, server.getPort, server.getStartcode))
+          printed = false
+          for task in cluster_metrics.getLoad(server).getTasks
+            next unless task.getState.name == 'RUNNING'
+            puts(format('        %s', task.toString))
+            printed = true
+          end
+          if !printed
+            puts('        no active tasks')
           end
         end
       elsif format == 'simple'

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -934,7 +934,7 @@ module Hbase
         for server in cluster_metrics.getBackupMasters
           puts(format('    %s:%d %d', server.getHostname, server.getPort, server.getStartcode))
         end
-        master_coprocs = java.util.Arrays.toString(@admin.getMasterCoprocessors)
+        master_coprocs = @admin.getMasterCoprocessorNames.toString
         unless master_coprocs.nil?
           puts(format('master coprocessors: %s', master_coprocs))
         end

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -927,7 +927,6 @@ module Hbase
         unless master.nil?
           puts(format('active master:  %s:%d %d', master.getHostname, master.getPort, master.getStartcode))
           for task in cluster_metrics.getMasterTasks
-            next unless task.getState.name == 'RUNNING'
             puts(format('    %s', task.toString))
           end
         end
@@ -948,7 +947,6 @@ module Hbase
             puts(format('            %s', region.toString))
           end
           for task in cluster_metrics.getLoad(server).getTasks
-            next unless task.getState.name == 'RUNNING'
             puts(format('        %s', task.toString))
           end
         end

--- a/hbase-shell/src/main/ruby/shell/commands/status.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/status.rb
@@ -22,13 +22,14 @@ module Shell
     class Status < Command
       def help
         <<-EOF
-Show cluster status. Can be 'summary', 'simple', 'detailed', or 'replication'. The
+Show cluster status. Can be 'summary', 'simple', 'detailed', 'tasks', or 'replication'. The
 default is 'summary'. Examples:
 
   hbase> status
-  hbase> status 'simple'
   hbase> status 'summary'
+  hbase> status 'simple'
   hbase> status 'detailed'
+  hbase> status 'tasks'
   hbase> status 'replication'
   hbase> status 'replication', 'source'
   hbase> status 'replication', 'sink'


### PR DESCRIPTION
Expose monitored tasks state in ClusterStatus API via new option in ServerLoad.

Add shell support for interrogating monitored tasks state in ServerLoad.

Here's a prototype running on a branch-2 fork:

<img width="640" alt="Screen Shot 2022-02-03 at 5 57 26 PM" src="https://user-images.githubusercontent.com/71990/152463762-90bd396c-2f7f-4544-85e8-813d0d5dcaca.png">
