### PR TITLE
HBASE-27317 : Storefiletracking : Rectifying the option for columnfamily as mandatory

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFilePrettyPrinter.java
@@ -98,7 +98,7 @@ public class StoreFileListFilePrettyPrinter extends Configured implements Tool {
     if (args.length == 0) {
       formatter
         .printHelp("sft [--file=</path/to/tracker/file> | --table=<namespace:tablename|tablename>"
-          + " --region=<regionname> [--columnFamily=<columnfamily>] ]", options, true);
+          + " --region=<regionname> --columnFamily=<columnfamily> ]", options, true);
       return false;
     }
 
@@ -112,21 +112,21 @@ public class StoreFileListFilePrettyPrinter extends Configured implements Tool {
       if (StringUtils.isEmpty(regionName)) {
         err.println("Region name is not specified.");
         formatter.printHelp("sft [--file=</path/to/tracker/file> | --table=<namespace:tablename|"
-          + "tablename> --region=<regionname> [--columnFamily=<columnfamily>] ]", options, true);
+          + "tablename> --region=<regionname> --columnFamily=<columnfamily> ]", options, true);
         System.exit(1);
       }
       columnFamily = cmd.getOptionValue(columnFamilyOption);
       if (StringUtils.isEmpty(columnFamily)) {
         err.println("Column family is not specified.");
         formatter.printHelp("sft [--file=</path/to/tracker/file> | --table=<namespace:tablename|"
-          + "tablename> --region=<regionname> [--columnFamily=<columnfamily>] ]", options, true);
+          + "tablename> --region=<regionname> --columnFamily=<columnfamily> ]", options, true);
         System.exit(1);
       }
       String tableNameWtihNS = cmd.getOptionValue(tableNameOption);
       if (StringUtils.isEmpty(tableNameWtihNS)) {
         err.println("Table name is not specified.");
         formatter.printHelp("sft [--file=</path/to/tracker/file> | --table=<namespace:tablename|"
-          + "tablename> --region=<regionname> [--columnFamily=<columnfamily>] ]", options, true);
+          + "tablename> --region=<regionname> --columnFamily=<columnfamily> ]", options, true);
         System.exit(1);
       }
       TableName tn = TableName.valueOf(tableNameWtihNS);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFilePrettyPrinter.java
@@ -99,8 +99,7 @@ public class StoreFileListFilePrettyPrinter extends Configured implements Tool {
   public boolean parseOptions(String[] args) throws ParseException, IOException {
     HelpFormatter formatter = new HelpFormatter();
     if (args.length == 0) {
-      formatter
-        .printHelp(helpMsg, options, true);
+      formatter.printHelp(helpMsg, options, true);
       return false;
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFilePrettyPrinter.java
@@ -61,6 +61,9 @@ public class StoreFileListFilePrettyPrinter extends Configured implements Tool {
   private final String regionOption = "r";
   private final String tableNameOption = "t";
 
+  private final String helpMsg = "sft [--file=</path/to/tracker/file> | --table=<namespace:"
+    + "tablename|tablename> --region=<regionname> --columnFamily=<columnfamily> ]";
+
   private String namespace;
   private String regionName;
   private String columnFamily;
@@ -97,8 +100,7 @@ public class StoreFileListFilePrettyPrinter extends Configured implements Tool {
     HelpFormatter formatter = new HelpFormatter();
     if (args.length == 0) {
       formatter
-        .printHelp("sft [--file=</path/to/tracker/file> | --table=<namespace:tablename|tablename>"
-          + " --region=<regionname> --columnFamily=<columnfamily> ]", options, true);
+        .printHelp(helpMsg, options, true);
       return false;
     }
 
@@ -111,22 +113,19 @@ public class StoreFileListFilePrettyPrinter extends Configured implements Tool {
       regionName = cmd.getOptionValue(regionOption);
       if (StringUtils.isEmpty(regionName)) {
         err.println("Region name is not specified.");
-        formatter.printHelp("sft [--file=</path/to/tracker/file> | --table=<namespace:tablename|"
-          + "tablename> --region=<regionname> --columnFamily=<columnfamily> ]", options, true);
+        formatter.printHelp(helpMsg, options, true);
         System.exit(1);
       }
       columnFamily = cmd.getOptionValue(columnFamilyOption);
       if (StringUtils.isEmpty(columnFamily)) {
         err.println("Column family is not specified.");
-        formatter.printHelp("sft [--file=</path/to/tracker/file> | --table=<namespace:tablename|"
-          + "tablename> --region=<regionname> --columnFamily=<columnfamily> ]", options, true);
+        formatter.printHelp(helpMsg, options, true);
         System.exit(1);
       }
       String tableNameWtihNS = cmd.getOptionValue(tableNameOption);
       if (StringUtils.isEmpty(tableNameWtihNS)) {
         err.println("Table name is not specified.");
-        formatter.printHelp("sft [--file=</path/to/tracker/file> | --table=<namespace:tablename|"
-          + "tablename> --region=<regionname> --columnFamily=<columnfamily> ]", options, true);
+        formatter.printHelp(helpMsg, options, true);
         System.exit(1);
       }
       TableName tn = TableName.valueOf(tableNameWtihNS);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFilePrettyPrinter.java
@@ -61,8 +61,8 @@ public class StoreFileListFilePrettyPrinter extends Configured implements Tool {
   private final String regionOption = "r";
   private final String tableNameOption = "t";
 
-  private final String helpMsg = "sft [--file=</path/to/tracker/file> | --table=<namespace:"
-    + "tablename|tablename> --region=<regionname> --columnFamily=<columnfamily> ]";
+  private final String helpMsg = "sft [--f=</path/to/tracker/file> | --t=<namespace:"
+    + "tablename|tablename> --r=<regionname> --cf=<columnfamily> ]";
 
   private String namespace;
   private String regionName;


### PR DESCRIPTION
This is to rectify the columnfamily argument from optional to mandatory. In the sysout message it is wrongly put as optional parameter but it is actually a mandatory parameter.