### PR TITLE
HBASE-27097 SimpleRpcServer is broken

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleRpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleRpcServer.java
@@ -69,6 +69,7 @@ import org.apache.hbase.thirdparty.com.google.common.util.concurrent.ThreadFacto
  * put itself on new queue for Responder to pull from and return result to client.
  * @see BlockingRpcClient
  */
+@Deprecated()
 @InterfaceAudience.LimitedPrivate({ HBaseInterfaceAudience.CONFIG })
 public class SimpleRpcServer extends RpcServer {
 
@@ -464,20 +465,9 @@ public class SimpleRpcServer extends RpcServer {
     return listener.getAddress();
   }
 
-  /**
-   * This is a wrapper around
-   * {@link java.nio.channels.WritableByteChannel#write(java.nio.ByteBuffer)}. If the amount of data
-   * is large, it writes to channel in smaller chunks. This is to avoid jdk from creating many
-   * direct buffers as the size of buffer increases. This also minimizes extra copies in NIO layer
-   * as a result of multiple write operations required to write a large buffer.
-   * @param channel     writable byte channel to write to
-   * @param bufferChain Chain of buffers to write
-   * @return number of bytes written
-   * @see java.nio.channels.WritableByteChannel#write(java.nio.ByteBuffer)
-   */
   protected long channelWrite(GatheringByteChannel channel, BufferChain bufferChain)
     throws IOException {
-    long count = bufferChain.write(channel, NIO_BUFFER_LIMIT);
+    long count = bufferChain.write(channel);
     if (count > 0) {
       this.metrics.sentBytes(count);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleRpcServerResponder.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleRpcServerResponder.java
@@ -36,6 +36,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 /**
  * Sends responses of RPC back to clients.
  */
+@Deprecated
 @InterfaceAudience.Private
 class SimpleRpcServerResponder extends Thread {
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleServerCall.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.RequestHeader
  * Datastructure that holds all necessary to a method invocation and then afterward, carries the
  * result.
  */
+@Deprecated
 @InterfaceAudience.Private
 class SimpleServerCall extends ServerCall<SimpleServerRpcConnection> {
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleServerRpcConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleServerRpcConnection.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.RequestHeader
 /** Reads calls from a connection and queues them for handling. */
 @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "VO_VOLATILE_INCREMENT",
     justification = "False positive according to http://sourceforge.net/p/findbugs/bugs/1032/")
+@Deprecated
 @InterfaceAudience.Private
 class SimpleServerRpcConnection extends ServerRpcConnection {
 


### PR DESCRIPTION
Replace `BufferChain#write(channel,int)` with a simpler `#write(channel)` implementation that does not attempt to "chunk" data to be written. This method was used exclusively by `SimpleRpcServer`. The code was unnecessarily complex and caused short writes when values were large, which were exposed by MAC verification failures when SASL is enabled, so was corrected and simplified. Any difference in performance from this change will be limited to `SimpleRpcServer`. Testing under load confirms the fix and does not show significant regression.

`SimpleRpcServer` and its related code is now also marked as `@Deprecated`.