### PR TITLE
HBASE-26809: Report client backoff time for server overloaded

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncBatchRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncBatchRpcRetryingCaller.java
@@ -488,7 +488,7 @@ class AsyncBatchRpcRetryingCaller<T> {
       delayNs = getPauseTime(pauseNsToUse, tries - 1);
     }
     Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
-    if(isServerOverloaded){
+    if (isServerOverloaded) {
       metrics.ifPresent(m -> m.incrementServerOverloadedBackoffTime(delayNs, TimeUnit.NANOSECONDS));
     }
     retryTimer.newTimeout(t -> groupAndSend(actions, tries + 1), delayNs, TimeUnit.NANOSECONDS);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncBatchRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncBatchRpcRetryingCaller.java
@@ -487,8 +487,9 @@ class AsyncBatchRpcRetryingCaller<T> {
     } else {
       delayNs = getPauseTime(pauseNsToUse, tries - 1);
     }
-    Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
+
     if (isServerOverloaded) {
+      Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
       metrics.ifPresent(m -> m.incrementServerOverloadedBackoffTime(delayNs, TimeUnit.NANOSECONDS));
     }
     retryTimer.newTimeout(t -> groupAndSend(actions, tries + 1), delayNs, TimeUnit.NANOSECONDS);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncBatchRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncBatchRpcRetryingCaller.java
@@ -487,6 +487,10 @@ class AsyncBatchRpcRetryingCaller<T> {
     } else {
       delayNs = getPauseTime(pauseNsToUse, tries - 1);
     }
+    Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
+    if(isServerOverloaded){
+      metrics.ifPresent(m -> m.incrementServerOverloadedBackoffTime(delayNs, TimeUnit.NANOSECONDS));
+    }
     retryTimer.newTimeout(t -> groupAndSend(actions, tries + 1), delayNs, TimeUnit.NANOSECONDS);
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRpcRetryingCaller.java
@@ -139,6 +139,10 @@ public abstract class AsyncRpcRetryingCaller<T> {
       delayNs = getPauseTime(pauseNsToUse, tries - 1);
     }
     tries++;
+    Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
+    if(HBaseServerException.isServerOverloaded(error)){
+      metrics.ifPresent(m -> m.incrementServerOverloadedBackoffTime(delayNs, TimeUnit.NANOSECONDS));
+    }
     retryTimer.newTimeout(t -> doCall(), delayNs, TimeUnit.NANOSECONDS);
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRpcRetryingCaller.java
@@ -139,8 +139,8 @@ public abstract class AsyncRpcRetryingCaller<T> {
       delayNs = getPauseTime(pauseNsToUse, tries - 1);
     }
     tries++;
-    Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
     if (HBaseServerException.isServerOverloaded(error)) {
+      Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
       metrics.ifPresent(m -> m.incrementServerOverloadedBackoffTime(delayNs, TimeUnit.NANOSECONDS));
     }
     retryTimer.newTimeout(t -> doCall(), delayNs, TimeUnit.NANOSECONDS);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRpcRetryingCaller.java
@@ -140,7 +140,7 @@ public abstract class AsyncRpcRetryingCaller<T> {
     }
     tries++;
     Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
-    if(HBaseServerException.isServerOverloaded(error)){
+    if (HBaseServerException.isServerOverloaded(error)) {
       metrics.ifPresent(m -> m.incrementServerOverloadedBackoffTime(delayNs, TimeUnit.NANOSECONDS));
     }
     retryTimer.newTimeout(t -> doCall(), delayNs, TimeUnit.NANOSECONDS);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncScanSingleRegionRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncScanSingleRegionRpcRetryingCaller.java
@@ -444,8 +444,9 @@ class AsyncScanSingleRegionRpcRetryingCaller {
       return;
     }
     tries++;
-    Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
+
     if (HBaseServerException.isServerOverloaded(error)) {
+      Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
       metrics.ifPresent(m -> m.incrementServerOverloadedBackoffTime(delayNs, TimeUnit.NANOSECONDS));
     }
     retryTimer.newTimeout(t -> call(), delayNs, TimeUnit.NANOSECONDS);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncScanSingleRegionRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncScanSingleRegionRpcRetryingCaller.java
@@ -445,7 +445,7 @@ class AsyncScanSingleRegionRpcRetryingCaller {
     }
     tries++;
     Optional<MetricsConnection> metrics = conn.getConnectionMetrics();
-    if(HBaseServerException.isServerOverloaded(error)){
+    if (HBaseServerException.isServerOverloaded(error)) {
       metrics.ifPresent(m -> m.incrementServerOverloadedBackoffTime(delayNs, TimeUnit.NANOSECONDS));
     }
     retryTimer.newTimeout(t -> call(), delayNs, TimeUnit.NANOSECONDS);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetricsConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetricsConnection.java
@@ -315,6 +315,7 @@ public class MetricsConnection implements StatisticTrackable {
   protected final Histogram numActionsPerServerHist;
   protected final Counter nsLookups;
   protected final Counter nsLookupsFailed;
+  protected final Timer overloadedBackoffTimer;
 
   // dynamic metrics
 
@@ -376,6 +377,8 @@ public class MetricsConnection implements StatisticTrackable {
       registry.histogram(name(MetricsConnection.class, "numActionsPerServer", scope));
     this.nsLookups = registry.counter(name(this.getClass(), NS_LOOKUPS, scope));
     this.nsLookupsFailed = registry.counter(name(this.getClass(), NS_LOOKUPS_FAILED, scope));
+    this.overloadedBackoffTimer = registry.timer(name(this.getClass(),
+      "overloadedBackoffDurationMs", scope));
 
     this.reporter = JmxReporter.forRegistry(this.registry).build();
     this.reporter.start();
@@ -447,6 +450,11 @@ public class MetricsConnection implements StatisticTrackable {
   public void incrDelayRunnersAndUpdateDelayInterval(long interval) {
     this.runnerStats.incrDelayRunners();
     this.runnerStats.updateDelayInterval(interval);
+  }
+
+  /** Update the overloaded backoff time **/
+  public void incrementServerOverloadedBackoffTime(long time, TimeUnit timeUnit){
+    overloadedBackoffTimer.update(time, timeUnit);
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetricsConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MetricsConnection.java
@@ -377,8 +377,8 @@ public class MetricsConnection implements StatisticTrackable {
       registry.histogram(name(MetricsConnection.class, "numActionsPerServer", scope));
     this.nsLookups = registry.counter(name(this.getClass(), NS_LOOKUPS, scope));
     this.nsLookupsFailed = registry.counter(name(this.getClass(), NS_LOOKUPS_FAILED, scope));
-    this.overloadedBackoffTimer = registry.timer(name(this.getClass(),
-      "overloadedBackoffDurationMs", scope));
+    this.overloadedBackoffTimer =
+      registry.timer(name(this.getClass(), "overloadedBackoffDurationMs", scope));
 
     this.reporter = JmxReporter.forRegistry(this.registry).build();
     this.reporter.start();
@@ -453,7 +453,7 @@ public class MetricsConnection implements StatisticTrackable {
   }
 
   /** Update the overloaded backoff time **/
-  public void incrementServerOverloadedBackoffTime(long time, TimeUnit timeUnit){
+  public void incrementServerOverloadedBackoffTime(long time, TimeUnit timeUnit) {
     overloadedBackoffTimer.update(time, timeUnit);
   }
 


### PR DESCRIPTION
Enable metric reporting on backoff time when a server is overloaded. 