### PR TITLE
HBASE-27232 Fix checking for encoded block size when deciding if bloc…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -449,7 +449,7 @@ public class HFileBlock implements Cacheable {
   }
 
   /** Returns the on-disk size of the data part + checksum (header excluded). */
-  public int getOnDiskSizeWithoutHeader() {
+  int getOnDiskSizeWithoutHeader() {
     return onDiskSizeWithoutHeader;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -449,7 +449,7 @@ public class HFileBlock implements Cacheable {
   }
 
   /** Returns the on-disk size of the data part + checksum (header excluded). */
-  int getOnDiskSizeWithoutHeader() {
+  public int getOnDiskSizeWithoutHeader() {
     return onDiskSizeWithoutHeader;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -173,8 +173,7 @@ public class HFileWriterImpl implements HFile.Writer {
     closeOutputStream = path != null;
     this.cacheConf = cacheConf;
     float encodeBlockSizeRatio = conf.getFloat(UNIFIED_ENCODED_BLOCKSIZE_RATIO, 0f);
-    this.encodedBlockSizeLimit = encodeBlockSizeRatio >0 ?
-      (int) (hFileContext.getBlocksize() * encodeBlockSizeRatio) : 0;
+    this.encodedBlockSizeLimit = (int) (hFileContext.getBlocksize() * encodeBlockSizeRatio);
 
     finishInit(conf);
     if (LOG.isTraceEnabled()) {
@@ -312,14 +311,14 @@ public class HFileWriterImpl implements HFile.Writer {
    */
   protected void checkBlockBoundary() throws IOException {
     boolean shouldFinishBlock = false;
-    //This means hbase.writer.unified.encoded.blocksize.ratio was set to something different from 0
-    //and we should use the encoding ratio
-    if (encodedBlockSizeLimit > 0){
+    // This means hbase.writer.unified.encoded.blocksize.ratio was set to something different from 0
+    // and we should use the encoding ratio
+    if (encodedBlockSizeLimit > 0) {
       shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= encodedBlockSizeLimit;
     } else {
       shouldFinishBlock = blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
     }
-    if(shouldFinishBlock) {
+    if (shouldFinishBlock) {
       finishBlock();
       writeInlineBlocks(false);
       newBlock();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -316,7 +316,8 @@ public class HFileWriterImpl implements HFile.Writer {
     if (encodedBlockSizeLimit > 0) {
       shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= encodedBlockSizeLimit;
     } else {
-      shouldFinishBlock = blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
+      shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= hFileContext.getBlocksize() ||
+        blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
     }
     if (shouldFinishBlock) {
       finishBlock();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -312,7 +312,7 @@ public class HFileWriterImpl implements HFile.Writer {
    */
   protected void checkBlockBoundary() throws IOException {
     boolean shouldFinishBlock = false;
-    //This means hbase.writer.unified.encoded.blocksize.ratio was set to something different from 1
+    //This means hbase.writer.unified.encoded.blocksize.ratio was set to something different from 0
     //and we should use the encoding ratio
     if (encodedBlockSizeLimit > 0){
       shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= encodedBlockSizeLimit;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -316,8 +316,8 @@ public class HFileWriterImpl implements HFile.Writer {
     if (encodedBlockSizeLimit > 0) {
       shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= encodedBlockSizeLimit;
     } else {
-      shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= hFileContext.getBlocksize() ||
-        blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
+      shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= hFileContext.getBlocksize()
+        || blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
     }
     if (shouldFinishBlock) {
       finishBlock();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -1151,28 +1151,21 @@ public class TestHStoreFile {
     Path dir = new Path(new Path(this.testDir, "7e0102"), "familyname");
     Path path = new Path(dir, "1234567890");
 
-    DataBlockEncoding dataBlockEncoderAlgo =
-      DataBlockEncoding.FAST_DIFF;
+    DataBlockEncoding dataBlockEncoderAlgo = DataBlockEncoding.FAST_DIFF;
 
     conf.setDouble("hbase.writer.unified.encoded.blocksize.ratio", 1);
 
     cacheConf = new CacheConfig(conf);
-    HFileContext meta = new HFileContextBuilder().withBlockSize(BLOCKSIZE_SMALL)
-      .withChecksumType(CKTYPE)
-      .withBytesPerCheckSum(CKBYTES)
-      .withDataBlockEncoding(dataBlockEncoderAlgo)
-      .build();
+    HFileContext meta =
+      new HFileContextBuilder().withBlockSize(BLOCKSIZE_SMALL).withChecksumType(CKTYPE)
+        .withBytesPerCheckSum(CKBYTES).withDataBlockEncoding(dataBlockEncoderAlgo).build();
     // Make a store file and write data to it.
     StoreFileWriter writer = new StoreFileWriter.Builder(conf, cacheConf, this.fs)
-      .withFilePath(path)
-      .withMaxKeyCount(2000)
-      .withFileContext(meta)
-      .build();
+      .withFilePath(path).withMaxKeyCount(2000).withFileContext(meta).build();
     writeStoreFile(writer);
-    //writer.close();
 
-    HStoreFile storeFile = new HStoreFile(fs, writer.getPath(), conf,
-      cacheConf, BloomType.NONE, true);
+    HStoreFile storeFile =
+      new HStoreFile(fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true);
     storeFile.initReader();
     StoreFileReader reader = storeFile.getReader();
 
@@ -1180,27 +1173,21 @@ public class TestHStoreFile {
     byte[] value = fileInfo.get(HFileDataBlockEncoder.DATA_BLOCK_ENCODING);
     assertEquals(dataBlockEncoderAlgo.name(), Bytes.toString(value));
 
-    HFile.Reader fReader = HFile.createReader(fs, writer.getPath(), storeFile.getCacheConf(),
-      true, conf);
+    HFile.Reader fReader =
+      HFile.createReader(fs, writer.getPath(), storeFile.getCacheConf(), true, conf);
 
     FSDataInputStreamWrapper fsdis = new FSDataInputStreamWrapper(fs, writer.getPath());
     long fileSize = fs.getFileStatus(writer.getPath()).getLen();
-    FixedFileTrailer trailer =
-      FixedFileTrailer.readFromStream(fsdis.getStream(false), fileSize);
-    long offset = trailer.getFirstDataBlockOffset(),
-      max = trailer.getLastDataBlockOffset();
+    FixedFileTrailer trailer = FixedFileTrailer.readFromStream(fsdis.getStream(false), fileSize);
+    long offset = trailer.getFirstDataBlockOffset(), max = trailer.getLastDataBlockOffset();
     HFileBlock block;
-    int blockCount = 0;
     while (offset <= max) {
       block = fReader.readBlock(offset, -1, /* cacheBlock */
-        false, /* pread */ false,
-        /* isCompaction */ false, /* updateCacheMetrics */
+        false, /* pread */ false, /* isCompaction */ false, /* updateCacheMetrics */
         false, null, null);
       offset += block.getOnDiskSizeWithHeader();
-      blockCount += 1;
       double diff = block.getOnDiskSizeWithHeader() - BLOCKSIZE_SMALL;
-      if(offset <= max)
-        assertTrue(diff >=0 && diff < (BLOCKSIZE_SMALL*0.05));
+      if (offset <= max) assertTrue(diff >= 0 && diff < (BLOCKSIZE_SMALL * 0.05));
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -1187,7 +1187,9 @@ public class TestHStoreFile {
         false, null, null);
       offset += block.getOnDiskSizeWithHeader();
       double diff = block.getOnDiskSizeWithHeader() - BLOCKSIZE_SMALL;
-      if (offset <= max) assertTrue(diff >= 0 && diff < (BLOCKSIZE_SMALL * 0.05));
+      if (offset <= max) {
+        assertTrue(diff >= 0 && diff < (BLOCKSIZE_SMALL * 0.05));
+      }
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -66,6 +66,9 @@ import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheFactory;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.FixedFileTrailer;
+import org.apache.hadoop.hbase.io.hfile.HFile;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
 import org.apache.hadoop.hbase.io.hfile.HFileDataBlockEncoder;
@@ -1141,4 +1144,64 @@ public class TestHStoreFile {
     byte[] value = fileInfo.get(HFileDataBlockEncoder.DATA_BLOCK_ENCODING);
     assertArrayEquals(dataBlockEncoderAlgo.getNameInBytes(), value);
   }
+
+  @Test
+  public void testDataBlockSizeEncoded() throws Exception {
+    // Make up a directory hierarchy that has a regiondir ("7e0102") and familyname.
+    Path dir = new Path(new Path(this.testDir, "7e0102"), "familyname");
+    Path path = new Path(dir, "1234567890");
+
+    DataBlockEncoding dataBlockEncoderAlgo =
+      DataBlockEncoding.FAST_DIFF;
+
+    conf.setDouble("hbase.writer.unified.encoded.blocksize.ratio", 1);
+
+    cacheConf = new CacheConfig(conf);
+    HFileContext meta = new HFileContextBuilder().withBlockSize(BLOCKSIZE_SMALL)
+      .withChecksumType(CKTYPE)
+      .withBytesPerCheckSum(CKBYTES)
+      .withDataBlockEncoding(dataBlockEncoderAlgo)
+      .build();
+    // Make a store file and write data to it.
+    StoreFileWriter writer = new StoreFileWriter.Builder(conf, cacheConf, this.fs)
+      .withFilePath(path)
+      .withMaxKeyCount(2000)
+      .withFileContext(meta)
+      .build();
+    writeStoreFile(writer);
+    //writer.close();
+
+    HStoreFile storeFile = new HStoreFile(fs, writer.getPath(), conf,
+      cacheConf, BloomType.NONE, true);
+    storeFile.initReader();
+    StoreFileReader reader = storeFile.getReader();
+
+    Map<byte[], byte[]> fileInfo = reader.loadFileInfo();
+    byte[] value = fileInfo.get(HFileDataBlockEncoder.DATA_BLOCK_ENCODING);
+    assertEquals(dataBlockEncoderAlgo.name(), Bytes.toString(value));
+
+    HFile.Reader fReader = HFile.createReader(fs, writer.getPath(), storeFile.getCacheConf(),
+      true, conf);
+
+    FSDataInputStreamWrapper fsdis = new FSDataInputStreamWrapper(fs, writer.getPath());
+    long fileSize = fs.getFileStatus(writer.getPath()).getLen();
+    FixedFileTrailer trailer =
+      FixedFileTrailer.readFromStream(fsdis.getStream(false), fileSize);
+    long offset = trailer.getFirstDataBlockOffset(),
+      max = trailer.getLastDataBlockOffset();
+    HFileBlock block;
+    int blockCount = 0;
+    while (offset <= max) {
+      block = fReader.readBlock(offset, -1, /* cacheBlock */
+        false, /* pread */ false,
+        /* isCompaction */ false, /* updateCacheMetrics */
+        false, null, null);
+      offset += block.getOnDiskSizeWithHeader();
+      blockCount += 1;
+      double diff = block.getOnDiskSizeWithHeader() - BLOCKSIZE_SMALL;
+      if(offset <= max)
+        assertTrue(diff >=0 && diff < (BLOCKSIZE_SMALL*0.05));
+    }
+  }
+
 }


### PR DESCRIPTION
 On HFileWriterImpl.checkBlockBoundary, we useed to consider the unencoded and uncompressed data size when deciding to close a block and start a new one. That could lead to varying "on-disk" block sizes, depending on the encoding efficiency for the cells in each block.

[HBASE-17757](https://issues.apache.org/jira/browse/HBASE-17757) introduced the hbase.writer.unified.encoded.blocksize.ratio property, as ration of the original configured block size, to be compared against the encoded size. This was an attempt to ensure homogeneous block sizes. However, the check introduced by [HBASE-17757](https://issues.apache.org/jira/browse/HBASE-17757) also considers the unencoded size, which in the cases where encoding efficiency is higher than what's configured in hbase.writer.unified.encoded.blocksize.ratio, it would still lead to varying block sizes.

This patch changes that logic, to only consider encoded size if hbase.writer.unified.encoded.blocksize.ratio property is set, otherwise, it will consider the unencoded size. This gives a finer control over the on-disk block sizes and the overall number of blocks when encoding is in use.