### PR TITLE
HBASE-27194 Add test coverage for SimpleRpcServer

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSecureNettyRpcServer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSecureNettyRpcServer.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
-import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNameTestRule;
 import org.apache.hadoop.hbase.security.HBaseKerberosUtils;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RPCTests;
@@ -35,7 +35,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TestName;
 
 @Category({ RPCTests.class, MediumTests.class })
 public class TestSecureNettyRpcServer extends TestNettyRpcServer {
@@ -51,7 +50,7 @@ public class TestSecureNettyRpcServer extends TestNettyRpcServer {
   private static UserGroupInformation UGI;
 
   @Rule
-  public TestName name = new TestName();
+  public TableNameTestRule name = new TableNameTestRule();
 
   @Before
   public void setup() throws Exception {
@@ -60,7 +59,7 @@ public class TestSecureNettyRpcServer extends TestNettyRpcServer {
     KDC = TEST_UTIL.setupMiniKdc(KEYTAB_FILE);
     PRINCIPAL = "hbase/" + HOST;
     KDC.createPrincipal(KEYTAB_FILE, PRINCIPAL);
-    final String principalName = PRINCIPAL + "@" + KDC.getRealm();
+    String principalName = PRINCIPAL + "@" + KDC.getRealm();
     HBaseKerberosUtils.setPrincipalForTesting(principalName);
     Configuration conf = TEST_UTIL.getConfiguration();
     HBaseKerberosUtils.setSecuredConfiguration(conf, principalName, principalName);
@@ -74,6 +73,7 @@ public class TestSecureNettyRpcServer extends TestNettyRpcServer {
     if (KDC != null) {
       KDC.stop();
     }
+    KEYTAB_FILE.delete();
     TEST_UTIL.cleanupTestDir();
   }
 
@@ -83,7 +83,7 @@ public class TestSecureNettyRpcServer extends TestNettyRpcServer {
     UGI.doAs(new PrivilegedExceptionAction<Void>() {
       @Override
       public Void run() throws Exception {
-        doTest(TableName.valueOf(name.getMethodName().replace('[', '_').replace(']', '_')));
+        doTest(name.getTableName());
         return null;
       }
     });

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSecureNettyRpcServer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSecureNettyRpcServer.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.ipc;
+
+import java.io.File;
+import java.security.PrivilegedExceptionAction;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.security.HBaseKerberosUtils;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.RPCTests;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+@Category({ RPCTests.class, MediumTests.class })
+public class TestSecureNettyRpcServer extends TestNettyRpcServer {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestSecureNettyRpcServer.class);
+
+  private static File KEYTAB_FILE;
+  private static MiniKdc KDC;
+  private static String HOST = "localhost";
+  private static String PRINCIPAL;
+  private static UserGroupInformation UGI;
+
+  @Rule
+  public TestName name = new TestName();
+
+  @Before
+  public void setup() throws Exception {
+    TEST_UTIL = new HBaseTestingUtil();
+    KEYTAB_FILE = new File(TEST_UTIL.getDataTestDir("keytab").toUri().getPath());
+    KDC = TEST_UTIL.setupMiniKdc(KEYTAB_FILE);
+    PRINCIPAL = "hbase/" + HOST;
+    KDC.createPrincipal(KEYTAB_FILE, PRINCIPAL);
+    final String principalName = PRINCIPAL + "@" + KDC.getRealm();
+    HBaseKerberosUtils.setPrincipalForTesting(principalName);
+    Configuration conf = TEST_UTIL.getConfiguration();
+    HBaseKerberosUtils.setSecuredConfiguration(conf, principalName, principalName);
+    UGI = login(KEYTAB_FILE.toString(), principalName);
+    super.setup();
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    super.tearDown();
+    if (KDC != null) {
+      KDC.stop();
+    }
+    TEST_UTIL.cleanupTestDir();
+  }
+
+  @Override
+  @Test
+  public void testNettyRpcServer() throws Exception {
+    UGI.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        doTest(TableName.valueOf(name.getMethodName().replace('[', '_').replace(']', '_')));
+        return null;
+      }
+    });
+  }
+
+  static UserGroupInformation login(String krbKeytab, String krbPrincipal) throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(CommonConfigurationKeys.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
+    UserGroupInformation.setConfiguration(conf);
+    UserGroupInformation.loginUserFromKeytab(krbPrincipal, krbKeytab);
+    return UserGroupInformation.getLoginUser();
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSecureSimpleRpcServer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSecureSimpleRpcServer.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
-import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNameTestRule;
 import org.apache.hadoop.hbase.security.HBaseKerberosUtils;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RPCTests;
@@ -35,7 +35,6 @@ import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.rules.TestName;
 
 @Category({ RPCTests.class, MediumTests.class })
 public class TestSecureSimpleRpcServer extends TestSimpleRpcServer {
@@ -51,7 +50,7 @@ public class TestSecureSimpleRpcServer extends TestSimpleRpcServer {
   private static UserGroupInformation UGI;
 
   @Rule
-  public TestName name = new TestName();
+  public TableNameTestRule name = new TableNameTestRule();
 
   @BeforeClass
   public static void setupClass() throws Exception {
@@ -60,7 +59,7 @@ public class TestSecureSimpleRpcServer extends TestSimpleRpcServer {
     KDC = TEST_UTIL.setupMiniKdc(KEYTAB_FILE);
     PRINCIPAL = "hbase/" + HOST;
     KDC.createPrincipal(KEYTAB_FILE, PRINCIPAL);
-    final String principalName = PRINCIPAL + "@" + KDC.getRealm();
+    String principalName = PRINCIPAL + "@" + KDC.getRealm();
     HBaseKerberosUtils.setPrincipalForTesting(principalName);
     Configuration conf = TEST_UTIL.getConfiguration();
     HBaseKerberosUtils.setSecuredConfiguration(conf, principalName, principalName);
@@ -75,6 +74,7 @@ public class TestSecureSimpleRpcServer extends TestSimpleRpcServer {
     if (KDC != null) {
       KDC.stop();
     }
+    KEYTAB_FILE.delete();
     TEST_UTIL.cleanupTestDir();
   }
 
@@ -84,7 +84,7 @@ public class TestSecureSimpleRpcServer extends TestSimpleRpcServer {
     UGI.doAs(new PrivilegedExceptionAction<Void>() {
       @Override
       public Void run() throws Exception {
-        doTest(TableName.valueOf(name.getMethodName()));
+        doTest(name.getTableName());
         return null;
       }
     });

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSecureSimpleRpcServer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSecureSimpleRpcServer.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.ipc;
+
+import java.io.File;
+import java.security.PrivilegedExceptionAction;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.security.HBaseKerberosUtils;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.RPCTests;
+import org.apache.hadoop.minikdc.MiniKdc;
+import org.apache.hadoop.security.UserGroupInformation;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+@Category({ RPCTests.class, MediumTests.class })
+public class TestSecureSimpleRpcServer extends TestSimpleRpcServer {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestSecureSimpleRpcServer.class);
+
+  private static File KEYTAB_FILE;
+  private static MiniKdc KDC;
+  private static String HOST = "localhost";
+  private static String PRINCIPAL;
+  private static UserGroupInformation UGI;
+
+  @Rule
+  public TestName name = new TestName();
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    TEST_UTIL = new HBaseTestingUtil();
+    KEYTAB_FILE = new File(TEST_UTIL.getDataTestDir("keytab").toUri().getPath());
+    KDC = TEST_UTIL.setupMiniKdc(KEYTAB_FILE);
+    PRINCIPAL = "hbase/" + HOST;
+    KDC.createPrincipal(KEYTAB_FILE, PRINCIPAL);
+    final String principalName = PRINCIPAL + "@" + KDC.getRealm();
+    HBaseKerberosUtils.setPrincipalForTesting(principalName);
+    Configuration conf = TEST_UTIL.getConfiguration();
+    HBaseKerberosUtils.setSecuredConfiguration(conf, principalName, principalName);
+    UGI = login(KEYTAB_FILE.toString(), principalName);
+    TestSimpleRpcServer.setupClass();
+
+  }
+
+  @AfterClass
+  public static void tearDownClass() throws Exception {
+    TestSimpleRpcServer.tearDownClass();
+    if (KDC != null) {
+      KDC.stop();
+    }
+    TEST_UTIL.cleanupTestDir();
+  }
+
+  @Override
+  @Test
+  public void testSimpleRpcServer() throws Exception {
+    UGI.doAs(new PrivilegedExceptionAction<Void>() {
+      @Override
+      public Void run() throws Exception {
+        doTest(TableName.valueOf(name.getMethodName()));
+        return null;
+      }
+    });
+  }
+
+  static UserGroupInformation login(String krbKeytab, String krbPrincipal) throws Exception {
+    Configuration conf = new Configuration();
+    conf.set(CommonConfigurationKeys.HADOOP_SECURITY_AUTHENTICATION, "kerberos");
+    UserGroupInformation.setConfiguration(conf);
+    UserGroupInformation.loginUserFromKeytab(krbPrincipal, krbKeytab);
+    return UserGroupInformation.getLoginUser();
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcServer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcServer.java
@@ -20,8 +20,6 @@ package org.apache.hadoop.hbase.ipc;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
-import java.util.Arrays;
-import java.util.Collection;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.TableName;
@@ -36,24 +34,20 @@ import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RPCTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.LoadTestKVGenerator;
-import org.junit.After;
-import org.junit.Before;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
-import org.junit.runner.RunWith;
-import org.junit.runners.Parameterized;
-import org.junit.runners.Parameterized.Parameters;
 
 @Category({ RPCTests.class, MediumTests.class })
-@RunWith(Parameterized.class)
-public class TestNettyRpcServer {
+public class TestSimpleRpcServer {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-    HBaseClassTestRule.forClass(TestNettyRpcServer.class);
+    HBaseClassTestRule.forClass(TestSimpleRpcServer.class);
 
   private static final byte[] FAMILY = Bytes.toBytes("f");
   private static final byte[] QUALIFIER = Bytes.toBytes("q");
@@ -66,36 +60,27 @@ public class TestNettyRpcServer {
   @Rule
   public TestName name = new TestName();
 
-  @Parameterized.Parameter
-  public String allocatorType;
-
-  @Parameters
-  public static Collection<Object[]> parameters() {
-    return Arrays.asList(new Object[][] { { NettyRpcServer.POOLED_ALLOCATOR_TYPE },
-      { NettyRpcServer.UNPOOLED_ALLOCATOR_TYPE }, { NettyRpcServer.HEAP_ALLOCATOR_TYPE },
-      { SimpleByteBufAllocator.class.getName() } });
-  }
-
-  @Before
-  public void setup() throws Exception {
+  @SuppressWarnings("deprecation")
+  @BeforeClass
+  public static void setupClass() throws Exception {
     // A subclass may have already created TEST_UTIL and is now upcalling to us
     if (TEST_UTIL == null) {
       TEST_UTIL = new HBaseTestingUtil();
     }
+    // Set RPC server impl to SimpleRpcServer
     TEST_UTIL.getConfiguration().set(RpcServerFactory.CUSTOM_RPC_SERVER_IMPL_CONF_KEY,
-      NettyRpcServer.class.getName());
-    TEST_UTIL.getConfiguration().set(NettyRpcServer.HBASE_NETTY_ALLOCATOR_KEY, allocatorType);
+      SimpleRpcServer.class.getName());
     TEST_UTIL.startMiniCluster();
   }
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDownClass() throws Exception {
     TEST_UTIL.shutdownMiniCluster();
   }
 
   @Test
-  public void testNettyRpcServer() throws Exception {
-    doTest(TableName.valueOf(name.getMethodName().replace('[', '_').replace(']', '_')));
+  public void testSimpleRpcServer() throws Exception {
+    doTest(TableName.valueOf(name.getMethodName()));
   }
 
   protected void doTest(TableName tableName) throws Exception {


### PR DESCRIPTION
Add test coverage for `SimpleRpcServer`.

Improve the way we test both `SimpleRpcServer` and `NettyRpcServer`: Use `LoadTestKVGenerator` to generate random values with varying sizes between 1000 bytes and 1M bytes, and also to verify them when reading the values back.

Add secure test coverage for both `SimpleRpcServer` and `NettyRpcServer.`