### PR TITLE
HBASE-26839 Fix compatibility issues in 2.4.11RC0

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/RandomRowFilter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/RandomRowFilter.java
@@ -20,7 +20,7 @@
 package org.apache.hadoop.hbase.filter;
 
 import java.util.Objects;
-import java.util.concurrent.ThreadLocalRandom;
+import java.util.Random;
 
 import org.apache.hadoop.hbase.Cell;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -35,6 +35,7 @@ import org.apache.hbase.thirdparty.com.google.protobuf.InvalidProtocolBufferExce
  */
 @InterfaceAudience.Public
 public class RandomRowFilter extends FilterBase {
+  protected static final Random random = new Random();
 
   protected float chance;
   protected boolean filterOutRow;
@@ -103,7 +104,7 @@ public class RandomRowFilter extends FilterBase {
       filterOutRow = false;
     } else {
       // roll the dice
-      filterOutRow = !(ThreadLocalRandom.current().nextFloat() < chance);
+      filterOutRow = !(random.nextFloat() < chance);
     }
     return filterOutRow;
   }

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/SecurityHeadersFilter.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/SecurityHeadersFilter.java
@@ -70,10 +70,27 @@ public class SecurityHeadersFilter implements Filter {
   public void destroy() {
   }
 
+  /**
+   * @param conf configuration
+   * @param isSecure use secure defaults if 'true'
+   * @return default parameters, as a map
+   */
   public static Map<String, String> getDefaultParameters(Configuration conf, boolean isSecure) {
     Map<String, String> params = new HashMap<>();
     params.put("hsts", conf.get("hbase.http.filter.hsts.value", isSecure ? DEFAULT_HSTS : ""));
     params.put("csp", conf.get("hbase.http.filter.csp.value", isSecure ? DEFAULT_CSP : ""));
     return params;
   }
+
+  /**
+   * @param conf configuration
+   * @return default parameters, as a map
+   * @deprecated Use {@link SecurityHeadersFilter#getDefaultParameters(Configuration, boolean)}
+   *   instead.
+   */
+  @Deprecated
+  public static Map<String, String> getDefaultParameters(Configuration conf) {
+    return getDefaultParameters(conf, false);
+  }
+
 }


### PR DESCRIPTION
In org.apache.hadoop.hbase.http.SecurityHeadersFilter, marked LimitedPrivate(CONFIG), static method getDefaultParameters(Configuration) returning Map<String,String> was removed.

In org.apache.hadoop.hbase.filter.RandomRowFilter, marked Public, the protected field 'random' of type java.util.Random was removed, which might cause NoSuchFieldError exceptions in downstreamers.