### PR TITLE
HBASE-27172 Upgrade OpenTelemetry dependency to 1.15.0

### DIFF
--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -234,7 +234,6 @@
     <dependency>
       <groupId>io.opentelemetry.javaagent</groupId>
       <artifactId>opentelemetry-javaagent</artifactId>
-      <classifier>all</classifier>
     </dependency>
     <dependency>
       <groupId>junit</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -802,8 +802,8 @@
     <jruby.version>9.3.4.0</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <opentelemetry.version>1.0.1</opentelemetry.version>
-    <opentelemetry-javaagent.version>1.0.1</opentelemetry-javaagent.version>
+    <opentelemetry.version>1.15.0</opentelemetry.version>
+    <opentelemetry-javaagent.version>1.15.0</opentelemetry-javaagent.version>
     <log4j2.version>2.17.2</log4j2.version>
     <mockito-core.version>2.28.2</mockito-core.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
@@ -1546,7 +1546,6 @@
         <groupId>io.opentelemetry.javaagent</groupId>
         <artifactId>opentelemetry-javaagent</artifactId>
         <version>${opentelemetry-javaagent.version}</version>
-        <classifier>all</classifier>
       </dependency>
       <dependency>
         <groupId>com.lmax</groupId>


### PR DESCRIPTION
- the agent jar dropped the `-all` classifier after 1.8.0