### PR TITLE
HBASE-26938 Compaction failures after StoreFileTracker integration (branch-2, branch-2.5)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CompactSplit.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CompactSplit.java
@@ -420,7 +420,13 @@ public class CompactSplit implements CompactionRequester, PropagatingConfigurati
       throws IOException {
     // don't even select for compaction if disableCompactions is set to true
     if (!isCompactionsEnabled()) {
-      LOG.info(String.format("User has disabled compactions"));
+      LOG.info("User has disabled compactions");
+      return Optional.empty();
+    }
+    if (store.isCompacting()) {
+      // There is only one Compactor instance for a given store. We cannot concurrently compact
+      // the store.
+      LOG.debug("Store is already compacting");
       return Optional.empty();
     }
     Optional<CompactionContext> compaction = store.requestCompaction(priority, tracker, user);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -156,8 +156,6 @@ public class HStore implements Store, HeapSize, StoreConfigInformation,
   // rows that has cells from both memstore and files (or only files)
   private LongAdder mixedRowReadsCount = new LongAdder();
 
-  private boolean cacheOnWriteLogged;
-
   /**
    * Lock specific to archiving compacted store files.  This avoids races around
    * the combination of retrieving the list of compacted files and moving them to
@@ -290,7 +288,6 @@ public class HStore implements Store, HeapSize, StoreConfigInformation,
         this, memstore.getClass().getSimpleName(), policyName, verifyBulkLoads,
         parallelPutCountPrintThreshold, family.getDataBlockEncoding(),
         family.getCompressionType());
-    cacheOnWriteLogged = false;
   }
 
   private StoreContext initializeStoreContext(ColumnFamilyDescriptor family) throws IOException {
@@ -576,6 +573,13 @@ public class HStore implements Store, HeapSize, StoreConfigInformation,
   @Override
   public Collection<HStoreFile> getCompactedFiles() {
     return this.storeEngine.getStoreFileManager().getCompactedfiles();
+  }
+
+  @Override
+  public boolean isCompacting() {
+    synchronized (filesCompacting) {
+      return !filesCompacting.isEmpty();
+    }
   }
 
   /**
@@ -2404,4 +2408,5 @@ public class HStore implements Store, HeapSize, StoreConfigInformation,
       mixedRowReadsCount.increment();
     }
   }
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/Store.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/Store.java
@@ -54,6 +54,8 @@ public interface Store {
 
   Collection<? extends StoreFile> getCompactedFiles();
 
+  boolean isCompacting();
+
   /**
    * When was the last edit done in the memstore
    */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
@@ -355,10 +355,12 @@ public abstract class Compactor<T extends CellSink> {
         smallestReadPoint = Math.min(fd.minSeqIdToKeep, smallestReadPoint);
         cleanSeqId = true;
       }
-      if (writer != null){
-        LOG.warn("Writer exists when it should not: " + getCompactionTargets().stream()
+      if (writer != null) {
+        String message = "Writer exists when it should not: " + getCompactionTargets().stream()
           .map(n -> n.toString())
-          .collect(Collectors.joining(", ", "{ ", " }")));
+          .collect(Collectors.joining(", ", "{ ", " }"));
+        LOG.error(message);
+        throw new IllegalStateException(message);
       }
       writer = sinkFactory.createWriter(scanner, fd, dropCache, request.isMajor());
       finished = performCompaction(fd, scanner, smallestReadPoint, cleanSeqId,
@@ -564,7 +566,7 @@ public abstract class Compactor<T extends CellSink> {
   /**
    * Reset the Writer when the new storefiles were successfully added
    */
-  public void resetWriter(){
+  public void resetWriter() {
     writer = null;
   }
 }


### PR DESCRIPTION
One `Compactor` instance is reused for the lifetime of a store, and it has a `writer` field that at issue here. 

More than one compaction cannot be concurrently selected and executed against a given store or else readers or writers of the `writer` field will encounter multithreaded correctness problems. Yet I am seeing concurrent selection and execution of compaction activity against the store in the test scenario.

In the test scenario I have increased the size of the small and large compaction thread pools, to 10 and 5 threads, respectively, and increased the default point for blocking files to 24, and in the scenario the store is flushing furiously. Operation under these conditions used to be reliable, but perhaps only by an accidental serialization of compaction activity prior to the SFT changes. 

With this change in place the reliability and performance under the test scenario returns to previous baseline for DEFAULT SFT. No ERRORs. 

Suggestions of alternative approaches to fixing this are welcome too.