### PR TITLE
HBASE-26926 VerifyReplication should use region startKey to check PeerTable

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/replication/VerifyReplication.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/replication/VerifyReplication.java
@@ -196,7 +196,15 @@ public class VerifyReplication extends Configured implements Tool {
         TableName peerTableName = TableName.valueOf(peerName);
         replicatedConnection = ConnectionFactory.createConnection(peerConf);
         replicatedTable = replicatedConnection.getTable(peerTableName);
-        scan.withStartRow(value.getRow());
+
+        byte[] startRow = null;
+        if (tableSplit instanceof TableSnapshotInputFormat.TableSnapshotRegionSplit) {
+          startRow = ((TableSnapshotInputFormat.TableSnapshotRegionSplit) tableSplit).getRegion()
+            .getStartKey();
+        } else {
+          startRow = ((TableSplit) tableSplit).getStartRow();
+        }
+        scan.withStartRow(startRow);
 
         byte[] endRow = null;
         if (tableSplit instanceof TableSnapshotInputFormat.TableSnapshotRegionSplit) {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/replication/TestVerifyReplication.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/replication/TestVerifyReplication.java
@@ -138,6 +138,16 @@ public class TestVerifyReplication extends TestReplicationBase {
     Scan scan = new Scan();
     ResultScanner rs = htable2.getScanner(scan);
     Put put = null;
+
+    int numRowOnlyInPeer = 10;
+    for (int i = 0; i < numRowOnlyInPeer; i++) {
+      //the row keys of redundant data(start with prefix "+") in peer table are all smaller than
+      //the first row key of source table
+      put = new Put(Bytes.toBytes("+" + i));
+      put.addColumn(famName, row, Bytes.toBytes("only in peer"));
+      htable2.put(put);
+    }
+
     for (Result result : rs) {
       put = new Put(result.getRow());
       Cell firstVal = result.rawCells()[0];
@@ -147,7 +157,7 @@ public class TestVerifyReplication extends TestReplicationBase {
     }
     Delete delete = new Delete(put.getRow());
     htable2.delete(delete);
-    runVerifyReplication(args, 0, NB_ROWS_IN_BATCH);
+    runVerifyReplication(args, 0, NB_ROWS_IN_BATCH + numRowOnlyInPeer);
   }
 
   /**


### PR DESCRIPTION
https://github.com/apache/hbase/blob/master/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/replication/VerifyReplication.java#L199

Here we miss the case: peer table has redundant data, which are all smaller than the source table's first rowKey