### PR TITLE
HBASE-27050 Support unit test pattern matching again

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1785,6 +1785,7 @@
           <configuration>
             <groups>${surefire.firstPartGroups}</groups>
             <failIfNoTests>false</failIfNoTests>
+            <failIfNoSpecifiedTests>false</failIfNoSpecifiedTests>
             <trimStackTrace>false</trimStackTrace>
             <skip>${surefire.skipFirstPart}</skip>
             <forkCount>${surefire.firstPartForkCount}</forkCount>


### PR DESCRIPTION
Sometimes we want to run a build with a subset of unit tests to be executed over multiple modules, like:

    mvn clean install -DskipITs -Dtest=Test*Encode*

which will execute some tests in common, some in server, etc. but not in checkstyle, which fails

    [ERROR] Failed to execute goal org.apache.maven.plugins:maven-surefire-plugin:3.0.0-M6:test
    (default-test) on project hbase-checkstyle:
    No tests matching pattern "Test*Encode*" were executed!
    (Set -Dsurefire.failIfNoSpecifiedTests=false to ignore this error.) -> [Help 1]

We already set `failIfNoTests` to false in the surefire configuration. Apparently `failIfNoSpecifiedTests` is also necessary to support the above. When `failIfNoSpecifiedTests` is specified in the configuration or on the command line, surefire behaves as expected.

This behavior has changed in branch-2.5 and up.

Open to suggestions for other solutions.
