### PR TITLE
HBASE-27061 two phase bulkload is broken when SFT is in use.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -354,7 +354,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
   private final int rowLockWaitDuration;
   static final int DEFAULT_ROWLOCK_WAIT_DURATION = 30000;
 
-  private Path regionDir;
+  private Path regionWalDir;
   private FileSystem walFS;
 
   // set to true if the region is restored from snapshot
@@ -2052,11 +2052,11 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
    * @throws IOException if there is an error getting WALRootDir
    */
   public Path getWALRegionDir() throws IOException {
-    if (regionDir == null) {
-      regionDir = CommonFSUtils.getWALRegionDir(conf, getRegionInfo().getTable(),
+    if (regionWalDir == null) {
+      regionWalDir = CommonFSUtils.getWALRegionDir(conf, getRegionInfo().getTable(),
         getRegionInfo().getEncodedName());
     }
-    return regionDir;
+    return regionWalDir;
   }
 
   @Override
@@ -6814,7 +6814,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
           boolean reqTmp = store.storeEngine.requireWritingToTmpDirFirst();
           if (bulkLoadListener != null) {
             finalPath = bulkLoadListener.prepareBulkLoad(familyName, path, copyFile,
-              reqTmp ? null : regionDir.toString());
+              reqTmp ? null : fs.getRegionDir().toString());
           }
           Pair<Path, Path> pair = null;
           if (reqTmp) {


### PR DESCRIPTION
To reproduce the bug I've used hbase with hbase root dir pointing to s3 bucket and WAL dir pointing to HDFS. 2 phase bulkload was used:
Phase1 (Completed successfully):
_**hbase org.apache.hadoop.hbase.mapreduce.ImportTsv -Dimporttsv.separator=',' -Dimporttsv.bulk.output=output -Dimporttsv.columns=HBASE_ROW_KEY,name,department employees /tmp/test.csv**_

Phase2 (Failed with IllegalArgumentException on the RS side):
**_hbase org.apache.hadoop.hbase.mapreduce.LoadIncrementalHFiles output employees_**

With the provided changes Phase2 was completed successfully. 
