### PR TITLE
HBASE-26860 Backport "HBASE-25681 Add a switch for server/table queryMeter" to branch-2.4

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableQueryMeter.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableQueryMeter.java
@@ -25,6 +25,9 @@ import org.apache.yetus.audience.InterfaceAudience;
 @InterfaceAudience.Private
 public interface MetricsTableQueryMeter {
 
+  String TABLE_READ_QUERY_PER_SECOND = "tableReadQueryPerSecond";
+  String TABLE_WRITE_QUERY_PER_SECOND = "tableWriteQueryPerSecond";
+
   /**
    * Update table read QPS
    * @param tableName The table the metric is for

--- a/hbase-hadoop-compat/src/test/java/org/apache/hadoop/hbase/test/MetricsAssertHelper.java
+++ b/hbase-hadoop-compat/src/test/java/org/apache/hadoop/hbase/test/MetricsAssertHelper.java
@@ -150,6 +150,16 @@ public interface MetricsAssertHelper {
   boolean checkCounterExists(String name, BaseSource source);
 
   /**
+   * Check if a gauge exists.
+   *
+   * @param name   name of the gauge.
+   * @param source The BaseSource{@link BaseSource} that will provide the tags,
+   *               gauges, and counters.
+   * @return boolean true if gauge metric exists.
+   */
+  boolean checkGaugeExists(String name, BaseSource source);
+
+  /**
    * Get the value of a gauge as a double.
    *
    * @param name   name of the gauge.

--- a/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableQueryMeterImpl.java
+++ b/hbase-hadoop2-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsTableQueryMeterImpl.java
@@ -33,9 +33,6 @@ public class MetricsTableQueryMeterImpl implements MetricsTableQueryMeter {
   private final Map<TableName, TableMeters> metersByTable = new ConcurrentHashMap<>();
   private final MetricRegistry metricRegistry;
 
-  private final static String TABLE_READ_QUERY_PER_SECOND = "tableReadQueryPerSecond";
-  private final static String TABLE_WRITE_QUERY_PER_SECOND = "tableWriteQueryPerSecond";
-
   public MetricsTableQueryMeterImpl(MetricRegistry metricRegistry) {
     this.metricRegistry = metricRegistry;
   }

--- a/hbase-hadoop2-compat/src/test/java/org/apache/hadoop/hbase/test/MetricsAssertHelperImpl.java
+++ b/hbase-hadoop2-compat/src/test/java/org/apache/hadoop/hbase/test/MetricsAssertHelperImpl.java
@@ -211,9 +211,16 @@ public class MetricsAssertHelperImpl implements MetricsAssertHelper {
   public boolean checkCounterExists(String name, BaseSource source) {
     getMetrics(source);
     String cName = canonicalizeMetricName(name);
-    return (counters.get(cName) != null) ? true : false;
+    return counters.get(cName) != null;
   }
-  
+
+  @Override
+  public boolean checkGaugeExists(String name, BaseSource source) {
+    getMetrics(source);
+    String cName = canonicalizeMetricName(name);
+    return gauges.get(cName) != null;
+  }
+
   @Override
   public double getGaugeDouble(String name, BaseSource source) {
     getMetrics(source);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServer.java
@@ -40,6 +40,12 @@ public class MetricsRegionServer {
   public static final String RS_ENABLE_TABLE_METRICS_KEY =
       "hbase.regionserver.enable.table.latencies";
   public static final boolean RS_ENABLE_TABLE_METRICS_DEFAULT = true;
+  public static final String RS_ENABLE_SERVER_QUERY_METER_METRICS_KEY =
+      "hbase.regionserver.enable.server.query.meter";
+  public static final boolean RS_ENABLE_SERVER_QUERY_METER_METRICS_KEY_DEFAULT = true;
+  public static final String RS_ENABLE_TABLE_QUERY_METER_METRICS_KEY =
+      "hbase.regionserver.enable.table.query.meter";
+  public static final boolean RS_ENABLE_TABLE_QUERY_METER_METRICS_KEY_DEFAULT = true;
 
   public static final String SLOW_METRIC_TIME = "hbase.ipc.slow.metric.time";
   private final MetricsRegionServerSource serverSource;
@@ -73,9 +79,12 @@ public class MetricsRegionServer {
     bulkLoadTimer = metricRegistry.timer("Bulkload");
 
     slowMetricTime = conf.getLong(SLOW_METRIC_TIME, DEFAULT_SLOW_METRIC_TIME);
-    serverReadQueryMeter = metricRegistry.meter("ServerReadQueryPerSecond");
-    serverWriteQueryMeter = metricRegistry.meter("ServerWriteQueryPerSecond");
     quotaSource = CompatibilitySingletonFactory.getInstance(MetricsRegionServerQuotaSource.class);
+    if (conf.getBoolean(RS_ENABLE_SERVER_QUERY_METER_METRICS_KEY,
+      RS_ENABLE_SERVER_QUERY_METER_METRICS_KEY_DEFAULT)) {
+      serverReadQueryMeter = metricRegistry.meter("ServerReadQueryPerSecond");
+      serverWriteQueryMeter = metricRegistry.meter("ServerWriteQueryPerSecond");
+    }
   }
 
   MetricsRegionServer(MetricsRegionServerWrapper regionServerWrapper,
@@ -93,7 +102,9 @@ public class MetricsRegionServer {
    */
   static RegionServerTableMetrics createTableMetrics(Configuration conf) {
     if (conf.getBoolean(RS_ENABLE_TABLE_METRICS_KEY, RS_ENABLE_TABLE_METRICS_DEFAULT)) {
-      return new RegionServerTableMetrics();
+      return new RegionServerTableMetrics(
+        conf.getBoolean(RS_ENABLE_TABLE_QUERY_METER_METRICS_KEY,
+          RS_ENABLE_TABLE_QUERY_METER_METRICS_KEY_DEFAULT));
     }
     return null;
   }
@@ -270,21 +281,27 @@ public class MetricsRegionServer {
     if (tableMetrics != null && tn != null) {
       tableMetrics.updateTableReadQueryMeter(tn, count);
     }
-    this.serverReadQueryMeter.mark(count);
+    if (serverReadQueryMeter != null) {
+      serverReadQueryMeter.mark(count);
+    }
   }
 
   public void updateWriteQueryMeter(TableName tn, long count) {
     if (tableMetrics != null && tn != null) {
       tableMetrics.updateTableWriteQueryMeter(tn, count);
     }
-    this.serverWriteQueryMeter.mark(count);
+    if (serverWriteQueryMeter != null) {
+      serverWriteQueryMeter.mark(count);
+    }
   }
 
   public void updateWriteQueryMeter(TableName tn) {
     if (tableMetrics != null && tn != null) {
       tableMetrics.updateTableWriteQueryMeter(tn);
     }
-    this.serverWriteQueryMeter.mark();
+    if (serverWriteQueryMeter != null) {
+      serverWriteQueryMeter.mark();
+    }
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerTableMetrics.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerTableMetrics.java
@@ -29,12 +29,14 @@ import org.apache.yetus.audience.InterfaceAudience;
 public class RegionServerTableMetrics {
 
   private final MetricsTableLatencies latencies;
-  private final MetricsTableQueryMeter queryMeter;
+  private MetricsTableQueryMeter queryMeter;
 
-  public RegionServerTableMetrics() {
+  public RegionServerTableMetrics(boolean enableTableQueryMeter) {
     latencies = CompatibilitySingletonFactory.getInstance(MetricsTableLatencies.class);
-    queryMeter = new MetricsTableQueryMeterImpl(MetricRegistries.global().
-      get(((MetricsTableLatenciesImpl) latencies).getMetricRegistryInfo()).get());
+    if (enableTableQueryMeter) {
+      queryMeter = new MetricsTableQueryMeterImpl(MetricRegistries.global().
+        get(((MetricsTableLatenciesImpl) latencies).getMetricRegistryInfo()).get());
+    }
   }
 
   public void updatePut(TableName table, long time) {
@@ -86,18 +88,20 @@ public class RegionServerTableMetrics {
   }
 
   public void updateTableReadQueryMeter(TableName table, long count) {
-    queryMeter.updateTableReadQueryMeter(table, count);
-  }
-
-  public void updateTableReadQueryMeter(TableName table) {
-    queryMeter.updateTableReadQueryMeter(table);
+    if (queryMeter != null) {
+      queryMeter.updateTableReadQueryMeter(table, count);
+    }
   }
 
   public void updateTableWriteQueryMeter(TableName table, long count) {
-    queryMeter.updateTableWriteQueryMeter(table, count);
+    if (queryMeter != null) {
+      queryMeter.updateTableWriteQueryMeter(table, count);
+    }
   }
 
   public void updateTableWriteQueryMeter(TableName table) {
-    queryMeter.updateTableWriteQueryMeter(table);
+    if (queryMeter != null) {
+      queryMeter.updateTableWriteQueryMeter(table);
+    }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsRegionServer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsRegionServer.java
@@ -17,11 +17,14 @@
  */
 package org.apache.hadoop.hbase.regionserver;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.CompatibilityFactory;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.test.MetricsAssertHelper;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
@@ -57,7 +60,9 @@ public class TestMetricsRegionServer {
   @Before
   public void setUp() {
     wrapper = new MetricsRegionServerWrapperStub();
-    rsm = new MetricsRegionServer(wrapper, new Configuration(false), null);
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(MetricsRegionServer.RS_ENABLE_SERVER_QUERY_METER_METRICS_KEY, false);
+    rsm = new MetricsRegionServer(wrapper, conf, null);
     serverSource = rsm.getMetricsSource();
   }
 
@@ -245,5 +250,26 @@ public class TestMetricsRegionServer {
     HELPER.assertCounter("pauseTimeWithGc_num_ops", 1, serverSource);
   }
 
+  @Test
+  public void testServerQueryMeterSwitch() {
+    TableName tn1 = TableName.valueOf("table1");
+    // has been set disable in setUp()
+    rsm.updateReadQueryMeter(tn1, 500L);
+    assertFalse(HELPER.checkGaugeExists("ServerReadQueryPerSecond_count", serverSource));
+    rsm.updateWriteQueryMeter(tn1, 500L);
+    assertFalse(HELPER.checkGaugeExists("ServerWriteQueryPerSecond_count", serverSource));
+
+    // enable
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(MetricsRegionServer.RS_ENABLE_SERVER_QUERY_METER_METRICS_KEY, true);
+    rsm = new MetricsRegionServer(wrapper, conf, null);
+    serverSource = rsm.getMetricsSource();
+    rsm.updateReadQueryMeter(tn1, 500L);
+    assertTrue(HELPER.checkGaugeExists("ServerWriteQueryPerSecond_count", serverSource));
+    HELPER.assertGauge("ServerReadQueryPerSecond_count", 500L, serverSource);
+    assertTrue(HELPER.checkGaugeExists("ServerWriteQueryPerSecond_count", serverSource));
+    rsm.updateWriteQueryMeter(tn1, 500L);
+    HELPER.assertGauge("ServerWriteQueryPerSecond_count", 500L, serverSource);
+  }
 }
 


### PR DESCRIPTION
Note: This was a clean cherry-pick of https://github.com/apache/hbase/commit/8ff17c68e2fb71c818cd16e6d3445d0c2658798b. If there's a better way for a committer to simply cherry-pick that into branch-2.4, be my guest and we can close that. Happy to do whatever's easiest.