### PR TITLE
HBASE-26876 Use toStringBinary for rowkey in RegionServerCallable error string

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionServerCallable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionServerCallable.java
@@ -194,7 +194,7 @@ public abstract class RegionServerCallable<T, S> implements RetryingCallable<T> 
 
   @Override
   public String getExceptionMessageAdditionalDetail() {
-    return "row '" + Bytes.toString(row) + "' on table '" + tableName + "' at " + location;
+    return "row '" + Bytes.toStringBinary(row) + "' on table '" + tableName + "' at " + location;
   }
 
   @Override


### PR DESCRIPTION
Simple change, did not think it worth a dedicated test. The AsyncTable client callers already appropriately use toStringBinary. For example, here: https://github.com/apache/hbase/blob/branch-2/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncSingleRequestRpcRetryingCaller.java#L85. I checked a few other places I knew of as well.