### PR TITLE
HBASE-26807 Addendum: adhere to maxAttempts in RawAsyncTableImpl.batch

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
@@ -743,6 +743,7 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
       .operationTimeout(operationTimeoutNs, TimeUnit.NANOSECONDS)
       .rpcTimeout(rpcTimeoutNs, TimeUnit.NANOSECONDS).pause(pauseNs, TimeUnit.NANOSECONDS)
       .pauseForServerOverloaded(pauseNsForServerOverloaded, TimeUnit.NANOSECONDS)
+      .maxAttempts(maxAttempts)
       .startLogErrorsCnt(startLogErrorsCnt).call();
   }
 


### PR DESCRIPTION
This method was accidentally dropped when resolving conflicts in this backport [here](https://github.com/apache/hbase/pull/4273/commits/8755447efc72cbe7afc414e62bfe00d681d2b954#diff-7ab88c464bf7557dd7e4ff33ab640c4a8401126c0bbe1c0916c698dcef7f8b3bL747). Adding it back. I took another pass at that PR's diff both in general and with specific focus on the chained methods, and this is the only error I could find.