### PR TITLE
HBASE-27224 HFile tool statistic sampling produces misleading results

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -732,7 +732,7 @@ public class HFilePrettyPrinter extends Configured implements Tool {
    * Simple reporter which collects registered histograms for printing to an output stream in
    * {@link #report()}.
    */
-  private static class SimpleReporter {
+  private static final class SimpleReporter {
     /**
      * Returns a new {@link Builder} for {@link SimpleReporter}.
      * @return a {@link Builder} instance for a {@link SimpleReporter}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -861,9 +861,9 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       String countAtOrBelow = Long.toString(countAtOrBelowVal);
       countAtOrBelow = StringUtils.leftPad(countAtOrBelow, 17, " ");
       if (range == Long.MAX_VALUE) {
-        output.printf(locale, "%s <= inf%n", countAtOrBelow);
+        output.printf(locale, "inf <= %s%n", countAtOrBelow);
       } else {
-        output.printf(locale, "%s <= %d%n", countAtOrBelow, range);
+        output.printf(locale, "%d <= %s%n", range, countAtOrBelow);
       }
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -41,7 +41,6 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.TimeZone;
 import java.util.concurrent.atomic.LongAdder;
-import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
 import org.apache.hadoop.fs.FileSystem;
@@ -836,6 +835,7 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       // 100, etc) will have a count printed if any values were seen in that range. If no values
       // were seen for a range, that range will be excluded to keep the output small.
       if (stats.hasRangeCounts()) {
+        output.printf(locale, "           (range <= count):%n");
         long lastVal = 0;
         long lastRange = 0;
         for (long range : stats.getRanges()) {
@@ -857,14 +857,9 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       }
     }
 
-    private void printRangeCount(long range, long countAtOrBelowVal) {
-      String countAtOrBelow = Long.toString(countAtOrBelowVal);
-      countAtOrBelow = StringUtils.leftPad(countAtOrBelow, 17, " ");
-      if (range == Long.MAX_VALUE) {
-        output.printf(locale, "inf <= %s%n", countAtOrBelow);
-      } else {
-        output.printf(locale, "%d <= %s%n", range, countAtOrBelow);
-      }
+    private void printRangeCount(long range, long countAtOrBelow) {
+      String rangeString = range == Long.MAX_VALUE ? "inf" : Long.toString(range);
+      output.printf(locale, "%17s <= %d%n", rangeString, countAtOrBelow);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -831,6 +831,10 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       output.printf(locale, "            99.9%% <= %2.2f%n", snapshot.get999thPercentile());
       output.printf(locale, "             count = %d%n", histogram.getCount());
 
+      // if printStatRanges was enabled with -d arg, below we'll create an approximate histogram
+      // of counts based on the configured ranges in RANGES. Each range of sizes (i.e. <= 50, <=
+      // 100, etc) will have a count printed if any values were seen in that range. If no values
+      // were seen for a range, that range will be excluded to keep the output small.
       if (stats.hasRangeCounts()) {
         long lastVal = 0;
         long lastRange = 0;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFilePrettyPrinter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFilePrettyPrinter.java
@@ -157,7 +157,7 @@ public class TestHFilePrettyPrinter {
 
   private void assertContainsRanges(String result, int... rangeCountPairs) {
     for (int i = 0; i < rangeCountPairs.length - 1; i += 2) {
-      String expected = rangeCountPairs[i] + " <= " + rangeCountPairs[i + 1];
+      String expected = rangeCountPairs[i + 1] + " <= " + rangeCountPairs[i];
       assertTrue("expected:\n" + result + "\nto contain: '" + expected + "'",
         result.contains(expected));
     }


### PR DESCRIPTION
Wraps the existing codahale Histogram in a KeyValueStats object. This object tracks the global min and max sizes for the statistic, since Histogram's is subject to sampling. Additionally adds a new `-d` argument which enables printing of detailed size range counts. This can be useful for further visualizing the distribution of sizes. 

Below is an example form a real HFile. Prior to this patch, the max value shown was only 25k due to the sampling done by Histogram. Additionally, the new buckets (printed when `-d` is passed) make it easy to see that there are actually a few doze quite large rows in this file.

```
Stats:
   Key length:
               min = 43
               max = 137
              mean = 104.97
            stddev = 25.93
            median = 105.00
              75% <= 137.00
              95% <= 137.00
              98% <= 137.00
              99% <= 137.00
            99.9% <= 137.00
             count = 852277
                0 <= 10
              785 <= 50
           404643 <= 100
           446849 <= 500
   Val length:
               min = 1
               max = 2696196
              mean = 1633.66
            stddev = 4670.94
            median = 502.00
              75% <= 895.00
              95% <= 7567.30
              98% <= 16551.24
              99% <= 24558.18
            99.9% <= 52617.90
             count = 852544
              475 <= 1
           423450 <= 500
           238256 <= 1000
           139640 <= 5000
            19226 <= 10000
            29689 <= 50000
             1097 <= 100000
              620 <= 500000
               41 <= 750000
               19 <= 1000000
               31 <= 5000000
   Row size (bytes):
               min = 67
               max = 2696274
              mean = 1826.62
            stddev = 5465.38
            median = 619.50
              75% <= 1011.75
              95% <= 7299.55
              98% <= 16604.48
              99% <= 25200.41
            99.9% <= 82035.61
             count = 852277
                0 <= 50
               73 <= 100
           274776 <= 500
           359139 <= 1000
           167021 <= 5000
            19391 <= 10000
            30066 <= 50000
             1099 <= 100000
              621 <= 500000
               41 <= 750000
               19 <= 1000000
               31 <= 5000000
   Row size (columns):
               min = 1
               max = 2
              mean = 1.00
            stddev = 0.03
            median = 1.00
              75% <= 1.00
              95% <= 1.00
              98% <= 1.00
              99% <= 1.00
            99.9% <= 1.97
             count = 852277
           852010 <= 1
              267 <= 3
```