### PR TITLE
HBASE-27030 Fix undefined local variable error in draining_servers.rb

### DIFF
--- a/bin/draining_servers.rb
+++ b/bin/draining_servers.rb
@@ -61,6 +61,7 @@ end
 def getServerNames(hostOrServers, config)
   ret = []
   connection = ConnectionFactory.createConnection(config)
+  admin = nil
 
   hostOrServers.each do |host_or_server|
     # check whether it is already serverName. No need to connect to cluster


### PR DESCRIPTION
HBASE-21812 replaced a for-loop with an each block. Each block introduces a new scope, so a local variable defined inside it cannot be accessed afterwards.

```
  NameError: undefined local variable or method `admin' for main:Object
    getServerNames at /opt/khp/hbase/bin/draining_servers.rb:81
        addServers at /opt/khp/hbase/bin/draining_servers.rb:88
            <main> at /opt/khp/hbase/bin/draining_servers.rb:146
```

This commit defines the admin local variable in the current scope beforehand, so that we can still access it after the block.