### PR TITLE
HBASE-27395 Adding description to Prometheus metrics

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prometheus/PrometheusHadoopServlet.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prometheus/PrometheusHadoopServlet.java
@@ -41,10 +41,7 @@ public class PrometheusHadoopServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    String tmpStr = req.getParameter("description");
-    boolean description = tmpStr != null && tmpStr.equals("true");
-
-    writeMetrics(resp.getWriter(), description);
+    writeMetrics(resp.getWriter(), "true".equals(req.getParameter("description")));
   }
 
   static String toPrometheusName(String metricRecordName, String metricName) {
@@ -70,11 +67,11 @@ public class PrometheusHadoopServlet extends HttpServlet {
 
           if (desc) {
             String description = metrics.description();
-            if (!description.isEmpty()) writer.append("# HELP ").append(description).append("\n");
+            if (!description.isEmpty()) writer.append("# HELP ").append(description).append('\n');
           }
 
           writer.append("# TYPE ").append(key).append(" ")
-            .append(metrics.type().toString().toLowerCase()).append("\n").append(key).append("{");
+            .append(metrics.type().toString().toLowerCase()).append('\n').append(key).append("{");
 
           /* add tags */
           String sep = "";

--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prometheus/PrometheusHadoopServlet.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/prometheus/PrometheusHadoopServlet.java
@@ -41,7 +41,10 @@ public class PrometheusHadoopServlet extends HttpServlet {
 
   @Override
   protected void doGet(HttpServletRequest req, HttpServletResponse resp) throws IOException {
-    writeMetrics(resp.getWriter());
+    String tmpStr = req.getParameter("description");
+    boolean description = tmpStr != null && tmpStr.equals("true");
+
+    writeMetrics(resp.getWriter(), description);
   }
 
   static String toPrometheusName(String metricRecordName, String metricName) {
@@ -57,13 +60,19 @@ public class PrometheusHadoopServlet extends HttpServlet {
    */
   @RestrictedApi(explanation = "Should only be called in tests or self", link = "",
       allowedOnPath = ".*/src/test/.*|.*/PrometheusHadoopServlet\\.java")
-  void writeMetrics(Writer writer) throws IOException {
+  void writeMetrics(Writer writer, boolean desc) throws IOException {
     Collection<MetricsRecord> metricRecords = MetricsExportHelper.export();
     for (MetricsRecord metricsRecord : metricRecords) {
       for (AbstractMetric metrics : metricsRecord.metrics()) {
         if (metrics.type() == MetricType.COUNTER || metrics.type() == MetricType.GAUGE) {
 
           String key = toPrometheusName(metricsRecord.name(), metrics.name());
+
+          if (desc) {
+            String description = metrics.description();
+            if (!description.isEmpty()) writer.append("# HELP ").append(description).append("\n");
+          }
+
           writer.append("# TYPE ").append(key).append(" ")
             .append(metrics.type().toString().toLowerCase()).append("\n").append(key).append("{");
 

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/prometheus/TestPrometheusServlet.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/prometheus/TestPrometheusServlet.java
@@ -60,7 +60,8 @@ public class TestPrometheusServlet {
 
     // WHEN
     PrometheusHadoopServlet prom2Servlet = new PrometheusHadoopServlet();
-    prom2Servlet.writeMetrics(writer);
+    // Test with no description
+    prom2Servlet.writeMetrics(writer, false);
 
     // THEN
     String writtenMetrics = stream.toString(UTF_8.name());


### PR DESCRIPTION
You can access metrics description while using '/prometheus' endpoint via "description=true" URL parameter.
Example: `http://HOSTNAME:16010/prometheus?description=true`

Apache JIRA: https://issues.apache.org/jira/browse/HBASE-27395