### PR TITLE
HBASE-27195 Clean up netty worker/thread pool configuration

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcServer.java
@@ -64,10 +64,11 @@ public class NettyRpcServer extends RpcServer {
   /**
    * Name of property to change netty rpc server eventloop thread count. Default is 0. Tests may set
    * this down from unlimited.
+   * @deprecated Use NettyEventLoopGroupConfig#NETTY_WORKER_COUNT_KEY instead.
    */
+  @Deprecated
   public static final String HBASE_NETTY_EVENTLOOP_RPCSERVER_THREADCOUNT_KEY =
     "hbase.netty.eventloop.rpcserver.thread.count";
-  private static final int EVENTLOOP_THREADCOUNT_DEFAULT = 0;
 
   /**
    * Name of property to change the byte buf allocator for the netty channels. Default is no value,
@@ -104,10 +105,13 @@ public class NettyRpcServer extends RpcServer {
       eventLoopGroup = config.group();
       channelClass = config.serverChannelClass();
     } else {
+      // Prefer NettyEventLoopGroupConfig.NETTY_WORKER_COUNT_KEY over
+      // HBASE_NETTY_EVENTLOOP_RPCSERVER_THREADCOUNT_KEY
       int threadCount = server == null
-        ? EVENTLOOP_THREADCOUNT_DEFAULT
-        : server.getConfiguration().getInt(HBASE_NETTY_EVENTLOOP_RPCSERVER_THREADCOUNT_KEY,
-          EVENTLOOP_THREADCOUNT_DEFAULT);
+        ? NettyEventLoopGroupConfig.DEFAULT_NETTY_WORKER_COUNT
+        : server.getConfiguration().getInt(NettyEventLoopGroupConfig.NETTY_WORKER_COUNT_KEY,
+          server.getConfiguration().getInt(HBASE_NETTY_EVENTLOOP_RPCSERVER_THREADCOUNT_KEY,
+            NettyEventLoopGroupConfig.DEFAULT_NETTY_WORKER_COUNT));
       eventLoopGroup = new NioEventLoopGroup(threadCount,
         new DefaultThreadFactory("NettyRpcServer", true, Thread.MAX_PRIORITY));
       channelClass = NioServerSocketChannel.class;

--- a/hbase-server/src/test/resources/hbase-site.xml
+++ b/hbase-server/src/test/resources/hbase-site.xml
@@ -277,9 +277,4 @@
     <value>3</value>
     <description>Default is unbounded</description>
   </property>
-  <property>
-    <name>hbase.netty.eventloop.rpcserver.thread.count</name>
-    <value>3</value>
-    <description>Default is unbounded</description>
-  </property>
 </configuration>


### PR DESCRIPTION
The configuration settings "hbase.netty.worker.count" and "hbase.netty.eventloop.rpcserver.thread.count" appear to duplicate each other. The latter is not used internally but might have been used by downstreamers because it was exposed by a LP(Config) class. Prefer the former. Keep the latter in place but mark as deprecated.

Makes `NettyEventLoopGroupConfig` LP(Config).

Also formalizes another setting found in `NettyEventLoopGroupConfig`, "hbase.netty.nativetransport".