### PR TITLE
HBASE-27029 When HMaster is stopped, the local region cannot be flushed normally

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -583,11 +583,11 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         sleeper.sleep();
       }
       stopInfoServer();
-      closeClusterConnection();
-      stopServiceThreads();
       if (this.rpcServices != null) {
         this.rpcServices.stop();
       }
+      stopServiceThreads();
+      closeClusterConnection();
       closeZooKeeper();
     } finally {
       if (this.clusterSchemaService != null) {


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-27029