### PR TITLE
HBASE-27406 Make "/prometheus" endpoint accessible from HBase UI

### DIFF
--- a/hbase-rest/src/main/resources/hbase-webapps/rest/rest.jsp
+++ b/hbase-rest/src/main/resources/hbase-webapps/rest/rest.jsp
@@ -58,7 +58,17 @@ String listenPort = conf.get("hbase.rest.port", "8080");
                   <li class="active"><a href="/rest.jsp">Home</a></li>
                   <li><a href="/logs/">Local logs</a></li>
                   <li><a href="/logLevel">Log Level</a></li>
-                  <li><a href="/jmx">Metrics Dump</a></li>
+                  <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      Metrics <span class="caret"></span>
+                    </a>
+                    <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                      <li><a target="_blank" href="/jmx">JMX</a></li>
+                      <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                      <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                      <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+                    </ul>
+                  </li>
                   <li><a href="/prof">Profiler</a></li>
                   <% if (HBaseConfiguration.isShowConfInServlet()) { %>
                   <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
@@ -162,7 +162,17 @@ AssignmentManager assignmentManager = master.getAssignmentManager();
                 <li><a href="/logs/">Local Logs</a></li>
                 <li><a href="/logLevel">Log Level</a></li>
                 <li><a href="/dump">Debug Dump</a></li>
-                <li><a href="/jmx">Metrics Dump</a></li>
+                <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Metrics <span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                    <li><a target="_blank" href="/jmx">JMX</a></li>
+                    <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+                  </ul>
+                </li>
                 <li><a href="/prof">Profiler</a></li>
                 <%if HBaseConfiguration.isShowConfInServlet()%>
                 <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
@@ -114,7 +114,17 @@ org.apache.hadoop.hbase.zookeeper.MasterAddressTracker;
                 <li><a href="/rsOperationDetails.jsp">Operation Details</a></li>
                 <li><a href="/logLevel">Log Level</a></li>
                 <li><a href="/dump">Debug Dump</a></li>
-                <li><a href="/jmx">Metrics Dump</a></li>
+                <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Metrics <span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                    <li><a target="_blank" href="/jmx">JMX</a></li>
+                    <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+                  </ul>
+                </li>
                 <li><a href="/prof">Profiler</a></li>
                 <%if HBaseConfiguration.isShowConfInServlet()%>
                 <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-server/src/main/resources/hbase-webapps/master/header.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/header.jsp
@@ -70,7 +70,17 @@
             <li><a href="/logs/">Local Logs</a></li>
             <li><a href="/logLevel">Log Level</a></li>
             <li><a href="/dump">Debug Dump</a></li>
-            <li><a href="/jmx">Metrics Dump</a></li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Metrics <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <li><a target="_blank" href="/jmx">JMX</a></li>
+                <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+              </ul>
+            </li>
             <li><a href="/prof">Profiler</a></li>
             <% if (HBaseConfiguration.isShowConfInServlet()) { %>
             <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-server/src/main/resources/hbase-webapps/regionserver/header.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/regionserver/header.jsp
@@ -56,7 +56,17 @@
             <li><a href="/rsOperationDetails.jsp">Operation Details</a></li>
             <li><a href="/logLevel">Log Level</a></li>
             <li><a href="/dump">Debug Dump</a></li>
-            <li><a href="/jmx">Metrics Dump</a></li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Metrics <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <li><a target="_blank" href="/jmx">JMX</a></li>
+                <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+              </ul>
+            </li>
             <li><a href="/prof">Profiler</a></li>
             <% if (HBaseConfiguration.isShowConfInServlet()) { %>
             <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-thrift/src/main/resources/hbase-webapps/thrift/thrift.jsp
+++ b/hbase-thrift/src/main/resources/hbase-webapps/thrift/thrift.jsp
@@ -74,7 +74,17 @@ String qop = conf.get("hbase.thrift.security.qop", "None");
                 <li class="active"><a href="/">Home</a></li>
                 <li><a href="/logs/">Local logs</a></li>
                 <li><a href="/logLevel">Log Level</a></li>
-                <li><a href="/jmx">Metrics Dump</a></li>
+                <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Metrics <span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                    <li><a target="_blank" href="/jmx">JMX</a></li>
+                    <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+                  </ul>
+                </li>
                 <li><a href="/prof">Profiler</a></li>
                 <% if (HBaseConfiguration.isShowConfInServlet()) { %>
                 <li><a href="/conf">HBase Configuration</a></li>


### PR DESCRIPTION
Before this change, Prometheus metrics were only accessible via the '/prometheus' endpoint.

I made changes in the UI, so instead of _Metrics Dump_ there's a dropdown menu called _Metrics_ with the JMX and Prometheus metrics.

I also included the metrics description, so there are four endpoints available from there:
- JMX
- JMX with description 
- Prometheus
- Prometheus with description

**Apache JIRA:** https://issues.apache.org/jira/browse/HBASE-27406