### PR TITLE
HBASE-26992 Brotli compressor has unexpected behavior during reinitialization

### DIFF
--- a/hbase-compression/hbase-compression-brotli/src/main/java/org/apache/hadoop/hbase/io/compress/brotli/BrotliCompressor.java
+++ b/hbase-compression/hbase-compression-brotli/src/main/java/org/apache/hadoop/hbase/io/compress/brotli/BrotliCompressor.java
@@ -162,8 +162,8 @@ public class BrotliCompressor implements CanReinit, Compressor {
       int newBufferSize = BrotliCodec.getBufferSize(conf);
       if (bufferSize != newBufferSize) {
         bufferSize = newBufferSize;
-        this.inBuf = ByteBuffer.allocateDirect(bufferSize);
-        this.outBuf = ByteBuffer.allocateDirect(bufferSize);
+        this.inBuf = ByteBuffer.allocate(bufferSize);
+        this.outBuf = ByteBuffer.allocate(bufferSize);
       }
     }
     reset();


### PR DESCRIPTION
Due to a copy and paste error in BrotliCompressor#reinit we can reallocate a direct buffer instead of an on heap buffer. Not a functional problem right now but in all other cases the allocation is a heap buffer so could be a future surprise, and is in any case incorrect.
