### PR TITLE
HBASE-27117 Update the method comments for RegionServerAccounting

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreFlusher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreFlusher.java
@@ -432,14 +432,14 @@ public class MemStoreFlusher implements FlushRequester {
   }
 
   /**
-   * Return true if global memory usage is above the high watermark
+   * Return the FlushType if global memory usage is above the high watermark
    */
   private FlushType isAboveHighWaterMark() {
     return server.getRegionServerAccounting().isAboveHighWaterMark();
   }
 
   /**
-   * Return true if we're above the low watermark
+   * Return the FlushType if we're above the low watermark
    */
   private FlushType isAboveLowWaterMark() {
     return server.getRegionServerAccounting().isAboveLowWaterMark();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerAccounting.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerAccounting.java
@@ -161,8 +161,8 @@ public class RegionServerAccounting {
   }
 
   /**
-   * Return true if we are above the memstore high water mark
-   * @return the flushtype
+   * Return the FlushType if we are above the memstore high water mark
+   * @return the FlushType
    */
   public FlushType isAboveHighWaterMark() {
     // for onheap memstore we check if the global memstore size and the
@@ -193,7 +193,8 @@ public class RegionServerAccounting {
   }
 
   /**
-   * Return true if we're above the low watermark
+   * Return the FlushType if we're above the low watermark
+   * @return the FlushType
    */
   public FlushType isAboveLowWaterMark() {
     // for onheap memstore we check if the global memstore size and the


### PR DESCRIPTION
JIRA: HBASE-27117.

After [HBASE-15787](https://issues.apache.org/jira/browse/HBASE-15787), the return value type of RegionServerAccounting#isAboveHighWaterMark and RegionServerAccounting#isAboveLowWaterMark are no longer boolean.