### PR TITLE
HBASE-27329 Introduce prefix tree index block encoding use less space

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/IndexBlockEncoder.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/IndexBlockEncoder.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.encoding;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellComparator;
+import org.apache.hadoop.hbase.io.HeapSize;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.yetus.audience.InterfaceAudience;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.util.List;
+
+@InterfaceAudience.Private
+public interface IndexBlockEncoder {
+  /**
+   * Starts encoding for a block of Index data.
+   */
+  void startBlockEncoding(boolean rootIndexBlock, DataOutput out) throws IOException;
+
+  /**
+   * Encodes index block.
+   */
+  void encode(List<byte[]> blockKeys, List<Long> blockOffsets, List<Integer> onDiskDataSizes,
+    DataOutput out) throws IOException;
+
+  /**
+   * Ends encoding for a block of index data.
+   */
+  void endBlockEncoding(DataOutput out) throws IOException;
+
+  /**
+   * Create a HFileIndexBlock seeker which find data within a block.
+   * @return A newly created seeker.
+   */
+  IndexEncodedSeeker createSeeker();
+
+  /**
+   * An interface which enable to seek while underlying data is encoded. It works on one HFile Index Block.
+   */
+  interface IndexEncodedSeeker extends HeapSize {
+    /**
+     * Init with root index block.
+     */
+    void initRootIndex(ByteBuff buffer, int numEntries, CellComparator comparator, int treeLevel)
+      throws IOException;
+
+    /**
+     * Get i's entry in root index block.
+     */
+    Cell getRootBlockKey(int i);
+
+    int rootBlockContainingKey(Cell key);
+
+    long rootBlockBlockOffsets(int rootLevelIndex);
+
+    int rootBlockOnDiskDataSizes(int rootLevelIndex);
+
+    /**
+     * Search non-root index block.
+     */
+    SearchResult locateNonRootIndexEntry(ByteBuff nonRootBlock, Cell key) throws IOException;
+  }
+
+  class SearchResult {
+    public int entryIndex;
+    public long offset;
+    public int onDiskSize;
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/IndexBlockEncoding.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/IndexBlockEncoding.java
@@ -33,10 +33,11 @@ public enum IndexBlockEncoding {
   /** Disable index block encoding. */
   NONE(0, null),
   // id 1 is reserved for the PREFIX_TREE algorithm to be added later
-  PREFIX_TREE(1, null);
+  PREFIX_TREE(1, "org.apache.hadoop.hbase.io.encoding.PrefixTreeIndexBlockEncoder");
 
   private final short id;
   private final byte[] idInBytes;
+  private IndexBlockEncoder encoder;
   private final String encoderCls;
 
   public static final int ID_SIZE = Bytes.SIZEOF_SHORT;
@@ -118,4 +119,24 @@ public enum IndexBlockEncoding {
     return algorithm;
   }
 
+  /**
+   * Return new index block encoder for given algorithm type.
+   * @return index block encoder if algorithm is specified, null if none is selected.
+   */
+  public IndexBlockEncoder getEncoder() {
+    if (encoder == null && id != 0) {
+      // lazily create the encoder
+      encoder = createEncoder(encoderCls);
+    }
+    return encoder;
+  }
+
+  static IndexBlockEncoder createEncoder(String fullyQualifiedClassName) {
+    try {
+      return Class.forName(fullyQualifiedClassName).asSubclass(IndexBlockEncoder.class)
+        .getDeclaredConstructor().newInstance();
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
 }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/PrefixTreeIndexBlockEncoder.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/PrefixTreeIndexBlockEncoder.java
@@ -1,0 +1,223 @@
+package org.apache.hadoop.hbase.io.encoding;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellComparator;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
+import org.apache.hadoop.hbase.io.util.UFIntTool;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.ClassSize;
+import org.apache.hadoop.hbase.util.ObjectIntPair;
+import org.apache.yetus.audience.InterfaceAudience;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+@InterfaceAudience.Private
+public class PrefixTreeIndexBlockEncoder implements IndexBlockEncoder {
+  private static byte VERSION = 0;
+
+  @Override
+  public void startBlockEncoding(boolean rootIndexBlock, DataOutput out)
+    throws IOException {
+  }
+
+  @Override
+  public void encode(List<byte[]> blockKeys, List<Long> blockOffsets, List<Integer> onDiskDataSizes,
+    DataOutput out) throws IOException {
+    List<byte[]> rowKeys = new ArrayList<>(blockKeys.size());
+    for (int i = 0; i < blockKeys.size(); i++) {
+      byte[] key = blockKeys.get(i);
+      KeyValue.KeyOnlyKeyValue rowKey = new KeyValue.KeyOnlyKeyValue(key, 0, key.length);
+      rowKeys.add(CellUtil.cloneRow(rowKey));
+    }
+
+    PrefixTreeUtil.TokenizerNode node = PrefixTreeUtil.buildPrefixTree(rowKeys);
+    PrefixTreeUtil.PrefixTreeDataWidth dataWidth = new PrefixTreeUtil.PrefixTreeDataWidth();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    PrefixTreeUtil.serializePrefixTree(node, dataWidth, outputStream);
+    byte[] data = outputStream.toByteArray();
+
+    out.write(VERSION);
+    PrefixTreeUtil.serialize(out, dataWidth);
+    out.writeInt(blockKeys.size());
+    out.writeInt(data.length);
+    out.write(data);
+
+    long minBlockOffset = blockOffsets.get(0);
+    long maxBlockOffset = blockOffsets.get(blockOffsets.size() - 1);
+    int minOnDiskDataSize = Integer.MAX_VALUE;
+    int maxOnDiskDataSize = Integer.MIN_VALUE;
+    for (int i = 0; i < onDiskDataSizes.size(); ++i) {
+      if (minOnDiskDataSize > onDiskDataSizes.get(i)) {
+        minOnDiskDataSize = onDiskDataSizes.get(i);
+      }
+      if (maxOnDiskDataSize < onDiskDataSizes.get(i)) {
+        maxOnDiskDataSize = onDiskDataSizes.get(i);
+      }
+    }
+
+    int blockOffsetWidth = UFIntTool.numBytes(maxBlockOffset - minBlockOffset);
+    int onDiskDataSizeWidth = UFIntTool.numBytes(maxOnDiskDataSize - minOnDiskDataSize);
+
+    out.write(blockOffsetWidth);
+    out.write(onDiskDataSizeWidth);
+    out.writeLong(minBlockOffset);
+    out.writeInt(minOnDiskDataSize);
+
+    outputStream.reset();
+    for (int i = 0; i < blockOffsets.size(); ++i) {
+      UFIntTool.writeBytes(blockOffsetWidth, (blockOffsets.get(i) - minBlockOffset), outputStream);
+      UFIntTool.writeBytes(onDiskDataSizeWidth, (onDiskDataSizes.get(i) - minOnDiskDataSize),
+        outputStream);
+    }
+    data = outputStream.toByteArray();
+    out.write(data);
+  }
+
+  @Override
+  public void endBlockEncoding(DataOutput out) throws IOException {
+  }
+
+  @Override
+  public IndexEncodedSeeker createSeeker() {
+    return new PrefixTreeIndexBlockEncodedSeeker();
+  }
+
+  static class PrefixTreeIndexBlockEncodedSeeker implements IndexEncodedSeeker{
+
+    private PrefixTreeUtil.PrefixTreeDataWidth dataWidth = new PrefixTreeUtil.PrefixTreeDataWidth();
+    private ByteBuffer prefixTreeNodeData = null;
+    private ByteBuffer blockOffsetAndSizeData = null;
+    private int blockOffsetWidth;
+    private int onDiskDataSizeWidth;
+    private long minBlockOffset;
+    private int minOnDiskDataSize;
+
+    @Override
+    public long heapSize() {
+      long heapSize = ClassSize.align(ClassSize.OBJECT);
+
+      if (prefixTreeNodeData != null) {
+        heapSize += ClassSize.align(ClassSize.BYTE_BUFFER + prefixTreeNodeData.capacity());
+      }
+      if (blockOffsetAndSizeData != null) {
+        heapSize += ClassSize.align(ClassSize.BYTE_BUFFER + blockOffsetAndSizeData.capacity());
+      }
+
+      // dataWidth
+      heapSize += ClassSize.REFERENCE;
+      // blockOffsetWidth onDiskDataSizeWidth minOnDiskDataSize
+      heapSize += 3 * Bytes.SIZEOF_INT;
+      // PrefixTreeDataWidth's data.
+      heapSize += 5 * Bytes.SIZEOF_INT;
+      // minBlockOffset
+      heapSize += Bytes.SIZEOF_LONG;
+      return ClassSize.align(heapSize);
+    }
+
+    @Override
+    public void initRootIndex(ByteBuff data, int numEntries, CellComparator comparator,
+      int treeLevel) throws IOException {
+      byte version = data.get();
+      if (version != VERSION) {
+        throw new IOException("Corrupted data, version should be 0, but it is " + version);
+      }
+      PrefixTreeUtil.deserialize(data, dataWidth);
+      int numEntry = data.getInt();
+      int prefixNodeLength = data.getInt();
+
+      ObjectIntPair<ByteBuffer> tmpPair = new ObjectIntPair<>();
+      data.asSubByteBuffer(data.position(), prefixNodeLength, tmpPair);
+      ByteBuffer dup = tmpPair.getFirst().duplicate();
+      dup.position(tmpPair.getSecond());
+      dup.limit(tmpPair.getSecond() + prefixNodeLength);
+      prefixTreeNodeData = dup.slice();
+
+      data.skip(prefixNodeLength);
+      blockOffsetWidth = data.get();
+      onDiskDataSizeWidth = data.get();
+      minBlockOffset = data.getLong();
+      minOnDiskDataSize = data.getInt();
+      int blockOffsetsAndonDiskDataSize = numEntry * (blockOffsetWidth + onDiskDataSizeWidth);
+
+      data.asSubByteBuffer(data.position(), blockOffsetsAndonDiskDataSize, tmpPair);
+      dup = tmpPair.getFirst().duplicate();
+      dup.position(tmpPair.getSecond());
+      dup.limit(tmpPair.getSecond() + blockOffsetsAndonDiskDataSize);
+      blockOffsetAndSizeData = dup.slice();
+    }
+
+    @Override
+    public Cell getRootBlockKey(int i) {
+      byte[] row = PrefixTreeUtil.get(prefixTreeNodeData, 0, dataWidth, i);
+      return PrivateCellUtil.createFirstOnRow(row);
+    }
+
+    @Override
+    public int rootBlockContainingKey(Cell key) {
+      return PrefixTreeUtil.search(prefixTreeNodeData, 0, CellUtil.cloneRow(key), 0, dataWidth);
+    }
+
+    @Override
+    public long rootBlockBlockOffsets(int rootLevelIndex) {
+      int pos = rootLevelIndex * (blockOffsetWidth + onDiskDataSizeWidth);
+      return UFIntTool.fromBytes(blockOffsetAndSizeData, pos, blockOffsetWidth) + minBlockOffset;
+    }
+
+    @Override
+    public int rootBlockOnDiskDataSizes(int rootLevelIndex) {
+      int pos = rootLevelIndex * (blockOffsetWidth + onDiskDataSizeWidth);
+      int currentOnDiskSize =
+        (int) UFIntTool.fromBytes(blockOffsetAndSizeData, pos + blockOffsetWidth,
+          onDiskDataSizeWidth) + minOnDiskDataSize;
+      return currentOnDiskSize;
+    }
+
+    @Override
+    public SearchResult locateNonRootIndexEntry(ByteBuff nonRootBlock, Cell key)
+      throws IOException {
+      PrefixTreeUtil.PrefixTreeDataWidth meta = new PrefixTreeUtil.PrefixTreeDataWidth();
+      byte version = nonRootBlock.get();
+      if (version != VERSION) {
+        throw new IOException("Corrupted data, version should be 0, but it is " + version);
+      }
+      PrefixTreeUtil.deserialize(nonRootBlock, meta);
+      int numEntry = nonRootBlock.getInt();
+      int prefixNodeLength = nonRootBlock.getInt();
+
+      ObjectIntPair<ByteBuffer> tmpPair = new ObjectIntPair<>();
+      nonRootBlock.asSubByteBuffer(nonRootBlock.position(), prefixNodeLength, tmpPair);
+      ByteBuffer dup = tmpPair.getFirst().duplicate();
+      dup.position(tmpPair.getSecond());
+      dup.limit(tmpPair.getSecond() + prefixNodeLength);
+      ByteBuffer prefixTreeNodeData = dup.slice();
+
+      nonRootBlock.skip(prefixNodeLength);
+
+      int entryIndex = PrefixTreeUtil.search(prefixTreeNodeData, 0, CellUtil.cloneRow(key), 0, meta);
+      SearchResult result = new SearchResult();
+      result.entryIndex = entryIndex;
+
+      if (entryIndex >= 0 && entryIndex < numEntry) {
+        int blockOffsetWidth = nonRootBlock.get();
+        int onDiskDataSizeWidth = nonRootBlock.get();
+        long minBlockOffset = nonRootBlock.getLong();
+        int minOnDiskDataSize = nonRootBlock.getInt();
+
+        int pos = nonRootBlock.position() + entryIndex * (blockOffsetWidth + onDiskDataSizeWidth);
+        result.offset = UFIntTool.fromBytes(nonRootBlock, pos, blockOffsetWidth) + minBlockOffset;
+        result.onDiskSize =
+          (int) UFIntTool.fromBytes(nonRootBlock, pos + blockOffsetWidth, onDiskDataSizeWidth)
+            + minOnDiskDataSize;
+      }
+
+      return result;
+    }
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/PrefixTreeUtil.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/PrefixTreeUtil.java
@@ -1,0 +1,596 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.encoding;
+
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
+import org.apache.hadoop.hbase.io.util.UFIntTool;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.hadoop.hbase.util.ByteBufferUtils;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import java.io.DataOutput;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+@InterfaceAudience.Private
+public class PrefixTreeUtil {
+
+  private static final Logger LOG = LoggerFactory.getLogger(PrefixTreeUtil.class);
+
+  /**
+   * Build tree from begin
+   *
+   * @return the tree
+   */
+  public static TokenizerNode buildPrefixTree(List<byte[]> rowKeys) {
+    // root node.
+    TokenizerNode node = new TokenizerNode();
+    int start = 0;
+    // Get max common prefix
+    int common = maxCommonPrefix(rowKeys, 0, rowKeys.size() - 1, 0);
+    if (common > 0) {
+      byte[] commonB = Bytes.copy(rowKeys.get(0), 0, common);
+      node.nodeData = commonB;
+      for (int i = 0; i < rowKeys.size(); i++) {
+        if (rowKeys.get(i).length == common) {
+          node.numOccurrences++;
+          if (node.index == null) {
+            node.index = new ArrayList<>(1);
+          }
+          node.index.add(i);
+          start = i + 1;
+        } else {
+          break;
+        }
+      }
+    } else {
+      // Only root node data can be empty.
+      node.nodeData = new byte[0];
+    }
+    constructAndSplitChild(node, rowKeys, start, rowKeys.size() - 1, common);
+    return node;
+  }
+
+  /**
+   * Calculate max common prefix
+   *
+   * @return the max common prefix num bytes
+   */
+  static int  maxCommonPrefix(List<byte[]> rowKeys, int start, int end, int startPos) {
+    // only one entry.
+    if (start == end) {
+      return rowKeys.get(start).length - startPos;
+    }
+    int common = 0;
+    for (int round = 0; round <= rowKeys.get(start).length - startPos - 1; round++) {
+      boolean same = true;
+      for (int i = start + 1; i <= end; i++) {
+        if (startPos + common > rowKeys.get(i).length - 1) {
+          same = false;
+          break;
+        }
+        if (rowKeys.get(start)[startPos + common] != rowKeys.get(i)[startPos + common]) {
+          same = false;
+          break;
+        }
+      }
+      if (same) {
+        common++;
+      } else {
+        break;
+      }
+    }
+    return common;
+  }
+
+  /**
+   * No common prefix split it.
+   *
+   */
+  static void constructAndSplitChild(TokenizerNode node, List<byte[]> rowKeys, int start,
+    int end, int startPos) {
+    int middle = start;
+    for (int i = start + 1; i <= end; i++) {
+      if (startPos > rowKeys.get(i).length - 1) {
+        middle = i - 1;
+        break;
+      }
+      if (rowKeys.get(start)[startPos] != rowKeys.get(i)[startPos]) {
+        middle = i - 1;
+        break;
+      }
+    }
+    constructCommonNodeAndChild(node, rowKeys, start, middle, startPos);
+    if (middle + 1 <= end) {
+      // right
+      constructCommonNodeAndChild(node, rowKeys, middle + 1, end, startPos);
+    }
+  }
+
+  /**
+   * Get max common prefix as node and build children.
+   *
+   */
+  static TokenizerNode constructCommonNodeAndChild(TokenizerNode node, List<byte[]> rowKeys, int start,
+    int end, int startPos) {
+    int common = maxCommonPrefix(rowKeys, start, end, startPos);
+    if (common > 0) {
+      TokenizerNode child = new TokenizerNode();
+      child.parent = node;
+      node.children.add(child);
+      byte[] commonB = Bytes.copy(rowKeys.get(start), startPos, common);
+      child.nodeData = commonB;
+      int newStart = start;
+      for (int i = start; i <= end; i++) {
+        if (rowKeys.get(i).length == (startPos + common)) {
+          child.numOccurrences++;
+          if (child.index == null) {
+            child.index = new ArrayList<>(1);
+          }
+          child.index.add(i);
+          newStart = i + 1;
+        } else {
+          break;
+        }
+      }
+      if (start != end && newStart <= end) {
+        if (newStart == start) {
+          // no common prefix.
+          constructAndSplitChild(child, rowKeys, newStart, end, startPos + common);
+        } else {
+          // can have common prefix.
+          constructCommonNodeAndChild(child, rowKeys, newStart, end, startPos + common);
+        }
+      }
+    } else {
+      // no common prefix, split
+      constructAndSplitChild(node, rowKeys, start, end, startPos);
+    }
+    return node;
+  }
+
+  public static void getNodeMetaInfo(TokenizerNode node, TokenizerNodeMeta meta) {
+    if (node.nodeData.length > meta.maxNodeDataLength) {
+      meta.maxNodeDataLength = node.nodeData.length;
+    }
+    meta.totalNodeDataLength += node.nodeData.length;
+    meta.countNodeDataNum++;
+
+    if (node.children.size() > meta.maxChildNum) {
+      meta.maxChildNum = node.children.size();
+    }
+    meta.totalChildNum += node.children.size();
+    meta.countChildNum++;
+
+    if (node.numOccurrences > meta.maxNumOccurrences) {
+      meta.maxNumOccurrences = node.numOccurrences;
+    }
+    meta.countNumOccurrences++;
+    if (node.index != null) {
+      for (Integer entry : node.index) {
+        if (entry > meta.maxIndex) {
+          meta.maxIndex = entry;
+        }
+      }
+    }
+    if (node.children.isEmpty()) {
+      meta.leafNodes.add(node);
+      meta.countIndexNum++;
+    } else {
+      meta.nonLeafNodes.add(node);
+    }
+    for (TokenizerNode child : node.children) {
+      getNodeMetaInfo(child, meta);
+    }
+  }
+
+  public static void serializePrefixTree(TokenizerNode node, PrefixTreeDataWidth dataWidth,
+    ByteArrayOutputStream outputStream)
+    throws IOException {
+    TokenizerNodeMeta meta = new TokenizerNodeMeta();
+    PrefixTreeUtil.getNodeMetaInfo(node, meta);
+    int totalLength = 0;
+    dataWidth.nodeDataLengthWidth = UFIntTool.numBytes(meta.maxNodeDataLength);
+    totalLength += meta.totalNodeDataLength;
+    totalLength += dataWidth.nodeDataLengthWidth * meta.countNodeDataNum;
+
+    dataWidth.fanOutWidth = UFIntTool.numBytes(meta.maxChildNum);
+    // fan Out
+    totalLength += dataWidth.fanOutWidth * meta.countChildNum;
+    // fan Byte
+    totalLength += meta.totalChildNum;
+
+    // nextnodeoffset
+    totalLength += 4 * meta.countChildNum;
+
+    dataWidth.occurrencesWidth = UFIntTool.numBytes(meta.maxNumOccurrences);
+    totalLength += dataWidth.occurrencesWidth * meta.countNumOccurrences;
+
+    dataWidth.indexWidth = UFIntTool.numBytes(meta.maxIndex);
+    totalLength += dataWidth.indexWidth * meta.countIndexNum;
+
+    dataWidth.childNodeOffsetWidth = UFIntTool.numBytes(totalLength);
+
+    // track the starting position of each node in final output
+    int negativeIndex = 0;
+    for (int i = meta.leafNodes.size() - 1; i >= 0; i--) {
+      TokenizerNode leaf = meta.leafNodes.get(i);
+      // no children
+      int leafNodeWidth = dataWidth.nodeDataLengthWidth + leaf.nodeData.length + dataWidth.fanOutWidth
+        + dataWidth.occurrencesWidth + leaf.numOccurrences * dataWidth.indexWidth;
+      negativeIndex += leafNodeWidth;
+      leaf.nodeWidth = leafNodeWidth;
+      leaf.negativeIndex = negativeIndex;
+    }
+    for (int i = meta.nonLeafNodes.size() - 1; i >= 0; i--) {
+      TokenizerNode nonLeaf = meta.nonLeafNodes.get(i);
+      int leafNodeWidth = dataWidth.nodeDataLengthWidth + nonLeaf.nodeData.length + dataWidth.fanOutWidth
+        + nonLeaf.children.size() + nonLeaf.children.size() * dataWidth.childNodeOffsetWidth
+        + dataWidth.occurrencesWidth + nonLeaf.numOccurrences * dataWidth.indexWidth;
+      negativeIndex += leafNodeWidth;
+      nonLeaf.nodeWidth = leafNodeWidth;
+      nonLeaf.negativeIndex = negativeIndex;
+    }
+
+    for (int i = 0; i < meta.nonLeafNodes.size(); i++) {
+      serialize(meta.nonLeafNodes.get(i), outputStream, dataWidth);
+    }
+    for (int i = 0; i < meta.leafNodes.size(); i++) {
+      serialize(meta.leafNodes.get(i), outputStream, dataWidth);
+    }
+  }
+
+  static void serialize(TokenizerNode node, ByteArrayOutputStream os, PrefixTreeDataWidth dataWidth)
+    throws IOException {
+    UFIntTool.writeBytes(dataWidth.nodeDataLengthWidth, node.nodeData.length, os);
+    os.write(node.nodeData, 0, node.nodeData.length);
+    UFIntTool.writeBytes(dataWidth.fanOutWidth, node.children.size(), os);
+    for (TokenizerNode child : node.children) {
+      // child's first byte.
+      os.write(child.nodeData[0]);
+    }
+    for (TokenizerNode child : node.children) {
+      UFIntTool.writeBytes(dataWidth.childNodeOffsetWidth, node.negativeIndex - child.negativeIndex, os);
+    }
+    UFIntTool.writeBytes(dataWidth.occurrencesWidth, node.numOccurrences, os);
+    for (int i = 0; i < node.numOccurrences; i++) {
+      UFIntTool.writeBytes(dataWidth.indexWidth, node.index.get(i), os);
+    }
+  }
+
+  public static void serialize(DataOutput out, PrefixTreeDataWidth dataWidth) throws
+    IOException {
+    out.writeByte(dataWidth.nodeDataLengthWidth);
+    out.writeByte(dataWidth.fanOutWidth);
+    out.writeByte(dataWidth.occurrencesWidth);
+    out.writeByte(dataWidth.indexWidth);
+    out.writeByte(dataWidth.childNodeOffsetWidth);
+  }
+
+  public static void deserialize(ByteBuff data, PrefixTreeDataWidth dataWidth) {
+    dataWidth.nodeDataLengthWidth = data.get();
+    dataWidth.fanOutWidth = data.get();
+    dataWidth.occurrencesWidth = data.get();
+    dataWidth.indexWidth = data.get();
+    dataWidth.childNodeOffsetWidth = data.get();
+  }
+
+  /**
+   * Get the node index, that search key >= index and search key < (index + 1)
+   *
+   */
+  public static int search(ByteBuffer data, int bbStartPos, byte[] skey, int keyStartPos,
+    PrefixTreeDataWidth meta) {
+    int nodeDataLength = getNodeDataLength(data, bbStartPos, meta);
+    int cs =
+      ByteBufferUtils.compareTo(skey, keyStartPos, Math.min(skey.length - keyStartPos, nodeDataLength),
+        data, bbStartPos + meta.nodeDataLengthWidth, nodeDataLength);
+
+    int pos = bbStartPos + meta.nodeDataLengthWidth + nodeDataLength;
+    int fanOut = getNodeFanOut(data, pos, meta);
+    pos += meta.fanOutWidth + fanOut + fanOut * meta.childNodeOffsetWidth;
+    int numOccurrences = getNodeNumOccurrences(data, pos, meta);
+    pos += meta.occurrencesWidth;
+
+    if (cs == 0) {
+      // continue search
+      if (fanOut == 0) {
+        // no children, should be numOccurrences > 0
+        int index = getNodeIndex(data, pos, 0, meta);
+        if (skey.length == keyStartPos + nodeDataLength) {
+          // == current node
+          return index;
+        } else {
+          // > current node.
+          return index;
+        }
+      }
+      if (skey.length > keyStartPos + nodeDataLength) {
+        int fanOffset = bbStartPos + meta.nodeDataLengthWidth + nodeDataLength + meta.fanOutWidth;
+        byte searchForByte = skey[keyStartPos + nodeDataLength];
+
+        int fanIndexInBlock =
+          unsignedBinarySearch(data, fanOffset, fanOffset + fanOut, searchForByte);
+        int nodeOffsetStartPos = fanOffset + fanOut;
+        if (fanIndexInBlock >= 0) {
+          // found it, but need to adjust for position of fan in overall block
+          int fanIndex = fanIndexInBlock - fanOffset;
+          int nodeOffset = getNodeOffset(data, nodeOffsetStartPos, fanIndex, meta);
+          return search(data, bbStartPos + nodeOffset, skey, keyStartPos + nodeDataLength, meta);
+        } else {
+          int fanIndex = fanIndexInBlock + fanOffset;// didn't find it, so compensate in reverse
+          int insertionPoint = (-fanIndex - 1) - 1;
+          if (insertionPoint < 0) {
+            // < first children
+            int nodeOffset = getNodeOffset(data, nodeOffsetStartPos, 0, meta);
+            return getFirstLeafNode(data, bbStartPos + nodeOffset, meta) - 1;
+          } else {
+            int nodeOffset = getNodeOffset(data, nodeOffsetStartPos, insertionPoint, meta);
+            return getLastLeafNode(data, bbStartPos + nodeOffset, meta);
+          }
+        }
+      } else {
+        //skey.length == keyStartPos + nodeDataLength
+        if (numOccurrences > 0) {
+          // == current node and current node is a leaf node.
+          return getNodeIndex(data, pos, 0, meta);
+        } else {
+          // need -1, == current node and current node not a leaf node.
+          return getFirstLeafNode(data, bbStartPos, meta) - 1;
+        }
+      }
+    } else if (cs > 0) {
+      // search key bigger than (>) current node, get biggest
+      if (fanOut == 0) {
+        if (numOccurrences > 0) {
+          if (numOccurrences == 1) {
+            return getNodeIndex(data, pos, 0, meta);
+          } else {
+            //TODO
+            throw new IllegalStateException(
+              "numOccurrences = " + numOccurrences + " > 1 not expected.");
+          }
+        } else {
+          throw new IllegalStateException(
+            "numOccurrences = " + numOccurrences + ", fanOut = " + fanOut + " not expected.");
+        }
+      } else {
+        return getLastLeafNode(data, bbStartPos, meta);
+      }
+    } else {
+      // search key small than (<) current node, get smallest.
+      if (numOccurrences > 0) {
+        return getNodeIndex(data, pos, 0, meta) - 1;
+      } else {
+        return getFirstLeafNode(data, bbStartPos, meta) - 1;
+      }
+    }
+  }
+
+  static int getNodeDataLength(ByteBuffer data, int offset, PrefixTreeDataWidth meta) {
+    int dataLength = (int) UFIntTool.fromBytes(data, offset, meta.nodeDataLengthWidth);
+    return dataLength;
+  }
+
+  static int getNodeFanOut(ByteBuffer data, int offset, PrefixTreeDataWidth meta) {
+    int fanOut = (int) UFIntTool.fromBytes(data, offset, meta.fanOutWidth);
+    return fanOut;
+  }
+
+  static int getNodeNumOccurrences(ByteBuffer data, int offset, PrefixTreeDataWidth meta) {
+    int numOccurrences = (int) UFIntTool.fromBytes(data, offset, meta.occurrencesWidth);
+    return numOccurrences;
+  }
+
+  static int getNodeOffset(ByteBuffer data, int offset, int index, PrefixTreeDataWidth meta) {
+    int nodeOffset =
+      (int) UFIntTool.fromBytes(data, offset + (index * meta.childNodeOffsetWidth), meta.childNodeOffsetWidth);
+    return nodeOffset;
+  }
+
+  static int getNodeIndex(ByteBuffer data, int offset, int index, PrefixTreeDataWidth meta) {
+    int nodeIndex =
+      (int) UFIntTool.fromBytes(data, offset + (index * meta.indexWidth), meta.indexWidth);
+    return nodeIndex;
+  }
+
+  /**
+   * Get the node's first leaf node
+   *
+   */
+  static int getFirstLeafNode(ByteBuffer data, int bbStartPos, PrefixTreeDataWidth meta) {
+    int dataLength = getNodeDataLength(data, bbStartPos, meta);
+    int pos = bbStartPos + meta.nodeDataLengthWidth + dataLength;
+    int fanOut = getNodeFanOut(data, pos, meta);
+    pos += meta.fanOutWidth + fanOut + fanOut * meta.childNodeOffsetWidth;
+    int numOccurrences = getNodeNumOccurrences(data, pos, meta);
+    pos += meta.occurrencesWidth;
+    if (numOccurrences > 0 || fanOut == 0) {
+      // return current node.
+      return getNodeIndex(data, pos, 0, meta);
+    } else {
+      int nodeOffsetStartPos =
+        bbStartPos + meta.nodeDataLengthWidth + dataLength + meta.fanOutWidth + fanOut;
+      int nodeOffset = getNodeOffset(data, nodeOffsetStartPos, 0, meta);
+      return getFirstLeafNode(data, bbStartPos + nodeOffset, meta);
+    }
+  }
+
+  /**
+   * Get the node's last leaf node
+   *
+   */
+  static int getLastLeafNode(ByteBuffer data, int bbStartPos, PrefixTreeDataWidth meta) {
+    int dataLength = getNodeDataLength(data, bbStartPos, meta);
+    int pos = bbStartPos + meta.nodeDataLengthWidth + dataLength;
+    int fanOut = getNodeFanOut(data, pos, meta);
+    pos += meta.fanOutWidth + fanOut + fanOut * meta.childNodeOffsetWidth;
+    //int numOccurrences = getNodeNumOccurrences(data, pos, meta);
+    pos += meta.occurrencesWidth;
+    if (fanOut == 0) {
+      return getNodeIndex(data, pos, 0, meta);
+    } else {
+      int nodeOffsetStartPos =
+        bbStartPos + meta.nodeDataLengthWidth + dataLength + meta.fanOutWidth + fanOut;
+      int nodeOffset = getNodeOffset(data, nodeOffsetStartPos, fanOut - 1, meta);
+      return getLastLeafNode(data, bbStartPos + nodeOffset, meta);
+    }
+  }
+
+  public static int unsignedBinarySearch(ByteBuffer a, int fromIndex, int toIndex, byte key) {
+    int unsignedKey = key & 0xff;
+    int low = fromIndex;
+    int high = toIndex - 1;
+
+    while (low <= high) {
+      int mid = low + ((high - low) >> 1);
+      int midVal = a.get(mid) & 0xff;
+
+      if (midVal < unsignedKey) {
+        low = mid + 1;
+      } else if (midVal > unsignedKey) {
+        high = mid - 1;
+      } else {
+        return mid; // key found
+      }
+    }
+    return -(low + 1); // key not found.
+  }
+
+  public static byte[] get(ByteBuffer data, int bbStartPos, PrefixTreeDataWidth dataWidth, int index) {
+    return get(data, bbStartPos, dataWidth, index, new byte[0]);
+  }
+
+  static byte[] get(ByteBuffer data, int bbStartPos, PrefixTreeDataWidth meta, int index, byte[] prefix) {
+    int dataLength = getNodeDataLength(data, bbStartPos, meta);
+    byte[] bdata = new byte[dataLength];
+    ByteBuffer dup = data.duplicate();
+    dup.position(bbStartPos + meta.nodeDataLengthWidth);
+    dup.get(bdata, 0, dataLength);
+    bdata = Bytes.add(prefix, bdata);
+
+    int pos = bbStartPos + meta.nodeDataLengthWidth + dataLength;
+    int fanOut = getNodeFanOut(data, pos, meta);
+    pos += meta.fanOutWidth + fanOut + fanOut * meta.childNodeOffsetWidth;
+    int numOccurrences = getNodeNumOccurrences(data, pos, meta);
+    pos += meta.occurrencesWidth;
+    if (numOccurrences > 0) {
+      int currentNodeIndex = getNodeIndex(data, pos, 0, meta);
+      if (currentNodeIndex == index) {
+        return bdata;
+      }
+    }
+    if (fanOut == 0) {
+      int currentNodeIndex = getNodeIndex(data, pos, 0, meta);
+      if (currentNodeIndex == index) {
+        return bdata;
+      } else {
+        throw new IllegalStateException(
+          "Unexpected, search index=" + index + ", but find to " + currentNodeIndex);
+      }
+    } else {
+      int nodeOffsetStartPos =
+        bbStartPos + meta.nodeDataLengthWidth + dataLength + meta.fanOutWidth + fanOut;
+      int locateIndex = locateWhichChild(data, bbStartPos, meta, index, fanOut, nodeOffsetStartPos);
+      int nodeOffset = getNodeOffset(data, nodeOffsetStartPos, locateIndex, meta);
+      return get(data, bbStartPos + nodeOffset, meta, index, bdata);
+    }
+  }
+
+  static int locateWhichChild(ByteBuffer data, int bbStartPos, PrefixTreeDataWidth meta, int index, int fanOut, int nodeOffsetStartPos) {
+    for (int i = 0; i < fanOut; i++) {
+      int nodeOffset = getNodeOffset(data, nodeOffsetStartPos, i, meta);
+      int lastLeafNode = getLastLeafNode(data, bbStartPos + nodeOffset, meta);
+      if (lastLeafNode >= index) {
+        return i;
+      }
+    }
+    throw new IllegalStateException("Unexpected unable to find index=" + index);
+  }
+
+  public static class TokenizerNode {
+
+    public byte[] nodeData = null;
+
+    /**
+     * ref to parent trie node
+     */
+    public TokenizerNode parent = null;
+
+    /**
+     * child nodes.
+     */
+    public ArrayList<TokenizerNode> children = new ArrayList<>();
+
+    /*
+     * A count of occurrences in the input byte[]s, not the trie structure. 0 for branch nodes, 1+ for
+     * nubs and leaves.
+     */
+    public int numOccurrences = 0;
+
+    public List<Integer> index = null;
+
+    public List<KeyValue.KeyOnlyKeyValue> keys = null;
+
+    /*
+     * A positive value indicating how many bytes before the end of the block this node will start. If
+     * the section is 55 bytes and negativeOffset is 9, then the node will start at 46.
+     */
+    public int negativeIndex = 0;
+
+    public int nodeWidth = 0;
+  }
+
+  public static class TokenizerNodeMeta {
+
+    public int maxNodeDataLength = 0;
+    public int totalNodeDataLength = 0;
+    public int countNodeDataNum = 0;
+
+    public int maxChildNum = 0;
+    public int totalChildNum = 0;
+    public int countChildNum = 0;
+
+    public int maxNumOccurrences = 0;
+    public int countNumOccurrences = 0;
+
+    public int maxIndex = 0;
+    public int countIndexNum = 0;
+
+    public ArrayList<TokenizerNode> nonLeafNodes = new ArrayList<>();
+
+    public ArrayList<TokenizerNode> leafNodes = new ArrayList<>();
+  }
+
+  public static class PrefixTreeDataWidth {
+    public int nodeDataLengthWidth = 0;
+
+    public int fanOutWidth = 0;
+
+    public int occurrencesWidth = 0;
+
+    public int indexWidth = 0;
+
+    public int childNodeOffsetWidth = 0;
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/util/UFIntTool.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/util/UFIntTool.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.hadoop.hbase.io.util;
+
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.nio.ByteBuffer;
+
+/**
+ * UFInt is an abbreviation for Unsigned Fixed-width Integer.
+ *
+ * This class converts between positive ints and 1-4 bytes that represent the int.  All input ints
+ * must be positive.  Max values stored in N bytes are:
+ *
+ * N=1: 2^8  =&gt;           256
+ * N=2: 2^16 =&gt;        65,536
+ * N=3: 2^24 =&gt;    16,777,216
+ * N=4: 2^31 =&gt; 2,147,483,648 (Integer.MAX_VALUE)
+ *
+ * This was created to get most of the memory savings of a variable length integer when encoding
+ * an array of input integers, but to fix the number of bytes for each integer to the number needed
+ * to store the maximum integer in the array.  This enables a binary search to be performed on the
+ * array of encoded integers.
+ *
+ * PrefixTree nodes often store offsets into a block that can fit into 1 or 2 bytes.  Note that if
+ * the maximum value of an array of numbers needs 2 bytes, then it's likely that a majority of the
+ * numbers will also require 2 bytes.
+ *
+ * warnings:
+ *  * no input validation for max performance
+ *  * no negatives
+ */
+@InterfaceAudience.Private
+public class UFIntTool {
+
+  private static final int NUM_BITS_IN_LONG = 64;
+
+  public static long maxValueForNumBytes(int numBytes) {
+    return (1L << (numBytes * 8)) - 1;
+  }
+
+  public static int numBytes(final long value) {
+    if (value == 0) {// 0 doesn't work with the formula below
+      return 1;
+    }
+    return (NUM_BITS_IN_LONG + 7 - Long.numberOfLeadingZeros(value)) / 8;
+  }
+
+  public static byte[] getBytes(int outputWidth, final long value) {
+    byte[] bytes = new byte[outputWidth];
+    writeBytes(outputWidth, value, bytes, 0);
+    return bytes;
+  }
+
+  public static void writeBytes(int outputWidth, final long value, byte[] bytes, int offset) {
+    bytes[offset + outputWidth - 1] = (byte) value;
+    for (int i = outputWidth - 2; i >= 0; --i) {
+      bytes[offset + i] = (byte) (value >>> (outputWidth - i - 1) * 8);
+    }
+  }
+
+  private static final long[] MASKS = new long[] {
+    (long) 255,
+    (long) 255 << 8,
+    (long) 255 << 16,
+    (long) 255 << 24,
+    (long) 255 << 32,
+    (long) 255 << 40,
+    (long) 255 << 48,
+    (long) 255 << 56
+  };
+
+  public static void writeBytes(int outputWidth, final long value, OutputStream os) throws IOException {
+    for (int i = outputWidth - 1; i >= 0; --i) {
+      os.write((byte) ((value & MASKS[i]) >>> (8 * i)));
+    }
+  }
+
+  public static long fromBytes(final byte[] bytes) {
+    long value = 0;
+    value |= bytes[0] & 0xff;// these seem to do ok without casting the byte to int
+    for (int i = 1; i < bytes.length; ++i) {
+      value <<= 8;
+      value |= bytes[i] & 0xff;
+    }
+    return value;
+  }
+
+  public static long fromBytes(final byte[] bytes, final int offset, final int width) {
+    long value = 0;
+    value |= bytes[0 + offset] & 0xff;// these seem to do ok without casting the byte to int
+    for (int i = 1; i < width; ++i) {
+      value <<= 8;
+      value |= bytes[i + offset] & 0xff;
+    }
+    return value;
+  }
+
+  public static long fromBytes(final ByteBuffer buffer, final int offset, final int width) {
+    long value = 0;
+    value |= buffer.get(0 + offset) & 0xff;// these seem to do ok without casting the byte to int
+    for (int i = 1; i < width; ++i) {
+      value <<= 8;
+      value |= buffer.get(i + offset) & 0xff;
+    }
+    return value;
+  }
+
+  public static long fromBytes(final ByteBuff buffer, final int offset, final int width) {
+    long value = 0;
+    value |= buffer.get(0 + offset) & 0xff;// these seem to do ok without casting the byte to int
+    for (int i = 1; i < width; ++i) {
+      value <<= 8;
+      value |= buffer.get(i + offset) & 0xff;
+    }
+    return value;
+  }
+}

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/encoding/TestPrefixTreeUtil.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/encoding/TestPrefixTreeUtil.java
@@ -1,0 +1,96 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.encoding;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.io.ByteArrayOutputStream;
+import org.apache.hadoop.hbase.testclassification.IOTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.List;
+
+@Category({ IOTests.class, SmallTests.class })
+public class TestPrefixTreeUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(TestPrefixTreeUtil.class);
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestPrefixTreeUtil.class);
+
+  @Test
+  public void testSearchPrefixTree() throws IOException {
+    List<byte[]> childs = new ArrayList<>();
+    childs.add(Bytes.toBytes("00c7-202206201519-wx0t"));
+    childs.add(Bytes.toBytes("00c7-202206201519-wx0zcldi7lnsiyas-N"));
+    childs.add(Bytes.toBytes("00c7-202206201520-wx0re"));
+    childs.add(Bytes.toBytes("00c7-202206201520-wx0ulgrwi7d542tm-N"));
+    childs.add(Bytes.toBytes("00c7-202206201520-wx0x7"));
+    childs.add(Bytes.toBytes("00c7-202206201521"));
+    childs.add(Bytes.toBytes("00c7-202206201521-wx05xfbtw2mopyhs-C"));
+    childs.add(Bytes.toBytes("00c7-202206201521-wx08"));
+    childs.add(Bytes.toBytes("00c7-202206201521-wx0c"));
+    childs.add(Bytes.toBytes("00c7-202206201521-wx0go"));
+    childs.add(Bytes.toBytes("00c7-202206201522-wx0t"));
+    childs.add(Bytes.toBytes("00c8-202206200751-wx0ah4gnbwptdyna-F"));
+
+    PrefixTreeUtil.TokenizerNode node = PrefixTreeUtil.buildPrefixTree(childs);
+    PrefixTreeUtil.PrefixTreeDataWidth dataWidth = new PrefixTreeUtil.PrefixTreeDataWidth();
+    ByteArrayOutputStream outputStream = new ByteArrayOutputStream();
+    PrefixTreeUtil.serializePrefixTree(node, dataWidth, outputStream);
+    byte[] data = outputStream.toByteArray();
+    ByteBuffer prefixTreeNodeData = ByteBuffer.wrap(data);
+    for (int i = 0; i < childs.size(); i++) {
+      byte[] result = PrefixTreeUtil.get(prefixTreeNodeData, 0, dataWidth, i);
+      Assert.assertTrue(Bytes.compareTo(result, childs.get(i)) == 0);
+    }
+
+    for (int i = 0; i < childs.size(); i++) {
+      int result = PrefixTreeUtil.search(prefixTreeNodeData, 0, childs.get(i), 0, dataWidth);
+      Assert.assertEquals(result, i);
+    }
+
+    byte[] skey = Bytes.toBytes("00c7-202206201519");
+    int result = PrefixTreeUtil.search(prefixTreeNodeData, 0, skey, 0, dataWidth);
+    Assert.assertEquals(-1, result);
+
+    skey = Bytes.toBytes("00c7-202206201520");
+    result = PrefixTreeUtil.search(prefixTreeNodeData, 0, skey, 0, dataWidth);
+    Assert.assertEquals(1, result);
+
+    skey = Bytes.toBytes("00c7-202206201520-wx0x7-");
+    result = PrefixTreeUtil.search(prefixTreeNodeData, 0, skey, 0, dataWidth);
+    Assert.assertEquals(4, result);
+
+    skey = Bytes.toBytes("00c7-202206201521-wx0");
+    result = PrefixTreeUtil.search(prefixTreeNodeData, 0, skey, 0, dataWidth);
+    Assert.assertEquals(5, result);
+
+    skey = Bytes.toBytes("00c8-202206200751-wx0ah4gnbwptdyna-F-");
+    result = PrefixTreeUtil.search(prefixTreeNodeData, 0, skey, 0, dataWidth);
+    Assert.assertEquals(11, result);
+  }
+
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockIndexChunk.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockIndexChunk.java
@@ -26,6 +26,10 @@ public interface BlockIndexChunk {
 
   List<byte[]> getBlockKeys();
 
+  List<Long> getBlockOffsets();
+
+  List<Integer> getOnDiskDataSizes();
+
   List<Integer> getSecondaryIndexOffsetMarks();
 
   int getEntryBySubEntry(long k);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
@@ -1528,6 +1528,16 @@ public class HFileBlockIndex {
     }
 
     @Override
+    public List<Long> getBlockOffsets() {
+      return blockOffsets;
+    }
+
+    @Override
+    public List<Integer> getOnDiskDataSizes() {
+      return onDiskDataSizes;
+    }
+
+    @Override
     public List<Integer> getSecondaryIndexOffsetMarks() {
       return secondaryIndexOffsetMarks;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileIndexBlockEncoderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileIndexBlockEncoderImpl.java
@@ -19,8 +19,16 @@ package org.apache.hadoop.hbase.io.hfile;
 
 import java.io.DataOutput;
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellComparator;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoder;
 import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoding;
+import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.ClassSize;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -70,16 +78,200 @@ public class HFileIndexBlockEncoderImpl implements HFileIndexBlockEncoder {
   @Override
   public void encode(BlockIndexChunk blockIndexChunk, boolean rootIndexBlock, DataOutput out)
     throws IOException {
-    // TODO
+    IndexBlockEncoder encoder = this.indexBlockEncoding.getEncoder();
+    encoder.startBlockEncoding(rootIndexBlock, out);
+    encoder.encode(blockIndexChunk.getBlockKeys(), blockIndexChunk.getBlockOffsets(),
+      blockIndexChunk.getOnDiskDataSizes(), out);
+    encoder.endBlockEncoding(out);
   }
 
   @Override
   public EncodedSeeker createSeeker() {
-    return null;
+    return new IndexBlockEncodedSeeker(this.indexBlockEncoding.getEncoder().createSeeker());
   }
 
   @Override
   public String toString() {
     return getClass().getSimpleName() + "(indexBlockEncoding=" + indexBlockEncoding + ")";
+  }
+
+  protected static class IndexBlockEncodedSeeker implements EncodedSeeker {
+    private int rootIndexNumEntries;
+    protected int searchTreeLevel;
+    private IndexBlockEncoder.IndexEncodedSeeker encodedSeeker;
+
+    /**
+     * Pre-computed mid-key
+     */
+    private AtomicReference<Cell> midKey = new AtomicReference<>();
+
+    IndexBlockEncodedSeeker(IndexBlockEncoder.IndexEncodedSeeker encodedSeeker) {
+      this.encodedSeeker = encodedSeeker;
+    }
+
+    @Override
+    public long heapSize() {
+      long heapSize = ClassSize.align(ClassSize.OBJECT);
+
+      if (encodedSeeker != null) {
+        heapSize += ClassSize.REFERENCE;
+        heapSize += ClassSize.align(encodedSeeker.heapSize());
+      }
+
+      // the midkey atomicreference
+      heapSize += ClassSize.REFERENCE;
+      // rootIndexNumEntries searchTreeLevel
+      heapSize += 2 * Bytes.SIZEOF_INT;
+      return ClassSize.align(heapSize);
+    }
+
+    @Override
+    public void initRootIndex(HFileBlock blk, int numEntries, CellComparator comparator,
+      int treeLevel) throws IOException {
+      this.rootIndexNumEntries = numEntries;
+      this.searchTreeLevel = treeLevel;
+      ByteBuff data = blk.getBufferWithoutHeader();
+      encodedSeeker.initRootIndex(data, numEntries, comparator, treeLevel);
+    }
+
+    @Override
+    public boolean isEmpty() {
+      return rootIndexNumEntries <= 0;
+    }
+
+    @Override
+    public Cell getRootBlockKey(int i) {
+      return encodedSeeker.getRootBlockKey(i);
+    }
+
+    @Override
+    public int getRootBlockCount() {
+      return rootIndexNumEntries;
+    }
+
+    @Override
+    public Cell midkey(HFile.CachingBlockReader cachingBlockReader) throws IOException {
+      if (rootIndexNumEntries == 0) {
+        throw new IOException("HFile empty");
+      }
+
+      Cell targetMidKey = this.midKey.get();
+      if (targetMidKey != null) {
+        return targetMidKey;
+      }
+      targetMidKey = getRootBlockKey(rootIndexNumEntries / 2);
+      this.midKey.set(targetMidKey);
+      return targetMidKey;
+    }
+
+    @Override
+    public int rootBlockContainingKey(Cell key) {
+      return encodedSeeker.rootBlockContainingKey(key);
+    }
+
+    @Override
+    public BlockWithScanInfo loadDataBlockWithScanInfo(Cell key, HFileBlock currentBlock,
+      boolean cacheBlocks, boolean pread, boolean isCompaction,
+      DataBlockEncoding expectedDataBlockEncoding, HFile.CachingBlockReader cachingBlockReader)
+      throws IOException {
+      int rootLevelIndex = rootBlockContainingKey(key);
+      if (rootLevelIndex < 0 || rootLevelIndex >= rootIndexNumEntries) {
+        return null;
+      }
+
+      // Read the next-level (intermediate or leaf) index block.
+      long currentOffset = encodedSeeker.rootBlockBlockOffsets(rootLevelIndex);
+      int currentOnDiskSize = encodedSeeker.rootBlockOnDiskDataSizes(rootLevelIndex);
+
+      int lookupLevel = 1; // How many levels deep we are in our lookup.
+      IndexBlockEncoder.SearchResult searchResult = null;
+
+      HFileBlock block = null;
+      while (true) {
+        try {
+          // Must initialize it with null here, because if don't and once an exception happen in
+          // readBlock, then we'll release the previous assigned block twice in the finally block.
+          // (See HBASE-22422)
+          block = null;
+          if (currentBlock != null && currentBlock.getOffset() == currentOffset) {
+            // Avoid reading the same block again, even with caching turned off.
+            // This is crucial for compaction-type workload which might have
+            // caching turned off. This is like a one-block cache inside the
+            // scanner.
+            block = currentBlock;
+          } else {
+            // Call HFile's caching block reader API. We always cache index
+            // blocks, otherwise we might get terrible performance.
+            boolean shouldCache = cacheBlocks || (lookupLevel < searchTreeLevel);
+            BlockType expectedBlockType;
+            if (lookupLevel < searchTreeLevel - 1) {
+              expectedBlockType = BlockType.INTERMEDIATE_INDEX;
+            } else if (lookupLevel == searchTreeLevel - 1) {
+              expectedBlockType = BlockType.LEAF_INDEX;
+            } else {
+              // this also accounts for ENCODED_DATA
+              expectedBlockType = BlockType.DATA;
+            }
+            block =
+              cachingBlockReader.readBlock(currentOffset, currentOnDiskSize, shouldCache, pread,
+                isCompaction, true, expectedBlockType, expectedDataBlockEncoding);
+          }
+
+          if (block == null) {
+            throw new IOException(
+              "Failed to read block at offset " + currentOffset + ", onDiskSize=" + currentOnDiskSize);
+          }
+
+          // Found a data block, break the loop and check our level in the tree.
+          if (block.getBlockType().isData()) {
+            break;
+          }
+
+          // Not a data block. This must be a leaf-level or intermediate-level
+          // index block. We don't allow going deeper than searchTreeLevel.
+          if (++lookupLevel > searchTreeLevel) {
+            throw new IOException(
+              "Search Tree Level overflow: lookupLevel=" + lookupLevel + ", searchTreeLevel="
+                + searchTreeLevel);
+          }
+
+          // Locate the entry corresponding to the given key in the non-root
+          // (leaf or intermediate-level) index block.
+          ByteBuff buffer = block.getBufferWithoutHeader();
+          searchResult = encodedSeeker.locateNonRootIndexEntry(buffer, key);
+          if (searchResult.entryIndex == -1) {
+            // This has to be changed
+            // For now change this to key value
+            throw new IOException("The key " + CellUtil.getCellKeyAsString(key) + " is before the"
+              + " first key of the non-root index block " + block);
+          }
+
+          currentOffset = searchResult.offset;
+          currentOnDiskSize = searchResult.onDiskSize;
+
+        } finally {
+          if (block != null && !block.getBlockType().isData()) {
+            // Release the block immediately if it is not the data block
+            block.release();
+          }
+        }
+      }
+
+      if (lookupLevel != searchTreeLevel) {
+        assert block.getBlockType().isData();
+        // Though we have retrieved a data block we have found an issue
+        // in the retrieved data block. Hence returned the block so that
+        // the ref count can be decremented
+        if (block != null) {
+          block.release();
+        }
+        throw new IOException(
+          "Reached a data block at level " + lookupLevel + " but the number of levels is "
+            + searchTreeLevel);
+      }
+
+      // set the next indexed key for the current block.
+      return new BlockWithScanInfo(block, null);
+    }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -239,8 +239,14 @@ public class HFileWriterImpl implements HFile.Writer {
       throw new IOException("Key cannot be null or empty");
     }
     if (lastCell != null) {
-      int keyComp = PrivateCellUtil.compareKeyIgnoresMvcc(this.hFileContext.getCellComparator(),
-        lastCell, cell);
+      int keyComp = 0;
+      if (hFileContext.getIndexBlockEncoding() == IndexBlockEncoding.PREFIX_TREE) {
+        keyComp = this.hFileContext.getCellComparator().compareRows(lastCell, cell);
+      } else {
+        keyComp =
+          PrivateCellUtil.compareKeyIgnoresMvcc(this.hFileContext.getCellComparator(), lastCell,
+            cell);
+      }
       if (keyComp > 0) {
         String message = getLexicalErrorMessage(cell);
         throw new IOException(message);


### PR DESCRIPTION
A simple implementation which only consider cell row and not cell qualifier. 

00c7-202206201519-wx0t
00c7-202206201519-wx0zcldi7lnsiyas-N
00c7-202206201520-wx0re
00c7-202206201520-wx0ulgrwi7d542tm-N
00c7-202206201520-wx0x7
00c7-202206201521
00c7-202206201521-wx05xfbtw2mopyhs-C
00c7-202206201521-wx08
00c7-202206201521-wx0c
00c7-202206201521-wx0go
00c7-202206201522-wx0t
00c8-202206200751-wx0ah4gnbwptdyna-F

The prefix tree node is like this:
<img width="818" alt="image" src="https://user-images.githubusercontent.com/1531353/190049685-ffd86881-2f32-4502-b793-414f1a9180db.png">
