### PR TITLE
HBASE-26790 getAllRegionLocations can cache locations with null hostname (branch-2 backport)

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableRegionLocatorImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableRegionLocatorImpl.java
@@ -64,8 +64,12 @@ class AsyncTableRegionLocatorImpl implements AsyncTableRegionLocator {
       }
       CompletableFuture<List<HRegionLocation>> future = AsyncMetaTableAccessor
         .getTableHRegionLocations(conn.getTable(TableName.META_TABLE_NAME), tableName);
-      addListener(future, (locs, error) -> locs
-        .forEach(loc -> conn.getLocator().getNonMetaRegionLocator().addLocationToCache(loc)));
+      addListener(future, (locs, error) -> locs.forEach(loc -> {
+        // the cache assumes that all locations have a serverName. only add if that's true
+        if (loc.getServerName() != null) {
+          conn.getLocator().getNonMetaRegionLocator().addLocationToCache(loc);
+        }
+      }));
       return future;
     }, getClass().getSimpleName() + ".getAllRegionLocations");
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HRegionLocator.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HRegionLocator.java
@@ -101,7 +101,11 @@ public class HRegionLocator implements RegionLocator {
         for (HRegionLocation location : locations.getRegionLocations()) {
           regions.add(location);
         }
-        connection.cacheLocation(tableName, locations);
+        RegionLocations cleaned = locations.removeElementsWithNullLocation();
+        // above can return null if all locations had null location
+        if (cleaned != null) {
+          connection.cacheLocation(tableName, cleaned);
+        }
       }
       return regions;
     }, HRegionLocator::getRegionNames, supplier);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocator.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocator.java
@@ -28,6 +28,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -65,6 +66,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
+
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.hbase.thirdparty.com.google.common.io.Closeables;
 
@@ -514,9 +516,9 @@ public class TestAsyncNonMetaRegionLocator {
   }
 
   // caching of getAllRegionLocations is async. so we give it a couple tries
-  private void checkRegionsWithRetries(AsyncConnectionImpl conn, List<RegionInfo> regions, RegionInfo chosen, int retries)
-    throws InterruptedException {
-    while(true) {
+  private void checkRegionsWithRetries(AsyncConnectionImpl conn, List<RegionInfo> regions,
+    RegionInfo chosen, int retries) throws InterruptedException {
+    while (true) {
       try {
         checkRegions(conn, regions, chosen);
         break;
@@ -531,9 +533,8 @@ public class TestAsyncNonMetaRegionLocator {
 
   private void checkRegions(AsyncConnectionImpl conn, List<RegionInfo> regions, RegionInfo chosen) {
     for (RegionInfo region : regions) {
-      RegionLocations fromCache =
-        conn.getLocator().getNonMetaRegionLocator()
-          .getRegionLocationInCache(TABLE_NAME, region.getStartKey());
+      RegionLocations fromCache = conn.getLocator().getNonMetaRegionLocator()
+        .getRegionLocationInCache(TABLE_NAME, region.getStartKey());
       if (region.equals(chosen)) {
         assertNull(fromCache);
       } else {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocator.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocator.java
@@ -26,8 +26,8 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
-
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collection;
@@ -41,6 +41,7 @@ import org.apache.hadoop.hbase.CatalogReplicaMode;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.NotServingRegionException;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
@@ -52,6 +53,7 @@ import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
 import org.junit.After;
 import org.junit.AfterClass;
@@ -63,7 +65,7 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
-
+import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 import org.apache.hbase.thirdparty.com.google.common.io.Closeables;
 
 @Category({ MediumTests.class, ClientTests.class })
@@ -474,6 +476,69 @@ public class TestAsyncNonMetaRegionLocator {
     for (RegionInfo region : regions) {
       assertNotNull(conn.getLocator().getNonMetaRegionLocator().getRegionLocationInCache(TABLE_NAME,
         region.getStartKey()));
+    }
+  }
+
+  @Test
+  public void testDoNotCacheLocationWithNullServerNameWhenGetAllLocations() throws Exception {
+    createMultiRegionTable();
+    AsyncConnectionImpl conn = (AsyncConnectionImpl) ConnectionFactory
+      .createAsyncConnection(TEST_UTIL.getConfiguration()).get();
+    List<RegionInfo> regions = TEST_UTIL.getAdmin().getRegions(TABLE_NAME);
+    RegionInfo chosen = regions.get(0);
+
+    // re-populate region cache
+    AsyncTableRegionLocator regionLocator = conn.getRegionLocator(TABLE_NAME);
+    regionLocator.clearRegionLocationCache();
+    regionLocator.getAllRegionLocations().get();
+
+    // expect all to be non-null at first
+    int tries = 3;
+    checkRegionsWithRetries(conn, regions, null, tries);
+
+    // clear servername from region info
+    Put put = MetaTableAccessor.makePutFromRegionInfo(chosen, EnvironmentEdgeManager.currentTime());
+    MetaTableAccessor.addEmptyLocation(put, 0);
+    MetaTableAccessor.putsToMetaTable(TEST_UTIL.getConnection(), Lists.newArrayList(put));
+
+    // re-populate region cache again. check that we succeeded in nulling the servername
+    regionLocator.clearRegionLocationCache();
+    for (HRegionLocation loc : regionLocator.getAllRegionLocations().get()) {
+      if (loc.getRegion().equals(chosen)) {
+        assertNull(loc.getServerName());
+      }
+    }
+
+    // expect all but chosen to be non-null. chosen should be null because serverName was null
+    checkRegionsWithRetries(conn, regions, chosen, tries);
+  }
+
+  // caching of getAllRegionLocations is async. so we give it a couple tries
+  private void checkRegionsWithRetries(AsyncConnectionImpl conn, List<RegionInfo> regions, RegionInfo chosen, int retries)
+    throws InterruptedException {
+    while(true) {
+      try {
+        checkRegions(conn, regions, chosen);
+        break;
+      } catch (AssertionError e) {
+        if (retries-- <= 0) {
+          throw e;
+        }
+        Thread.sleep(500);
+      }
+    }
+  }
+
+  private void checkRegions(AsyncConnectionImpl conn, List<RegionInfo> regions, RegionInfo chosen) {
+    for (RegionInfo region : regions) {
+      RegionLocations fromCache =
+        conn.getLocator().getNonMetaRegionLocator()
+          .getRegionLocationInCache(TABLE_NAME, region.getStartKey());
+      if (region.equals(chosen)) {
+        assertNull(fromCache);
+      } else {
+        assertNotNull(fromCache);
+      }
     }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRegionLocationCaching.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRegionLocationCaching.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -39,6 +40,7 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 
 @Category({ MediumTests.class, ClientTests.class })
@@ -98,10 +100,10 @@ public class TestRegionLocationCaching {
     checkRegions(conn, regions, chosen);
   }
 
-  private void checkRegions(ConnectionImplementation conn, List<RegionInfo> regions, RegionInfo chosen) {
+  private void checkRegions(ConnectionImplementation conn, List<RegionInfo> regions,
+    RegionInfo chosen) {
     for (RegionInfo region : regions) {
-      RegionLocations fromCache =
-        conn.getCachedLocation(TABLE_NAME, region.getStartKey());
+      RegionLocations fromCache = conn.getCachedLocation(TABLE_NAME, region.getStartKey());
       if (region.equals(chosen)) {
         assertNull(fromCache);
       } else {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRegionLocationCaching.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRegionLocationCaching.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -41,6 +42,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
+
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 
 @Category({ MediumTests.class, ClientTests.class })
@@ -75,7 +77,7 @@ public class TestRegionLocationCaching {
   @Test
   public void testDoNotCacheLocationWithNullServerNameWhenGetAllLocations() throws Exception {
     TableName tableName = TableName.valueOf(name.getMethodName());
-    TEST_UTIL.createTable(tableName, new byte[][] { FAMILY});
+    TEST_UTIL.createTable(tableName, new byte[][] { FAMILY });
     TEST_UTIL.waitUntilAllRegionsAssigned(tableName);
 
     ConnectionImplementation conn = (ConnectionImplementation) TEST_UTIL.getConnection();
@@ -107,8 +109,8 @@ public class TestRegionLocationCaching {
     checkRegions(tableName, conn, regions, chosen);
   }
 
-  private void checkRegions(TableName tableName, ConnectionImplementation conn, List<RegionInfo> regions,
-    RegionInfo chosen) {
+  private void checkRegions(TableName tableName, ConnectionImplementation conn,
+    List<RegionInfo> regions, RegionInfo chosen) {
     for (RegionInfo region : regions) {
       RegionLocations fromCache = conn.getCachedLocation(tableName, region.getStartKey());
       if (region.equals(chosen)) {


### PR DESCRIPTION
Backport required a separate impl for blocking client. Change is simple, but pushing PR to let test suite run