### PR TITLE
HBASE-27167 s390x: Skip tests on unsupported compression libs

### DIFF
--- a/hbase-compression/hbase-compression-aircompressor/pom.xml
+++ b/hbase-compression/hbase-compression-aircompressor/pom.xml
@@ -178,5 +178,17 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <!-- Aircompressor does not yet support big endian -->
+      <id>s390x-aircompressor-skip-tests</id>
+      <activation>
+        <os>
+          <arch>s390x</arch>
+        </os>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
   </profiles>
 </project>

--- a/hbase-compression/hbase-compression-brotli/pom.xml
+++ b/hbase-compression/hbase-compression-brotli/pom.xml
@@ -163,5 +163,17 @@
         </dependency>
       </dependencies>
     </profile>
+    <profile>
+      <!-- Brotli4j does not yet support s390x -->
+      <id>s390x-brotli-skip-tests</id>
+      <activation>
+        <os>
+          <arch>s390x</arch>
+        </os>
+      </activation>
+      <properties>
+        <skipTests>true</skipTests>
+      </properties>
+    </profile>
   </profiles>
 </project>


### PR DESCRIPTION
The brotli4j and aircompressor dependencies don't have s390x arch support yet. Even though aircompressor is pure java, it only supports little-endian right now. 

This PR adds profiles to automatically set skipTests for `hbase-compression-aircompressor` and `hbase-compression-brotli` on s390x so builds can complete successfully.
