### PR TITLE
HBASE-26741 Incorrect exception handling in shell

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -252,7 +252,7 @@ under the terms of the MIT license.
     THE SOFTWARE.
 
 ----
-This project incorporates portions of the 'Protocol Buffers' project avaialble
+This project incorporates portions of the 'Protocol Buffers' project available
 under a '3-clause BSD' license.
 
   Copyright 2008, Google Inc.
@@ -612,3 +612,30 @@ available under the Creative Commons By Attribution 3.0 License.
         this trademark restriction does not form part of this License.
 
         Creative Commons may be contacted at https://creativecommons.org/.
+
+----
+This project incorporates portions of the 'Ruby' project available
+under a '2-clause BSD' license.
+
+  Copyright (C) 1993-2013 Yukihiro Matsumoto. All rights reserved.
+
+  Redistribution and use in source and binary forms, with or without
+  modification, are permitted provided that the following conditions
+  are met:
+  1. Redistributions of source code must retain the above copyright
+  notice, this list of conditions and the following disclaimer.
+  2. Redistributions in binary form must reproduce the above copyright
+  notice, this list of conditions and the following disclaimer in the
+  documentation and/or other materials provided with the distribution.
+
+  THIS SOFTWARE IS PROVIDED BY THE AUTHOR AND CONTRIBUTORS ``AS IS'' AND
+  ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE
+  ARE DISCLAIMED.  IN NO EVENT SHALL THE AUTHOR OR CONTRIBUTORS BE LIABLE
+  FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS
+  OR SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION)
+  HOWEVER CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT
+  LIABILITY, OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY
+  OUT OF THE USE OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF
+  SUCH DAMAGE.

--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 Apache HBase
-Copyright 2007-2020 The Apache Software Foundation
+Copyright 2007-2022 The Apache Software Foundation
 
 This product includes software developed at
 The Apache Software Foundation (http://www.apache.org/).

--- a/hbase-shell/src/main/ruby/irb/hirb.rb
+++ b/hbase-shell/src/main/ruby/irb/hirb.rb
@@ -146,7 +146,7 @@ module IRB
               end
             end
             attr = STDOUT.tty? ? ATTR_TTY : ATTR_PLAIN
-            print "#{attr[1]}Traceback#{attr[]} (most recent call last peter):\n"
+            print "#{attr[1]}Traceback#{attr[]} (most recent call last):\n"
             unless lasts.empty?
               puts lasts.reverse
               printf "... %d levels...\n", levels if levels > 0

--- a/hbase-shell/src/main/ruby/irb/hirb.rb
+++ b/hbase-shell/src/main/ruby/irb/hirb.rb
@@ -116,7 +116,9 @@ module IRB
           rescue SystemExit, SignalException
             raise
           rescue Exception
-            # Raise exception so Shell::exception_handler can catch it.
+            # HBASE-26741: Raise exception so Shell::exception_handler can catch it.
+            # This modifies this copied method from JRuby so that the HBase shell can
+            # manage the exception and set a proper exit code on the process.
             raise
           end
           if exc


### PR DESCRIPTION
Override eval_input in HIRB to modify exception handling logic.