### PR TITLE
HBASE-27225 Add BucketAllocator bucket size statistic logging

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketAllocator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketAllocator.java
@@ -650,12 +650,14 @@ public final class BucketAllocator {
     IndexStatistics[] stats = getIndexStatistics(total);
     LOG.debug("Bucket allocator statistics follow:");
     LOG.debug(
-      "  Free bytes={}; used bytes={}; total bytes={}; wasted bytes={}; fragmentation bytes={}; completelyFreeBuckets={}",
+      "  Free bytes={}; used bytes={}; total bytes={}; wasted bytes={}; fragmentation bytes={}; "
+        + "completelyFreeBuckets={}",
       total.freeBytes(), total.usedBytes(), total.totalBytes(), total.wastedBytes(),
       total.fragmentationBytes(), total.completelyFreeBuckets());
     for (IndexStatistics s : stats) {
       LOG.debug(
-        "  Object size {}; used={}; free={}; total={}; wasted bytes={}; fragmentation bytes={}, full buckets={}",
+        "  Object size {}; used={}; free={}; total={}; wasted bytes={}; fragmentation bytes={}, "
+          + "full buckets={}",
         s.itemSize(), s.usedCount(), s.freeCount(), s.totalCount(), s.wastedBytes(),
         s.fragmentationBytes(), s.fullBuckets());
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -738,6 +738,8 @@ public class BucketCache implements BlockCache, HeapSize {
       + cacheStats.getEvictedCount() + ", " + "evictedPerRun=" + cacheStats.evictedPerEviction()
       + ", " + "allocationFailCount=" + cacheStats.getAllocationFailCount());
     cacheStats.reset();
+
+    bucketAllocator.logDebugStatistics();
   }
 
   public long getRealCacheSize() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -580,7 +580,7 @@ public class BucketCache implements BlockCache, HeapSize {
    * {@link BucketEntry#refCnt} becoming 0.
    */
   void freeBucketEntry(BucketEntry bucketEntry) {
-    bucketAllocator.freeBlock(bucketEntry.offset());
+    bucketAllocator.freeBlock(bucketEntry.offset(), bucketEntry.getLength());
     realCacheSize.add(-1 * bucketEntry.getLength());
   }
 
@@ -1121,8 +1121,9 @@ public class BucketCache implements BlockCache, HeapSize {
       checkIOErrorIsTolerated();
       // Since we failed sync, free the blocks in bucket allocator
       for (int i = 0; i < entries.size(); ++i) {
-        if (bucketEntries[i] != null) {
-          bucketAllocator.freeBlock(bucketEntries[i].offset());
+        BucketEntry bucketEntry = bucketEntries[i];
+        if (bucketEntry != null) {
+          bucketAllocator.freeBlock(bucketEntry.offset(), bucketEntry.getLength());
           bucketEntries[i] = null;
         }
       }
@@ -1540,7 +1541,7 @@ public class BucketCache implements BlockCache, HeapSize {
         succ = true;
       } finally {
         if (!succ) {
-          alloc.freeBlock(offset);
+          alloc.freeBlock(offset, len);
         }
       }
       realCacheSize.add(len);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestBucketCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestBucketCache.java
@@ -190,6 +190,12 @@ public class TestBucketCache {
       BucketSizeInfo bucketSizeInfo = mAllocator.roundUpToBucketSizeInfo(blockSize);
       IndexStatistics indexStatistics = bucketSizeInfo.statistics();
       assertEquals("unexpected freeCount for " + bucketSizeInfo, 0, indexStatistics.freeCount());
+
+      // we know the block sizes above are multiples of 1024, but default bucket sizes give an
+      // additional 1024 on top of that so this counts towards fragmentation in our test
+      // real life may have worse fragmentation because blocks may not be perfectly sized to block
+      // size, given encoding/compression and large rows
+      assertEquals(1024 * indexStatistics.totalCount(), indexStatistics.fragmentationBytes());
     }
 
     mAllocator.logDebugStatistics();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestBucketCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestBucketCache.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.when;
 
 import java.io.File;
 import java.io.IOException;
@@ -189,6 +190,8 @@ public class TestBucketCache {
       IndexStatistics indexStatistics = bucketSizeInfo.statistics();
       assertEquals("unexpected freeCount for " + bucketSizeInfo, 0, indexStatistics.freeCount());
     }
+
+    mAllocator.logDebugStatistics();
 
     for (long offset : allocations) {
       assertEquals(mAllocator.sizeOfAllocation(offset), mAllocator.freeBlock(offset));
@@ -674,7 +677,7 @@ public class TestBucketCache {
 
     // initialize an mocked ioengine.
     IOEngine ioEngine = Mockito.mock(IOEngine.class);
-    Mockito.when(ioEngine.usesSharedMemory()).thenReturn(false);
+    when(ioEngine.usesSharedMemory()).thenReturn(false);
     // Mockito.doNothing().when(ioEngine).write(Mockito.any(ByteBuffer.class), Mockito.anyLong());
     Mockito.doThrow(RuntimeException.class).when(ioEngine).write(Mockito.any(ByteBuffer.class),
       Mockito.anyLong());


### PR DESCRIPTION
Example output (with log4j log formatting prefixes removed for clarity):

```
Bucket allocator statistics follow:
  Free bytes=5325249536; used bytes=35391673344; total bytes=40716922880; waisted bytes=355258368; completelyFreeBuckets=843
  Object size 33792; used=195000; free=114; total=195114; waisted bytes=10741760; full buckets=1048
  Object size 66560; used=275656; free=46; total=275702; waisted bytes=114128896; full buckets=2932
  Object size 99328; used=76785; free=12; total=76797; waisted bytes=46185472; full buckets=1218
  Object size 132096; used=6090; free=20; total=6110; waisted bytes=11315200; full buckets=129
  Object size 525312; used=3303; free=8; total=3311; waisted bytes=155653120; full buckets=300
  Object size 787456; used=152; free=2; total=154; waisted bytes=17233920; full buckets=21
  Object size 1573888; used=107; free=3373; total=3480; waisted bytes=0; full buckets=26
```
