### PR TITLE
HBASE-27060 Addendum spotless fix

### DIFF
--- a/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/client/coprocessor/TestAggregationClient.java
+++ b/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/client/coprocessor/TestAggregationClient.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.client.coprocessor;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
+
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;


### PR DESCRIPTION
This should have been a relatively simple backport, but ran into some issues:

- in the original backport, i tested the change using `mvn clean verify -pl hbase-server -am`. I forgot that AggregationClient had moved to hbase-endpoint, so this erroneously made it seem like the backport was good (since it just didn't compile hbase-endpoint at all). But actually HBaseTastingUtil doesn't exist in branch-2*. 
- I fixed that with an addendum, but somehow my editor messed up the import grouping, so now it's failing due to spotless. 

Lesson learned: make sure to test the right modules if not doing a PR (i tried, but will be more careful next time), and make sure to run spotless:apply any time i make a non-cherrypick change.

Submitting this as a PR so i can run the full pre-commit checks and be absolutely sure that this will be the last addendum for this issue. 