### PR TITLE
HBASE-26680 Close and do not write trailer for the broken WAL writer

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
@@ -270,6 +270,9 @@ public abstract class AbstractProtobufLogWriter {
       short replication, long blockSize, StreamSlowMonitor monitor)
       throws IOException, StreamLacksCapabilityException;
 
+  /**
+   * simply close the output, do not need to write trailer like the Writer.close
+   */
   protected abstract void closeOutput();
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
@@ -166,38 +166,43 @@ public abstract class AbstractProtobufLogWriter {
   public void init(FileSystem fs, Path path, Configuration conf, boolean overwritable,
       long blocksize, StreamSlowMonitor monitor) throws IOException,
       StreamLacksCapabilityException {
-    this.conf = conf;
-    boolean doCompress = initializeCompressionContext(conf, path);
-    this.trailerWarnSize = conf.getInt(WAL_TRAILER_WARN_SIZE, DEFAULT_WAL_TRAILER_WARN_SIZE);
-    int bufferSize = CommonFSUtils.getDefaultBufferSize(fs);
-    short replication = (short) conf.getInt("hbase.regionserver.hlog.replication",
-      CommonFSUtils.getDefaultReplication(fs, path));
+    try {
+      this.conf = conf;
+      boolean doCompress = initializeCompressionContext(conf, path);
+      this.trailerWarnSize = conf.getInt(WAL_TRAILER_WARN_SIZE, DEFAULT_WAL_TRAILER_WARN_SIZE);
+      int bufferSize = CommonFSUtils.getDefaultBufferSize(fs);
+      short replication = (short) conf.getInt("hbase.regionserver.hlog.replication",
+        CommonFSUtils.getDefaultReplication(fs, path));
 
-    initOutput(fs, path, overwritable, bufferSize, replication, blocksize, monitor);
+      initOutput(fs, path, overwritable, bufferSize, replication, blocksize, monitor);
 
-    boolean doTagCompress = doCompress &&
-      conf.getBoolean(CompressionContext.ENABLE_WAL_TAGS_COMPRESSION, true);
-    boolean doValueCompress = doCompress &&
-      conf.getBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, false);
-    WALHeader.Builder headerBuilder = WALHeader.newBuilder()
-      .setHasCompression(doCompress)
-      .setHasTagCompression(doTagCompress)
-      .setHasValueCompression(doValueCompress);
-    if (doValueCompress) {
-      headerBuilder.setValueCompressionAlgorithm(
-        CompressionContext.getValueCompressionAlgorithm(conf).ordinal());
-    }
-    length.set(writeMagicAndWALHeader(ProtobufLogReader.PB_WAL_MAGIC,
-      buildWALHeader(conf, headerBuilder)));
+      boolean doTagCompress =
+        doCompress && conf.getBoolean(CompressionContext.ENABLE_WAL_TAGS_COMPRESSION, true);
+      boolean doValueCompress =
+        doCompress && conf.getBoolean(CompressionContext.ENABLE_WAL_VALUE_COMPRESSION, false);
+      WALHeader.Builder headerBuilder =
+        WALHeader.newBuilder().setHasCompression(doCompress).setHasTagCompression(doTagCompress)
+          .setHasValueCompression(doValueCompress);
+      if (doValueCompress) {
+        headerBuilder.setValueCompressionAlgorithm(
+          CompressionContext.getValueCompressionAlgorithm(conf).ordinal());
+      }
+      length.set(writeMagicAndWALHeader(ProtobufLogReader.PB_WAL_MAGIC,
+        buildWALHeader(conf, headerBuilder)));
 
-    initAfterHeader(doCompress);
+      initAfterHeader(doCompress);
 
-    // instantiate trailer to default value.
-    trailer = WALTrailer.newBuilder().build();
+      // instantiate trailer to default value.
+      trailer = WALTrailer.newBuilder().build();
 
-    if (LOG.isTraceEnabled()) {
-      LOG.trace("Initialized protobuf WAL={}, compression={}, tagCompression={}" +
-        ", valueCompression={}", path, doCompress, doTagCompress, doValueCompress);
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Initialized protobuf WAL={}, compression={}, tagCompression={}"
+          + ", valueCompression={}", path, doCompress, doTagCompress, doValueCompress);
+      }
+    } catch (Exception e) {
+      LOG.warn("Init output failed, path={}", path, e);
+      closeOutput();
+      throw e;
     }
   }
 
@@ -264,6 +269,8 @@ public abstract class AbstractProtobufLogWriter {
   protected abstract void initOutput(FileSystem fs, Path path, boolean overwritable, int bufferSize,
       short replication, long blockSize, StreamSlowMonitor monitor)
       throws IOException, StreamLacksCapabilityException;
+
+  protected abstract void closeOutput();
 
   /**
    * return the file length after written.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AsyncProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AsyncProtobufLogWriter.java
@@ -47,7 +47,6 @@ import org.slf4j.LoggerFactory;
 import org.apache.hbase.thirdparty.com.google.common.base.Throwables;
 import org.apache.hbase.thirdparty.io.netty.channel.Channel;
 import org.apache.hbase.thirdparty.io.netty.channel.EventLoopGroup;
-
 import org.apache.hadoop.hbase.shaded.protobuf.generated.WALProtos.WALHeader;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.WALProtos.WALTrailer;
 
@@ -197,6 +196,17 @@ public class AsyncProtobufLogWriter extends AbstractProtobufLogWriter
     this.asyncOutputWrapper = new OutputStreamWrapper(output);
   }
 
+  @Override
+  protected void closeOutput() {
+    if (this.output != null) {
+      try {
+        this.output.close();
+      } catch (IOException e) {
+        LOG.warn("Close output failed", e);
+      }
+    }
+  }
+  
   private long writeWALMetadata(Consumer<CompletableFuture<Long>> action) throws IOException {
     CompletableFuture<Long> future = new CompletableFuture<>();
     action.accept(future);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogWriter.java
@@ -132,6 +132,17 @@ public class ProtobufLogWriter extends AbstractProtobufLogWriter
   }
 
   @Override
+  protected void closeOutput() {
+    if (this.output != null) {
+      try {
+        this.output.close();
+      } catch (IOException e) {
+        LOG.warn("Close output failed", e);
+      }
+    }
+  }
+
+  @Override
   protected long writeMagicAndWALHeader(byte[] magic, WALHeader header) throws IOException {
     output.write(magic);
     header.writeDelimitedTo(output);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/FSHLogProvider.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/FSHLogProvider.java
@@ -90,13 +90,6 @@ public class FSHLogProvider extends AbstractFSWALProvider<FSHLog> {
       } else {
         LOG.debug("Error instantiating log writer.", e);
       }
-      if (writer != null) {
-        try{
-          writer.close();
-        } catch(IOException ee){
-          LOG.error("cannot close log writer", ee);
-        }
-      }
       throw new IOException("cannot get log writer", e);
     }
   }


### PR DESCRIPTION

Broken writers need to be closed, so that when doing log split, there will be no need to recover lease for those length 0 wals.
