### PR TITLE
HBASE-26985 check permission for SecureBulkLoadManager

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SecureBulkLoadManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SecureBulkLoadManager.java
@@ -132,6 +132,10 @@ public class SecureBulkLoadManager {
     }
     if (!fs.exists(baseStagingDir)) {
       fs.mkdirs(baseStagingDir, PERM_HIDDEN);
+      if (!PERM_HIDDEN.equals(PERM_HIDDEN.applyUMask(FsPermission.getUMask(conf)))) {
+        LOG.info("Modifying permissions to " + PERM_HIDDEN);
+        fileSystem.setPermission(baseStagingDir, PERM_HIDDEN);
+      }
     }
   }
 


### PR DESCRIPTION
HBASE-26985 check permission for SecureBulkLoadManager

SecureBulkLoadManager will create baseStagingDir if not exist. start method use 
fs.mkdirs(baseStagingDir, PERM_HIDDEN); to create directory with permission -rwx–x–x.BUT if umask is too strict such as 077 ,this directory will create with 0700 so it too strict for GROUP and OTHER user to own execute permission.In this modification, we check whether permissions are affected by umask, and if so, correct permissions to -rwx–x–x