### PR TITLE
HBASE-26828 Increase the concurrency when running UTs in pre commit job

### DIFF
--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -45,7 +45,10 @@ pipeline {
         // These tests currently have known failures. Once they burn down to 0, remove from here so that new problems will cause a failure.
         TESTS_FILTER = 'cc,checkstyle,javac,javadoc,pylint,shellcheck,whitespace,perlcritic,ruby-lint,rubocop,mvnsite'
         EXCLUDE_TESTS_URL = "${JENKINS_URL}/job/HBase-Find-Flaky-Tests/job/${CHANGE_TARGET}/lastSuccessfulBuild/artifact/output/excludes"
-
+        // set build parallel
+        BUILD_THREAD = 4
+        SUREFIRE_FIRST_PART_FORK_COUNT = '0.5C'
+        SUREFIRE_SECOND_PART_FORK_COUNT = '0.5C'
         // a global view of paths. parallel stages can land on the same host concurrently, so each
         // stage works in its own subdirectory. there is an "output" under each of these
         // directories, which we retrieve after the build is complete.

--- a/dev-support/jenkins_precommit_github_yetus.sh
+++ b/dev-support/jenkins_precommit_github_yetus.sh
@@ -147,6 +147,16 @@ YETUS_ARGS+=("--github-use-emoji-vote")
 if [[ -n "${ASF_NIGHTLIES_GENERAL_CHECK_BASE}" ]]; then
   YETUS_ARGS+=("--asf-nightlies-general-check-base=${ASF_NIGHTLIES_GENERAL_CHECK_BASE}")
 fi
+# pass build parallelism in
+if [[ -n "${BUILD_THREAD}" ]]; then
+  YETUS_ARGS+=("--build-thread=${BUILD_THREAD}")
+fi
+if [[ -n "${SUREFIRE_FIRST_PART_FORK_COUNT}" ]]; then
+  YETUS_ARGS+=("--surefire-first-part-fork-count=${SUREFIRE_FIRST_PART_FORK_COUNT}")
+fi
+if [[ -n "${SUREFIRE_SECOND_PART_FORK_COUNT}" ]]; then
+  YETUS_ARGS+=("--surefire-second-part-fork-count=${SUREFIRE_SECOND_PART_FORK_COUNT}")
+fi
 
 echo "Launching yetus with command line:"
 echo "${TESTPATCHBIN} ${YETUS_ARGS[*]}"


### PR DESCRIPTION
Increase the maven build thread to 4, and also increase the surefire fork count from 0.25C to 0.5C.

This could save us a lot of time.

Please see #4211 for the result.