### PR TITLE
HBASE-26901 delete with null columnQualifier occurs NullPointerException when NewVersionBehavior is on

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/querymatcher/NewVersionBehaviorTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/querymatcher/NewVersionBehaviorTracker.java
@@ -165,9 +165,7 @@ public class NewVersionBehaviorTracker implements ColumnTracker, DeleteTracker {
    * Else return MAX_VALUE.
    */
   protected long prepare(Cell cell) {
-    boolean matchCq =
-        PrivateCellUtil.matchingQualifier(cell, lastCqArray, lastCqOffset, lastCqLength);
-    if (!matchCq) {
+    if (isColumnQualifierChanged(cell)) {
       // The last cell is family-level delete and this is not, or the cq is changed,
       // we should construct delColMap as a deep copy of delFamMap.
       delColMap.clear();
@@ -175,8 +173,7 @@ public class NewVersionBehaviorTracker implements ColumnTracker, DeleteTracker {
         delColMap.put(e.getKey(), e.getValue().getDeepCopy());
       }
       countCurrentCol = 0;
-    }
-    if (matchCq && !PrivateCellUtil.isDelete(lastCqType) && lastCqType == cell.getTypeByte()
+    } else if (!PrivateCellUtil.isDelete(lastCqType) && lastCqType == cell.getTypeByte()
         && lastCqTs == cell.getTimestamp()) {
       // Put with duplicate timestamp, ignore.
       return lastCqMvcc;
@@ -188,6 +185,15 @@ public class NewVersionBehaviorTracker implements ColumnTracker, DeleteTracker {
     lastCqMvcc = cell.getSequenceId();
     lastCqType = cell.getTypeByte();
     return Long.MAX_VALUE;
+  }
+
+  private boolean isColumnQualifierChanged(Cell cell) {
+    if (delColMap.isEmpty()
+        && (PrivateCellUtil.isDeleteColumns(cell) || PrivateCellUtil.isDeleteColumnVersion(cell))) {
+      // for null columnQualifier
+      return true;
+    }
+    return !PrivateCellUtil.matchingQualifier(cell, lastCqArray, lastCqOffset, lastCqLength);
   }
 
   // DeleteTracker

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestNewVersionBehaviorFromClientSide.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestNewVersionBehaviorFromClientSide.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hbase.regionserver;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
-
+import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
@@ -358,4 +358,14 @@ public class TestNewVersionBehaviorFromClientSide {
     }
   }
 
+  @Test
+  public void testNullColumnQualifier() throws IOException {
+    try (Table t = createTable()) {
+      Delete del = new Delete(ROW);
+      del.addColumn(FAMILY, null);
+      t.delete(del);
+      Result r = t.get(new Get(ROW)); //NPE
+      assertTrue(r.isEmpty());
+    }
+  }
 }


### PR DESCRIPTION
since  [HBASE-15616](https://issues.apache.org/jira/browse/HBASE-15616), setting column qualifier as null is possible.

but when NewVersionBehavior is on, delete with null columnQualifier occurs NullPointerException.


```java
@Test
public void testNullColumnQualifier() throws IOException {
  try (Table t = createTable()) {
    Delete del = new Delete(ROW);
    del.addColumn(FAMILY, null);
    t.delete(del);
    Result r = t.get(new Get(ROW)); //NPE happens.
    assertTrue(r.isEmpty());
  }
} 
```

* stacktrace
```
Caused by: java.lang.NullPointerException at org.apache.hadoop.hbase.regionserver.querymatcher.NewVersionBehaviorTracker.add(NewVersionBehaviorTracker.java:214) at org.apache.hadoop.hbase.regionserver.querymatcher.NormalUserScanQueryMatcher.match(NormalUserScanQueryMatcher.java:73) at org.apache.hadoop.hbase.regionserver.StoreScanner.next(StoreScanner.java:627) at org.apache.hadoop.hbase.regionserver.KeyValueHeap.next(KeyValueHeap.java:157) at org.apache.hadoop.hbase.regionserver.HRegion$RegionScannerImpl.populateResult(HRegion.java:6672) at org.apache.hadoop.hbase.regionserver.HRegion$RegionScannerImpl.nextInternal(HRegion.java:6836) at org.apache.hadoop.hbase.regionserver.HRegion$RegionScannerImpl.nextRaw(HRegion.java:6606) at org.apache.hadoop.hbase.regionserver.HRegion$RegionScannerImpl.next(HRegion.java:6583) at org.apache.hadoop.hbase.regionserver.HRegion$RegionScannerImpl.next(HRegion.java:6570) at org.apache.hadoop.hbase.regionserver.RSRpcServices.get(RSRpcServices.java:2645) at org.apache.hadoop.hbase.regionserver.RSRpcServices.get(RSRpcServices.java:2571) at org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos$ClientService$2.callBlockingMethod(ClientProtos.java:42274) at org.apache.hadoop.hbase.ipc.RpcServer.call(RpcServer.java:418) ... 3 more
```


 
NPE happens because delColMap is not initialized and empty.
in this case delColMap.ceilingEntry for empty returns null and NPE happens.
https://github.com/apache/hbase/blob/1efd8fe53c13cdbfde7cb3d0ff7ebea7b8b7d3bb/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/querymatcher/NewVersionBehaviorTracker.java#L214

delColMap expected to be initialized (deep copying of delFamMap) when columnQualifier is changed.
But, when null columnQualifier is presented, matchingCq == true and delColMap is never initialized for null columnQualifier deletes.
https://github.com/apache/hbase/blob/1efd8fe53c13cdbfde7cb3d0ff7ebea7b8b7d3bb/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/querymatcher/NewVersionBehaviorTracker.java#L168-L169

I changed to initialize delColMap if  null columnQualifier is presented.
and only if cell is not for columnFamily or columnFamilfyVersion tombstone which is no need to initialize delColMap (for the performance).
```
  private boolean isColumnQualifierChanged(Cell cell) {
    if (delColMap.isEmpty()
        && (PrivateCellUtil.isDeleteColumns(cell) || PrivateCellUtil.isDeleteColumnVersion(cell))) {
      // for null columnQualifier
      return true;
    }
    return !PrivateCellUtil.matchingQualifier(cell, lastCqArray, lastCqOffset, lastCqLength);
  }
```

I inverted ```matchCq``` to  ```isColumnQualifierChanged``` and reformed if/else statement, I thought it's more clear and fit for purpose.


