### PR TITLE
HBASE-26978 Update inmemory_compaction.adoc

### DIFF
--- a/src/main/asciidoc/_chapters/inmemory_compaction.adoc
+++ b/src/main/asciidoc/_chapters/inmemory_compaction.adoc
@@ -81,12 +81,12 @@ Note how the IN_MEMORY_COMPACTION attribute shows as part of the _METADATA_ map.
 There is also a global configuration, _hbase.hregion.compacting.memstore.type_ which you can set in your _hbase-site.xml_ file. Use it to set the
 default on creation of a new table (On creation of a column family Store, we look first to the column family configuration looking for the
 _IN_MEMORY_COMPACTION_ setting, and if none, we then consult the _hbase.hregion.compacting.memstore.type_ value using its content; default is
-_BASIC_).
+_NONE_).
 
-By default, new hbase system tables will have _BASIC_ in-memory compaction set.  To specify otherwise,
-on new table-creation, set _hbase.hregion.compacting.memstore.type_ to _NONE_ (Note, setting this value
+By default, new hbase system tables will have _NONE_ in-memory compaction set.  To specify otherwise,
+on new table-creation, set _hbase.systemtables.compacting.memstore.type_ to _BASIC_ / _EAGER_ / _ADAPTIVE_ (Note, setting this value
 post-creation of system tables will not have a retroactive effect; you will have to alter your tables
-to set the in-memory attribute to _NONE_).
+to set the in-memory attribute).
 
 When an in-memory flush happens is calculated by dividing the configured region flush size (Set in the table descriptor
 or read from _hbase.hregion.memstore.flush.size_) by the number of column families and then multiplying by


### PR DESCRIPTION
The default value of `hbase.hregion.compacting.memstore.type` was changed from `BASIC` to `DEFAULT` by [HBASE-20539](https://issues.apache.org/jira/browse/HBASE-20539).

We should update its doc `inmemory_compaction.adoc` accordingly.