### PR TITLE
HBASE-26789 Automatically add default security headers to http/rest if SSL enabled

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -626,9 +626,11 @@ public class HttpServer implements FilterContainer {
         ClickjackingPreventionFilter.class.getName(),
         ClickjackingPreventionFilter.getDefaultParameters(conf));
 
+    HttpConfig httpConfig = new HttpConfig(conf);
+
     addGlobalFilter("securityheaders",
         SecurityHeadersFilter.class.getName(),
-        SecurityHeadersFilter.getDefaultParameters(conf));
+        SecurityHeadersFilter.getDefaultParameters(conf, httpConfig.isSecure()));
 
     // But security needs to be enabled prior to adding the other servlets
     if (authenticationEnabled) {

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/SecurityHeadersFilter.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/SecurityHeadersFilter.java
@@ -39,8 +39,8 @@ import org.slf4j.LoggerFactory;
 public class SecurityHeadersFilter implements Filter {
   private static final Logger LOG =
       LoggerFactory.getLogger(SecurityHeadersFilter.class);
-  private static final String DEFAULT_HSTS = "";
-  private static final String DEFAULT_CSP = "";
+  private static final String DEFAULT_HSTS = "max-age=63072000;includeSubDomains;preload";
+  private static final String DEFAULT_CSP = "default-src https: data: 'unsafe-inline' 'unsafe-eval'";
   private FilterConfig filterConfig;
 
   @Override
@@ -70,12 +70,10 @@ public class SecurityHeadersFilter implements Filter {
   public void destroy() {
   }
 
-  public static Map<String, String> getDefaultParameters(Configuration conf) {
+  public static Map<String, String> getDefaultParameters(Configuration conf, boolean isSecure) {
     Map<String, String> params = new HashMap<>();
-    params.put("hsts", conf.get("hbase.http.filter.hsts.value",
-        DEFAULT_HSTS));
-    params.put("csp", conf.get("hbase.http.filter.csp.value",
-        DEFAULT_CSP));
+    params.put("hsts", conf.get("hbase.http.filter.hsts.value", isSecure ? DEFAULT_HSTS : ""));
+    params.put("csp", conf.get("hbase.http.filter.csp.value", isSecure ? DEFAULT_CSP : ""));
     return params;
   }
 }

--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
@@ -147,11 +147,12 @@ public class RESTServer implements Constants {
     ctxHandler.addFilter(holder, PATH_SPEC_ANY, EnumSet.allOf(DispatcherType.class));
   }
 
-  private void addSecurityHeadersFilter(ServletContextHandler ctxHandler, Configuration conf) {
+  private void addSecurityHeadersFilter(ServletContextHandler ctxHandler,
+    Configuration conf, boolean isSecure) {
     FilterHolder holder = new FilterHolder();
     holder.setName("securityheaders");
     holder.setClassName(SecurityHeadersFilter.class.getName());
-    holder.setInitParameters(SecurityHeadersFilter.getDefaultParameters(conf));
+    holder.setInitParameters(SecurityHeadersFilter.getDefaultParameters(conf, isSecure));
     ctxHandler.addFilter(holder, PATH_SPEC_ANY, EnumSet.allOf(DispatcherType.class));
   }
 
@@ -301,7 +302,9 @@ public class RESTServer implements Constants {
     httpConfig.setSendDateHeader(false);
 
     ServerConnector serverConnector;
+    boolean isSecure = false;
     if (conf.getBoolean(REST_SSL_ENABLED, false)) {
+      isSecure = true;
       HttpConfiguration httpsConfig = new HttpConfiguration(httpConfig);
       httpsConfig.addCustomizer(new SecureRequestCustomizer());
 
@@ -389,7 +392,7 @@ public class RESTServer implements Constants {
     }
     addCSRFFilter(ctxHandler, conf);
     addClickjackingPreventionFilter(ctxHandler, conf);
-    addSecurityHeadersFilter(ctxHandler, conf);
+    addSecurityHeadersFilter(ctxHandler, conf, isSecure);
     HttpServerUtil.constrainHttpMethods(ctxHandler, servlet.getConfiguration()
         .getBoolean(REST_HTTP_ALLOW_OPTIONS_METHOD, REST_HTTP_ALLOW_OPTIONS_METHOD_DEFAULT));
 

--- a/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/TestRESTServerSSL.java
+++ b/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/TestRESTServerSSL.java
@@ -18,8 +18,6 @@
 package org.apache.hadoop.hbase.rest;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
 import java.io.File;
 import java.security.KeyPair;
 import java.security.cert.X509Certificate;
@@ -107,6 +105,12 @@ public class TestRESTServerSSL {
 
     Response response = sslClient.get("/version", Constants.MIMETYPE_TEXT);
     assertEquals(200, response.getCode());
+
+    // Default security headers
+    assertEquals("max-age=63072000;includeSubDomains;preload",
+      response.getHeader("Strict-Transport-Security"));
+    assertEquals("default-src https: data: 'unsafe-inline' 'unsafe-eval'",
+      response.getHeader("Content-Security-Policy"));
   }
 
   @Test(expected = org.apache.http.client.ClientProtocolException.class)


### PR DESCRIPTION
Originally it was implemented with empty default values, but it actually makes sense to automatically enabled them if SSL is turned on. It's still possible to override via config, but the default behaviour is more secure.