### PR TITLE
HBASE-27000 Block cache stats (Misses Caching) display error in RS web UI

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/BlockCacheTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/BlockCacheTmpl.jamon
@@ -210,7 +210,7 @@ org.apache.hadoop.util.StringUtils.TraditionalBinaryPrefix;
     </tr>
     <tr>
         <td>Misses Caching</td>
-        <td><% String.format("%,d", bc.getStats().getMissCount()) %></td>
+        <td><% String.format("%,d", bc.getStats().getMissCachingCount()) %></td>
         <td>Block requests that were cache misses but only requests set to use block cache</td>
     </tr>
     <tr>


### PR DESCRIPTION
JIRA: HBASE-27000.

Block cache stats (Misses Caching) display error in RS web UI.

<img width="968" alt="image" src="https://user-images.githubusercontent.com/55134131/166920376-6bf4b7bc-8426-4cc7-b9e5-822f47cdf875.png">
