### PR TITLE
HBASE-27183 Support regionserver to connect to HMaster proxy port

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1567,6 +1567,10 @@ public final class HConstants {
    */
   public static final int BATCH_ROWS_THRESHOLD_DEFAULT = 5000;
 
+  public static final String CONSUME_MASTER_PROXY_PORT =
+    "hbase.client.consume.master.proxy.port";
+  public static final boolean CONSUME_MASTER_PROXY_PORT_DEFAULT = false;
+
   private HConstants() {
     // Can't be instantiated with this ctor.
   }

--- a/hbase-protocol-shaded/src/main/protobuf/server/zookeeper/ZooKeeper.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/zookeeper/ZooKeeper.proto
@@ -55,6 +55,7 @@ message Master {
   // Major RPC version so that clients can know what version the master can accept.
   optional uint32 rpc_version = 2;
   optional uint32 info_port = 3;
+  optional uint32 proxy_port = 4;
 }
 
 /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnection.java
@@ -97,7 +97,7 @@ public interface AsyncClusterConnection extends AsyncConnection {
    * Get live region servers from masters.
    */
   CompletableFuture<List<ServerName>> getLiveRegionServers(MasterAddressTracker masterAddrTracker,
-    int count);
+    int count, boolean consumeMasterProxyPort);
 
   /**
    * Get the bootstrap node list of another region server.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnectionImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnectionImpl.java
@@ -130,10 +130,14 @@ class AsyncClusterConnectionImpl extends AsyncConnectionImpl implements AsyncClu
 
   @Override
   public CompletableFuture<List<ServerName>>
-    getLiveRegionServers(MasterAddressTracker masterAddrTracker, int count) {
+    getLiveRegionServers(MasterAddressTracker masterAddrTracker, int count,
+    boolean consumeMasterProxyPort) {
     CompletableFuture<List<ServerName>> future = new CompletableFuture<>();
+    ServerName masterServerName = consumeMasterProxyPort ?
+      masterAddrTracker.getMasterAddressWithProxyPortIfAvailable(false) :
+      masterAddrTracker.getMasterAddress();
     RegionServerStatusService.Interface stub = RegionServerStatusService
-      .newStub(rpcClient.createRpcChannel(masterAddrTracker.getMasterAddress(), user, rpcTimeout));
+      .newStub(rpcClient.createRpcChannel(masterServerName, user, rpcTimeout));
     HBaseRpcController controller = rpcControllerFactory.newController();
     stub.getLiveRegionServers(controller,
       GetLiveRegionServersRequest.newBuilder().setCount(count).build(), resp -> {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyAsyncClusterConnection.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyAsyncClusterConnection.java
@@ -155,7 +155,8 @@ public class DummyAsyncClusterConnection implements AsyncClusterConnection {
 
   @Override
   public CompletableFuture<List<ServerName>>
-    getLiveRegionServers(MasterAddressTracker masterAddrTracker, int count) {
+    getLiveRegionServers(MasterAddressTracker masterAddrTracker, int count,
+      boolean consumeMasterProxyPort) {
     return null;
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/AlwaysStandByHMaster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/AlwaysStandByHMaster.java
@@ -45,9 +45,9 @@ public class AlwaysStandByHMaster extends HMaster {
   private static class AlwaysStandByMasterManager extends ActiveMasterManager {
     private static final Logger LOG = LoggerFactory.getLogger(AlwaysStandByMasterManager.class);
 
-    AlwaysStandByMasterManager(ZKWatcher watcher, ServerName sn, Server master)
+    AlwaysStandByMasterManager(ZKWatcher watcher, ServerName sn, Server master, int proxyPort)
       throws InterruptedIOException {
-      super(watcher, sn, master);
+      super(watcher, sn, master, proxyPort);
     }
 
     /**
@@ -94,7 +94,7 @@ public class AlwaysStandByHMaster extends HMaster {
   }
 
   protected ActiveMasterManager createActiveMasterManager(ZKWatcher zk, ServerName sn,
-    org.apache.hadoop.hbase.Server server) throws InterruptedIOException {
-    return new AlwaysStandByMasterManager(zk, sn, server);
+    org.apache.hadoop.hbase.Server server, int proxyPort) throws InterruptedIOException {
+    return new AlwaysStandByMasterManager(zk, sn, server, proxyPort);
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestActiveMasterManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestActiveMasterManager.java
@@ -220,7 +220,7 @@ public class TestActiveMasterManager {
         String backupZn =
           ZNodePaths.joinZNode(zk.getZNodePaths().backupMasterAddressesZNode, backupSn.toString());
         backupZNodes.add(backupZn);
-        MasterAddressTracker.setMasterAddress(zk, backupZn, backupSn, 1234);
+        MasterAddressTracker.setMasterAddress(zk, backupZn, backupSn, 1234, -1);
         TEST_UTIL.waitFor(10000,
           () -> activeMasterManager.getBackupMasters().size() == backupZNodes.size());
       }
@@ -305,7 +305,7 @@ public class TestActiveMasterManager {
       this.clusterStatusTracker = new ClusterStatusTracker(zk, this);
       clusterStatusTracker.start();
 
-      this.activeMasterManager = new ActiveMasterManager(zk, master, this);
+      this.activeMasterManager = new ActiveMasterManager(zk, master, this, -1);
       zk.registerListener(activeMasterManager);
     }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterProxyPort.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterProxyPort.java
@@ -1,0 +1,106 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.master;
+
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hbase.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
+
+@Category({ MasterTests.class, MediumTests.class })
+public class TestMasterProxyPort {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestMasterProxyPort.class);
+
+  private static HBaseTestingUtil TEST_UTIL1;
+  private static HBaseTestingUtil TEST_UTIL2;
+
+  @Before
+  public void setUp() throws Exception {
+    TEST_UTIL1 = new HBaseTestingUtil();
+    TEST_UTIL2 = new HBaseTestingUtil();
+  }
+
+  @Test
+  public void testProxyPortPublishByMaster() throws Exception {
+    TEST_UTIL1.startMiniCluster();
+    Optional<ServerName> activeMaster1 =
+      TEST_UTIL1.getMiniHBaseCluster().getRegionServer(0).getActiveMaster();
+    Configuration conf = TEST_UTIL2.getConfiguration();
+    conf.setInt(HMaster.MASTER_PROXY_PORT_EXPOSE, activeMaster1.get().getPort());
+    TEST_UTIL2.startMiniCluster();
+    Optional<ServerName> activeMaster2 =
+      TEST_UTIL2.getMiniHBaseCluster().getRegionServer(0).getActiveMaster();
+    Assert.assertNotEquals(activeMaster1.get().getPort(), activeMaster2.get().getPort());
+    TEST_UTIL1.shutdownMiniCluster();
+    TEST_UTIL2.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testProxyPortConsume() throws Exception {
+    TEST_UTIL1.startMiniCluster();
+    Optional<ServerName> activeMaster1 =
+      TEST_UTIL1.getMiniHBaseCluster().getRegionServer(0).getActiveMaster();
+    Configuration conf = TEST_UTIL2.getConfiguration();
+    conf.setBoolean(HConstants.CONSUME_MASTER_PROXY_PORT, true);
+    TEST_UTIL2.startMiniCluster();
+    Optional<ServerName> activeMaster2 =
+      TEST_UTIL2.getMiniHBaseCluster().getRegionServer(0).getActiveMaster();
+    Assert.assertNotEquals(activeMaster1.get().getPort(), activeMaster2.get().getPort());
+    TEST_UTIL1.shutdownMiniCluster();
+    TEST_UTIL2.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testProxyPortPublishAndConsume() throws Exception {
+    TEST_UTIL1.startMiniCluster();
+    Optional<ServerName> activeMaster1 =
+      TEST_UTIL1.getMiniHBaseCluster().getRegionServer(0).getActiveMaster();
+    Configuration conf = TEST_UTIL2.getConfiguration();
+    conf.setInt(HMaster.MASTER_PROXY_PORT_EXPOSE, activeMaster1.get().getPort());
+    conf.setBoolean(HConstants.CONSUME_MASTER_PROXY_PORT, true);
+    ExecutorService executorService = Executors.newSingleThreadExecutor(
+      new ThreadFactoryBuilder().setNameFormat("testProxyPortPublishAndConsume-%d").setDaemon(true)
+        .build());
+    executorService.submit(() -> TEST_UTIL2.startMiniCluster());
+    for (int i = 0; i < 25; i++) {
+      Thread.sleep(1000);
+      // Cluster2 is not going to come up because Cluster2 RS is trying to connect to
+      // Cluster1 master port.
+      Assert.assertNull(TEST_UTIL2.getMiniHBaseCluster());
+    }
+    TEST_UTIL2.shutdownMiniCluster();
+    executorService.shutdown();
+  }
+
+}

--- a/hbase-zookeeper/src/test/java/org/apache/hadoop/hbase/zookeeper/TestMasterAddressTracker.java
+++ b/hbase-zookeeper/src/test/java/org/apache/hadoop/hbase/zookeeper/TestMasterAddressTracker.java
@@ -114,7 +114,7 @@ public class TestMasterAddressTracker {
     if (sn != null) {
       LOG.info("Creating master node");
       MasterAddressTracker.setMasterAddress(zk, zk.getZNodePaths().masterAddressZNode, sn,
-        infoPort);
+        infoPort, -1);
 
       // Wait for the node to be created
       LOG.info("Waiting for master address manager to be notified");
@@ -192,8 +192,8 @@ public class TestMasterAddressTracker {
     String backupZNode2 =
       ZNodePaths.joinZNode(zk.getZNodePaths().backupMasterAddressesZNode, backupMaster2.toString());
     // Add backup masters
-    MasterAddressTracker.setMasterAddress(zk, backupZNode1, backupMaster1, 2222);
-    MasterAddressTracker.setMasterAddress(zk, backupZNode2, backupMaster2, 3333);
+    MasterAddressTracker.setMasterAddress(zk, backupZNode1, backupMaster1, 2222, -1);
+    MasterAddressTracker.setMasterAddress(zk, backupZNode2, backupMaster2, 3333, -1);
     TEST_UTIL.waitFor(30000, () -> addressTracker.getBackupMasters().size() == 2);
     backupMasters = addressTracker.getBackupMasters();
     assertEquals(2, backupMasters.size());

--- a/hbase-zookeeper/src/test/java/org/apache/hadoop/hbase/zookeeper/TestZKNodeTracker.java
+++ b/hbase-zookeeper/src/test/java/org/apache/hadoop/hbase/zookeeper/TestZKNodeTracker.java
@@ -321,12 +321,12 @@ public class TestZKNodeTracker {
     assertNotNull(ZKUtil.getData(zkw, nodeName));
 
     // Check that we don't delete if we're not supposed to
-    ZKUtil.setData(zkw, nodeName, MasterAddressTracker.toByteArray(sn, 0));
+    ZKUtil.setData(zkw, nodeName, MasterAddressTracker.toByteArray(sn, 0, -1));
     MasterAddressTracker.deleteIfEquals(zkw, ServerName.valueOf("127.0.0.2:52", 45L).toString());
     assertNotNull(ZKUtil.getData(zkw, nodeName));
 
     // Check that we delete when we're supposed to
-    ZKUtil.setData(zkw, nodeName, MasterAddressTracker.toByteArray(sn, 0));
+    ZKUtil.setData(zkw, nodeName, MasterAddressTracker.toByteArray(sn, 0, -1));
     MasterAddressTracker.deleteIfEquals(zkw, sn.toString());
     assertNull(ZKUtil.getData(zkw, nodeName));
 


### PR DESCRIPTION
Regionservers get active master address from Zookeeper/Master registry and tries to make RPC calls to master.

For security concerns, regionservers might require making connection to a different proxy port of master rather than it's original port retrieved from Zookeeper.

Configs:

1. `hbase.master.expose.proxy.port`: Master can use this config (int) to expose new proxy port on active and backup master znodes.
2. `hbase.client.consume.master.proxy.port`: Clients/Regionservers can use this config (boolean) to determine whether to connect to active master on new proxy port that master has exposed or continue using original port of master for connection.