### PR TITLE
HBASE-26797 HBase 1.x clients will choke on rep_barrier rows when scanning hbase 2.x meta

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionManager.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionManager.java
@@ -1286,6 +1286,7 @@ class ConnectionManager {
       Scan s = new Scan();
       s.setReversed(true);
       s.withStartRow(metaKey);
+      s.addFamily(HConstants.CATALOG_FAMILY);
 
       if (this.useMetaReplicas) {
         s.setConsistency(Consistency.TIMELINE);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionManager.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionManager.java
@@ -1286,6 +1286,10 @@ class ConnectionManager {
       Scan s = new Scan();
       s.setReversed(true);
       s.withStartRow(metaKey);
+
+      // Adding a filter on CATALOG_FAMILY is necessary for compatibility
+      // with hbase 2.x and beyond, which adds additional column families.
+      // See HBASE-26797
       s.addFamily(HConstants.CATALOG_FAMILY);
 
       if (this.useMetaReplicas) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetaScanner.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetaScanner.java
@@ -220,6 +220,9 @@ public class MetaScanner {
   throws IOException {
     byte[] searchRow = HRegionInfo.createRegionName(userTableName, row, HConstants.NINES, false);
     Scan scan = Scan.createGetClosestRowOrBeforeReverseScan(searchRow);
+    // Adding a filter on CATALOG_FAMILY is necessary for compatibility
+    // with hbase 2.x and beyond, which adds additional column families.
+    // See HBASE-26797
     scan.addFamily(HConstants.CATALOG_FAMILY);
     if (useMetaReplicas) {
       scan.setConsistency(Consistency.TIMELINE);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetaScanner.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetaScanner.java
@@ -220,6 +220,7 @@ public class MetaScanner {
   throws IOException {
     byte[] searchRow = HRegionInfo.createRegionName(userTableName, row, HConstants.NINES, false);
     Scan scan = Scan.createGetClosestRowOrBeforeReverseScan(searchRow);
+    scan.addFamily(HConstants.CATALOG_FAMILY);
     if (useMetaReplicas) {
       scan.setConsistency(Consistency.TIMELINE);
     }


### PR DESCRIPTION
I found it really hard to add a test case for this. I think i'd need to modify meta to add a dummy extra CF and then put a bad row in there and validate that it gets ignored by these reads. That should be straightforward, but alters to meta are disallowed in a few places. I could probably add some sort of internal-only config to disable those checks for the purpose of test, or maybe a setter which sets a volatile value? It's hard to access them from the TestingUtility, but maybe doable. Let me know if you'd like me to go through those efforts to test this, but I think it might not be worth it?