### PR TITLE
HBASE-27001 The deleted variable cannot be printed out

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/CleanerChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/CleanerChore.java
@@ -529,7 +529,7 @@ public abstract class CleanerChore<T extends FileCleanerDelegate> extends Schedu
       LOG.info("unexpected exception: ", e);
       deleted = false;
     }
-    LOG.trace("Finish deleting {} under {}, deleted=", type, dir, deleted);
+    LOG.trace("Finish deleting {} under {}, deleted = {}", type, dir, deleted);
     return deleted;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SecureBulkLoadManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SecureBulkLoadManager.java
@@ -398,10 +398,7 @@ public class SecureBulkLoadManager {
           throw new IOException("Failed to move HFile: " + p + " to " + stageP);
         }
       }
-
-      if (StringUtils.isNotEmpty(customStaging)) {
-        fs.setPermission(stageP, PERM_ALL_ACCESS);
-      }
+      fs.setPermission(stageP, PERM_ALL_ACCESS);
 
       return stageP.toString();
     }


### PR DESCRIPTION
In the deleteAction method of CleanerChore class, the delete variable cannot be printed out

`LOG.trace("Finish deleting {} under {}, deleted=", type, dir, deleted); `