### PR TITLE
HBASE-27420 Allow non-loopback for zk standalone server in minizkcluster

### DIFF
--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MiniZooKeeperCluster.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MiniZooKeeperCluster.java
@@ -237,7 +237,8 @@ public class MiniZooKeeperCluster {
       while (true) {
         try {
           standaloneServerFactory = new NIOServerCnxnFactory();
-          standaloneServerFactory.configure(new InetSocketAddress(LOOPBACK_HOST, currentClientPort),
+          String bindAddr = configuration.get("hbase.zookeeper.property.clientPortAddress", LOOPBACK_HOST);
+          standaloneServerFactory.configure(new InetSocketAddress(bindAddr, currentClientPort),
             configuration.getInt(HConstants.ZOOKEEPER_MAX_CLIENT_CNXNS,
               HConstants.DEFAULT_ZOOKEEPER_MAX_CLIENT_CNXNS));
         } catch (BindException e) {

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MiniZooKeeperCluster.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MiniZooKeeperCluster.java
@@ -237,7 +237,8 @@ public class MiniZooKeeperCluster {
       while (true) {
         try {
           standaloneServerFactory = new NIOServerCnxnFactory();
-          String bindAddr = configuration.get("hbase.zookeeper.property.clientPortAddress", LOOPBACK_HOST);
+          String bindAddr =
+            configuration.get("hbase.zookeeper.property.clientPortAddress", LOOPBACK_HOST);
           standaloneServerFactory.configure(new InetSocketAddress(bindAddr, currentClientPort),
             configuration.getInt(HConstants.ZOOKEEPER_MAX_CLIENT_CNXNS,
               HConstants.DEFAULT_ZOOKEEPER_MAX_CLIENT_CNXNS));


### PR DESCRIPTION
Link to JIRA: https://issues.apache.org/jira/browse/HBASE-27420

Add a provision to allow zk to listen for client connections on non-loopback IP.