### PR TITLE
HBASE-27018 Add a tool command list_liveservers

### DIFF
--- a/hbase-shell/src/main/ruby/shell.rb
+++ b/hbase-shell/src/main/ruby/shell.rb
@@ -473,6 +473,7 @@ Shell.load_command_group(
     splitormerge_enabled
     clear_compaction_queues
     list_deadservers
+    list_liveservers
     clear_deadservers
     clear_block_cache
     stop_master

--- a/hbase-shell/src/main/ruby/shell.rb
+++ b/hbase-shell/src/main/ruby/shell.rb
@@ -16,6 +16,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+# frozen_string_literal: true
+
 require 'irb'
 require 'irb/workspace'
 

--- a/hbase-shell/src/main/ruby/shell.rb
+++ b/hbase-shell/src/main/ruby/shell.rb
@@ -16,9 +16,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
-
-# frozen_string_literal: true
-
 require 'irb'
 require 'irb/workspace'
 

--- a/hbase-shell/src/main/ruby/shell/commands/list_liveservers.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/list_liveservers.rb
@@ -1,0 +1,44 @@
+#
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Shell
+  module Commands
+    # List live region servers
+    class ListLiveservers < Command
+      def help
+        <<~EOF
+           List all live region servers in hbase
+           Examples:
+           hbase> list_liveservers
+        EOF
+      end
+
+      def command
+        formatter.header(['SERVERNAME'])
+
+        servers = admin.list_liveservers
+        servers.each do |server|
+          formatter.row([server.toString])
+        end
+
+        formatter.footer(servers.size)
+      end
+    end
+  end
+end


### PR DESCRIPTION
JIRA: HBASE-27018.

To make it easier for us to query the living region Servers. We can add a command `list_liveservers`. There are already `list_deadServers` and `list_Decommissioned_regionServers`.

![image](https://user-images.githubusercontent.com/55134131/167519933-6455e445-80fe-4383-ad0f-6ab08c33707b.png)
