### PR TITLE
HBASE-27106 update asciidoctor site building.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -824,8 +824,8 @@
     <commons-crypto.version>1.0.0</commons-crypto.version>
     <curator.version>4.2.0</curator.version>
     <!-- Plugin Dependencies -->
-    <asciidoctor.plugin.version>2.1.0</asciidoctor.plugin.version>
-    <asciidoctorj.pdf.version>1.5.3</asciidoctorj.pdf.version>
+    <asciidoctor.plugin.version>2.2.2</asciidoctor.plugin.version>
+    <asciidoctorj.pdf.version>2.0.6</asciidoctorj.pdf.version>
     <build.helper.maven.version>3.0.0</build.helper.maven.version>
     <buildnumber.maven.version>1.4</buildnumber.maven.version>
     <!--
@@ -2566,11 +2566,6 @@
             <groupId>org.asciidoctor</groupId>
             <artifactId>asciidoctorj-pdf</artifactId>
             <version>${asciidoctorj.pdf.version}</version>
-          </dependency>
-          <dependency>
-            <groupId>org.jruby</groupId>
-            <artifactId>jruby-complete</artifactId>
-            <version>${jruby.version}</version>
           </dependency>
         </dependencies>
         <executions>


### PR DESCRIPTION
- update asciidoctor maven plugin to latest
- update the asciidoctor pdf dependency to latest
- allow the plugin to use its own version of jruby

tested with a local build via the jenkins script for site build.