### PR TITLE
Backport "HBASE-27052 TestAsyncTableScanner.testScanWrongColumnFamily is flaky" to branch-2

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/AbstractTestAsyncTableScan.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/AbstractTestAsyncTableScan.java
@@ -17,17 +17,22 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import static org.apache.hadoop.hbase.client.trace.hamcrest.AttributesMatchers.containsEntry;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
+import static org.hamcrest.Matchers.anyOf;
+import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.endsWith;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
+import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
@@ -46,6 +51,7 @@ import org.apache.hadoop.hbase.MiniClusterRule;
 import org.apache.hadoop.hbase.StartMiniClusterOption;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.Waiter;
+import org.apache.hadoop.hbase.ipc.RemoteWithExtrasException;
 import org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException;
 import org.apache.hadoop.hbase.trace.OpenTelemetryClassRule;
 import org.apache.hadoop.hbase.trace.OpenTelemetryTestRule;
@@ -176,7 +182,8 @@ public abstract class AbstractTestAsyncTableScan {
   /**
    * Used by implementation classes to assert the correctness of spans having errors.
    */
-  protected abstract void assertTraceError(final Matcher<String> exceptionTypeNameMatcher);
+  protected abstract void
+    assertTraceError(final Matcher<io.opentelemetry.api.common.Attributes> exceptionMatcher);
 
   protected final List<Result> convertFromBatchResult(List<Result> results) {
     assertEquals(0, results.size() % 2);
@@ -269,7 +276,14 @@ public abstract class AbstractTestAsyncTableScan {
     } else {
       fail("Found unexpected Exception " + e);
     }
-    assertTraceError(endsWith(NoSuchColumnFamilyException.class.getName()));
+    assertTraceError(anyOf(
+      containsEntry(is(SemanticAttributes.EXCEPTION_TYPE),
+        endsWith(NoSuchColumnFamilyException.class.getName())),
+      allOf(
+        containsEntry(is(SemanticAttributes.EXCEPTION_TYPE),
+          endsWith(RemoteWithExtrasException.class.getName())),
+        containsEntry(is(SemanticAttributes.EXCEPTION_MESSAGE),
+          containsString(NoSuchColumnFamilyException.class.getName())))));
   }
 
   private void testScan(int start, boolean startInclusive, int stop, boolean stopInclusive,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableScan.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableScan.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasExceptionWithType;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasException;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasParentSpanId;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
@@ -145,7 +145,8 @@ public class TestAsyncTableScan extends AbstractTestAsyncTableScan {
   }
 
   @Override
-  protected void assertTraceError(Matcher<String> exceptionTypeNameMatcher) {
+  protected void
+    assertTraceError(Matcher<io.opentelemetry.api.common.Attributes> exceptionMatcher) {
     final String parentSpanName = testName.getMethodName();
     final Matcher<SpanData> parentSpanMatcher = allOf(hasName(parentSpanName), hasEnded());
     waitForSpan(parentSpanMatcher);
@@ -163,7 +164,7 @@ public class TestAsyncTableScan extends AbstractTestAsyncTableScan {
     final Matcher<SpanData> scanOperationSpanMatcher =
       allOf(hasName(startsWith("SCAN " + TABLE_NAME.getNameWithNamespaceInclAsString())),
         hasParentSpanId(parentSpanId), hasStatusWithCode(StatusCode.ERROR),
-        hasExceptionWithType(exceptionTypeNameMatcher), hasEnded());
+        hasException(exceptionMatcher), hasEnded());
     assertThat(spans, hasItem(scanOperationSpanMatcher));
     final String scanOperationSpanId = spans.stream().filter(scanOperationSpanMatcher::matches)
       .map(SpanData::getSpanId).findAny().orElseThrow(AssertionError::new);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableScanAll.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableScanAll.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasExceptionWithType;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasException;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasParentSpanId;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
@@ -116,7 +116,8 @@ public class TestAsyncTableScanAll extends AbstractTestAsyncTableScan {
   }
 
   @Override
-  protected void assertTraceError(Matcher<String> exceptionTypeNameMatcher) {
+  protected void
+    assertTraceError(Matcher<io.opentelemetry.api.common.Attributes> exceptionMatcher) {
     final String parentSpanName = testName.getMethodName();
     final Matcher<SpanData> parentSpanMatcher = allOf(hasName(parentSpanName), hasEnded());
     waitForSpan(parentSpanMatcher);
@@ -134,7 +135,7 @@ public class TestAsyncTableScanAll extends AbstractTestAsyncTableScan {
     final Matcher<SpanData> scanOperationSpanMatcher =
       allOf(hasName(startsWith("SCAN " + TABLE_NAME.getNameWithNamespaceInclAsString())),
         hasParentSpanId(parentSpanId), hasStatusWithCode(StatusCode.ERROR),
-        hasExceptionWithType(exceptionTypeNameMatcher), hasEnded());
+        hasException(exceptionMatcher), hasEnded());
     assertThat(spans, hasItem(scanOperationSpanMatcher));
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableScanner.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasExceptionWithType;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasException;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasParentSpanId;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
@@ -128,7 +128,8 @@ public class TestAsyncTableScanner extends AbstractTestAsyncTableScan {
   }
 
   @Override
-  protected void assertTraceError(Matcher<String> exceptionTypeNameMatcher) {
+  protected void
+    assertTraceError(Matcher<io.opentelemetry.api.common.Attributes> exceptionMatcher) {
     final String parentSpanName = testName.getMethodName();
     final Matcher<SpanData> parentSpanMatcher = allOf(hasName(parentSpanName), hasEnded());
     waitForSpan(parentSpanMatcher);
@@ -146,7 +147,7 @@ public class TestAsyncTableScanner extends AbstractTestAsyncTableScan {
     final Matcher<SpanData> scanOperationSpanMatcher =
       allOf(hasName(startsWith("SCAN " + TABLE_NAME.getNameWithNamespaceInclAsString())),
         hasParentSpanId(parentSpanId), hasStatusWithCode(StatusCode.ERROR),
-        hasExceptionWithType(exceptionTypeNameMatcher), hasEnded());
+        hasException(exceptionMatcher), hasEnded());
     assertThat(spans, hasItem(scanOperationSpanMatcher));
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRawAsyncTableScan.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRawAsyncTableScan.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasEnded;
-import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasExceptionWithType;
+import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasException;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasParentSpanId;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasStatusWithCode;
@@ -142,7 +142,8 @@ public class TestRawAsyncTableScan extends AbstractTestAsyncTableScan {
   }
 
   @Override
-  protected void assertTraceError(Matcher<String> exceptionTypeNameMatcher) {
+  protected void
+    assertTraceError(Matcher<io.opentelemetry.api.common.Attributes> exceptionMatcher) {
     final String parentSpanName = testName.getMethodName();
     final Matcher<SpanData> parentSpanMatcher = allOf(hasName(parentSpanName), hasEnded());
     waitForSpan(parentSpanMatcher);
@@ -160,7 +161,7 @@ public class TestRawAsyncTableScan extends AbstractTestAsyncTableScan {
     final Matcher<SpanData> scanOperationSpanMatcher =
       allOf(hasName(startsWith("SCAN " + TABLE_NAME.getNameWithNamespaceInclAsString())),
         hasParentSpanId(parentSpanId), hasStatusWithCode(StatusCode.ERROR),
-        hasExceptionWithType(exceptionTypeNameMatcher), hasEnded());
+        hasException(exceptionMatcher), hasEnded());
     assertThat(spans, hasItem(scanOperationSpanMatcher));
     final String scanOperationSpanId = spans.stream().filter(scanOperationSpanMatcher::matches)
       .map(SpanData::getSpanId).findAny().orElseThrow(AssertionError::new);


### PR DESCRIPTION
Backport of #4451