### PR TITLE
HBASE-26821 Bump dependencies in /dev-support/git-jira-release-audit

### DIFF
--- a/dev-support/git-jira-release-audit/requirements.txt
+++ b/dev-support/git-jira-release-audit/requirements.txt
@@ -19,7 +19,7 @@ blessed==1.17.0
 certifi==2019.11.28
 cffi==1.13.2
 chardet==3.0.4
-cryptography==2.8
+cryptography=3.3.2
 defusedxml==0.6.0
 enlighten==1.4.0
 gitdb2==2.0.6
@@ -35,5 +35,5 @@ requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1
 six==1.14.0
 smmap2==2.0.5
-urllib3==1.25.8
+urllib3==1.26.5
 wcwidth==0.1.8


### PR DESCRIPTION
Bumps urllib3 from 1.25.8 to 1.26.5 to resolve two dependabot warnings

 - CRLF injection (Moderate) urllib3 (pip) · dev-support/git-jira-release-audit/requirements.txt

  - Catastrophic backtracking in URL authority parser when passed URL containing many @ characters (High) urllib3 (pip) · dev-support/git-jira-release-audit/requirements.txt

Bumps cryptography from 2.8 to 3.3.2 to resolve one dependabot warning

  - RSA decryption vulnerable to Bleichenbacher timing vulnerability (Moderate) cryptography (pip) · dev-support/git-jira-release-audit/requirements.txt