### PR TITLE
HBASE-22349 slop in StochasticLoadBalancer

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BaseLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/BaseLoadBalancer.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Random;
 import java.util.Set;
 import java.util.TreeMap;
@@ -137,6 +138,28 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
       }
     }
     return isServerExistsWithMoreRegions && isServerExistsWithZeroRegions;
+  }
+
+  protected final boolean sloppyRegionServerExist(ClusterLoadState cs) {
+    if (slop < 0) {
+      LOG.debug("Slop is less than zero, not checking for sloppiness.");
+      return false;
+    }
+    float average = cs.getLoadAverage(); // for logging
+    int floor = (int) Math.floor(average * (1 - slop));
+    int ceiling = (int) Math.ceil(average * (1 + slop));
+    if (!(cs.getMaxLoad() > ceiling || cs.getMinLoad() < floor)) {
+      NavigableMap<ServerAndLoad, List<RegionInfo>> serversByLoad = cs.getServersByLoad();
+      if (LOG.isTraceEnabled()) {
+        // If nothing to balance, then don't say anything unless trace-level logging.
+        LOG.trace("Skipping load balancing because balanced cluster; " + "servers=" +
+          cs.getNumServers() + " regions=" + cs.getNumRegions() + " average=" + average +
+          " mostloaded=" + serversByLoad.lastKey().getLoad() + " leastloaded=" +
+          serversByLoad.firstKey().getLoad());
+      }
+      return false;
+    }
+    return true;
   }
 
   /**
@@ -372,16 +395,6 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
     return Collections.unmodifiableMap(assignments);
   }
 
-  protected final float normalizeSlop(float slop) {
-    if (slop < 0) {
-      return 0;
-    }
-    if (slop > 1) {
-      return 1;
-    }
-    return slop;
-  }
-
   protected float getDefaultSlop() {
     return 0.2f;
   }
@@ -394,7 +407,7 @@ public abstract class BaseLoadBalancer implements LoadBalancer {
   }
 
   protected void loadConf(Configuration conf) {
-    this.slop = normalizeSlop(conf.getFloat("hbase.regions.slop", getDefaultSlop()));
+    this.slop = conf.getFloat("hbase.regions.slop", getDefaultSlop());
     this.rackManager = new RackManager(conf);
     useRegionFinder = conf.getBoolean("hbase.master.balancer.uselocality", true);
     if (useRegionFinder) {

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/SimpleLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/SimpleLoadBalancer.java
@@ -191,24 +191,9 @@ public class SimpleLoadBalancer extends BaseLoadBalancer {
     if (idleRegionServerExist(c)) {
       return true;
     }
-
     // Check if we even need to do any load balancing
     // HBASE-3681 check sloppiness first
-    float average = cs.getLoadAverage(); // for logging
-    int floor = (int) Math.floor(average * (1 - slop));
-    int ceiling = (int) Math.ceil(average * (1 + slop));
-    if (!(cs.getMaxLoad() > ceiling || cs.getMinLoad() < floor)) {
-      NavigableMap<ServerAndLoad, List<RegionInfo>> serversByLoad = cs.getServersByLoad();
-      if (LOG.isTraceEnabled()) {
-        // If nothing to balance, then don't say anything unless trace-level logging.
-        LOG.trace("Skipping load balancing because balanced cluster; " + "servers=" +
-          cs.getNumServers() + " regions=" + cs.getNumRegions() + " average=" + average +
-          " mostloaded=" + serversByLoad.lastKey().getLoad() + " leastloaded=" +
-          serversByLoad.firstKey().getLoad());
-      }
-      return false;
-    }
-    return true;
+    return sloppyRegionServerExist(cs);
   }
 
   /**

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -203,11 +203,6 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     return this.candidateGenerators;
   }
 
-  @Override
-  protected float getDefaultSlop() {
-    return 0.001f;
-  }
-
   protected List<CandidateGenerator> createCandidateGenerators() {
     List<CandidateGenerator> candidateGenerators = new ArrayList<CandidateGenerator>(4);
     candidateGenerators.add(GeneratorType.RANDOM.ordinal(), new RandomCandidateGenerator());
@@ -353,6 +348,12 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
 
     if (idleRegionServerExist(cluster)){
       LOG.info("Running balancer because cluster has idle server(s)."+
+        " function cost={}", functionCost());
+      return true;
+    }
+
+    if (sloppyRegionServerExist(cs)) {
+      LOG.info("Running balancer because cluster has sloppy server(s)."+
         " function cost={}", functionCost());
       return true;
     }

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/BalancerTestBase.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/BalancerTestBase.java
@@ -60,83 +60,122 @@ public class BalancerTestBase {
   protected static Configuration conf;
 
   protected int[] largeCluster = new int[] { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
-      0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 56 };
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0,
+    0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 56 };
 
   // int[testnum][servernumber] -> numregions
   protected int[][] clusterStateMocks = new int[][]{
-      // 1 node
-      new int[]{0},
-      new int[]{1},
-      new int[]{10},
-      // 2 node
-      new int[]{0, 0},
-      new int[]{2, 0},
-      new int[]{2, 1},
-      new int[]{2, 2},
-      new int[]{2, 3},
-      new int[]{2, 4},
-      new int[]{1, 1},
-      new int[]{0, 1},
-      new int[]{10, 1},
-      new int[]{514, 1432},
-      new int[]{48, 53},
-      // 3 node
-      new int[]{0, 1, 2},
-      new int[]{1, 2, 3},
-      new int[]{0, 2, 2},
-      new int[]{0, 3, 0},
-      new int[]{0, 4, 0},
-      new int[]{20, 20, 0},
-      // 4 node
-      new int[]{0, 1, 2, 3},
-      new int[]{4, 0, 0, 0},
-      new int[]{5, 0, 0, 0},
-      new int[]{6, 6, 0, 0},
-      new int[]{6, 2, 0, 0},
-      new int[]{6, 1, 0, 0},
-      new int[]{6, 0, 0, 0},
-      new int[]{4, 4, 4, 7},
-      new int[]{4, 4, 4, 8},
-      new int[]{0, 0, 0, 7},
-      // 5 node
-      new int[]{1, 1, 1, 1, 4},
-      // 6 nodes
-      new int[]{1500, 500, 500, 500, 10, 0},
-      new int[]{1500, 500, 500, 500, 500, 0},
-      // more nodes
-      new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
-      new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 10},
-      new int[]{6, 6, 5, 6, 6, 6, 6, 6, 6, 1},
-      new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 54},
-      new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 55},
-      new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 56},
-      new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 16},
-      new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 8},
-      new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 9},
-      new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 10},
-      new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 123},
-      new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 155},
-      new int[]{10, 7, 12, 8, 11, 10, 9, 14},
-      new int[]{13, 14, 6, 10, 10, 10, 8, 10},
-      new int[]{130, 14, 60, 10, 100, 10, 80, 10},
-      new int[]{130, 140, 60, 100, 100, 100, 80, 100},
-      new int[]{0, 5 , 5, 5, 5},
-      largeCluster,
+    // 1 node
+    new int[]{0},
+    new int[]{1},
+    new int[]{10},
+    // 2 node
+    new int[]{0, 0},
+    new int[]{2, 0},
+    new int[]{2, 1},
+    new int[]{2, 2},
+    new int[]{2, 3},
+    new int[]{2, 4},
+    new int[]{1, 1},
+    new int[]{0, 1},
+    new int[]{10, 1},
+    new int[]{514, 1432},
+    new int[]{48, 53},
+    // 3 node
+    new int[]{0, 1, 2},
+    new int[]{1, 2, 3},
+    new int[]{0, 2, 2},
+    new int[]{0, 3, 0},
+    new int[]{0, 4, 0},
+    new int[]{20, 20, 0},
+    // 4 node
+    new int[]{0, 1, 2, 3},
+    new int[]{4, 0, 0, 0},
+    new int[]{5, 0, 0, 0},
+    new int[]{6, 6, 0, 0},
+    new int[]{6, 2, 0, 0},
+    new int[]{6, 1, 0, 0},
+    new int[]{6, 0, 0, 0},
+    new int[]{4, 4, 4, 7},
+    new int[]{4, 4, 4, 8},
+    new int[]{0, 0, 0, 7},
+    // 5 node
+    new int[]{1, 1, 1, 1, 4},
+    // 6 nodes
+    new int[]{1500, 500, 500, 500, 10, 0},
+    new int[]{1500, 500, 500, 500, 500, 0},
+    // more nodes
+    new int[]{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+    new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 10},
+    new int[]{6, 6, 5, 6, 6, 6, 6, 6, 6, 1},
+    new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 54},
+    new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 55},
+    new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 56},
+    new int[]{0, 0, 0, 0, 0, 0, 0, 0, 0, 16},
+    new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 8},
+    new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 9},
+    new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 10},
+    new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 123},
+    new int[]{1, 1, 1, 1, 1, 1, 1, 1, 1, 155},
+    new int[]{10, 7, 12, 8, 11, 10, 9, 14},
+    new int[]{13, 14, 6, 10, 10, 10, 8, 10},
+    new int[]{130, 14, 60, 10, 100, 10, 80, 10},
+    new int[]{130, 140, 60, 100, 100, 100, 80, 100},
+    new int[]{0, 5 , 5, 5, 5},
+    largeCluster,
 
   };
 
+  // int[testnum][servernumber] -> numregions
+  protected int[][] clusterStateMocksWithNoSlop = new int[][] {
+    // 1 node
+    new int[]{0},
+    new int[]{1},
+    new int[]{10},
+    // 2 node
+    new int[]{0, 0},
+    new int[]{2, 1},
+    new int[]{2, 2},
+    new int[]{2, 3},
+    new int[]{1, 1},
+    new int[]{80, 120},
+    new int[]{1428, 1432},
+    // more nodes
+    new int[]{100, 90, 120, 90, 110, 100, 90, 120},
+  };
+
+  // int[testnum][servernumber] -> numregions
+  protected int[][] clusterStateMocksWithSlop = new int[][] {
+    // 2 node
+    new int[]{1, 4},
+    new int[]{10, 20},
+    new int[]{80, 123},
+    // more nodes
+    new int[]{100, 100, 100, 100, 100, 100, 100, 100, 100, 200},
+    new int[] {
+      10, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+      , 5, 5, 5, 5, 5, 5, 5, 5, 5, 5
+    },
+  };
 
   // This class is introduced because IP to rack resolution can be lengthy.
   public static class MockMapping implements DNSToSwitchMapping {
@@ -349,6 +388,23 @@ public class BalancerTestBase {
     if (sal == null) sal = new ServerAndLoad(sn, 0);
     sal = new ServerAndLoad(sn, sal.getLoad() + diff);
     map.put(sn, sal);
+  }
+
+  protected TreeMap<ServerName, List<RegionInfo>> mockClusterServers(int[][] mockCluster) {
+    // dimension1: table, dimension2: regions per server
+    int numTables = mockCluster.length;
+    TreeMap<ServerName, List<RegionInfo>> servers = new TreeMap<>();
+    for (int i = 0; i < numTables; i++) {
+      TableName tableName = TableName.valueOf("table" + i);
+      for (int j = 0; j < mockCluster[i].length; j++) {
+        ServerName serverName = ServerName.valueOf("server" + j, 1000, -1);
+        int numRegions = mockCluster[i][j];
+        List<RegionInfo> regions = createRegions(numRegions, tableName);
+        servers.putIfAbsent(serverName, new ArrayList<>());
+        servers.get(serverName).addAll(regions);
+      }
+    }
+    return servers;
   }
 
   protected TreeMap<ServerName, List<RegionInfo>> mockClusterServers(int[] mockCluster) {

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/StochasticBalancerTestBase.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/StochasticBalancerTestBase.java
@@ -46,7 +46,6 @@ public class StochasticBalancerTestBase extends BalancerTestBase {
   public static void beforeAllTests() throws Exception {
     conf = HBaseConfiguration.create();
     conf.setClass("hbase.util.ip.to.rack.determiner", MockMapping.class, DNSToSwitchMapping.class);
-    conf.setFloat("hbase.regions.slop", 0.0f);
     conf.setFloat("hbase.master.balancer.stochastic.localityCost", 0);
     conf.setBoolean("hbase.master.balancer.stochastic.runMaxSteps", true);
     loadBalancer = new StochasticLoadBalancer(dummyMetricsStochasticBalancer);

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancer.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancer.java
@@ -399,7 +399,7 @@ public class TestStochasticLoadBalancer extends StochasticBalancerTestBase {
     Map<ServerName, List<RegionInfo>> servers = mockClusterServers(mockCluster);
     return hasEmptyBalancerPlans(servers);
   }
-  
+
   private boolean hasEmptyBalancerPlans(int[][] mockCluster) {
     Map<ServerName, List<RegionInfo>> servers = mockClusterServers(mockCluster);
     return hasEmptyBalancerPlans(servers);

--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -618,11 +618,20 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
     <name>hbase.regions.slop</name>
-    <value>0.001</value>
-    <description>Rebalance if any regionserver has average + (average * slop) regions.
-      The default value of this parameter is 0.001 in StochasticLoadBalancer (the default load
-      balancer), while the default is 0.2 in other load balancers (i.e.,
-      SimpleLoadBalancer).</description>
+    <value>0.2</value>
+    <description>The load balancer can trigger for several reasons. This value controls one of
+      those reasons. Run the balancer if any regionserver has a region count outside the range of
+      average +/- (average * slop) regions.
+      If the value of slop is negative, disable sloppiness checks. The balancer can still run for
+      other reasons, but sloppiness will not be one of them.
+      If the value of slop is 0, run the balancer if any server has a region count more than 1
+      from the average.
+      If the value of slop is 100, run the balancer if any server has a region count greater than
+      101 times the average.
+      The default value of this parameter is 0.2, which runs the balancer if any server has a region
+      count less than 80% of the average, or greater than 120% of the average.
+      Note that for the default StochasticLoadBalancer, this does not guarantee any balancing
+      actions will be taken, but only that the balancer will attempt to run.</description>
   </property>
   <property>
     <name>hbase.normalizer.period</name>

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBalancerDecision.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/balancer/TestBalancerDecision.java
@@ -65,7 +65,9 @@ public class TestBalancerDecision extends StochasticBalancerTestBase {
     loadBalancer.setClusterInfoProvider(provider);
     loadBalancer.onConfigurationChange(conf);
     float minCost = conf.getFloat("hbase.master.balancer.stochastic.minCostNeedBalance", 0.05f);
+    float slop = conf.getFloat(HConstants.LOAD_BALANCER_SLOP_KEY, 0.2f);
     conf.setFloat("hbase.master.balancer.stochastic.minCostNeedBalance", 1.0f);
+    conf.setFloat(HConstants.LOAD_BALANCER_SLOP_KEY, -1f);
     try {
       // Test with/without per table balancer.
       boolean[] perTableBalancerConfigs = {true, false};
@@ -100,6 +102,7 @@ public class TestBalancerDecision extends StochasticBalancerTestBase {
       // reset config
       conf.unset(HConstants.HBASE_MASTER_LOADBALANCE_BYTABLE);
       conf.setFloat("hbase.master.balancer.stochastic.minCostNeedBalance", minCost);
+      conf.setFloat(HConstants.LOAD_BALANCER_SLOP_KEY, slop);
       loadBalancer.onConfigurationChange(conf);
     }
   }


### PR DESCRIPTION
[HBASE-22349](https://issues.apache.org/jira/browse/HBASE-22349)

Slop is a concept used within `SimpleLoadBalancer` but has always been referenced in `StochasticLoadBalancer` without any effect. This change proposes that we start using the concept of slop, as another trigger for a balancer run. This is similar to HBASE-24139, where a server with 0 regions is considered a trigger to run the balancer.

In this way we can guarantee balancer attempts to run in other cases that a balancer run is desirable, such as only 1 region on a server, or 2x or 3x the average region count on a server.

I remove the `normalizeSlop` method for two reasons:
1. A negative value will indicate the slop value should not be used at all
2. Values greater than 1 can still be useful (setting slop to 2 would mean to trigger a balancer run if a server had >3x the average region count for the cluster.)

As far as I can tell, the default slop of `0.001f` never had any meaning for the `StochasticLoadBalancer` before this change. I choose to reuse the default slop of `0.2f` as used in the `SimpleLoadBalancer`.