### PR TITLE
HBASE-27292. Fix build failure against Hadoop 3.3.4 due to added dependency on okhttp.

### DIFF
--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -413,6 +413,15 @@
                     <pattern>org.agrona</pattern>
                     <shadedPattern>${shaded.prefix}.org.agrona</shadedPattern>
                   </relocation>
+                  <!-- okhttp -->
+                  <relocation>
+                    <pattern>okhttp3.</pattern>
+                    <shadedPattern>${shaded.prefix}.okhttp3.</shadedPattern>
+                  </relocation>
+                  <relocation>
+                    <pattern>kotlin.</pattern>
+                    <shadedPattern>${shaded.prefix}.kotlin.</shadedPattern>
+                  </relocation>
                 </relocations>
                 <transformers>
                   <!-- Need to filter out some extraneous license files.


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-27292

```
$ mvn clean install -DskipTests -Phadoop-3.0 -Dhadoop-three.version=3.3.4
...
[ERROR] Found artifact with unexpected contents: '/home/rocky/srcs/hbase/hbase-shaded/hbase-shaded-mapreduce/target/hbase-shaded-mapreduce-3.0.0-alpha-4-SNAPSHOT.jar'
    Please check the following and either correct the build or update
    the allowed list with reasoning.

    okhttp3/
    okhttp3/Request$Builder.class
    ...
    kotlin/
    kotlin/collections/
    kotlin/collections/ArraysUtilJVM.class
    ...
```