### PR TITLE
HBASE-27224 HFile tool statistic sampling produces misleading results

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/MutableHistogram.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/MutableHistogram.java
@@ -59,6 +59,14 @@ public class MutableHistogram extends MutableMetric implements MetricHistogram {
     return histogram.getMax();
   }
 
+  public String getName() {
+    return name;
+  }
+
+  public Snapshot getSnapshot() {
+    return histogram.snapshot();
+  }
+
   @Override
   public synchronized void snapshot(MetricsRecordBuilder metricsRecordBuilder, boolean all) {
     snapshot(name, desc, histogram, metricsRecordBuilder, all);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -17,18 +17,8 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
-import static com.codahale.metrics.MetricRegistry.name;
-
 import com.codahale.metrics.ConsoleReporter;
-import com.codahale.metrics.Counter;
-import com.codahale.metrics.Gauge;
-import com.codahale.metrics.Histogram;
-import com.codahale.metrics.Meter;
-import com.codahale.metrics.MetricFilter;
 import com.codahale.metrics.MetricRegistry;
-import com.codahale.metrics.ScheduledReporter;
-import com.codahale.metrics.Snapshot;
-import com.codahale.metrics.Timer;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.IOException;
@@ -43,9 +33,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
-import java.util.SortedMap;
 import java.util.TimeZone;
-import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
@@ -64,6 +52,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.Tag;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
+import org.apache.hadoop.hbase.metrics.Snapshot;
 import org.apache.hadoop.hbase.mob.MobUtils;
 import org.apache.hadoop.hbase.regionserver.HStoreFile;
 import org.apache.hadoop.hbase.regionserver.TimeRangeTracker;
@@ -73,6 +62,8 @@ import org.apache.hadoop.hbase.util.BloomFilterUtil;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.HFileArchiveUtil;
+import org.apache.hadoop.metrics2.lib.MutableRangeHistogram;
+import org.apache.hadoop.metrics2.lib.MutableSizeHistogram;
 import org.apache.hadoop.util.Tool;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -584,15 +575,17 @@ public class HFilePrettyPrinter extends Configured implements Tool {
   private static class KeyValueStatsCollector {
     private final MetricRegistry metricsRegistry = new MetricRegistry();
     private final ByteArrayOutputStream metricsOutput = new ByteArrayOutputStream();
-    private final SimpleReporter simpleReporter = SimpleReporter.forRegistry(metricsRegistry)
-      .outputTo(new PrintStream(metricsOutput)).filter(MetricFilter.ALL).build();
 
-    Histogram keyLen = metricsRegistry.histogram(name(HFilePrettyPrinter.class, "Key length"));
-    Histogram valLen = metricsRegistry.histogram(name(HFilePrettyPrinter.class, "Val length"));
-    Histogram rowSizeBytes =
-      metricsRegistry.histogram(name(HFilePrettyPrinter.class, "Row size (bytes)"));
-    Histogram rowSizeCols =
-      metricsRegistry.histogram(name(HFilePrettyPrinter.class, "Row size (columns)"));
+    MutableSizeHistogram keyLen = new MutableSizeHistogram("Key length", "Size of cell keys");
+    MutableSizeHistogram valLen = new MutableSizeHistogram("Val length", "Size of cell values");
+    MutableSizeHistogram rowSizeBytes =
+      new MutableSizeHistogram("Row size (bytes)", "Size of rows in bytes");
+    MutableColumnCountHistogram rowSizeCols =
+      new MutableColumnCountHistogram("Row size (columns)", "Size of rows in columns");
+
+    private final SimpleReporter simpleReporter = SimpleReporter.newBuilder().addHistogram(keyLen)
+      .addHistogram(valLen).addHistogram(rowSizeBytes).addHistogram(rowSizeCols)
+      .outputTo(new PrintStream(metricsOutput)).build();
 
     long curRowBytes = 0;
     long curRowCols = 0;
@@ -604,7 +597,7 @@ public class HFilePrettyPrinter extends Configured implements Tool {
     private long curRowKeyLength;
 
     public void collect(Cell cell) {
-      valLen.update(cell.getValueLength());
+      valLen.add(cell.getValueLength());
       if (prevCell != null && CellComparator.getInstance().compareRows(prevCell, cell) != 0) {
         // new row
         collectRow();
@@ -616,9 +609,9 @@ public class HFilePrettyPrinter extends Configured implements Tool {
     }
 
     private void collectRow() {
-      rowSizeBytes.update(curRowBytes);
-      rowSizeCols.update(curRowCols);
-      keyLen.update(curRowKeyLength);
+      rowSizeBytes.add(curRowBytes);
+      rowSizeCols.add(curRowCols);
+      keyLen.add(curRowKeyLength);
 
       if (curRowBytes > maxRowBytes && prevCell != null) {
         biggestRow = CellUtil.cloneRow(prevCell);
@@ -640,7 +633,6 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       if (prevCell == null) return "no data available for statistics";
 
       // Dump the metrics to the output stream
-      simpleReporter.stop();
       simpleReporter.report();
 
       return metricsOutput.toString() + "Key of biggest row: " + Bytes.toStringBinary(biggestRow);
@@ -648,41 +640,60 @@ public class HFilePrettyPrinter extends Configured implements Tool {
   }
 
   /**
-   * Almost identical to ConsoleReporter, but extending ScheduledReporter, as extending
-   * ConsoleReporter in this version of dropwizard is now too much trouble.
+   * MutableRangeHistogram with buckets designed for column counts
    */
-  private static class SimpleReporter extends ScheduledReporter {
+  static class MutableColumnCountHistogram extends MutableRangeHistogram {
+
+    private final static long[] RANGES = { 1, 3, 5, 10, 50, 100, 500, 1000, 5000, 10000 };
+
+    public MutableColumnCountHistogram(String name, String description) {
+      super(name, description);
+    }
+
+    @Override
+    public String getRangeType() {
+      return "ColumnsRangeCount";
+    }
+
+    @Override
+    public long[] getRanges() {
+      return RANGES;
+    }
+  }
+
+  /**
+   * Simple reporter which collects registered histograms for printing to an output stream in
+   * {@link #report()}.
+   */
+  private static class SimpleReporter {
     /**
      * Returns a new {@link Builder} for {@link ConsoleReporter}.
-     * @param registry the registry to report
      * @return a {@link Builder} instance for a {@link ConsoleReporter}
      */
-    public static Builder forRegistry(MetricRegistry registry) {
-      return new Builder(registry);
+    public static Builder newBuilder() {
+      return new Builder();
     }
 
     /**
      * A builder for {@link SimpleReporter} instances. Defaults to using the default locale and time
-     * zone, writing to {@code System.out}, converting rates to events/second, converting durations
-     * to milliseconds, and not filtering metrics.
+     * zone, writing to {@code System.out}.
      */
     public static class Builder {
-      private final MetricRegistry registry;
-      private PrintStream output;
-      private Locale locale;
-      private TimeZone timeZone;
-      private TimeUnit rateUnit;
-      private TimeUnit durationUnit;
-      private MetricFilter filter;
 
-      private Builder(MetricRegistry registry) {
-        this.registry = registry;
+      private final List<MutableRangeHistogram> histograms = new ArrayList<>();
+      private PrintStream output;
+      private final Locale locale;
+      private final TimeZone timeZone;
+
+      private Builder() {
         this.output = System.out;
         this.locale = Locale.getDefault();
         this.timeZone = TimeZone.getDefault();
-        this.rateUnit = TimeUnit.SECONDS;
-        this.durationUnit = TimeUnit.MILLISECONDS;
-        this.filter = MetricFilter.ALL;
+      }
+
+      public Builder addHistogram(MutableRangeHistogram histogram) {
+        histograms.add(histogram);
+        return this;
       }
 
       /**
@@ -696,32 +707,22 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       }
 
       /**
-       * Only report metrics which match the given filter.
-       * @param filter a {@link MetricFilter}
-       * @return {@code this}
-       */
-      public Builder filter(MetricFilter filter) {
-        this.filter = filter;
-        return this;
-      }
-
-      /**
        * Builds a {@link ConsoleReporter} with the given properties.
        * @return a {@link ConsoleReporter}
        */
       public SimpleReporter build() {
-        return new SimpleReporter(registry, output, locale, timeZone, rateUnit, durationUnit,
-          filter);
+        return new SimpleReporter(histograms, output, locale, timeZone);
       }
     }
 
+    private final List<MutableRangeHistogram> histograms;
     private final PrintStream output;
     private final Locale locale;
     private final DateFormat dateFormat;
 
-    private SimpleReporter(MetricRegistry registry, PrintStream output, Locale locale,
-      TimeZone timeZone, TimeUnit rateUnit, TimeUnit durationUnit, MetricFilter filter) {
-      super(registry, "simple-reporter", filter, rateUnit, durationUnit);
+    private SimpleReporter(List<MutableRangeHistogram> histograms, PrintStream output,
+      Locale locale, TimeZone timeZone) {
+      this.histograms = histograms;
       this.output = output;
       this.locale = locale;
 
@@ -729,16 +730,13 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       dateFormat.setTimeZone(timeZone);
     }
 
-    @Override
-    public void report(SortedMap<String, Gauge> gauges, SortedMap<String, Counter> counters,
-      SortedMap<String, Histogram> histograms, SortedMap<String, Meter> meters,
-      SortedMap<String, Timer> timers) {
+    public void report() {
       // we know we only have histograms
       if (!histograms.isEmpty()) {
-        for (Map.Entry<String, Histogram> entry : histograms.entrySet()) {
-          output.print("   " + StringUtils.substringAfterLast(entry.getKey(), "."));
+        for (MutableRangeHistogram entry : histograms) {
+          output.print("   " + entry.getName());
           output.println(':');
-          printHistogram(entry.getValue());
+          printHistogram(entry);
         }
         output.println();
       }
@@ -747,19 +745,24 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       output.flush();
     }
 
-    private void printHistogram(Histogram histogram) {
+    private void printHistogram(MutableRangeHistogram histogram) {
       Snapshot snapshot = histogram.getSnapshot();
       output.printf(locale, "               min = %d%n", snapshot.getMin());
       output.printf(locale, "               max = %d%n", snapshot.getMax());
-      output.printf(locale, "              mean = %2.2f%n", snapshot.getMean());
-      output.printf(locale, "            stddev = %2.2f%n", snapshot.getStdDev());
-      output.printf(locale, "            median = %2.2f%n", snapshot.getMedian());
-      output.printf(locale, "              75%% <= %2.2f%n", snapshot.get75thPercentile());
-      output.printf(locale, "              95%% <= %2.2f%n", snapshot.get95thPercentile());
-      output.printf(locale, "              98%% <= %2.2f%n", snapshot.get98thPercentile());
-      output.printf(locale, "              99%% <= %2.2f%n", snapshot.get99thPercentile());
-      output.printf(locale, "            99.9%% <= %2.2f%n", snapshot.get999thPercentile());
+      output.printf(locale, "              mean = %d%n", snapshot.getMean());
+      output.printf(locale, "            median = %d%n", snapshot.getMedian());
+      output.printf(locale, "              75%% <= %d%n", snapshot.get75thPercentile());
+      output.printf(locale, "              95%% <= %d%n", snapshot.get95thPercentile());
+      output.printf(locale, "              98%% <= %d%n", snapshot.get98thPercentile());
+      output.printf(locale, "              99%% <= %d%n", snapshot.get99thPercentile());
+      output.printf(locale, "            99.9%% <= %d%n", snapshot.get999thPercentile());
       output.printf(locale, "             count = %d%n", histogram.getCount());
+
+      for (long range : histogram.getRanges()) {
+        String countAtOrBelow = Long.toString(snapshot.getCountAtOrBelow(range));
+        countAtOrBelow = StringUtils.leftPad(countAtOrBelow, 17, " ");
+        output.printf(locale, "%s <= %d%n", countAtOrBelow, range);
+      }
     }
   }
 


### PR DESCRIPTION
Here's an example output:

```
Stats:
   Key length:
               min = 29
               max = 29
              mean = 29
            median = 29
              75% <= 29
              95% <= 29
              98% <= 29
              99% <= 29
            99.9% <= 29
             count = 1000
             1000 <= 10
             1000 <= 100
             1000 <= 1000
             1000 <= 10000
             1000 <= 100000
             1000 <= 1000000
             1000 <= 10000000
             1000 <= 100000000
   Val length:
               min = 3
               max = 3
              mean = 3
            median = 3
              75% <= 3
              95% <= 3
              98% <= 3
              99% <= 3
            99.9% <= 3
             count = 1000
             1000 <= 10
             1000 <= 100
             1000 <= 1000
             1000 <= 10000
             1000 <= 100000
             1000 <= 1000000
             1000 <= 10000000
             1000 <= 100000000
   Row size (bytes):
               min = 40
               max = 40
              mean = 40
            median = 40
              75% <= 40
              95% <= 40
              98% <= 40
              99% <= 40
            99.9% <= 40
             count = 1000
             1000 <= 10
             1000 <= 100
             1000 <= 1000
             1000 <= 10000
             1000 <= 100000
             1000 <= 1000000
             1000 <= 10000000
             1000 <= 100000000
   Row size (columns):
               min = 1
               max = 1
              mean = 1
            median = 1
              75% <= 1
              95% <= 1
              98% <= 1
              99% <= 1
            99.9% <= 1
             count = 1000
             1000 <= 1
             1000 <= 3
             1000 <= 5
             1000 <= 10
             1000 <= 50
             1000 <= 100
             1000 <= 500
             1000 <= 1000
             1000 <= 5000
             1000 <= 10000


Key of biggest row: row_00000000
```

Obviously looks weird with all the round numbers, but should give a very clear representation of the distribution once real numbers are in place.

If this feels too verbose for some people, I could hide the buckets behind a config/command line option.

The added test just verifies that we're properly including the histogram buckets in output. Given the sampling involved, I'm not sure I could reliably test that this fixes the `max` problem I encountered with codahale's histogram. Instead we rely on the fact that MutableRangeHistogram is so pervasively used. There are various tests of the various histogram classes in the hierarchy of MutableRangeHistogram.