### PR TITLE
HBASE-26680 Close and do not write trailer for the broken WAL writer(addendum)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractProtobufLogWriter.java
@@ -199,7 +199,7 @@ public abstract class AbstractProtobufLogWriter {
       }
     } catch (Exception e) {
       LOG.warn("Init output failed, path={}", path, e);
-      closeOutput();
+      closeOutputIfNecessary();
       throw e;
     }
   }
@@ -269,9 +269,10 @@ public abstract class AbstractProtobufLogWriter {
     throws IOException, StreamLacksCapabilityException;
 
   /**
-   * simply close the output, do not need to write trailer like the Writer.close
+   * It is straight forward to close the output, do not need to write trailer like the Writer.close
    */
-  protected abstract void closeOutput();
+  protected void closeOutputIfNecessary() {
+  }
 
   /**
    * return the file length after written.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AsyncProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AsyncProtobufLogWriter.java
@@ -195,7 +195,7 @@ public class AsyncProtobufLogWriter extends AbstractProtobufLogWriter
   }
 
   @Override
-  protected void closeOutput() {
+  protected void closeOutputIfNecessary() {
     if (this.output != null) {
       try {
         this.output.close();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/ProtobufLogWriter.java
@@ -127,7 +127,7 @@ public class ProtobufLogWriter extends AbstractProtobufLogWriter implements FSHL
   }
 
   @Override
-  protected void closeOutput() {
+  protected void closeOutputIfNecessary() {
     if (this.output != null) {
       try {
         this.output.close();


### PR DESCRIPTION
Address the source compatibility problem caused by adding method to the LimitedPrivate(CONFIG) abstract class.