### PR TITLE
HBASE-26903 Bump httpclient from 4.5.3 to 4.5.13

### DIFF
--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/client/Client.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/client/Client.java
@@ -23,7 +23,6 @@ import java.io.BufferedInputStream;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
-import java.io.FileInputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.net.URI;
@@ -40,7 +39,6 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.net.ssl.SSLContext;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.rest.Constants;
@@ -113,8 +111,11 @@ public class Client {
       Constants.DEFAULT_REST_CLIENT_CONN_TIMEOUT);
     int socketTimeout = this.conf.getInt(Constants.REST_CLIENT_SOCKET_TIMEOUT,
       Constants.DEFAULT_REST_CLIENT_SOCKET_TIMEOUT);
-    RequestConfig requestConfig = RequestConfig.custom().setConnectTimeout(connTimeout)
-        .setSocketTimeout(socketTimeout).build();
+    RequestConfig requestConfig = RequestConfig.custom()
+      .setConnectTimeout(connTimeout)
+      .setSocketTimeout(socketTimeout)
+      .setNormalizeUri(false) // URIs should not be normalized, see HBASE-26903
+      .build();
     httpClientBuilder.setDefaultRequestConfig(requestConfig);
 
     // Since HBASE-25267 we don't use the deprecated DefaultHttpClient anymore.

--- a/pom.xml
+++ b/pom.xml
@@ -783,11 +783,7 @@
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-math.version>3.6.1</commons-math.version>
     <disruptor.version>3.4.2</disruptor.version>
-    <!-- Updating the httpclient will break hbase-rest. It writes out URLs with '//' in it
-      especially when writing out 'no column families'. Later httpclients collapse the '//'
-      into single '/' as double-slash is not legal in an URL. Breaks #testDelete in
-      TestRemoteTable. -->
-    <httpclient.version>4.5.3</httpclient.version>
+    <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.13</httpcore.version>
     <metrics-core.version>3.2.6</metrics-core.version>
     <jackson.version>2.13.1</jackson.version>


### PR DESCRIPTION
Dependabot auto-generated a dependency upgrade (#4291) but we could not merge that PR as-is because it caused a unit test failure. There is a comment in our POM indicating this is a known issue:

    <!-- Updating the httpclient will break hbase-rest. It writes out URLs with '//' in it                                                                                          
      especially when writing out 'no column families'. Later httpclients collapse the '//'                                                                                         
      into single '/' as double-slash is not legal in an URL. Breaks #testDelete in                                                                                                 
      TestRemoteTable. -->  

However, staying back on a version of httpclient with CVE listed vulnerabilities just for this isn't a good option.

This change bumps httpclient from 4.5.3 to 4.5.13 to avoid a CVE of medium severity in this dependency.

Newer httpclient versions enable a URI normalization algorithm by default that rewrites URIs in a way that breaks some forms of valid REST gateway interactions, so this change also disables the unwanted behavior when building the httpclient instance in `Client`.