### PR TITLE
HBASE-26984 Chaos Monkey thread dies in ITBLL Chaos GracefulRollingRe…

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/GracefulRollingRestartRsAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/GracefulRollingRestartRsAction.java
@@ -63,6 +63,8 @@ public class GracefulRollingRestartRsAction extends RestartActionBaseAction {
         rm.load();
       } catch (Shell.ExitCodeException e) {
         getLogger().info("Problem restarting but presume successful; code={}", e.getExitCode(), e);
+      } catch (Exception e) {
+        getLogger().info("Exception but continuing...", e);
       }
       sleep(rand.nextInt((int) sleepTime));
     }

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/RestartActionBaseAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/RestartActionBaseAction.java
@@ -80,6 +80,8 @@ public abstract class RestartActionBaseAction extends Action {
     sleep(sleepTime);
     getLogger().info("Starting region server: {}", server);
     startRs(server);
+    // Sleep some time to make sure RS is online.
+    sleep(sleepTime);
   }
 
   void restartZKNode(ServerName server, long sleepTime) throws IOException {


### PR DESCRIPTION
…startRsAction (#4383)

There are two cases here:
  1. Chaos Monkey thread died and there is no chaos after that.
  2. Sometimes, regions are being moved back too quick that region server has not finished its initliazation yet.
     wait sometime to make sure that region server finishes its initialization.

Signed-off-by:  Wellington Chevreuil <wellington.chevreuil@gmail.com>