### PR TITLE
HBASE-27051 TestReplicationSource.testReplicationSourceInitializingMetric is flaky

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSource.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSource.java
@@ -571,9 +571,9 @@ public class TestReplicationSource {
     try {
       rs.startup();
       assertTrue(rs.isSourceActive());
-      Waiter.waitFor(conf, 1000, () -> rs.getSourceMetrics().getSourceInitializing() == 1);
+      Waiter.waitFor(conf, 10000, () -> rs.getSourceMetrics().getSourceInitializing() == 1);
       BadReplicationEndpoint.failing = false;
-      Waiter.waitFor(conf, 1000, () -> rs.getSourceMetrics().getSourceInitializing() == 0);
+      Waiter.waitFor(conf, 10000, () -> rs.getSourceMetrics().getSourceInitializing() == 0);
     } finally {
       rs.terminate("Done");
       rss.stop("Done");


### PR DESCRIPTION
Trivial fix, give the unit more time, for slow or loaded test hosts.