### PR TITLE
HBASE-27006 Move nightly integration testing to new larger test node class.

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -750,6 +750,11 @@ pipeline {
         // See http://hbase.apache.org/book.html#maven.release
         // TODO (HBASE-23870): replace this with invocation of the release tool
         stage ('packaging and integration') {
+          agent {
+            node {
+              label 'hbase-large'
+            }
+          }
           tools {
             maven 'maven_latest'
             // this needs to be set to the jdk that ought to be used to build releases on the branch the Jenkinsfile is stored in.

--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -765,6 +765,9 @@ pipeline {
             BRANCH = "${env.BRANCH_NAME}"
           }
           steps {
+            dir('component') {
+              checkout scm
+            }
             sh '''#!/bin/bash -e
               echo "Setting up directories"
               rm -rf "output-srctarball" && mkdir "output-srctarball"


### PR DESCRIPTION
Since the integration tests will eventually run on the large nodes w/k8s, have them start running their now to validate that we can schedule on the nodes.

Did a scan through our other jenkinsfiles and I believe everything except for `dev-support/adhoc_run_tests/Jenkinsfile` is strongly tied to the `hbase` label and thus will stay off of `hbase-large`. I also don't think we have that job configured to run at all, so maybe a follow on should delete it.