### PR TITLE
HBASE-27312 Update create-release to work with maven-gpg-plugin-3.0.1 and gnupg >= 2.1.x

### DIFF
--- a/dev-support/create-release/README.txt
+++ b/dev-support/create-release/README.txt
@@ -105,9 +105,9 @@ $ scp ~/gpg.example.apache.pub example.gce.host:
 #   gpg-agent's extra socket (this will restrict what commands the remote node is allowed to have
 #   your agent handle. Note that the gpg guide above can help you set this up in your ssh config
 #   rather than typing it in ssh like this every time.
-# Note that as of maven-gpg-plugin, with gnupg >= 2.1, the plugin uses `--pinentry-mode error`,
-#   which is apparently not supported over the `extra` socket. These instructions may require
-#   tweaking.
+# Note that as of maven-gpg-plugin 3.0.1, with gnupg >= 2.1, the plugin uses
+#   `--pinentry-mode error`, which is apparently not supported over the `extra` socket. These
+#   instructions may require tweaking.
 $ ssh -i ~/.ssh/my_id \
     -R "/run/user/1000/gnupg/S.gpg-agent:$(gpgconf --list-dir agent-extra-socket)" \
     -R "/run/user/1000/gnupg/S.gpg-agent.extra:$(gpgconf --list-dir agent-extra-socket)" \

--- a/dev-support/create-release/README.txt
+++ b/dev-support/create-release/README.txt
@@ -105,6 +105,9 @@ $ scp ~/gpg.example.apache.pub example.gce.host:
 #   gpg-agent's extra socket (this will restrict what commands the remote node is allowed to have
 #   your agent handle. Note that the gpg guide above can help you set this up in your ssh config
 #   rather than typing it in ssh like this every time.
+# Note that as of maven-gpg-plugin, with gnupg >= 2.1, the plugin uses `--pinentry-mode error`,
+#   which is apparently not supported over the `extra` socket. These instructions may require
+#   tweaking.
 $ ssh -i ~/.ssh/my_id \
     -R "/run/user/1000/gnupg/S.gpg-agent:$(gpgconf --list-dir agent-extra-socket)" \
     -R "/run/user/1000/gnupg/S.gpg-agent.extra:$(gpgconf --list-dir agent-extra-socket)" \

--- a/dev-support/create-release/do-release-docker.sh
+++ b/dev-support/create-release/do-release-docker.sh
@@ -311,7 +311,7 @@ if [ "${HOST_OS}" == "DARWIN" ]; then
   fi
   log "Launching ssh reverse tunnel from the container to gpg agent."
   log "    we should clean this up for you. If that fails the PID is in gpg-proxy.ssh.pid"
-  ssh -p 62222 -R "/home/${USER}/.gnupg/S.gpg-agent:$(gpgconf --list-dir agent-extra-socket)" \
+  ssh -p 62222 -R "/home/${USER}/.gnupg/S.gpg-agent:$(gpgconf --list-dir agent-socket)" \
       -i "${HOME}/.ssh/id_rsa" -N -n localhost >gpg-proxy.ssh.log 2>&1 &
   echo $! > "${WORKDIR}/gpg-proxy.ssh.pid"
 else
@@ -321,7 +321,7 @@ else
   # agent socket and agent extra socket to your local gpg-agent's extra socket. See the README.txt
   # for an example.
   GPG_PROXY_MOUNT=(--mount \
-      "type=bind,src=$(gpgconf --list-dir agent-extra-socket),dst=/home/${USER}/.gnupg/S.gpg-agent")
+      "type=bind,src=$(gpgconf --list-dir agent-socket),dst=/home/${USER}/.gnupg/S.gpg-agent")
 fi
 
 banner "Building $RELEASE_TAG; output will be at $WORKDIR/output"

--- a/dev-support/create-release/mac-sshd-gpg-agent/Dockerfile
+++ b/dev-support/create-release/mac-sshd-gpg-agent/Dockerfile
@@ -32,7 +32,7 @@
 #
 # test like:
 #
-# ssh -p 62222 -R "/home/${USER}/.gnupg/S.gpg-agent:$(gpgconf --list-dir agent-extra-socket)" \
+# ssh -p 62222 -R "/home/${USER}/.gnupg/S.gpg-agent:$(gpgconf --list-dir agent-socket)" \
 #     -i "${HOME}/.ssh/id_rsa" -N -n localhost
 #
 # launch a docker container to do work that shares the mount for the gpg agent

--- a/dev-support/create-release/release-util.sh
+++ b/dev-support/create-release/release-util.sh
@@ -30,7 +30,7 @@
 DRY_RUN=${DRY_RUN:-1} #default to dry run
 DEBUG=${DEBUG:-0}
 GPG=${GPG:-gpg}
-GPG_ARGS=(-v --no-autostart --batch --pinentry-mode error)
+GPG_ARGS=(--no-autostart --batch --pinentry-mode error)
 if [ -n "${GPG_KEY}" ]; then
   GPG_ARGS=("${GPG_ARGS[@]}" --local-user "${GPG_KEY}")
 fi

--- a/dev-support/create-release/release-util.sh
+++ b/dev-support/create-release/release-util.sh
@@ -30,7 +30,7 @@
 DRY_RUN=${DRY_RUN:-1} #default to dry run
 DEBUG=${DEBUG:-0}
 GPG=${GPG:-gpg}
-GPG_ARGS=(--no-autostart --batch)
+GPG_ARGS=(-v --no-autostart --batch --pinentry-mode error)
 if [ -n "${GPG_KEY}" ]; then
   GPG_ARGS=("${GPG_ARGS[@]}" --local-user "${GPG_KEY}")
 fi
@@ -670,10 +670,16 @@ make_binary_release() {
   # a third to assemble the binary artifact. Trying to do
   # all in the one invocation fails; a problem in our
   # assembly spec to in maven. TODO. Meantime, three invocations.
-  "${MVN[@]}" clean install -DskipTests
-  "${MVN[@]}" site -DskipTests
+  cmd=("${MVN[@]}" clean install -DskipTests)
+  echo "${cmd[*]}"
+  "${cmd[@]}"
+  cmd=("${MVN[@]}" site -DskipTests)
+  echo "${cmd[*]}"
+  "${cmd[@]}"
   kick_gpg_agent
-  "${MVN[@]}" install assembly:single -DskipTests -Dcheckstyle.skip=true "${PUBLISH_PROFILES[@]}"
+  cmd=("${MVN[@]}" install assembly:single -DskipTests -Dcheckstyle.skip=true "${PUBLISH_PROFILES[@]}")
+  echo "${cmd[*]}"
+  "${cmd[@]}"
 
   # Check there is a bin gz output. The build may not produce one: e.g. hbase-thirdparty.
   local f_bin_prefix="./${PROJECT}-assembly/target/${base_name}"


### PR DESCRIPTION
This is... a solution. It's probably fine for running on hardware you own with a source repository you trust. I'm not sure it's wise when running on a remote build machine...