### PR TITLE
HBASE-27059 DeserializationException should be InterfaceAudience.Public

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/exceptions/DeserializationException.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/exceptions/DeserializationException.java
@@ -22,7 +22,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 /**
  * Failed deserialization.
  */
-@InterfaceAudience.Private
+@InterfaceAudience.Public
 @SuppressWarnings("serial")
 public class DeserializationException extends HBaseException {
   public DeserializationException() {


### PR DESCRIPTION
It's thrown by numerous methods in InterfaceAudience.Public classes, like TableDescriptorBuilder, Mutation#getCellVisibility, etc.