### PR TITLE
HBASE-27423 Upgrade Jackson for CVE-2022-42003/42004

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -792,8 +792,8 @@
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.13</httpcore.version>
     <metrics-core.version>3.2.6</metrics-core.version>
-    <jackson.version>2.13.3</jackson.version>
-    <jackson.databind.version>2.13.3</jackson.databind.version>
+    <jackson.version>2.13.4</jackson.version>
+    <jackson.databind.version>2.14.0-rc1</jackson.databind.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>


### PR DESCRIPTION
Jackson 2.13.4 fixes CVE-2022-42004 and databind 2.14.0-rc1 fixes CVE-2022-42003.

Move jackson.version to 2.13.4.
Move jackson.databind.version to 2.14.0-rc1.