### PR TITLE
HBASE-26531 Trace coprocessor exec endpoints (addendum)

### DIFF
--- a/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/coprocessor/TestCoprocessorEndpointTracing.java
+++ b/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/coprocessor/TestCoprocessorEndpointTracing.java
@@ -45,6 +45,7 @@ import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ConnectionRule;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.MatcherPredicate;
@@ -106,7 +107,7 @@ public class TestCoprocessorEndpointTracing {
   private static final OpenTelemetryClassRule otelClassRule = OpenTelemetryClassRule.create();
   private static final MiniClusterRule miniclusterRule = MiniClusterRule.newBuilder()
     .setConfiguration(() -> {
-      final Configuration conf = new Configuration();
+      final Configuration conf = HBaseConfiguration.create();
       conf.setInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT, 5000);
       conf.setStrings(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,
         ProtobufCoprocessorService.class.getName());


### PR DESCRIPTION
Stuck by this again. branch-2 needs this configuration instance to be initialized as an
HBaseConfiguration. Forward-porting this change to master in order to keep the branches as similar as possible.