### PR TITLE
HBASE-27068 NPE occurs when the active master has not yet been elected

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/BackupMasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/BackupMasterStatusTmpl.jamon
@@ -24,12 +24,13 @@ java.util.*;
 org.apache.hadoop.hbase.ServerName;
 org.apache.hadoop.hbase.ClusterMetrics;
 org.apache.hadoop.hbase.master.HMaster;
+org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 </%import>
 <%if (!master.isActiveMaster()) %>
     <%java>
     ServerName active_master = master.getActiveMaster().orElse(null);
-    assert active_master != null : "Failed to retrieve active master's ServerName!";
-    int activeInfoPort = active_master == null ? 0 : master.getActiveMasterInfoPort();
+    Preconditions.checkState(active_master != null, "Failed to retrieve active master's ServerName!");
+    int activeInfoPort = master.getActiveMasterInfoPort();
     </%java>
     <div class="row inner_header">
         <div class="page-header">


### PR DESCRIPTION
JIRA: HBASE-27068.

When the active master has not yet been elected. We access the master web UI, a NPE will be thrown out. Assertion is now added, but assertion in production is disabled by default. We can use `Preconditions` instead.
