### PR TITLE
HBASE-27153 Improvements to read-path tracing

### DIFF
--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/AttributesMatchers.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.client.trace.hamcrest;
 import static org.hamcrest.Matchers.allOf;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasProperty;
+import static org.hamcrest.Matchers.is;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.api.common.Attributes;
@@ -54,6 +55,10 @@ public final class AttributesMatchers {
     return containsEntry(AttributeKey.stringKey(key), value);
   }
 
+  public static Matcher<Attributes> containsEntry(String key, long value) {
+    return containsEntry(AttributeKey.longKey(key), value);
+  }
+
   public static Matcher<Attributes> containsEntryWithStringValuesOf(String key, String... values) {
     return containsEntry(AttributeKey.stringArrayKey(key), Arrays.asList(values));
   }
@@ -61,6 +66,10 @@ public final class AttributesMatchers {
   public static Matcher<Attributes> containsEntryWithStringValuesOf(String key,
     Matcher<Iterable<? extends String>> matcher) {
     return new IsAttributesContaining<>(equalTo(AttributeKey.stringArrayKey(key)), matcher);
+  }
+
+  public static Matcher<Attributes> isEmpty() {
+    return hasProperty("empty", is(true));
   }
 
   private static final class IsAttributesContaining<T> extends TypeSafeMatcher<Attributes> {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/hfile/trace/HFileContextAttributesBuilderConsumer.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/hfile/trace/HFileContextAttributesBuilderConsumer.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.trace;
+
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.CHECKSUM_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.COMPRESSION_ALGORITHM_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.DATA_BLOCK_ENCODING_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.ENCRYPTION_CIPHER_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.HFILE_NAME_KEY;
+import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.READ_TYPE_KEY;
+
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.ContextKey;
+import java.util.Objects;
+import java.util.function.Consumer;
+import org.apache.hadoop.hbase.io.hfile.HFileContext;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.ReadType;
+import org.apache.hadoop.hbase.util.ChecksumType;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * <p>
+ * Populate fields on an {@link AttributesBuilder} based on an {@link HFileContext}. Passed around
+ * inside an active {@link Context}, indexed under {@link #CONTEXT_KEY}. The class is designed such
+ * that calls to the {@link #accept(AttributesBuilder)} method are idempotent with regards to the
+ * instance of this class.
+ * </p>
+ * <p>
+ * The true and truly ridiculous class name should be something more like
+ * {@code HFileContext_ContextAttributes_AttributesBuilder_Consumer}.
+ * </p>
+ */
+@InterfaceAudience.Private
+public class HFileContextAttributesBuilderConsumer implements Consumer<AttributesBuilder> {
+
+  /**
+   * Used to place extract attributes pertaining to the {@link HFileContext} that scopes the active
+   * {@link Context}.
+   */
+  public static final ContextKey<Consumer<AttributesBuilder>> CONTEXT_KEY =
+    ContextKey.named("db.hbase.io.hfile.context_attributes");
+
+  private final HFileContext hFileContext;
+
+  private boolean skipChecksum = false;
+  private ReadType readType = null;
+
+  public HFileContextAttributesBuilderConsumer(final HFileContext hFileContext) {
+    this.hFileContext = Objects.requireNonNull(hFileContext);
+  }
+
+  /**
+   * Specify that the {@link ChecksumType} should not be included in the attributes.
+   */
+  public HFileContextAttributesBuilderConsumer setSkipChecksum(final boolean skipChecksum) {
+    this.skipChecksum = skipChecksum;
+    return this;
+  }
+
+  /**
+   * Specify the {@link ReadType} involced in this IO operation.
+   */
+  public HFileContextAttributesBuilderConsumer setReadType(final ReadType readType) {
+    // TODO: this is not a part of the HFileBlock, its context of the operation. Should track this
+    // detail elsewhere.
+    this.readType = readType;
+    return this;
+  }
+
+  @Override
+  public void accept(AttributesBuilder builder) {
+    if (hFileContext.getHFileName() != null) {
+      builder.put(HFILE_NAME_KEY, hFileContext.getHFileName());
+    }
+    if (hFileContext.getCompression() != null) {
+      builder.put(COMPRESSION_ALGORITHM_KEY, hFileContext.getCompression().getName());
+    }
+    if (hFileContext.getDataBlockEncoding() != null) {
+      builder.put(DATA_BLOCK_ENCODING_KEY, hFileContext.getDataBlockEncoding().name());
+    }
+    if (
+      hFileContext.getEncryptionContext() != null
+        && hFileContext.getEncryptionContext().getCipher() != null
+    ) {
+      builder.put(ENCRYPTION_CIPHER_KEY, hFileContext.getEncryptionContext().getCipher().getName());
+    }
+    if (!skipChecksum && hFileContext.getChecksumType() != null) {
+      builder.put(CHECKSUM_KEY, hFileContext.getChecksumType().getName());
+    }
+    if (readType != null) {
+      builder.put(READ_TYPE_KEY, readType.name());
+    }
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.trace;
 
 import io.opentelemetry.api.common.AttributeKey;
 import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -55,6 +56,66 @@ public final class HBaseSemanticAttributes {
   public static final AttributeKey<Boolean> ROW_LOCK_READ_LOCK_KEY =
     AttributeKey.booleanKey("db.hbase.rowlock.readlock");
   public static final AttributeKey<String> WAL_IMPL = AttributeKey.stringKey("db.hbase.wal.impl");
+
+  /**
+   * Indicates the amount of data was read into a {@link ByteBuffer} of type
+   * {@link ByteBuffer#isDirect() direct}.
+   */
+  public static final AttributeKey<Long> DIRECT_BYTES_READ_KEY =
+    AttributeKey.longKey("db.hbase.io.direct_bytes_read");
+  /**
+   * Indicates the amount of data was read into a {@link ByteBuffer} not of type
+   * {@link ByteBuffer#isDirect() direct}.
+   */
+  public static final AttributeKey<Long> HEAP_BYTES_READ_KEY =
+    AttributeKey.longKey("db.hbase.io.heap_bytes_read");
+  /**
+   * Indicates the {@link org.apache.hadoop.hbase.io.compress.Compression.Algorithm} used to encode
+   * an HFile.
+   */
+  public static final AttributeKey<String> COMPRESSION_ALGORITHM_KEY =
+    AttributeKey.stringKey("db.hbase.io.hfile.data_block_encoding");
+  /**
+   * Indicates the {@link org.apache.hadoop.hbase.io.encoding.DataBlockEncoding} algorithm used to
+   * encode this HFile.
+   */
+  public static final AttributeKey<String> DATA_BLOCK_ENCODING_KEY =
+    AttributeKey.stringKey("db.hbase.io.hfile.data_block_encoding");
+  /**
+   * Indicates the {@link org.apache.hadoop.hbase.io.crypto.Cipher} used to encrypt this HFile.
+   */
+  public static final AttributeKey<String> ENCRYPTION_CIPHER_KEY =
+    AttributeKey.stringKey("db.hbase.io.hfile.encryption_cipher");
+  /**
+   * Indicates the {@link org.apache.hadoop.hbase.util.ChecksumType} used to encode this HFile.
+   */
+  public static final AttributeKey<String> CHECKSUM_KEY =
+    AttributeKey.stringKey("db.hbase.io.hfile.checksum_type");
+  /**
+   * Indicates the name of the HFile accessed.
+   */
+  public static final AttributeKey<String> HFILE_NAME_KEY =
+    AttributeKey.stringKey("db.hbase.io.hfile.file_name");
+  /**
+   * Indicated the type of read.
+   */
+  public static final AttributeKey<String> READ_TYPE_KEY =
+    AttributeKey.stringKey("db.hbase.io.hfile.read_type");
+  /**
+   * Identifies an entry in the Block Cache.
+   */
+  public static final AttributeKey<String> BLOCK_CACHE_KEY_KEY =
+    AttributeKey.stringKey("db.hbase.io.hfile.block_cache_key");
+
+  /**
+   * These values represent the different IO read strategies HBase may employ for accessing
+   * filesystem data.
+   */
+  public enum ReadType {
+    // TODO: promote this to the FSReader#readBlockData API. Or somehow instead use Scan.ReadType.
+    POSITIONAL_READ,
+    SEEK_PLUS_READ,
+  }
 
   /**
    * These are values used with {@link #DB_OPERATION}. They correspond with the implementations of

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -18,7 +18,13 @@
 package org.apache.hadoop.hbase.io.hfile;
 
 import static org.apache.hadoop.hbase.io.ByteBuffAllocator.HEAP;
+import static org.apache.hadoop.hbase.io.hfile.trace.HFileContextAttributesBuilderConsumer.CONTEXT_KEY;
 
+import io.opentelemetry.api.common.Attributes;
+import io.opentelemetry.api.common.AttributesBuilder;
+import io.opentelemetry.api.trace.Span;
+import io.opentelemetry.context.Context;
+import io.opentelemetry.context.Scope;
 import java.io.DataInputStream;
 import java.io.DataOutput;
 import java.io.DataOutputStream;
@@ -26,6 +32,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
@@ -46,11 +53,13 @@ import org.apache.hadoop.hbase.io.encoding.HFileBlockDecodingContext;
 import org.apache.hadoop.hbase.io.encoding.HFileBlockDefaultDecodingContext;
 import org.apache.hadoop.hbase.io.encoding.HFileBlockDefaultEncodingContext;
 import org.apache.hadoop.hbase.io.encoding.HFileBlockEncodingContext;
+import org.apache.hadoop.hbase.io.hfile.trace.HFileContextAttributesBuilderConsumer;
 import org.apache.hadoop.hbase.io.util.BlockIOUtils;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.MultiByteBuff;
 import org.apache.hadoop.hbase.nio.SingleByteBuff;
 import org.apache.hadoop.hbase.regionserver.ShipperListener;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.ReadType;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.ChecksumType;
 import org.apache.hadoop.hbase.util.ClassSize;
@@ -620,7 +629,9 @@ public class HFileBlock implements Cacheable {
     HFileBlock unpacked = shallowClone(this, newBuf);
 
     boolean succ = false;
-    try {
+    final Context context =
+      Context.current().with(CONTEXT_KEY, new HFileContextAttributesBuilderConsumer(fileContext));
+    try (Scope ignored = context.makeCurrent()) {
       HFileBlockDecodingContext ctx = blockType == BlockType.ENCODED_DATA
         ? reader.getBlockDecodingContext()
         : reader.getDefaultBlockDecodingContext();
@@ -1479,59 +1490,65 @@ public class HFileBlock implements Cacheable {
       boolean updateMetrics, boolean intoHeap) throws IOException {
       // Get a copy of the current state of whether to validate
       // hbase checksums or not for this read call. This is not
-      // thread-safe but the one constaint is that if we decide
+      // thread-safe but the one constraint is that if we decide
       // to skip hbase checksum verification then we are
       // guaranteed to use hdfs checksum verification.
       boolean doVerificationThruHBaseChecksum = streamWrapper.shouldUseHBaseChecksum();
       FSDataInputStream is = streamWrapper.getStream(doVerificationThruHBaseChecksum);
-
-      HFileBlock blk = readBlockDataInternal(is, offset, onDiskSizeWithHeaderL, pread,
-        doVerificationThruHBaseChecksum, updateMetrics, intoHeap);
-      if (blk == null) {
-        HFile.LOG.warn("HBase checksum verification failed for file " + pathName + " at offset "
-          + offset + " filesize " + fileSize + ". Retrying read with HDFS checksums turned on...");
-
-        if (!doVerificationThruHBaseChecksum) {
-          String msg = "HBase checksum verification failed for file " + pathName + " at offset "
-            + offset + " filesize " + fileSize + " but this cannot happen because doVerify is "
-            + doVerificationThruHBaseChecksum;
-          HFile.LOG.warn(msg);
-          throw new IOException(msg); // cannot happen case here
-        }
-        HFile.CHECKSUM_FAILURES.increment(); // update metrics
-
-        // If we have a checksum failure, we fall back into a mode where
-        // the next few reads use HDFS level checksums. We aim to make the
-        // next CHECKSUM_VERIFICATION_NUM_IO_THRESHOLD reads avoid
-        // hbase checksum verification, but since this value is set without
-        // holding any locks, it can so happen that we might actually do
-        // a few more than precisely this number.
-        is = this.streamWrapper.fallbackToFsChecksum(CHECKSUM_VERIFICATION_NUM_IO_THRESHOLD);
-        doVerificationThruHBaseChecksum = false;
-        blk = readBlockDataInternal(is, offset, onDiskSizeWithHeaderL, pread,
+      final Context context = Context.current().with(CONTEXT_KEY,
+        new HFileContextAttributesBuilderConsumer(fileContext)
+          .setSkipChecksum(doVerificationThruHBaseChecksum)
+          .setReadType(pread ? ReadType.POSITIONAL_READ : ReadType.SEEK_PLUS_READ));
+      try (Scope ignored = context.makeCurrent()) {
+        HFileBlock blk = readBlockDataInternal(is, offset, onDiskSizeWithHeaderL, pread,
           doVerificationThruHBaseChecksum, updateMetrics, intoHeap);
-        if (blk != null) {
-          HFile.LOG.warn("HDFS checksum verification succeeded for file " + pathName + " at offset "
-            + offset + " filesize " + fileSize);
-        }
-      }
-      if (blk == null && !doVerificationThruHBaseChecksum) {
-        String msg =
-          "readBlockData failed, possibly due to " + "checksum verification failed for file "
-            + pathName + " at offset " + offset + " filesize " + fileSize;
-        HFile.LOG.warn(msg);
-        throw new IOException(msg);
-      }
+        if (blk == null) {
+          HFile.LOG.warn("HBase checksum verification failed for file {} at offset {} filesize {}."
+            + " Retrying read with HDFS checksums turned on...", pathName, offset, fileSize);
 
-      // If there is a checksum mismatch earlier, then retry with
-      // HBase checksums switched off and use HDFS checksum verification.
-      // This triggers HDFS to detect and fix corrupt replicas. The
-      // next checksumOffCount read requests will use HDFS checksums.
-      // The decrementing of this.checksumOffCount is not thread-safe,
-      // but it is harmless because eventually checksumOffCount will be
-      // a negative number.
-      streamWrapper.checksumOk();
-      return blk;
+          if (!doVerificationThruHBaseChecksum) {
+            String msg = "HBase checksum verification failed for file " + pathName + " at offset "
+              + offset + " filesize " + fileSize + " but this cannot happen because doVerify is "
+              + doVerificationThruHBaseChecksum;
+            HFile.LOG.warn(msg);
+            throw new IOException(msg); // cannot happen case here
+          }
+          HFile.CHECKSUM_FAILURES.increment(); // update metrics
+
+          // If we have a checksum failure, we fall back into a mode where
+          // the next few reads use HDFS level checksums. We aim to make the
+          // next CHECKSUM_VERIFICATION_NUM_IO_THRESHOLD reads avoid
+          // hbase checksum verification, but since this value is set without
+          // holding any locks, it can so happen that we might actually do
+          // a few more than precisely this number.
+          is = this.streamWrapper.fallbackToFsChecksum(CHECKSUM_VERIFICATION_NUM_IO_THRESHOLD);
+          doVerificationThruHBaseChecksum = false;
+          blk = readBlockDataInternal(is, offset, onDiskSizeWithHeaderL, pread,
+            doVerificationThruHBaseChecksum, updateMetrics, intoHeap);
+          if (blk != null) {
+            HFile.LOG.warn(
+              "HDFS checksum verification succeeded for file {} at offset {} filesize" + " {}",
+              pathName, offset, fileSize);
+          }
+        }
+        if (blk == null && !doVerificationThruHBaseChecksum) {
+          String msg =
+            "readBlockData failed, possibly due to " + "checksum verification failed for file "
+              + pathName + " at offset " + offset + " filesize " + fileSize;
+          HFile.LOG.warn(msg);
+          throw new IOException(msg);
+        }
+
+        // If there is a checksum mismatch earlier, then retry with
+        // HBase checksums switched off and use HDFS checksum verification.
+        // This triggers HDFS to detect and fix corrupt replicas. The
+        // next checksumOffCount read requests will use HDFS checksums.
+        // The decrementing of this.checksumOffCount is not thread-safe,
+        // but it is harmless because eventually checksumOffCount will be
+        // a negative number.
+        streamWrapper.checksumOk();
+        return blk;
+      }
     }
 
     /**
@@ -1629,6 +1646,11 @@ public class HFileBlock implements Cacheable {
         throw new IOException("Invalid offset=" + offset + " trying to read " + "block (onDiskSize="
           + onDiskSizeWithHeaderL + ")");
       }
+
+      final Span span = Span.current();
+      final AttributesBuilder attributesBuilder = Attributes.builder();
+      Optional.of(Context.current()).map(val -> val.get(CONTEXT_KEY))
+        .ifPresent(c -> c.accept(attributesBuilder));
       int onDiskSizeWithHeader = checkAndGetSizeAsInt(onDiskSizeWithHeaderL, hdrSize);
       // Try and get cached header. Will serve us in rare case where onDiskSizeWithHeaderL is -1
       // and will save us having to seek the stream backwards to reread the header we
@@ -1653,8 +1675,9 @@ public class HFileBlock implements Cacheable {
         // in a LOG every time we seek. See HBASE-17072 for more detail.
         if (headerBuf == null) {
           if (LOG.isTraceEnabled()) {
-            LOG.trace("Extra see to get block size!", new RuntimeException());
+            LOG.trace("Extra seek to get block size!", new RuntimeException());
           }
+          span.addEvent("Extra seek to get block size!", attributesBuilder.build());
           headerBuf = HEAP.allocate(hdrSize);
           readAtOffset(is, headerBuf, hdrSize, false, offset, pread);
           headerBuf.rewind();
@@ -1707,6 +1730,7 @@ public class HFileBlock implements Cacheable {
           hFileBlock.sanityCheckUncompressed();
         }
         LOG.trace("Read {} in {} ms", hFileBlock, duration);
+        span.addEvent("Read block", attributesBuilder.build());
         // Cache next block header if we read it for the next time through here.
         if (nextBlockOnDiskSize != -1) {
           cacheNextBlockHeader(offset + hFileBlock.getOnDiskSizeWithHeader(), onDiskBlock,


### PR DESCRIPTION
Take another pass through tracing of the read path, make adjustments accordingly. One of the major concerns raised previously is that we create a span for every block access. Start by simplifying this to trace events and see what else comes up.

Block-level and stream-level interactions are represented as span events with attached attributes (that's otel terminology for "structured logs", attached to the spans). I made an effort to surface information that an operator might be interested in while diagnosing slow read performance, and details that the previous generation of dev had already seen fit to surface via trace-level logging. We no longer emit spans for `HFileReaderImpl.readBlock`. I hope this is a good compromise between visibility and performance.

Also added a span context for block-cache pre-fetching. 