### PR TITLE
HBASE-27047 Fix typo for metric drainingRegionServers

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterSource.java
@@ -54,7 +54,7 @@ public interface MetricsMasterSource extends BaseSource {
   String AVERAGE_LOAD_NAME = "averageLoad";
   String LIVE_REGION_SERVERS_NAME = "liveRegionServers";
   String DEAD_REGION_SERVERS_NAME = "deadRegionServers";
-  String DRAINING_REGION_SERVER_NAME = "draininigRegionServers";
+  String DRAINING_REGION_SERVER_NAME = "drainingRegionServers";
   String NUM_REGION_SERVERS_NAME = "numRegionServers";
   String NUM_DEAD_REGION_SERVERS_NAME = "numDeadRegionServers";
   String NUM_DRAINING_REGION_SERVERS_NAME = "numDrainingRegionServers";


### PR DESCRIPTION
JIRA: HBASE-27047.

Fix typo for metric drainingRegionServers. `draininigRegionServers` -> `drainingRegionServers`.