### PR TITLE
HBASE-27339 Improve sasl connection failure log message to include server

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
@@ -395,7 +395,8 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
         // A provider which failed authentication, but doesn't have the ability to relogin with
         // some external system (e.g. username/password, the password either works or it doesn't)
         if (!provider.canRetry()) {
-          LOG.warn("Exception encountered while connecting to the server " + remoteId.getAddress(), ex);
+          LOG.warn("Exception encountered while connecting to the server " + remoteId.getAddress(),
+            ex);
           if (ex instanceof RemoteException) {
             throw (RemoteException) ex;
           }
@@ -410,7 +411,8 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
         // Other providers, like kerberos, could request a new ticket from a keytab. Let
         // them try again.
         if (currRetries < maxRetries) {
-          LOG.debug("Exception encountered while connecting to the server " + remoteId.getAddress(), ex);
+          LOG.debug("Exception encountered while connecting to the server " + remoteId.getAddress(),
+            ex);
 
           // Invoke the provider to perform the relogin
           provider.relogin();

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
@@ -395,7 +395,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
         // A provider which failed authentication, but doesn't have the ability to relogin with
         // some external system (e.g. username/password, the password either works or it doesn't)
         if (!provider.canRetry()) {
-          LOG.warn("Exception encountered while connecting to the server : " + ex);
+          LOG.warn("Exception encountered while connecting to the server " + remoteId.getAddress(), ex);
           if (ex instanceof RemoteException) {
             throw (RemoteException) ex;
           }
@@ -410,7 +410,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
         // Other providers, like kerberos, could request a new ticket from a keytab. Let
         // them try again.
         if (currRetries < maxRetries) {
-          LOG.debug("Exception encountered while connecting to the server", ex);
+          LOG.debug("Exception encountered while connecting to the server " + remoteId.getAddress(), ex);
 
           // Invoke the provider to perform the relogin
           provider.relogin();

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
@@ -316,7 +316,7 @@ class NettyRpcConnection extends RpcConnection {
         private void fail(Channel ch, Throwable error) {
           IOException ex = toIOE(error);
           LOG.warn("Exception encountered while connecting to the server " + remoteId.getAddress(), ex);
-          failInit(ch, toIOE(ex));
+          failInit(ch, ex);
           rpcClient.failedServers.addToFailedServers(remoteId.getAddress(), error);
         }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
@@ -314,7 +314,9 @@ class NettyRpcConnection extends RpcConnection {
         }
 
         private void fail(Channel ch, Throwable error) {
-          failInit(ch, toIOE(error));
+          IOException ex = toIOE(error);
+          LOG.warn("Exception encountered while connecting to the server " + remoteId.getAddress(), ex);
+          failInit(ch, toIOE(ex));
           rpcClient.failedServers.addToFailedServers(remoteId.getAddress(), error);
         }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
@@ -315,7 +315,8 @@ class NettyRpcConnection extends RpcConnection {
 
         private void fail(Channel ch, Throwable error) {
           IOException ex = toIOE(error);
-          LOG.warn("Exception encountered while connecting to the server " + remoteId.getAddress(), ex);
+          LOG.warn("Exception encountered while connecting to the server " + remoteId.getAddress(),
+            ex);
           failInit(ch, ex);
           rpcClient.failedServers.addToFailedServers(remoteId.getAddress(), error);
         }


### PR DESCRIPTION
Include the remote server name in the logged exception message when the connection setup fails in BlockingRpcConnection.

Add an equivalent log line in NettyRpcConnection.