### PR TITLE
HBASE-27363: Fix the config key PREFETCH_PERSISTENCE_PATH_KEY and spotbugs

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -93,7 +93,7 @@ public class CacheConfig {
   public static final String DROP_BEHIND_CACHE_COMPACTION_KEY =
     "hbase.hfile.drop.behind.compaction";
 
-  public static final String PREFETCH_PERSISTENCE_PATH_KEY = "hbase.prefetch.file-list.path";
+  public static final String PREFETCH_PERSISTENCE_PATH_KEY = "hbase.prefetch.file.list.path";
 
   // Defaults
   public static final boolean DEFAULT_CACHE_DATA_ON_READ = true;


### PR DESCRIPTION
Apache Jira:  https://issues.apache.org/jira/browse/HBASE-27363

Summary:
1. Change the config key for PREFETCH_PERSISTENCE_PATH_KEY to hbase.prefetch.file.list.path 
2. Fix the spotbugs issue mentioned in https://issues.apache.org/jira/browse/HBASE-27313