### PR TITLE
HBASE-27424 Upgrade Jettison for CVE-2022-40149/40150

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -814,7 +814,7 @@
     <slf4j.version>1.7.30</slf4j.version>
     <clover.version>4.0.3</clover.version>
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
-    <jettison.version>1.3.8</jettison.version>
+    <jettison.version>1.5.1</jettison.version>
     <!--Make sure these joni/jcodings are compatible with the versions used by jruby-->
     <joni.version>2.1.42</joni.version>
     <jcodings.version>1.0.56</jcodings.version>


### PR DESCRIPTION
Jettison versions <= 1.5.0 are subject to CVE-2022-40149 and CVE-2022-40150.

Move jettison.version to 1.5.1.