### PR TITLE
HBASE-26944 Possible resource leak while creating new region scanner

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -3208,6 +3208,9 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
         scanner = region.getCoprocessorHost().postScannerOpen(scan, scanner);
       }
     } catch (Exception e) {
+      // Although region coprocessor is for advanced users and they should take care of the
+      // implementation to not damage the HBase system, closing the scanner on exception here does
+      // not have any bad side effect, so let's do it
       scanner.close();
       throw e;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -3203,8 +3203,13 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
     RegionScannerImpl coreScanner = region.getScanner(scan);
     Shipper shipper = coreScanner;
     RegionScanner scanner = coreScanner;
-    if (region.getCoprocessorHost() != null) {
-      scanner = region.getCoprocessorHost().postScannerOpen(scan, scanner);
+    try {
+      if (region.getCoprocessorHost() != null) {
+        scanner = region.getCoprocessorHost().postScannerOpen(scan, scanner);
+      }
+    } catch (Exception e) {
+      scanner.close();
+      throw e;
     }
     long scannerId = scannerIdGenerator.generateNewScannerId();
     builder.setScannerId(scannerId);


### PR DESCRIPTION
Scanner should be closed to avoid leak in case any exception thrown from RegionObserver#postScannerOpen 