### PR TITLE
HBASE-27264 Add options to consider compressed size when delimiting blocks during hfile writes

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCompressedSizePredicator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCompressedSizePredicator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
-import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
 import org.apache.yetus.audience.InterfaceAudience;
 
 import java.io.IOException;
@@ -36,14 +35,23 @@ public interface BlockCompressedSizePredicator {
 
   String BLOCK_COMPRESSED_SIZE_PREDICATOR = "hbase.block.compressed.size.predicator";
 
+  String MAX_BLOCK_SIZE_UNCOMPRESSED = "hbase.block.max.size.uncompressed";
+
   /**
    * Calculates an adjusted block size limit based on a compression rate predicate.
    * @param context the meta file information for the current file.
    * @param uncompressedBlockSize the total uncompressed size read for the block so far.
-   * @param blockContent The byte array containing the block content so far.
    * @return the adjusted block size limit based on a compression rate predicate.
    * @throws IOException
    */
-  int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize,
-      ByteArrayOutputStream blockContent) throws IOException;
+  int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize)
+    throws IOException;
+
+  /**
+   * Updates the predicator with both compressed and uncompressed sizes of latest block written.
+   * To be called once the block is finshed and flushed to disk after compression.
+   * @param uncompressed the uncompressed size of last block written.
+   * @param compressed the compressed size of last block written.
+   */
+  void updateLatestBlockSizes(int uncompressed, int compressed);
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCompressedSizePredicator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCompressedSizePredicator.java
@@ -19,16 +19,19 @@ package org.apache.hadoop.hbase.io.hfile;
 
 import org.apache.yetus.audience.InterfaceAudience;
 
-import java.io.IOException;
-
 /**
- * Allows for defining different compression rate predicates in implementing classes. Useful
+ * Allows for defining different compression rate predicates on its implementing classes. Useful
  * when compression is in place, and we want to define block size based on the compressed size,
- * rather than the default behaviour that considers the uncompressed size only.
- *
- * Since we don't actually know the compressed size until we actual apply compression in the block
- * byte buffer, we need to "predicate" this compression rate and minimize compression execution to
- * avoid excessive resources usage.
+ * rather than the default behaviour that considers the uncompressed size only. Since we don't
+ * actually know the compressed size until we actual apply compression in the block byte buffer, we
+ * need to "predicate" this compression rate and minimize compression execution to avoid excessive
+ * resources usage. Different approaches for predicating the compressed block size can be defined by
+ * implementing classes. The <code>updateLatestBlockSizes</code> allows for updating uncompressed
+ * and compressed size values, and is called during block finishing (when we finally apply
+ * compression on the block data). Final block size predicate logic is implemented in
+ * <code>shouldFinishBlock</code>, which is called by the block writer once uncompressed size has
+ * reached the configured BLOCK size, and additional checks should be applied to decide if the block
+ * can be finished.
  */
 @InterfaceAudience.Private
 public interface BlockCompressedSizePredicator {
@@ -38,20 +41,19 @@ public interface BlockCompressedSizePredicator {
   String MAX_BLOCK_SIZE_UNCOMPRESSED = "hbase.block.max.size.uncompressed";
 
   /**
-   * Calculates an adjusted block size limit based on a compression rate predicate.
-   * @param context the meta file information for the current file.
-   * @param uncompressedBlockSize the total uncompressed size read for the block so far.
-   * @return the adjusted block size limit based on a compression rate predicate.
-   * @throws IOException
+   * Updates the predicator with both compressed and uncompressed sizes of latest block written. To
+   * be called once the block is finshed and flushed to disk after compression.
+   * @param context      the HFileContext containg the configured max block size.
+   * @param uncompressed the uncompressed size of last block written.
+   * @param compressed   the compressed size of last block written.
    */
-  int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize)
-    throws IOException;
+  void updateLatestBlockSizes(HFileContext context, int uncompressed, int compressed);
 
   /**
-   * Updates the predicator with both compressed and uncompressed sizes of latest block written.
-   * To be called once the block is finshed and flushed to disk after compression.
-   * @param uncompressed the uncompressed size of last block written.
-   * @param compressed the compressed size of last block written.
+   * Decides if the block should be finished based on the comparison of its uncompressed size
+   * against an adjusted size based on a predicated compression factor.
+   * @param uncompressed true if the block should be finished. n
    */
-  void updateLatestBlockSizes(int uncompressed, int compressed);
+  boolean shouldFinishBlock(int uncompressed);
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCompressedSizePredicator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCompressedSizePredicator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import java.io.IOException;
+
+/**
+ * Allows for defining different compression rate predicates in implementing classes. Useful
+ * when compression is in place, and we want to define block size based on the compressed size,
+ * rather than the default behaviour that considers the uncompressed size only.
+ *
+ * Since we don't actually know the compressed size until we actual apply compression in the block
+ * byte buffer, we need to "predicate" this compression rate and minimize compression execution to
+ * avoid excessive resources usage.
+ */
+@InterfaceAudience.Private
+public interface BlockCompressedSizePredicator {
+
+  String BLOCK_COMPRESSED_SIZE_PREDICATOR = "hbase.block.compressed.size.predicator";
+
+  /**
+   * Calculates an adjusted block size limit based on a compression rate predicate.
+   * @param context the meta file information for the current file.
+   * @param uncompressedBlockSize the total uncompressed size read for the block so far.
+   * @param blockContent The byte array containing the block content so far.
+   * @return the adjusted block size limit based on a compression rate predicate.
+   * @throws IOException
+   */
+  int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize,
+      ByteArrayOutputStream blockContent) throws IOException;
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -912,7 +912,7 @@ public class HFileBlock implements Cacheable {
           // In order to avoid excessive compression size calculations, we do it only once when
           // the uncompressed size has reached BLOCKSIZE. We then use this compression size to
           // calculate the compression rate, and adjust the block size limit by this ratio.
-          if (adjustedBlockSize == 0) {
+          if (adjustedBlockSize == 0 || uncompressedBlockSize >= adjustedBlockSize) {
             int compressedSize = EncodedDataBlock.getCompressedSize(fileContext.getCompression(),
               fileContext.getCompression().getCompressor(), baosInMemory.getBuffer(), 0,
               baosInMemory.size());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -465,7 +465,7 @@ public class HFileBlock implements Cacheable {
   }
 
   /** Returns the uncompressed size of data part (header and checksum excluded). */
-  public int getUncompressedSizeWithoutHeader() {
+  int getUncompressedSizeWithoutHeader() {
     return uncompressedSizeWithoutHeader;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -734,6 +734,10 @@ public class HFileBlock implements Cacheable {
       BLOCK_READY
     }
 
+    public boolean isSizeLimitCompressed() {
+      return sizeLimitCompressed;
+    }
+
     private boolean sizeLimitCompressed;
 
     private int maxSizeCompressed;
@@ -818,12 +822,13 @@ public class HFileBlock implements Cacheable {
      */
     public Writer(Configuration conf, HFileDataBlockEncoder dataBlockEncoder,
       HFileContext fileContext) {
-      this(conf, dataBlockEncoder, fileContext, ByteBuffAllocator.HEAP, false, fileContext.getBlocksize());
+      this(conf, dataBlockEncoder, fileContext, ByteBuffAllocator.HEAP, false,
+        fileContext.getBlocksize());
     }
 
-
     public Writer(Configuration conf, HFileDataBlockEncoder dataBlockEncoder,
-      HFileContext fileContext, ByteBuffAllocator allocator, boolean sizeLimitcompleted, int maxSizeCompressed) {
+      HFileContext fileContext, ByteBuffAllocator allocator, boolean sizeLimitcompleted,
+      int maxSizeCompressed) {
       if (fileContext.getBytesPerChecksum() < HConstants.HFILEBLOCK_HEADER_SIZE) {
         throw new RuntimeException("Unsupported value of bytesPerChecksum. " + " Minimum is "
           + HConstants.HFILEBLOCK_HEADER_SIZE + " but the configured value is "
@@ -904,14 +909,14 @@ public class HFileBlock implements Cacheable {
       int uncompressedBlockSize = blockSizeWritten();
       if (uncompressedBlockSize >= fileContext.getBlocksize()) {
         if (sizeLimitCompressed && uncompressedBlockSize < maxSizeCompressed) {
-          //In order to avoid excessive compression size calculations, we do it only once when
-          //the uncompressed size has reached BLOCKSIZE. We then use this compression size to
-          //calculate the compression rate, and adjust the block size limit by this ratio.
+          // In order to avoid excessive compression size calculations, we do it only once when
+          // the uncompressed size has reached BLOCKSIZE. We then use this compression size to
+          // calculate the compression rate, and adjust the block size limit by this ratio.
           if (adjustedBlockSize == 0) {
             int compressedSize = EncodedDataBlock.getCompressedSize(fileContext.getCompression(),
               fileContext.getCompression().getCompressor(), baosInMemory.getBuffer(), 0,
               baosInMemory.size());
-            adjustedBlockSize = uncompressedBlockSize/compressedSize;
+            adjustedBlockSize = uncompressedBlockSize / compressedSize;
             adjustedBlockSize *= fileContext.getBlocksize();
           }
           return uncompressedBlockSize >= adjustedBlockSize;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -465,7 +465,7 @@ public class HFileBlock implements Cacheable {
   }
 
   /** Returns the uncompressed size of data part (header and checksum excluded). */
-  int getUncompressedSizeWithoutHeader() {
+  public int getUncompressedSizeWithoutHeader() {
     return uncompressedSizeWithoutHeader;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -294,10 +294,9 @@ public class HFileWriterImpl implements HFile.Writer {
     if (blockWriter != null) {
       throw new IllegalStateException("finishInit called twice");
     }
-    blockWriter =
-      new HFileBlock.Writer(conf, blockEncoder, hFileContext, cacheConf.getByteBuffAllocator(),
-        conf.getBoolean(BLOCK_SIZE_LIMIT_COMPRESSED, false),
-        conf.getInt(MAX_BLOCK_SIZE_COMPRESSED, hFileContext.getBlocksize()*10));
+    blockWriter = new HFileBlock.Writer(conf, blockEncoder, hFileContext,
+      cacheConf.getByteBuffAllocator(), conf.getBoolean(BLOCK_SIZE_LIMIT_COMPRESSED, false),
+      conf.getInt(MAX_BLOCK_SIZE_COMPRESSED, hFileContext.getBlocksize() * 10));
     // Data block index writer
     boolean cacheIndexesOnWrite = cacheConf.shouldCacheIndexesOnWrite();
     dataBlockIndexWriter = new HFileBlockIndex.BlockIndexWriter(blockWriter,
@@ -324,7 +323,9 @@ public class HFileWriterImpl implements HFile.Writer {
       shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= hFileContext.getBlocksize()
         || blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
     }
-    shouldFinishBlock &= blockWriter.shouldFinishBlock();
+    if (blockWriter.isSizeLimitCompressed()) {
+      shouldFinishBlock &= blockWriter.shouldFinishBlock();
+    }
     if (shouldFinishBlock) {
       finishBlock();
       writeInlineBlocks(false);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
-import static org.apache.hadoop.hbase.io.hfile.HFileBlock.BLOCK_DELIMIT_COMPRESSED;
 import static org.apache.hadoop.hbase.io.hfile.HFileBlock.MAX_BLOCK_SIZE_UNCOMPRESSED;
 
 import java.io.DataOutput;
@@ -295,7 +294,7 @@ public class HFileWriterImpl implements HFile.Writer {
       throw new IllegalStateException("finishInit called twice");
     }
     blockWriter = new HFileBlock.Writer(conf, blockEncoder, hFileContext,
-      cacheConf.getByteBuffAllocator(), conf.getBoolean(BLOCK_DELIMIT_COMPRESSED, false),
+      cacheConf.getByteBuffAllocator(),
       conf.getInt(MAX_BLOCK_SIZE_UNCOMPRESSED, hFileContext.getBlocksize() * 10));
     // Data block index writer
     boolean cacheIndexesOnWrite = cacheConf.shouldCacheIndexesOnWrite();
@@ -323,9 +322,7 @@ public class HFileWriterImpl implements HFile.Writer {
       shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= hFileContext.getBlocksize()
         || blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
     }
-    if (blockWriter.isDelimitByCompressedSize()) {
-      shouldFinishBlock &= blockWriter.shouldFinishBlock();
-    }
+    shouldFinishBlock &= blockWriter.shouldFinishBlock();
     if (shouldFinishBlock) {
       finishBlock();
       writeInlineBlocks(false);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -17,7 +17,7 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
-import static org.apache.hadoop.hbase.io.hfile.HFileBlock.MAX_BLOCK_SIZE_UNCOMPRESSED;
+import static org.apache.hadoop.hbase.io.hfile.BlockCompressedSizePredicator.MAX_BLOCK_SIZE_UNCOMPRESSED;
 
 import java.io.DataOutput;
 import java.io.DataOutputStream;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -17,8 +17,8 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
-import static org.apache.hadoop.hbase.io.hfile.HFileBlock.BLOCK_SIZE_LIMIT_COMPRESSED;
-import static org.apache.hadoop.hbase.io.hfile.HFileBlock.MAX_BLOCK_SIZE_COMPRESSED;
+import static org.apache.hadoop.hbase.io.hfile.HFileBlock.BLOCK_DELIMIT_COMPRESSED;
+import static org.apache.hadoop.hbase.io.hfile.HFileBlock.MAX_BLOCK_SIZE_UNCOMPRESSED;
 
 import java.io.DataOutput;
 import java.io.DataOutputStream;
@@ -295,8 +295,8 @@ public class HFileWriterImpl implements HFile.Writer {
       throw new IllegalStateException("finishInit called twice");
     }
     blockWriter = new HFileBlock.Writer(conf, blockEncoder, hFileContext,
-      cacheConf.getByteBuffAllocator(), conf.getBoolean(BLOCK_SIZE_LIMIT_COMPRESSED, false),
-      conf.getInt(MAX_BLOCK_SIZE_COMPRESSED, hFileContext.getBlocksize() * 10));
+      cacheConf.getByteBuffAllocator(), conf.getBoolean(BLOCK_DELIMIT_COMPRESSED, false),
+      conf.getInt(MAX_BLOCK_SIZE_UNCOMPRESSED, hFileContext.getBlocksize() * 10));
     // Data block index writer
     boolean cacheIndexesOnWrite = cacheConf.shouldCacheIndexesOnWrite();
     dataBlockIndexWriter = new HFileBlockIndex.BlockIndexWriter(blockWriter,
@@ -323,7 +323,7 @@ public class HFileWriterImpl implements HFile.Writer {
       shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= hFileContext.getBlocksize()
         || blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
     }
-    if (blockWriter.isSizeLimitCompressed()) {
+    if (blockWriter.isDelimitByCompressedSize()) {
       shouldFinishBlock &= blockWriter.shouldFinishBlock();
     }
     if (shouldFinishBlock) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -293,9 +293,9 @@ public class HFileWriterImpl implements HFile.Writer {
     if (blockWriter != null) {
       throw new IllegalStateException("finishInit called twice");
     }
-    blockWriter = new HFileBlock.Writer(conf, blockEncoder, hFileContext,
-      cacheConf.getByteBuffAllocator(),
-      conf.getInt(MAX_BLOCK_SIZE_UNCOMPRESSED, hFileContext.getBlocksize() * 10));
+    blockWriter =
+      new HFileBlock.Writer(conf, blockEncoder, hFileContext, cacheConf.getByteBuffAllocator(),
+        conf.getInt(MAX_BLOCK_SIZE_UNCOMPRESSED, hFileContext.getBlocksize() * 10));
     // Data block index writer
     boolean cacheIndexesOnWrite = cacheConf.shouldCacheIndexesOnWrite();
     dataBlockIndexWriter = new HFileBlockIndex.BlockIndexWriter(blockWriter,
@@ -322,7 +322,7 @@ public class HFileWriterImpl implements HFile.Writer {
       shouldFinishBlock = blockWriter.encodedBlockSizeWritten() >= hFileContext.getBlocksize()
         || blockWriter.blockSizeWritten() >= hFileContext.getBlocksize();
     }
-    shouldFinishBlock &= blockWriter.shouldFinishBlock();
+    shouldFinishBlock &= blockWriter.checkBoundariesWithPredicate();
     if (shouldFinishBlock) {
       finishBlock();
       writeInlineBlocks(false);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PreviousBlockCompressionRatePredicator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PreviousBlockCompressionRatePredicator.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
+import org.apache.hadoop.hbase.io.encoding.EncodedDataBlock;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import java.io.IOException;
+
+/**
+ * This BlockCompressedSizePredicator implementation adjusts the block size limit based on the
+ * compression rate of the block contents read so far. For the first block, adjusted size would be
+ * zero, so it performs a compression of current block contents and calculate compression rate and
+ * adjusted size. For subsequent blocks, it only performs this calculation once the previous block
+ * adjusted size has been reached, and the block is about to be closed.
+ */
+@InterfaceAudience.Private
+public class PreviousBlockCompressionRatePredicator implements BlockCompressedSizePredicator {
+  
+  int adjustedBlockSize;
+
+  /**
+   * Calculates an adjusted block size limit based on the compression rate of current block
+   * contents. This calculation is only performed if this is the first block, otherwise, if the
+   * adjusted size from previous block has been reached by the current one.
+   * @param context the meta file information for the current file.
+   * @param uncompressedBlockSize the total uncompressed size read for the block so far.
+   * @param contents The byte array containing the block content so far.
+   * @return the adjusted block size limit based on block compression rate.
+   * @throws IOException
+   */
+  @Override 
+  public int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize, 
+      ByteArrayOutputStream contents) throws IOException {
+    // In order to avoid excessive compression size calculations, we do it only once when
+    // the uncompressed size has reached BLOCKSIZE. We then use this compression size to
+    // calculate the compression rate, and adjust the block size limit by this ratio.
+    if (adjustedBlockSize == 0 || uncompressedBlockSize >= adjustedBlockSize) {
+      int compressedSize = EncodedDataBlock.getCompressedSize(context.getCompression(),
+        context.getCompression().getCompressor(), contents.getBuffer(), 0,
+        contents.size());
+      adjustedBlockSize = uncompressedBlockSize / compressedSize;
+      adjustedBlockSize *= context.getBlocksize();
+    }
+    return adjustedBlockSize;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/UncompressedBlockSizePredicator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/UncompressedBlockSizePredicator.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import java.io.IOException;
+
+/**
+ * This BlockCompressedSizePredicator implementation doesn't actually performs any predicate
+ * and simply return the configured BLOCK_SIZE value, without any adjustments. This is the default
+ * implementation if <b>hbase.block.compressed.size.predicator</b> property is not defined.
+ */
+@InterfaceAudience.Private
+public class UncompressedBlockSizePredicator implements BlockCompressedSizePredicator {
+
+  /**
+   * Returns the configured BLOCK_SIZE as the block size limit, without applying any compression
+   * rate adjustments.
+   * @param context the meta file information for the current file.
+   * @param uncompressedBlockSize the total uncompressed size read for the block so far.
+   * @param blockContent The byte array containing the block content so far.
+   * @return the configured BLOCK_SIZE as the block size limit, without applying any compression
+   * rate adjustments.
+   * @throws IOException
+   */
+  @Override
+  public int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize,
+    ByteArrayOutputStream blockContent) throws IOException {
+    return context.getBlocksize();
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/UncompressedBlockSizePredicator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/UncompressedBlockSizePredicator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
-import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
 import org.apache.yetus.audience.InterfaceAudience;
 
 import java.io.IOException;
@@ -35,14 +34,22 @@ public class UncompressedBlockSizePredicator implements BlockCompressedSizePredi
    * rate adjustments.
    * @param context the meta file information for the current file.
    * @param uncompressedBlockSize the total uncompressed size read for the block so far.
-   * @param blockContent The byte array containing the block content so far.
    * @return the configured BLOCK_SIZE as the block size limit, without applying any compression
    * rate adjustments.
    * @throws IOException
    */
   @Override
-  public int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize,
-    ByteArrayOutputStream blockContent) throws IOException {
+  public int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize)
+    throws IOException {
     return context.getBlocksize();
   }
+
+  /**
+   * Empty implementation. Does nothing.
+   * @param uncompressed the uncompressed size of last block written.
+   * @param compressed the compressed size of last block written.
+   */
+  @Override
+  public void updateLatestBlockSizes(int uncompressed, int compressed) {}
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/UncompressedBlockSizePredicator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/UncompressedBlockSizePredicator.java
@@ -19,37 +19,31 @@ package org.apache.hadoop.hbase.io.hfile;
 
 import org.apache.yetus.audience.InterfaceAudience;
 
-import java.io.IOException;
-
 /**
- * This BlockCompressedSizePredicator implementation doesn't actually performs any predicate
- * and simply return the configured BLOCK_SIZE value, without any adjustments. This is the default
- * implementation if <b>hbase.block.compressed.size.predicator</b> property is not defined.
+ * This BlockCompressedSizePredicator implementation doesn't actually performs any predicate and
+ * simply returns <b>true</b> on <code>shouldFinishBlock</code>. This is the default implementation
+ * if <b>hbase.block.compressed.size.predicator</b> property is not defined.
  */
 @InterfaceAudience.Private
 public class UncompressedBlockSizePredicator implements BlockCompressedSizePredicator {
 
   /**
-   * Returns the configured BLOCK_SIZE as the block size limit, without applying any compression
-   * rate adjustments.
-   * @param context the meta file information for the current file.
-   * @param uncompressedBlockSize the total uncompressed size read for the block so far.
-   * @return the configured BLOCK_SIZE as the block size limit, without applying any compression
-   * rate adjustments.
-   * @throws IOException
+   * Empty implementation. Does nothing.
+   * @param uncompressed the uncompressed size of last block written.
+   * @param compressed   the compressed size of last block written.
    */
   @Override
-  public int calculateCompressionSizeLimit(HFileContext context, int uncompressedBlockSize)
-    throws IOException {
-    return context.getBlocksize();
+  public void updateLatestBlockSizes(HFileContext context, int uncompressed, int compressed) {
   }
 
   /**
-   * Empty implementation. Does nothing.
-   * @param uncompressed the uncompressed size of last block written.
-   * @param compressed the compressed size of last block written.
+   * Dummy implementation that always returns true. This means, we will be only considering the
+   * block uncompressed size for deciding when to finish a block.
+   * @param uncompressed true if the block should be finished. n
    */
   @Override
-  public void updateLatestBlockSizes(int uncompressed, int compressed) {}
+  public boolean shouldFinishBlock(int uncompressed) {
+    return true;
+  }
 
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -191,15 +191,14 @@ public class TestHStoreFile {
   }
 
   public static void writeLargeStoreFile(final StoreFileWriter writer, byte[] fam, byte[] qualifier,
-    int rounds)
-    throws IOException {
+    int rounds) throws IOException {
     long now = EnvironmentEdgeManager.currentTime();
     try {
-      for(int i=0; i<rounds; i++) {
+      for (int i = 0; i < rounds; i++) {
         for (char d = FIRST_CHAR; d <= LAST_CHAR; d++) {
           for (char e = FIRST_CHAR; e <= LAST_CHAR; e++) {
             byte[] b = new byte[] { (byte) d, (byte) e };
-            byte[] key = new byte []{ (byte)i};
+            byte[] key = new byte[] { (byte) i };
             writer.append(new KeyValue(key, fam, qualifier, now, b));
           }
         }
@@ -1221,38 +1220,29 @@ public class TestHStoreFile {
     conf.setBoolean("hbase.block.size.limit.compressed", true);
     cacheConf = new CacheConfig(conf);
     HFileContext meta =
-      new HFileContextBuilder()
-        .withBlockSize(BLOCKSIZE_SMALL)
-        .withChecksumType(CKTYPE)
-        .withBytesPerCheckSum(CKBYTES)
-        .withDataBlockEncoding(dataBlockEncoderAlgo)
+      new HFileContextBuilder().withBlockSize(BLOCKSIZE_SMALL).withChecksumType(CKTYPE)
+        .withBytesPerCheckSum(CKBYTES).withDataBlockEncoding(dataBlockEncoderAlgo)
         .withCompression(Compression.Algorithm.GZ).build();
     // Make a store file and write data to it.
     StoreFileWriter writer = new StoreFileWriter.Builder(conf, cacheConf, this.fs)
-      .withFilePath(path)
-      .withMaxKeyCount(2000)
-      .withFileContext(meta)
-      .build();
-    writeLargeStoreFile(writer,
-      Bytes.toBytes(name.getMethodName()), Bytes.toBytes(name.getMethodName()), 200);
+      .withFilePath(path).withMaxKeyCount(2000).withFileContext(meta).build();
+    writeLargeStoreFile(writer, Bytes.toBytes(name.getMethodName()),
+      Bytes.toBytes(name.getMethodName()), 200);
     writer.close();
     HStoreFile storeFile =
       new HStoreFile(fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true);
     storeFile.initReader();
-    HFile.Reader fReader = HFile
-      .createReader(fs, writer.getPath(), storeFile.getCacheConf(), true, conf);
+    HFile.Reader fReader =
+      HFile.createReader(fs, writer.getPath(), storeFile.getCacheConf(), true, conf);
     FSDataInputStreamWrapper fsdis = new FSDataInputStreamWrapper(fs, writer.getPath());
     long fileSize = fs.getFileStatus(writer.getPath()).getLen();
-    FixedFileTrailer trailer = FixedFileTrailer
-      .readFromStream(fsdis.getStream(false), fileSize);
+    FixedFileTrailer trailer = FixedFileTrailer.readFromStream(fsdis.getStream(false), fileSize);
     long offset = trailer.getFirstDataBlockOffset(), max = trailer.getLastDataBlockOffset();
     HFileBlock block;
     int blockCount = 0;
     while (offset <= max) {
-      block = fReader.readBlock(offset, -1,
-        /* cacheBlock */ false, /* pread */ false,
-        /* isCompaction */ false, /* updateCacheMetrics */ false,
-        null, null);
+      block = fReader.readBlock(offset, -1, /* cacheBlock */ false, /* pread */ false,
+        /* isCompaction */ false, /* updateCacheMetrics */ false, null, null);
       offset += block.getOnDiskSizeWithHeader();
       blockCount += 1;
       assertTrue(block.getUncompressedSizeWithoutHeader() >= BLOCKSIZE_SMALL);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.regionserver;
 
+import static org.apache.hadoop.hbase.io.hfile.HFileBlock.BLOCK_DELIMIT_COMPRESSED;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -1217,7 +1218,7 @@ public class TestHStoreFile {
     Path dir = new Path(new Path(this.testDir, "7e0102"), "familyname");
     Path path = new Path(dir, "1234567890");
     DataBlockEncoding dataBlockEncoderAlgo = DataBlockEncoding.FAST_DIFF;
-    conf.setBoolean("hbase.block.size.limit.compressed", true);
+    conf.setBoolean(BLOCK_DELIMIT_COMPRESSED, true);
     cacheConf = new CacheConfig(conf);
     HFileContext meta =
       new HFileContextBuilder().withBlockSize(BLOCKSIZE_SMALL).withChecksumType(CKTYPE)

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -41,8 +41,6 @@ import java.util.OptionalLong;
 import java.util.TreeSet;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.BiFunction;
-import java.util.function.Function;
-
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -1220,19 +1218,20 @@ public class TestHStoreFile {
 
   @Test
   public void testDataBlockSizeCompressed() throws Exception {
-    conf.set(BLOCK_COMPRESSED_SIZE_PREDICATOR, PreviousBlockCompressionRatePredicator.class.getName());
-    testDataBlockSizeWithCompressionRatePredicator(11, (s,c) ->
-      (c > 2 && c < 11) ? s >= BLOCKSIZE_SMALL*10 : true );
+    conf.set(BLOCK_COMPRESSED_SIZE_PREDICATOR,
+      PreviousBlockCompressionRatePredicator.class.getName());
+    testDataBlockSizeWithCompressionRatePredicator(11,
+      (s, c) -> (c > 1 && c < 11) ? s >= BLOCKSIZE_SMALL * 10 : true);
   }
 
   @Test
   public void testDataBlockSizeUnCompressed() throws Exception {
     conf.set(BLOCK_COMPRESSED_SIZE_PREDICATOR, UncompressedBlockSizePredicator.class.getName());
-    testDataBlockSizeWithCompressionRatePredicator(100, (s,c) -> s < BLOCKSIZE_SMALL*10);
+    testDataBlockSizeWithCompressionRatePredicator(200, (s, c) -> s < BLOCKSIZE_SMALL * 10);
   }
 
   private void testDataBlockSizeWithCompressionRatePredicator(int expectedBlockCount,
-      BiFunction<Integer, Integer, Boolean> validation) throws Exception {
+    BiFunction<Integer, Integer, Boolean> validation) throws Exception {
     Path dir = new Path(new Path(this.testDir, "7e0102"), "familyname");
     Path path = new Path(dir, "1234567890");
     DataBlockEncoding dataBlockEncoderAlgo = DataBlockEncoding.FAST_DIFF;
@@ -1263,8 +1262,6 @@ public class TestHStoreFile {
         /* isCompaction */ false, /* updateCacheMetrics */ false, null, null);
       offset += block.getOnDiskSizeWithHeader();
       blockCount++;
-      System.out.println(">>>> " + block.getUncompressedSizeWithoutHeader());
-      System.out.println(">>>> " + blockCount);
       assertTrue(validation.apply(block.getUncompressedSizeWithoutHeader(), blockCount));
     }
     assertEquals(expectedBlockCount, blockCount);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -1244,7 +1244,7 @@ public class TestHStoreFile {
       block = fReader.readBlock(offset, -1, /* cacheBlock */ false, /* pread */ false,
         /* isCompaction */ false, /* updateCacheMetrics */ false, null, null);
       offset += block.getOnDiskSizeWithHeader();
-      blockCount += 1;
+      blockCount++;
       assertTrue(block.getUncompressedSizeWithoutHeader() >= BLOCKSIZE_SMALL);
     }
     assertEquals(blockCount, 100);


### PR DESCRIPTION
Here we propose two additional properties,"hbase.block.size.limit.compressed" and  "hbase.block.size.max.compressed" that would allow for consider the compressed size (if compression is in use) for delimiting blocks during hfile writing. When compression is enabled, certain datasets can have very high compression efficiency, so that the default 64KB block size and 10GB max file size can lead to hfiles with very large number of blocks. 

In this proposal, "hbase.block.size.limit.compressed" is a boolean flag that switches to compressed size for delimiting blocks, and "hbase.block.size.max.compressed" is an int with the limit, in bytes for the compressed block size, in order to avoid very large uncompressed blocks (defaulting to 320KB).