### PR TITLE
HBASE-27086 Fix graceful_stop cannot take previous balancer status by incompatibility of hbase shell prompt

### DIFF
--- a/bin/graceful_stop.sh
+++ b/bin/graceful_stop.sh
@@ -115,7 +115,7 @@ if [ "$nob" == "true"  ]; then
   HBASE_BALANCER_STATE=false
 else
   log "Disabling load balancer"
-  HBASE_BALANCER_STATE=$(echo 'balance_switch false' | "$bin"/hbase --config "${HBASE_CONF_DIR}" shell -n | tail -1)
+  HBASE_BALANCER_STATE=$(echo 'balance_switch false' | "$bin"/hbase --config "${HBASE_CONF_DIR}" shell -n | tail -2 | head -1)
   log "Previous balancer state was $HBASE_BALANCER_STATE"
 fi
 

--- a/hbase-shell/src/main/ruby/jar-bootstrap.rb
+++ b/hbase-shell/src/main/ruby/jar-bootstrap.rb
@@ -203,8 +203,7 @@ IRB.conf[:PROMPT][:CUSTOM] = {
 
 IRB.conf[:IRB_NAME] = 'hbase'
 IRB.conf[:AP_NAME] = 'hbase'
-if IRB.conf[:PROMPT_MODE] != :NULL
-  # When prompt mode is :NULL, hbase shell is started with pipe for stdin, so prompt isn't necessary
+if interactive
   IRB.conf[:PROMPT_MODE] = :CUSTOM
 end
 IRB.conf[:BACK_TRACE_LIMIT] = 0 unless full_backtrace

--- a/hbase-shell/src/main/ruby/jar-bootstrap.rb
+++ b/hbase-shell/src/main/ruby/jar-bootstrap.rb
@@ -203,7 +203,10 @@ IRB.conf[:PROMPT][:CUSTOM] = {
 
 IRB.conf[:IRB_NAME] = 'hbase'
 IRB.conf[:AP_NAME] = 'hbase'
-IRB.conf[:PROMPT_MODE] = :CUSTOM
+if IRB.conf[:PROMPT_MODE] != :NULL
+  # When prompt mode is :NULL, hbase shell is started with pipe for stdin, so prompt isn't necessary
+  IRB.conf[:PROMPT_MODE] = :CUSTOM
+end
 IRB.conf[:BACK_TRACE_LIMIT] = 0 unless full_backtrace
 
 # Create a workspace we'll use across sessions.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-27086

There're 2 issues

- `hbase shell` shows prompt always even through `echo "balance_switch false" | hbase shell -n` (noninteractive mode or piped)
- irb now shows an empty line at end of the output, so `tail -1` retrieve the empty line. need `tail -2 | head -1` to retrieve true/false for previous balancer status

Need this patch in branch-2.4, 2.5, 2, 3, master
