### PR TITLE
HBASE-27257 Remove unnecessary usage of CachedBlocksByFile from RS UI

### DIFF
--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/BlockCacheTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/BlockCacheTmpl.jamon
@@ -30,6 +30,7 @@ BlockCache bc;
 </%java>
 <%import>
 java.util.Map;
+org.apache.hadoop.hbase.io.hfile.BlockCacheUtil;
 org.apache.hadoop.hbase.io.hfile.BlockCacheUtil.CachedBlocksByFile;
 org.apache.hadoop.hbase.io.hfile.AgeSnapshot;
 org.apache.hadoop.hbase.io.hfile.CachedBlock;
@@ -281,9 +282,7 @@ are combined counts. Request count is sum of hits and misses.</p>
 <%java>
   String bcUrl = "http://hbase.apache.org/devapidocs/" + bc.getClass().getName().replaceAll("\\.", "/") + ".html";
   String bcName = bc.getClass().getSimpleName();
-  org.apache.hadoop.hbase.io.hfile.BlockCacheUtil.CachedBlocksByFile cbsbf =
-    org.apache.hadoop.hbase.io.hfile.BlockCacheUtil.getLoadedCachedBlocksByFile(config, bc);
-  AgeSnapshot cbsbfSnapshot = cbsbf.getAgeInCacheSnapshot();
+  int maxCachedBlocksByFile = BlockCacheUtil.getMaxCachedBlocksByFile(config);
 
   boolean bucketCache = bc.getClass().getSimpleName().equals("BucketCache");
   BucketCacheStats bucketCacheStats = null;
@@ -294,13 +293,6 @@ are combined counts. Request count is sum of hits and misses.</p>
     bucketAllocator = ((BucketCache)bc).getAllocator();
   }
 </%java>
-<%if cbsbf.isFull() %>
-<p>
-<div class="alert alert-danger">
-<strong>The stats below are incomplete!</strong> We ran into our accounting limit of <% cbsbf.getCount() %> blocks. Up the configuration <i>hbase.ui.blockcache.by.file.max</i>.
-</div>
-</p> 
-</%if>
 <table id="blocks_summary" class="table table-striped">
     <tr>
         <th>Attribute</th>
@@ -365,9 +357,13 @@ are combined counts. Request count is sum of hits and misses.</p>
 </%if>
 </table>
 <%doc>Call through to block cache Detail rendering template</%doc>
-<p>View block cache <a href="?format=json&bcn=<% name %>">as JSON</a> | Block cache <a href="?format=json&bcn=<% name %>&bcv=file">as JSON by file</a></p>
-<%java>
-cbsbf = null;
-</%java>
+<p>
+View block cache <a href="?format=json&bcn=<% name %>">as JSON</a> | Block cache <a href="?format=json&bcn=<% name %>&bcv=file">as JSON by file</a>
+<%if bc.getBlockCount() > maxCachedBlocksByFile %>
+<br>
+<b>Note</b>: JSON view of block cache will be incomplete, because block count <% bc.getBlockCount() %> is greater than <i>hbase.ui.blockcache.by.file.max</i> value of <% maxCachedBlocksByFile %>.
+Increase that value to get a complete picture.
+</%if>
+</p>
 </%def>
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheUtil.java
@@ -242,6 +242,12 @@ public class BlockCacheUtil {
     }
   }
 
+  private static final int DEFAULT_MAX = 1000000;
+
+  public static int getMaxCachedBlocksByFile(Configuration conf) {
+    return conf == null ? DEFAULT_MAX : conf.getInt("hbase.ui.blockcache.by.file.max", DEFAULT_MAX);
+  }
+
   /**
    * Use one of these to keep a running account of cached blocks by file. Throw it away when done.
    * This is different than metrics in that it is stats on current state of a cache. See
@@ -259,14 +265,13 @@ public class BlockCacheUtil {
      * displays warning in red when stats are incomplete.
      */
     private final int max;
-    public static final int DEFAULT_MAX = 1000000;
 
     CachedBlocksByFile() {
       this(null);
     }
 
     CachedBlocksByFile(final Configuration c) {
-      this.max = c == null ? DEFAULT_MAX : c.getInt("hbase.ui.blockcache.by.file.max", DEFAULT_MAX);
+      this.max = getMaxCachedBlocksByFile(c);
     }
 
     /**


### PR DESCRIPTION
I kept around the old warning, but moved it to near the "View as Json" links, since that's where it makes sense now.

Here's how it looks on one of my prod regionservers:
<img width="1689" alt="Screen Shot 2022-07-29 at 11 33 24 AM" src="https://user-images.githubusercontent.com/116591/181793897-0f5f2786-ece6-464b-ad9c-dd467699c0d5.png">

