### PR TITLE
HBASE-26784 Addendum: Close scanner request should properly inherit original timeout and priority

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcControllerImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcControllerImpl.java
@@ -262,4 +262,11 @@ public class HBaseRpcControllerImpl implements HBaseRpcController {
       action.run(false);
     }
   }
+
+  @Override public String toString() {
+    return "HBaseRpcControllerImpl{" + "callTimeout=" + callTimeout + ", done=" + done
+      + ", cancelled=" + cancelled + ", cancellationCbs=" + cancellationCbs + ", exception="
+      + exception + ", regionInfo=" + regionInfo + ", priority=" + priority + ", cellScanner="
+      + cellScanner + '}';
+  }
 }


### PR DESCRIPTION
Fixes a bug in the original implementation in https://github.com/apache/hbase/pull/4163, wherein we attempted to inherit the original controller priority/timeout but accidentally was using the same HBaseRpcController for both reading and writing the fields.

Improves tests to ensure that we are properly inheriting these fields.