### PR TITLE
HBASE-27027 Use jetty SslContextFactory.Server instead of deprecated SslContextFactory

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/HttpServer.java
@@ -418,7 +418,7 @@ public class HttpServer implements FilterContainer {
         } else if ("https".equals(scheme)) {
           HttpConfiguration httpsConfig = new HttpConfiguration(httpConfig);
           httpsConfig.addCustomizer(new SecureRequestCustomizer());
-          SslContextFactory sslCtxFactory = new SslContextFactory();
+          SslContextFactory.Server sslCtxFactory = new SslContextFactory.Server();
           sslCtxFactory.setNeedClientAuth(needsClientAuth);
           sslCtxFactory.setKeyManagerPassword(keyPassword);
 

--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
@@ -311,7 +311,7 @@ public class RESTServer implements Constants {
       HttpConfiguration httpsConfig = new HttpConfiguration(httpConfig);
       httpsConfig.addCustomizer(new SecureRequestCustomizer());
 
-      SslContextFactory sslCtxFactory = new SslContextFactory();
+      SslContextFactory.Server sslCtxFactory = new SslContextFactory.Server();
       String keystore = conf.get(REST_SSL_KEYSTORE_STORE);
       String keystoreType = conf.get(REST_SSL_KEYSTORE_TYPE);
       String password = HBaseConfiguration.getPassword(conf, REST_SSL_KEYSTORE_PASSWORD, null);

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftServer.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftServer.java
@@ -408,7 +408,7 @@ public class ThriftServer extends Configured implements Tool {
       HttpConfiguration httpsConfig = new HttpConfiguration(httpConfig);
       httpsConfig.addCustomizer(new SecureRequestCustomizer());
 
-      SslContextFactory sslCtxFactory = new SslContextFactory();
+      SslContextFactory.Server sslCtxFactory = new SslContextFactory.Server();
       String keystore = conf.get(THRIFT_SSL_KEYSTORE_STORE_KEY);
       String password =
         HBaseConfiguration.getPassword(conf, THRIFT_SSL_KEYSTORE_PASSWORD_KEY, null);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-27027