### PR TITLE
HBASE-27440 fix table HistogramMetrics leak in table metrics map

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/DynamicMetricsRegistry.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/DynamicMetricsRegistry.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.metrics2.lib;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
-import com.google.common.annotations.VisibleForTesting;
+import com.google.errorprone.annotations.RestrictedApi;
 import org.apache.hadoop.hbase.metrics.Interns;
 import org.apache.hadoop.metrics2.MetricsException;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -535,7 +535,8 @@ public class DynamicMetricsRegistry {
     metricsMap.clear();
   }
 
-  @VisibleForTesting
+  @RestrictedApi(explanation = "Should only be called in TestMetricsTableMetricsMap", link = "",
+    allowedOnPath = ".*/(DynamicMetricsRegistry|TestMetricsTableMetricsMap).java")
   public ConcurrentMap<String, MutableMetric> getMetricsMap() {
     return metricsMap;
   }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/DynamicMetricsRegistry.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/DynamicMetricsRegistry.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.metrics2.lib;
 
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.hbase.metrics.Interns;
 import org.apache.hadoop.metrics2.MetricsException;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -388,8 +389,9 @@ public class DynamicMetricsRegistry {
 
   public void removeHistogramMetrics(String baseName) {
     for (String suffix : histogramSuffixes) {
-      removeMetric(baseName + suffix);
+      helper.removeObjectName(baseName + suffix);
     }
+    metricsMap.remove(baseName);
   }
 
   /**
@@ -531,5 +533,10 @@ public class DynamicMetricsRegistry {
       helper.removeObjectName(name);
     }
     metricsMap.clear();
+  }
+
+  @VisibleForTesting
+  public ConcurrentMap<String, MutableMetric> getMetricsMap() {
+    return metricsMap;
   }
 }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/DynamicMetricsRegistry.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/metrics2/lib/DynamicMetricsRegistry.java
@@ -17,9 +17,9 @@
  */
 package org.apache.hadoop.metrics2.lib;
 
+import com.google.errorprone.annotations.RestrictedApi;
 import java.util.Collection;
 import java.util.concurrent.ConcurrentMap;
-import com.google.errorprone.annotations.RestrictedApi;
 import org.apache.hadoop.hbase.metrics.Interns;
 import org.apache.hadoop.metrics2.MetricsException;
 import org.apache.hadoop.metrics2.MetricsInfo;
@@ -536,7 +536,7 @@ public class DynamicMetricsRegistry {
   }
 
   @RestrictedApi(explanation = "Should only be called in TestMetricsTableMetricsMap", link = "",
-    allowedOnPath = ".*/(DynamicMetricsRegistry|TestMetricsTableMetricsMap).java")
+      allowedOnPath = ".*/(DynamicMetricsRegistry|TestMetricsTableMetricsMap).java")
   public ConcurrentMap<String, MutableMetric> getMetricsMap() {
     return metricsMap;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableMetricsMap.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableMetricsMap.java
@@ -18,9 +18,11 @@
 package org.apache.hadoop.hbase.regionserver;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -28,6 +30,11 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
 @Category({ RegionServerTests.class, SmallTests.class }) public class TestMetricsTableMetricsMap {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestMetricsTableMetricsMap.class);
+
   private String tableName = "testTableMetricsMap";
 
   private MetricsTableWrapperStub tableWrapper;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableMetricsMap.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableMetricsMap.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+@Category({ RegionServerTests.class, SmallTests.class }) public class TestMetricsTableMetricsMap {
+  private String tableName = "testTableMetricsMap";
+
+  private MetricsTableWrapperStub tableWrapper;
+  private MetricsTable mt;
+  private MetricsRegionServerWrapper rsWrapper;
+  private MetricsRegionServer rsm;
+  private MetricsTableAggregateSourceImpl agg;
+
+  @Before public void setUp() {
+    Configuration conf = new Configuration();
+
+    tableWrapper = new MetricsTableWrapperStub(tableName);
+    mt = new MetricsTable(tableWrapper);
+    rsWrapper = new MetricsRegionServerWrapperStub();
+
+    rsm = new MetricsRegionServer(rsWrapper, conf, mt);
+    MetricsTableAggregateSource tableSourceAgg = mt.getTableSourceAgg();
+    if (tableSourceAgg instanceof MetricsTableAggregateSourceImpl) {
+      agg = (MetricsTableAggregateSourceImpl) tableSourceAgg;
+    } else {
+      throw new RuntimeException(
+        "tableSourceAgg should be the instance of MetricsTableAggregateSourceImpl");
+    }
+  }
+
+  @Test public void testMetricsMap() throws InterruptedException {
+    // do major compaction
+    rsm.updateCompaction(tableName, true, 100, 200, 300, 400, 500);
+
+    int metricsMapSize = agg.getMetricsRegistry().getMetricsMap().size();
+    assertTrue("table metrics added then metricsMapSize should larger than 0", metricsMapSize > 0);
+
+    // just for metrics update
+    Thread.sleep(1000);
+    // delete table all metrics
+    agg.deleteTableSource(tableName);
+
+    metricsMapSize = agg.getMetricsRegistry().getMetricsMap().size();
+    assertEquals("table metrics all deleted then metricsSize should be 0", 0, metricsMapSize);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableMetricsMap.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsTableMetricsMap.java
@@ -17,6 +17,9 @@
  */
 package org.apache.hadoop.hbase.regionserver;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
@@ -26,10 +29,8 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
-
-@Category({ RegionServerTests.class, SmallTests.class }) public class TestMetricsTableMetricsMap {
+@Category({ RegionServerTests.class, SmallTests.class })
+public class TestMetricsTableMetricsMap {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
@@ -43,7 +44,8 @@ import static org.junit.Assert.assertTrue;
   private MetricsRegionServer rsm;
   private MetricsTableAggregateSourceImpl agg;
 
-  @Before public void setUp() {
+  @Before
+  public void setUp() {
     Configuration conf = new Configuration();
 
     tableWrapper = new MetricsTableWrapperStub(tableName);
@@ -60,7 +62,8 @@ import static org.junit.Assert.assertTrue;
     }
   }
 
-  @Test public void testMetricsMap() throws InterruptedException {
+  @Test
+  public void testMetricsMap() throws InterruptedException {
     // do major compaction
     rsm.updateCompaction(tableName, true, 100, 200, 300, 400, 500);
 


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13758677/196915944-71197086-2d53-4a85-8b5e-0a61441e8f64.png)

the method removeHistogramMetrics will cause the metricsMap leak!
because the put op in the map is the baseName but the remove is not , the origin code add the histogramSuffixe follow the baseName when remove.

![image](https://user-images.githubusercontent.com/13758677/196916259-196e3e8a-cde0-4989-8b64-de13b860522d.png)

