### PR TITLE
HBASE-27182 Rework tracing configuration

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -825,7 +825,7 @@ elif [ "${DEBUG}" = "true" ]; then
   echo "Skipped adding JDK11 JVM flags."
 fi
 
-if [[ -n "${HBASE_TRACE_OPTS}" ]]; then
+if [[ "${HBASE_OTEL_TRACING_ENABLED:-false}" = "true" ]] ; then
   if [ "${DEBUG}" = "true" ]; then
     echo "Attaching opentelemetry agent"
   fi


### PR DESCRIPTION
* Take advantage of the fact that OpenTelemetry can read its configuration from environment
  variables and make use of this where possible, only falling back to passing properties into the
  process launch configuration when it's necessary. DRY up tracing configuration and make it
  easier to manage in a container environment.
* Replace `HBASE_TRACE_OPTS`, which used to act as both a feature flag and a baseline for
  configuration shared across processes. Instead, use `HBASE_OTEL_TRACING_ENABLED` as a feature
  flag, and let configuration reuse be handled via the environment variables that otel supports
  naively.
* Add further explanation for how to write your configuration for our different deployment
  modes (standalone, pseudo-distributed, fully distributed) and in different environments.