### PR TITLE
HBASE-27316 Time based metrics will be reset after any get request

### DIFF
--- a/hbase-metrics/src/main/java/org/apache/hadoop/hbase/metrics/impl/FastLongHistogram.java
+++ b/hbase-metrics/src/main/java/org/apache/hadoop/hbase/metrics/impl/FastLongHistogram.java
@@ -312,8 +312,16 @@ public class FastLongHistogram {
    * Resets the histogram for new counting.
    */
   public Snapshot snapshotAndReset() {
-    final Bins oldBins = this.bins;
+    Snapshot snapshot = snapshot();
     this.bins = new Bins(this.bins, this.bins.counts.length - 3, 0.01, 0.99);
+    return snapshot;
+  }
+
+  /**
+   * do snapshot without reset
+   */
+  public Snapshot snapshot() {
+    final Bins oldBins = this.bins;
     final long[] percentiles = oldBins.getQuantiles(DEFAULT_QUANTILES);
     final long count = oldBins.count.sum();
 

--- a/hbase-metrics/src/main/java/org/apache/hadoop/hbase/metrics/impl/HistogramImpl.java
+++ b/hbase-metrics/src/main/java/org/apache/hadoop/hbase/metrics/impl/HistogramImpl.java
@@ -78,7 +78,7 @@ public class HistogramImpl implements Histogram {
 
   @Override
   public Snapshot snapshot() {
-    return histogram.snapshotAndReset();
+    return histogram.snapshot();
   }
 
   public long[] getQuantiles(double[] quantiles) {


### PR DESCRIPTION
Jmx metrics can be query by http request.

But metrics will be reset after any get request.

The root cause may be the implement of Histogram's method "snapshot"

public Snapshot snapshot() {
  return histogram.snapshotAndReset();
} 

It will call snapshot and reset at the same time.

I think it should not be reset cause we may need history metrics.