### PR TITLE
Backport "HBASE-26663 Upgrade Maven Enforcer Plugin" to branch-2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1632,8 +1632,8 @@
     <!-- Surefire argLine defaults to Linux, cygwin argLine is used in the os.windows profile -->
     <argLine>${hbase-surefire.argLine}</argLine>
     <jacoco.version>0.7.5.201505241946</jacoco.version>
-    <extra.enforcer.version>1.3</extra.enforcer.version>
-    <enforcer.version>3.0.0-M3</enforcer.version>
+    <extra.enforcer.version>1.5.1</extra.enforcer.version>
+    <enforcer.version>3.0.0</enforcer.version>
     <restrict-imports.enforcer.version>0.14.0</restrict-imports.enforcer.version>
     <!-- Location of test resources -->
     <test.build.classes>${project.build.directory}/test-classes</test.build.classes>


### PR DESCRIPTION
The upgrade is to get the fix in MENFORCER-336, making beanshell evaluation safe for use with `mvn
-T`. Also upgrade extra-enforcer-rules to 1.5.1, as per experience with HBASE-26664.

Signed-off-by: Duo Zhang <zhangduo@apache.org>
Signed-off-by: Sean Busbey <busbey@apache.org>