### PR TITLE
HBASE-27015. Fix log format for ServerManager

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
@@ -1096,7 +1096,7 @@ public class ServerManager {
     Path lastFlushedSeqIdPath = new Path(rootDir, LAST_FLUSHED_SEQ_ID_FILE);
     FileSystem fs = FileSystem.get(conf);
     if (!fs.exists(lastFlushedSeqIdPath)) {
-      LOG.info("No .lastflushedseqids found at" + lastFlushedSeqIdPath
+      LOG.info("No .lastflushedseqids found at " + lastFlushedSeqIdPath
         + " will record last flushed sequence id"
         + " for regions by regionserver report all over again");
       return;


### PR DESCRIPTION
JIRA: HBASE-27015.

A space is missing from the ServerManager log.

![image](https://user-images.githubusercontent.com/55134131/167301199-2cf8f3a1-2586-40cc-aafb-14ab3504485d.png)
