### PR TITLE
Backport "HBASE-27172 Upgrade OpenTelemetry dependency to 1.15.0" to branch-2.5

### DIFF
--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -230,7 +230,6 @@
     <dependency>
       <groupId>io.opentelemetry.javaagent</groupId>
       <artifactId>opentelemetry-javaagent</artifactId>
-      <classifier>all</classifier>
     </dependency>
     <dependency>
       <groupId>org.apache.logging.log4j</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -577,8 +577,8 @@
     <jruby.version>9.2.13.0</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <opentelemetry.version>1.0.1</opentelemetry.version>
-    <opentelemetry-javaagent.version>1.0.1</opentelemetry-javaagent.version>
+    <opentelemetry.version>1.15.0</opentelemetry.version>
+    <opentelemetry-javaagent.version>1.15.0</opentelemetry-javaagent.version>
     <log4j2.version>2.17.2</log4j2.version>
     <mockito-core.version>2.28.2</mockito-core.version>
     <!--Internally we use a different version of protobuf. See hbase-protocol-shaded-->
@@ -1336,7 +1336,6 @@
         <groupId>io.opentelemetry.javaagent</groupId>
         <artifactId>opentelemetry-javaagent</artifactId>
         <version>${opentelemetry-javaagent.version}</version>
-        <classifier>all</classifier>
       </dependency>
       <dependency>
         <groupId>com.lmax</groupId>


### PR DESCRIPTION
- the agent jar dropped the `-all` classifier after 1.8.0