### PR TITLE
HBASE-26895 on hbase shell, 'delete/deleteall' for a columnfamily is not working

### DIFF
--- a/hbase-shell/src/main/ruby/hbase/table.rb
+++ b/hbase-shell/src/main/ruby/hbase/table.rb
@@ -189,10 +189,18 @@ EOF
       if column != ""
         if column && all_version
           family, qualifier = parse_column_name(column)
-          d.addColumns(family, qualifier, timestamp)
+          if qualifier
+            d.addColumns(family, qualifier, timestamp)
+          else
+            d.addFamily(family, timestamp)
+          end
         elsif column && !all_version
           family, qualifier = parse_column_name(column)
-          d.addColumn(family, qualifier, timestamp)
+          if qualifier
+            d.addColumn(family, qualifier, timestamp)
+          else
+            d.addFamilyVersion(family, timestamp)
+          end
         end
       end
       d

--- a/hbase-shell/src/test/ruby/hbase/table_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/table_test.rb
@@ -164,6 +164,21 @@ module Hbase
       assert_nil(res)
     end
 
+    define_test "delete should set proper cell type" do
+      del = @test_table._createdelete_internal('104', 'x:a', 1212)
+      assert_equal(del.get('x'.to_java_bytes, 'a'.to_java_bytes).get(0).getType.getCode,
+                   org.apache.hadoop.hbase::KeyValue::Type::DeleteColumn.getCode)
+      del = @test_table._createdelete_internal('104', 'x:a', 1212, [], false)
+      assert_equal(del.get('x'.to_java_bytes, 'a'.to_java_bytes).get(0).getType.getCode,
+                   org.apache.hadoop.hbase::KeyValue::Type::Delete.getCode)
+      del = @test_table._createdelete_internal('104', 'x', 1212)
+      assert_equal(del.get('x'.to_java_bytes, nil).get(0).getType.getCode,
+                   org.apache.hadoop.hbase::KeyValue::Type::DeleteFamily.getCode)
+      del = @test_table._createdelete_internal('104', 'x', 1212, [], false)
+      assert_equal(del.get('x'.to_java_bytes, nil).get(0).getType.getCode,
+                   org.apache.hadoop.hbase::KeyValue::Type::DeleteFamilyVersion.getCode)
+    end
+
     #-------------------------------------------------------------------------------
 
     define_test "deleteall should work w/o columns and timestamps" do


### PR DESCRIPTION
HBASE-26895

on hbase shell,

'delete' or 'deleteall' for the whole columnFamily is not working properly.

 
```
hbase(main):026:0* put 'test', 'r1', 'f:1', 'a'
Took 0.0233 seconds
hbase(main):029:0> delete 'test', 'r1', 'f'
Took 0.0070 seconds
hbase(main):030:0> get 'test', 'r1'
COLUMN                                                                  CELL
 f:1                                                                    timestamp=1648114865022, value=a
1 row(s)
hbase(main):038:0> deleteall 'test', 'r1', 'f'
Took 0.0059 seconds
hbase(main):039:0> get 'test', 'r1'
COLUMN                                                                  CELL
 f:1                                                                    timestamp=1648114865022, value=a
1 row(s) 
 ```

looking inside of hbase-shell,
all delete/deleteall on hbase shell are converted to delete.addColumn/addColumns.
thus, delete/deleteall request without columnQualifier converted to 'null' qualifier deletion. (since [HBASE-15616](https://issues.apache.org/jira/browse/HBASE-15616), null columnQualifier is possible)
https://github.com/apache/hbase/blob/4f491fd5e40c0986dc92f8b231d419a2b07e5a0e/hbase-shell/src/main/ruby/hbase/table.rb#L190-L195


According to the description of help 'deleteall' and [HBASE-9549](https://issues.apache.org/jira/browse/HBASE-9549)
> "Users of the shell, MapReduce, REST, and Thrift who wish to interact with an entire column family must use "family" instead of "family:" (notice the omitted ':'). Including the ':' will be interpreted as an interaction with the empty qualifier in the "family" column family."
 
a column expression without ':' means whole family.
so in these cases, it's deletion request for the columnFamily,
and we should use addFamily/addFamilyVersion instead of addColumn/addColumns for deletion.