### PR TITLE
HBASE-25563 Add "2.4 Documentation" to the website

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -132,6 +132,14 @@
         <item name="Developer API" href="2.3/devapidocs/index.html" target="_blank" />
         <item name="Developer API (Test)" href="2.3/testdevapidocs/index.html" target="_blank" />
       </item>
+      <item name="2.4 Documentation">
+        <item name="Ref Guide" href="2.4/book.html" target="_blank" />
+        <item name="Reference Guide (PDF)" href="2.4/apache_hbase_reference_guide.pdf" target="_blank" />
+        <item name="User API" href="2.4/apidocs/index.html" target="_blank" />
+        <item name="User API (Test)" href="2.4/testapidocs/index.html" target="_blank" />
+        <item name="Developer API" href="2.4/devapidocs/index.html" target="_blank" />
+        <item name="Developer API (Test)" href="2.4/testdevapidocs/index.html" target="_blank" />
+      </item>
       <item name="2.5 Documentation">
         <item name="User API" href="2.5/apidocs/index.html" target="_blank" />
         <item name="User API (Test)" href="2.5/testapidocs/index.html" target="_blank" />


### PR DESCRIPTION
The content is in the website git repo but there's no menu on our homepage.