### PR TITLE
HBASE-27352 - Quoted string argument with spaces passed from command line are propagated wrongly to the underlying java class

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -875,7 +875,7 @@ if [ "${DEBUG}" = "true" ]; then
 fi
 
 # resolve the command arguments
-read -r -a CMD_ARGS <<< "$@"
+CMD_ARGS=("$@")
 if [ "${#JSHELL_ARGS[@]}" -gt 0 ] ; then
   CMD_ARGS=("${JSHELL_ARGS[@]}" "${CMD_ARGS[@]}")
 fi


### PR DESCRIPTION
It is due to the fact that [read -r -a CMD_ARGS <<< "$@" ](https://github.com/apache/hbase/blob/master/bin/hbase#L878) in the hbase script would split command line args after expansion of `$@` array (i.e. `"$@"`) . Instead a straightforward array copy can be used.