### PR TITLE
HBASE-27066 The Region Visualizer display failed

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
@@ -278,7 +278,7 @@ AssignmentManager assignmentManager = master.getAssignmentManager();
         </section>
         <section>
             <h2><a name="region_visualizer"></a>Region Visualizer</h2>
-            <& RegionVisualizerTmpl &>
+            <& RegionVisualizerTmpl; master = master &>
         </section>
         <section>
             <h2><a name="peers">Peers</a></h2>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/RegionVisualizerTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/RegionVisualizerTmpl.jamon
@@ -16,6 +16,20 @@ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 See the License for the specific language governing permissions and
 limitations under the License.
 </%doc>
+<%args>
+HMaster master;
+</%args>
+<%import>
+org.apache.hadoop.hbase.master.HMaster;
+org.apache.hadoop.hbase.ServerName;
+</%import>
+
+<%java>
+ServerName active_master = master.getActiveMaster().orElse(null);
+assert active_master != null : "Failed to retrieve active master's ServerName!";
+String activeHostname = active_master.getHostname();
+int activeInfoPort = master.getActiveMasterInfoPort();
+</%java>
 
     <script type="text/javascript" src="/static/js/vega@5.19.1.min.js"></script>
     <script type="text/javascript" src="/static/js/vega-lite@5.0.0.min.js"></script>
@@ -29,7 +43,7 @@ limitations under the License.
           description: 'Total `storefileSize` per Region Server',
           data: {
             name: 'region_info',
-            url: 'http://localhost:16010/api/v1/admin/cluster_metrics/live_servers',
+            url: 'http://<% activeHostname %>:<% activeInfoPort %>/api/v1/admin/cluster_metrics/live_servers',
             format: { type: 'json', property: 'data' }
           },
           transform: [

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/RegionVisualizerTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/RegionVisualizerTmpl.jamon
@@ -22,11 +22,12 @@ HMaster master;
 <%import>
 org.apache.hadoop.hbase.master.HMaster;
 org.apache.hadoop.hbase.ServerName;
+org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 </%import>
 
 <%java>
 ServerName active_master = master.getActiveMaster().orElse(null);
-assert active_master != null : "Failed to retrieve active master's ServerName!";
+Preconditions.checkState(active_master != null, "Failed to retrieve active master's ServerName!");
 String activeHostname = active_master.getHostname();
 int activeInfoPort = master.getActiveMasterInfoPort();
 </%java>


### PR DESCRIPTION
The `Region Visualizer` display failed. Because the active master hostname is `localhost`.

Before the change:
![image](https://user-images.githubusercontent.com/55134131/170643093-3f764319-cc2c-4ef7-837b-8f055d5945c2.png)

After the change:
![image](https://user-images.githubusercontent.com/55134131/170643118-1cc171db-a883-419c-ae5f-806cf4f62db8.png)
