### PR TITLE
HBASE-27020 Fix spotless warn for master branch

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -1237,10 +1237,10 @@ public class HStore
         writeCompactionWalRecord(compactedFiles, result);
       }
     }, () -> {
-        synchronized (filesCompacting) {
-          filesCompacting.removeAll(compactedFiles);
-        }
-      });
+      synchronized (filesCompacting) {
+        filesCompacting.removeAll(compactedFiles);
+      }
+    });
     // These may be null when the RS is shutting down. The space quota Chores will fix the Region
     // sizes later so it's not super-critical if we miss these.
     RegionServerServices rsServices = region.getRegionServerServices();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -1237,10 +1237,10 @@ public class HStore
         writeCompactionWalRecord(compactedFiles, result);
       }
     }, () -> {
-      synchronized (filesCompacting) {
-        filesCompacting.removeAll(compactedFiles);
-      }
-    });
+        synchronized (filesCompacting) {
+          filesCompacting.removeAll(compactedFiles);
+        }
+      });
     // These may be null when the RS is shutting down. The space quota Chores will fix the Region
     // sizes later so it's not super-critical if we miss these.
     RegionServerServices rsServices = region.getRegionServerServices();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -1232,13 +1232,11 @@ public class HStore
       allowedOnPath = ".*/(HStore|TestHStore).java")
   void replaceStoreFiles(Collection<HStoreFile> compactedFiles, Collection<HStoreFile> result,
     boolean writeCompactionMarker) throws IOException {
-    storeEngine.replaceStoreFiles(compactedFiles, result,
-      () -> {
-        if (writeCompactionMarker) {
-          writeCompactionWalRecord(compactedFiles, result);
-        }
-      },
-      () -> {
+    storeEngine.replaceStoreFiles(compactedFiles, result, () -> {
+      if (writeCompactionMarker) {
+        writeCompactionWalRecord(compactedFiles, result);
+      }
+    }, () -> {
       synchronized (filesCompacting) {
         filesCompacting.removeAll(compactedFiles);
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
@@ -409,7 +409,7 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
     // propogate the file changes to the underlying store file manager
     replaceStoreFiles(toBeRemovedStoreFiles, openedFiles, () -> {
     }, () -> {
-    }); // won't throw an exception
+      }); // won't throw an exception
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
@@ -34,7 +34,6 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Function;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.CellComparator;
@@ -408,7 +407,9 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
     List<HStoreFile> openedFiles = openStoreFiles(toBeAddedFiles, false);
 
     // propogate the file changes to the underlying store file manager
-    replaceStoreFiles(toBeRemovedStoreFiles, openedFiles, () -> {}, () -> {}); // won't throw an exception
+    replaceStoreFiles(toBeRemovedStoreFiles, openedFiles, () -> {
+    }, () -> {
+    }); // won't throw an exception
   }
 
   /**
@@ -491,8 +492,8 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
   }
 
   public void replaceStoreFiles(Collection<HStoreFile> compactedFiles,
-    Collection<HStoreFile> newFiles, IOExceptionRunnable walMarkerWriter,
-    Runnable actionUnderLock) throws IOException {
+    Collection<HStoreFile> newFiles, IOExceptionRunnable walMarkerWriter, Runnable actionUnderLock)
+    throws IOException {
     storeFileTracker.replace(StoreUtils.toStoreFileInfo(compactedFiles),
       StoreUtils.toStoreFileInfo(newFiles));
     walMarkerWriter.run();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
@@ -409,7 +409,7 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
     // propogate the file changes to the underlying store file manager
     replaceStoreFiles(toBeRemovedStoreFiles, openedFiles, () -> {
     }, () -> {
-      }); // won't throw an exception
+    }); // won't throw an exception
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSource.java
@@ -538,7 +538,6 @@ public class ReplicationSource implements ReplicationSourceInterface {
       }
     }
 
-
     if (!this.isSourceActive()) {
       setSourceStartupStatus(false);
       if (Thread.currentThread().isInterrupted()) {
@@ -569,7 +568,7 @@ public class ReplicationSource implements ReplicationSourceInterface {
       }
     }
 
-    if(!this.isSourceActive()) {
+    if (!this.isSourceActive()) {
       setSourceStartupStatus(false);
       if (Thread.currentThread().isInterrupted()) {
         // If source is not running and thread is interrupted this means someone has tried to

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/replication/TestBadReplicationPeer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/replication/TestBadReplicationPeer.java
@@ -1,4 +1,4 @@
-/**
+/*
  * Licensed to the Apache Software Foundation (ASF) under one
  * or more contributor license agreements.  See the NOTICE file
  * distributed with this work for additional information
@@ -39,7 +39,7 @@ import org.junit.rules.TestName;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-@Category({ MediumTests.class, ClientTests.class})
+@Category({ MediumTests.class, ClientTests.class })
 public class TestBadReplicationPeer {
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
@@ -65,15 +65,15 @@ public class TestBadReplicationPeer {
   }
 
   /*
-    Add dummy peer and make sure that we are able to remove that peer.
+   * Add dummy peer and make sure that we are able to remove that peer.
    */
   @Test
   public void testRemovePeerSucceeds() throws IOException {
     String peerId = "dummypeer_1";
     try (Connection connection = ConnectionFactory.createConnection(conf);
-      Admin admin = connection.getAdmin()){
+      Admin admin = connection.getAdmin()) {
       ReplicationPeerConfigBuilder rpcBuilder = ReplicationPeerConfig.newBuilder();
-      String quorum =  TEST_UTIL.getHBaseCluster().getMaster().getZooKeeper().getQuorum();
+      String quorum = TEST_UTIL.getHBaseCluster().getMaster().getZooKeeper().getQuorum();
       rpcBuilder.setClusterKey(quorum + ":/1");
       ReplicationPeerConfig rpc = rpcBuilder.build();
       admin.addReplicationPeer(peerId, rpc);


### PR DESCRIPTION
JIRA: HBASE-27020.

Fix spotless warn for master branch. We can see the spotless warn at https://ci-hbase.apache.org/job/HBase-PreCommit-GitHub-PR/job/PR-4416/1/artifact/yetus-general-check/output/branch-spotless.txt. There are some compile tasks that fail because of this.

