### PR TITLE
HBASE-27407 Fixing JMX description bug in JMXJsonServlet.java

### DIFF
--- a/hbase-http/src/main/java/org/apache/hadoop/hbase/http/jmx/JMXJsonServlet.java
+++ b/hbase-http/src/main/java/org/apache/hadoop/hbase/http/jmx/JMXJsonServlet.java
@@ -171,8 +171,8 @@ public class JMXJsonServlet extends HttpServlet {
         }
         beanWriter = this.jsonBeanWriter.open(writer);
         // Should we output description on each attribute and bean?
-        String tmpStr = request.getParameter(INCLUDE_DESCRIPTION);
-        boolean description = tmpStr != null && tmpStr.length() > 0;
+        boolean description = "true".equals(request.getParameter(INCLUDE_DESCRIPTION));
+
 
         // query per mbean attribute
         String getmethod = request.getParameter("get");


### PR DESCRIPTION
Fixed the bug in connection with the JMX metrics.
With this modification only "description=true" URL parameter will give the JMX metrics descriptions.

Apache JIRA: https://issues.apache.org/jira/browse/HBASE-27407