### PR TITLE
HBASE-27268 In trace log mode, the client does not print callId/startTime and the server does not print receiveTime

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
@@ -380,7 +380,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
     }
     if (LOG.isTraceEnabled()) {
       LOG.trace(
-        "Call: " + call.md.getName() + ", callTime: " + call.callStats.getCallTimeMs() + "ms");
+        "CallId: {}, call: {}, startTime: {}ms, callTime: {}ms", call.id, call.getStartTime(),
+        call.md.getName(), call.callStats.getCallTimeMs());
     }
     if (call.error != null) {
       if (call.error instanceof RemoteException) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
@@ -379,9 +379,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
       metrics.updateRpc(call.md, call.param, call.callStats);
     }
     if (LOG.isTraceEnabled()) {
-      LOG.trace(
-        "CallId: {}, call: {}, startTime: {}ms, callTime: {}ms", call.id, call.getStartTime(),
-        call.md.getName(), call.callStats.getCallTimeMs());
+      LOG.trace("CallId: {}, call: {}, startTime: {}ms, callTime: {}ms", call.id, call.md.getName(),
+        call.getStartTime(), call.callStats.getCallTimeMs());
     }
     if (call.error != null) {
       if (call.error instanceof RemoteException) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
@@ -390,9 +390,10 @@ public abstract class RpcServer implements RpcServerInterface, ConfigurationObse
       int qTime = (int) (startTime - receiveTime);
       int totalTime = (int) (endTime - receiveTime);
       if (LOG.isTraceEnabled()) {
-        LOG.trace("{}, response: {}, receiveTime: {}, queueTime: {}, processingTime: {}, totalTime: {}",
-          CurCall.get().toString(), TextFormat.shortDebugString(result), CurCall.get().getReceiveTime(),
-          qTime, processingTime, totalTime);
+        LOG.trace(
+          "{}, response: {}, receiveTime: {}, queueTime: {}, processingTime: {}, totalTime: {}",
+          CurCall.get().toString(), TextFormat.shortDebugString(result),
+          CurCall.get().getReceiveTime(), qTime, processingTime, totalTime);
       }
       // Use the raw request call size for now.
       long requestSize = call.getSize();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
@@ -390,9 +390,9 @@ public abstract class RpcServer implements RpcServerInterface, ConfigurationObse
       int qTime = (int) (startTime - receiveTime);
       int totalTime = (int) (endTime - receiveTime);
       if (LOG.isTraceEnabled()) {
-        LOG.trace(CurCall.get().toString() + ", response " + TextFormat.shortDebugString(result)
-          + " queueTime: " + qTime + " processingTime: " + processingTime + " totalTime: "
-          + totalTime);
+        LOG.trace("{}, response: {}, receiveTime: {}, queueTime: {}, processingTime: {}, totalTime: {}",
+          CurCall.get().toString(), TextFormat.shortDebugString(result), CurCall.get().getReceiveTime(),
+          qTime, processingTime, totalTime);
       }
       // Use the raw request call size for now.
       long requestSize = call.getSize();


### PR DESCRIPTION
HBASE-27268 In trace log mode, the client does not print callId/startTime and the server does not print receiveTime, so fix it.