### PR TITLE
HBASE-26954 Compilation of master vs hadoop-3.3.2 fails

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java
@@ -829,7 +829,6 @@ public class TableMapReduceUtil {
       org.apache.hbase.thirdparty.com.google.protobuf.UnsafeByteOperations.class, // hb-sh-protobuf
       org.apache.hbase.thirdparty.io.netty.channel.Channel.class,    // hbase-shaded-netty
       org.apache.zookeeper.ZooKeeper.class,                          // zookeeper
-      org.apache.htrace.core.Tracer.class,                           // htrace
       com.codahale.metrics.MetricRegistry.class,                     // metrics-core
       org.apache.commons.lang3.ArrayUtils.class,                     // commons-lang
       io.opentelemetry.api.trace.Span.class,                         // opentelemetry-api


### PR DESCRIPTION
I think this reference to HTrace was simply missed in early changes. It happens to have not been noticed because earlier versions of Hadoop provide an HTrace jar in the dependency set. Our import ban didn't catch this because we don't import the HTrace class, we refer to it via fully qualified class name. The restrict-imports enforcer-rule appears to work only on import statements.