### PR TITLE
HBASE-27089 Add “commons.crypto.stream.buffer.size” configuration

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/aes/CommonsCryptoAES.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/aes/CommonsCryptoAES.java
@@ -49,7 +49,8 @@ public class CommonsCryptoAES extends Cipher {
   public static final String CIPHER_MODE_KEY = "hbase.crypto.commons.mode";
   public static final String CIPHER_CLASSES_KEY = "hbase.crypto.commons.cipher.classes";
   public static final String CIPHER_JCE_PROVIDER_KEY = "hbase.crypto.commons.cipher.jce.provider";
-  public static final String CRYPTOSTREAM_BUFFERSIZE_KEY = "hbase.crypto.commons.cryptoStream.bufferSize";
+  public static final String CRYPTOSTREAM_BUFFERSIZE_KEY =
+    "hbase.crypto.commons.cryptoStream.bufferSize";
 
   private final String cipherMode;
   private Properties props;
@@ -83,8 +84,8 @@ public class CommonsCryptoAES extends Cipher {
 
     props.setProperty(CryptoCipherFactory.CLASSES_KEY, conf.get(CIPHER_CLASSES_KEY, ""));
     props.setProperty(CryptoCipherFactory.JCE_PROVIDER_KEY, conf.get(CIPHER_JCE_PROVIDER_KEY, ""));
-    props.setProperty(
-      CryptoInputStream.STREAM_BUFFER_SIZE_KEY, conf.get(CRYPTOSTREAM_BUFFERSIZE_KEY, ""));
+    props.setProperty(CryptoInputStream.STREAM_BUFFER_SIZE_KEY,
+      conf.get(CRYPTOSTREAM_BUFFERSIZE_KEY, ""));
 
     return props;
   }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/aes/CommonsCryptoAES.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/aes/CommonsCryptoAES.java
@@ -26,6 +26,7 @@ import java.security.SecureRandom;
 import java.util.Properties;
 import javax.crypto.spec.SecretKeySpec;
 import org.apache.commons.crypto.cipher.CryptoCipherFactory;
+import org.apache.commons.crypto.stream.CryptoInputStream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.crypto.Cipher;
 import org.apache.hadoop.hbase.io.crypto.CipherProvider;
@@ -48,6 +49,7 @@ public class CommonsCryptoAES extends Cipher {
   public static final String CIPHER_MODE_KEY = "hbase.crypto.commons.mode";
   public static final String CIPHER_CLASSES_KEY = "hbase.crypto.commons.cipher.classes";
   public static final String CIPHER_JCE_PROVIDER_KEY = "hbase.crypto.commons.cipher.jce.provider";
+  public static final String CRYPTOSTREAM_BUFFERSIZE_KEY = "hbase.crypto.commons.cryptoStream.bufferSize";
 
   private final String cipherMode;
   private Properties props;
@@ -81,6 +83,8 @@ public class CommonsCryptoAES extends Cipher {
 
     props.setProperty(CryptoCipherFactory.CLASSES_KEY, conf.get(CIPHER_CLASSES_KEY, ""));
     props.setProperty(CryptoCipherFactory.JCE_PROVIDER_KEY, conf.get(CIPHER_JCE_PROVIDER_KEY, ""));
+    props.setProperty(
+      CryptoInputStream.STREAM_BUFFER_SIZE_KEY, conf.get(CRYPTOSTREAM_BUFFERSIZE_KEY, ""));
 
     return props;
   }


### PR DESCRIPTION
Add “commons.crypto.stream.buffer.size” configuration  in hbase when doing encryption through commonsCryptoAES.