### PR TITLE
HBASE-26813 Remove javax.ws.rs-api dependency

### DIFF
--- a/hbase-http/pom.xml
+++ b/hbase-http/pom.xml
@@ -180,10 +180,6 @@
       <artifactId>javax.servlet-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-    </dependency>
-    <dependency>
       <groupId>com.github.stephenc.findbugs</groupId>
       <artifactId>findbugs-annotations</artifactId>
       <scope>compile</scope>

--- a/hbase-it/pom.xml
+++ b/hbase-it/pom.xml
@@ -140,16 +140,6 @@
   </build>
 
   <dependencies>
-    <!--This one is upfront to get in front of
-         any dependency that pulls in jersey-core.
-         Jersey-core has implemented version 1
-         Interfaces of what is in this dependency
-         which does version 2.-->
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <scope>test</scope>
-    </dependency>
 	<!-- Intra-project dependencies -->
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
@@ -2253,21 +2253,6 @@ Copyright (c) 2007-2017 The JRuby project
   </supplement>
   <supplement>
     <project>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-      <version>2.1.1</version>
-      <name>Java API for RESTful Web Services</name>
-      <licenses>
-        <license>
-          <name>Eclipse Public License 2.0</name>
-          <url>https://www.eclipse.org/legal/epl-v20.html</url>
-          <distribution>repo</distribution>
-        </license>
-      </licenses>
-    </project>
-  </supplement>
-  <supplement>
-    <project>
       <groupId>io.airlift</groupId>
       <artifactId>aircompressor</artifactId>
       <version>0.21</version>

--- a/hbase-rest/pom.xml
+++ b/hbase-rest/pom.xml
@@ -130,15 +130,6 @@
     </plugins>
   </build>
   <dependencies>
-    <!--This one is upfront to get in front of
-         any dependency that pulls in jersey-core.
-         Jersey-core has implemented version 1
-         Interfaces of what is in this dependency
-         which does version 2.-->
-    <dependency>
-      <groupId>javax.ws.rs</groupId>
-      <artifactId>javax.ws.rs-api</artifactId>
-    </dependency>
     <!-- Intra-project dependencies -->
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -1765,7 +1765,6 @@
     <jackson.databind.version>2.10.1</jackson.databind.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <servlet.api.version>3.1.0</servlet.api.version>
-    <wx.rs.api.version>2.1.1</wx.rs.api.version>
     <glassfish.jsp.version>2.3.2</glassfish.jsp.version>
     <glassfish.el.version>3.0.1-b08</glassfish.el.version>
     <jruby.version>9.2.13.0</jruby.version>
@@ -2427,11 +2426,6 @@
         <groupId>javax.servlet</groupId>
         <artifactId>javax.servlet-api</artifactId>
         <version>${servlet.api.version}</version>
-      </dependency>
-      <dependency>
-        <groupId>javax.ws.rs</groupId>
-        <artifactId>javax.ws.rs-api</artifactId>
-        <version>${wx.rs.api.version}</version>
       </dependency>
       <dependency>
         <groupId>com.sun.activation</groupId>


### PR DESCRIPTION
This is no longer needed since we've transitioned to the shaded Jersey shipped in
hbase-thirdparty.