### PR TITLE
Backport "HBASE-24163 MOB compactor implementations should use format specifiers when calling String.format" to branch-2.5

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/DefaultMobStoreCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/DefaultMobStoreCompactor.java
@@ -439,9 +439,9 @@ public class DefaultMobStoreCompactor extends DefaultCompactor {
                       mobRefSet.get().put(refTable.get(), fName);
                       writer.append(c);
                     } else {
-                      throw new IOException("MOB cell did not contain a tablename "
+                      throw new IOException(String.format("MOB cell did not contain a tablename "
                         + "tag. should not be possible. see ref guide on mob troubleshooting. "
-                        + "store=" + getStoreInfo() + " cell=" + c);
+                        + "store=%s cell=%s", getStoreInfo(), c));
                     }
                   }
                 }
@@ -495,9 +495,9 @@ public class DefaultMobStoreCompactor extends DefaultCompactor {
                 mobRefSet.get().put(refTable.get(), MobUtils.getMobFileName(c));
                 writer.append(c);
               } else {
-                throw new IOException("MOB cell did not contain a tablename "
-                  + "tag. should not be possible. see ref guide on mob troubleshooting. " + "store="
-                  + getStoreInfo() + " cell=" + c);
+                throw new IOException(String.format("MOB cell did not contain a tablename "
+                  + "tag. should not be possible. see ref guide on mob troubleshooting. "
+                  + "store=%s cell=%s", getStoreInfo(), c));
               }
             } else {
               String errMsg = String.format("Corrupted MOB reference: %s", c.toString());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/FaultyMobStoreCompactor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/FaultyMobStoreCompactor.java
@@ -246,9 +246,9 @@ public class FaultyMobStoreCompactor extends DefaultMobStoreCompactor {
                   mobRefSet.get().put(refTable.get(), MobUtils.getMobFileName(c));
                   writer.append(c);
                 } else {
-                  throw new IOException("MOB cell did not contain a tablename "
+                  throw new IOException(String.format("MOB cell did not contain a tablename "
                     + "tag. should not be possible. see ref guide on mob troubleshooting. "
-                    + "store=" + getStoreInfo() + " cell=" + c);
+                    + "store=%s cell=%s", getStoreInfo(), c));
                 }
               } else {
                 // If the value is not larger than the threshold, it's not regarded a mob. Retrieve
@@ -270,9 +270,9 @@ public class FaultyMobStoreCompactor extends DefaultMobStoreCompactor {
                     mobRefSet.get().put(refTable.get(), MobUtils.getMobFileName(c));
                     writer.append(c);
                   } else {
-                    throw new IOException("MOB cell did not contain a tablename "
+                    throw new IOException(String.format("MOB cell did not contain a tablename "
                       + "tag. should not be possible. see ref guide on mob troubleshooting. "
-                      + "store=" + getStoreInfo() + " cell=" + c);
+                      + "store=%s cell=%s", getStoreInfo(), c));
                   }
                 }
               }


### PR DESCRIPTION
Signed-off-by: stack <stack@apache.org>
Signed-off-by: Viraj Jasani <vjasani@apache.org>
Signed-off-by: Josh Elser <elserj@apache.org>