### PR TITLE
HBASE-26824 TestHBaseTestingUtil.testResolvePortConflict failing after HBASE-26582

### DIFF
--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/HBaseCommonTestingUtil.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/HBaseCommonTestingUtil.java
@@ -23,6 +23,7 @@ import java.net.ServerSocket;
 import java.util.Arrays;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.ThreadLocalRandom;
@@ -266,10 +267,11 @@ public class HBaseCommonTestingUtil {
 
     /** A set of ports that have been claimed using {@link #randomFreePort()}. */
     private final Set<Integer> takenRandomPorts = new HashSet<>();
-
+    private final Random random;
     private final AvailablePortChecker portChecker;
 
     public PortAllocator() {
+      this.random = new Random();
       this.portChecker = new AvailablePortChecker() {
         @Override
         public boolean available(int port) {
@@ -284,8 +286,13 @@ public class HBaseCommonTestingUtil {
       };
     }
 
-    public PortAllocator(AvailablePortChecker portChecker) {
+    public PortAllocator(Random random, AvailablePortChecker portChecker) {
+      this.random = random;
       this.portChecker = portChecker;
+    }
+
+    public PortAllocator(AvailablePortChecker portChecker) {
+      this(new Random(), portChecker);
     }
 
     /**
@@ -314,8 +321,7 @@ public class HBaseCommonTestingUtil {
      * dynamic allocation (see http://bit.ly/dynports).
      */
     private int randomPort() {
-      return MIN_RANDOM_PORT +
-        ThreadLocalRandom.current().nextInt(MAX_RANDOM_PORT - MIN_RANDOM_PORT);
+      return MIN_RANDOM_PORT + random.nextInt(MAX_RANDOM_PORT - MIN_RANDOM_PORT);
     }
 
     interface AvailablePortChecker {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestHBaseTestingUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestHBaseTestingUtil.java
@@ -429,7 +429,7 @@ public class TestHBaseTestingUtil {
     when(portChecker.available(anyInt())).thenReturn(true);
 
     HBaseTestingUtil.PortAllocator portAllocator =
-      new HBaseTestingUtil.PortAllocator(portChecker);
+      new HBaseTestingUtil.PortAllocator(random, portChecker);
 
     int port1 = portAllocator.randomFreePort();
     int port2 = portAllocator.randomFreePort();


### PR DESCRIPTION
Put back the ability to pass a Random instance to HBaseTestingUtil.PortAllocator so the test will pass again. 