### PR TITLE
HBASE-26630 TableSnapshotInputFormat terminates in the middle

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClientSideRegionScanner.java
@@ -93,9 +93,12 @@ public class ClientSideRegionScanner extends AbstractClientScanner {
   @Override
   public Result next() throws IOException {
     values.clear();
-    scanner.nextRaw(values);
-    if (values.isEmpty()) {
-      //we are done
+    boolean moreValues;
+    do {
+      moreValues = scanner.nextRaw(values);
+    } while (values.isEmpty() && moreValues);
+
+    if (!moreValues) {
       return null;
     }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-26630

When using SingleColumnValueFilter in TableSnapshotInputFormat, there was a problem that the job was terminated in the middle