### PR TITLE
HBASE-26783 ScannerCallable doubly clears meta cache on retries

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ScannerCallable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ScannerCallable.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.NotServingRegionException;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotEnabledException;
 import org.apache.hadoop.hbase.UnknownScannerException;
 import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
 import org.apache.hadoop.hbase.exceptions.ScannerResetException;
@@ -127,9 +128,18 @@ public class ScannerCallable extends ClientServiceCallable<Result[]> {
     return loc;
   }
 
-  protected final RegionLocations getRegionLocations(boolean reload, byte[] row)
+  /**
+   * Fetch region locations for the row. Since this is for prepare, we always useCache.
+   * This is because we can be sure that RpcRetryingCaller will have cleared the cache
+   * in error handling if this is a retry.
+   *
+   * @param row the row to look up region location for
+   */
+  protected final RegionLocations getRegionLocationsForPrepare(byte[] row)
     throws IOException {
-    return RpcRetryingCallerWithReadReplicas.getRegionLocations(!reload, id, getConnection(),
+    // always use cache, because cache will have been cleared if necessary
+    // in the try/catch before retrying
+    return RpcRetryingCallerWithReadReplicas.getRegionLocations(true, id, getConnection(),
       getTableName(), row);
   }
 
@@ -141,7 +151,13 @@ public class ScannerCallable extends ClientServiceCallable<Result[]> {
     if (Thread.interrupted()) {
       throw new InterruptedIOException();
     }
-    RegionLocations rl = getRegionLocations(reload, getRow());
+
+    if (reload && getTableName() != null && !getTableName().equals(TableName.META_TABLE_NAME)
+      && getConnection().isTableDisabled(getTableName())) {
+      throw new TableNotEnabledException(getTableName().getNameAsString() + " is disabled.");
+    }
+
+    RegionLocations rl = getRegionLocationsForPrepare(getRow());
     location = getLocationForReplica(rl);
     ServerName dest = location.getServerName();
     setStub(super.getConnection().getClient(dest));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/FromClientSideBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/FromClientSideBase.java
@@ -281,12 +281,24 @@ class FromClientSideBase {
           e.printStackTrace();
         }
         regions = locator.getAllRegionLocations();
-        if (regions.size() > originalCount) {
+        if (regions.size() > originalCount && allRegionsHaveHostnames(regions)) {
           break;
         }
       }
       return regions;
     }
+  }
+
+  // We need to check for null serverNames due to https://issues.apache.org/jira/browse/HBASE-26790,
+  // because the null serverNames cause the ScannerCallable to fail.
+  // we can remove this check once that is resolved
+  private boolean allRegionsHaveHostnames(List<HRegionLocation> regions) {
+    for (HRegionLocation region : regions) {
+      if (region.getServerName() == null) {
+        return false;
+      }
+    }
+    return true;
   }
 
   protected Result getSingleScanResult(Table ht, Scan scan) throws IOException {


### PR DESCRIPTION
I renamed the protected `getRegionLocations` method so that it's clear that it is meant to be used in the prepare method, as mentioned in the new javadoc as well.

I had to handle some complexity in the ReverseScannerCallable due to how it searches for the correct region location. Previously, the default RegionServerCallable.throwable call would not actually clear the cache, because the passed in `getRow()` value would be an empty row key in some cases which doesn't actually match anything in the cache. With my changes now, we keep track of the "locationSearchKey" which is the key used to find the actual region location in prepare. This way `throwable()` will be sure to clear the cache for the location we were reading from.

I've added some tests here:

- A test in TestMetaCache ensures that we're still clearing the cache when an exception occurs, which is the desired behavior. This is similar to what was added in [HBASE-15658](https://issues.apache.org/jira/browse/HBASE-15658).
- Additional tests in TestScannerCallable and TestReverseScannerCallable ensure that the specific semantics of the prepare/throwable are maintained -- throwable clears cache, prepare handles disabled tables, and prepare always uses cache.
- There is also some additional coverage in other tests that i discovered, but these should cover the specifics of what we need.