### PR TITLE
HBASE-27003 Optimize log format for PerformanceEvaluation

### DIFF
--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -1245,8 +1245,9 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     String generateStatus(final int sr, final int i, final int lr) {
-      return sr + "/" + i + "/" + lr + ", latency " + getShortLatencyReport()
-        + (!isRandomValueSize() ? "" : ", value size " + getShortValueSizeReport());
+      return "row [start=" + sr + ", current=" + i + ", last=" + lr + "], latency ["
+        + getShortLatencyReport() + "]"
+        + (!isRandomValueSize() ? "" : ", value size [" + getShortValueSizeReport() + "]");
     }
 
     boolean isRandomValueSize() {


### PR DESCRIPTION
JIRA: HBASE-27003.

The logs in PerformanceEvaluation look a little confusing to new users, we should optimize the format.

Before:
![image](https://user-images.githubusercontent.com/55134131/167113543-a39520e2-e951-42e5-ad0b-02dc8358b8af.png)

After:
![image](https://user-images.githubusercontent.com/55134131/167113553-e781064c-917c-48e2-ab11-5c042a5b6d8e.png)

