### PR TITLE
HBASE-26964 Fix java import in admin.rb

### DIFF
--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -27,6 +27,7 @@ java_import org.apache.hadoop.hbase.ServerName
 java_import org.apache.hadoop.hbase.TableName
 java_import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder
 java_import org.apache.hadoop.hbase.client.CoprocessorDescriptorBuilder
+java_import org.apache.hadoop.hbase.client.MobCompactPartitionPolicy
 java_import org.apache.hadoop.hbase.client.TableDescriptorBuilder
 java_import org.apache.hadoop.hbase.HConstants
 


### PR DESCRIPTION
The java_import for MobCompactPartitionPolicy in admin.rb is missed, which cause an error message for creating table.
```
hbase:006:0> create 't2', {NAME => 'f', IS_MOB => true, MOB_THRESHOLD => 1000000, MOB_COMPACT_PARTITION_POLICY => 'weekly'}
ERROR: uninitialized constant Hbase::Admin::MobCompactPartitionPolicy
Did you mean?  Hbase::Admin::MOB_COMPACT_PARTITION_POLICY
For usage try 'help "create"'
Took 0.6897 seconds
hbase:007:0> 
```