### PR TITLE
HBASE-27179 Fix build under OpenJDK 17

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3119,7 +3119,6 @@
         <maven.compiler.release>${releaseTarget}</maven.compiler.release>
         <!-- TODO: replicate logic for windows support -->
         <argLine>-Dio.netty.tryReflectionSetAccessible=true
-          --illegal-access=permit
           --add-modules jdk.unsupported
           --add-opens java.base/java.nio=ALL-UNNAMED
           --add-opens java.base/sun.nio.ch=ALL-UNNAMED
@@ -3127,6 +3126,7 @@
           --add-opens java.base/jdk.internal.ref=ALL-UNNAMED
           --add-opens java.base/java.lang.reflect=ALL-UNNAMED
           --add-exports java.base/jdk.internal.misc=ALL-UNNAMED
+          --add-exports java.security.jgss/sun.security.krb5=ALL-UNNAMED
           ${hbase-surefire.argLine}</argLine>
         <!-- We need a minimum HDFS version of 3.2.0 for HADOOP-12760 -->
         <hadoop-three.version>3.2.0</hadoop-three.version>


### PR DESCRIPTION
This pull request changes some Java flags to fix test issues with OpenJDK 17.
An missing export is added, and the option  --illegal-access=permit is removed since
it is ignored in OpenJDK 17

OpenJDK 17 is the current version with long time support, so it is a better option than version 16 or 18 for current projects. 

There are still some failures in org.apache.hadoop.hbase.http.TestProxyUserSpnegoHttpServer, but these ones are unrelated to this pull request or OpenJDK 17.