### PR TITLE
Backport "HBASE-27352 - Quoted string argument with spaces passed from command …" to branch-2

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -847,7 +847,7 @@ if [ "${DEBUG}" = "true" ]; then
 fi
 
 # resolve the command arguments
-read -r -a CMD_ARGS <<< "$@"
+CMD_ARGS=("$@")
 if [ "${#JSHELL_ARGS[@]}" -gt 0 ] ; then
   CMD_ARGS=("${JSHELL_ARGS[@]}" "${CMD_ARGS[@]}")
 fi


### PR DESCRIPTION
…line are propagated wrongly to the underlying java class (#4754)

Signed-off-by: Nick Dimiduk <ndimiduk@apache.org>