### PR TITLE
HBASE-27390: prevent NPE when task status is null

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredRPCHandlerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredRPCHandlerImpl.java
@@ -44,8 +44,8 @@ public class MonitoredRPCHandlerImpl extends MonitoredTaskImpl implements Monito
   private boolean snapshot = false;
   private Map<String, Object> callInfoMap = new HashMap<>();
 
-  public MonitoredRPCHandlerImpl() {
-    super(false);
+  public MonitoredRPCHandlerImpl(String description) {
+    super(false, description);
     // in this implementation, WAITING indicates that the handler is not
     // actively servicing an RPC call.
     setState(State.WAITING);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredTaskImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredTaskImpl.java
@@ -104,7 +104,7 @@ class MonitoredTaskImpl implements MonitoredTask {
 
   @Override
   public String getStatus() {
-    if(status == null){
+    if (status == null) {
       return "No task status available.";
     }
     return status;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredTaskImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredTaskImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.monitoring;
 
+import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -46,11 +47,13 @@ class MonitoredTaskImpl implements MonitoredTask {
 
   private static final Gson GSON = GsonUtil.createGson().create();
 
-  public MonitoredTaskImpl(boolean enableJournal) {
+  public MonitoredTaskImpl(boolean enableJournal, String description) {
     startTime = EnvironmentEdgeManager.currentTime();
     statusTime = startTime;
     stateTime = startTime;
     warnTime = startTime;
+    this.description = description;
+    this.status = "status unset";
     if (enableJournal) {
       journal = new ConcurrentLinkedQueue<>();
     } else {
@@ -104,9 +107,6 @@ class MonitoredTaskImpl implements MonitoredTask {
 
   @Override
   public String getStatus() {
-    if (status == null) {
-      return "No task status available.";
-    }
     return status;
   }
 
@@ -164,6 +164,7 @@ class MonitoredTaskImpl implements MonitoredTask {
 
   @Override
   public void setStatus(String status) {
+    Preconditions.checkNotNull(status, "Status is null");
     this.status = status;
     statusTime = EnvironmentEdgeManager.currentTime();
     if (journal != null) {
@@ -178,6 +179,7 @@ class MonitoredTaskImpl implements MonitoredTask {
 
   @Override
   public void setDescription(String description) {
+    Preconditions.checkNotNull(description, "Description is null");
     this.description = description;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredTaskImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredTaskImpl.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.monitoring;
 
-import com.google.common.base.Preconditions;
 import java.io.IOException;
 import java.util.Collections;
 import java.util.HashMap;
@@ -29,6 +28,7 @@ import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.GsonUtil;
 import org.apache.yetus.audience.InterfaceAudience;
 
+import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableList;
 import org.apache.hbase.thirdparty.com.google.gson.Gson;
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredTaskImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredTaskImpl.java
@@ -104,6 +104,9 @@ class MonitoredTaskImpl implements MonitoredTask {
 
   @Override
   public String getStatus() {
+    if(status == null){
+      return "No task status available.";
+    }
     return status;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/TaskMonitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/TaskMonitor.java
@@ -94,8 +94,7 @@ public class TaskMonitor {
 
   public synchronized MonitoredTask createStatus(String description, boolean ignore,
     boolean enableJournal) {
-    MonitoredTask stat = new MonitoredTaskImpl(enableJournal);
-    stat.setDescription(description);
+    MonitoredTask stat = new MonitoredTaskImpl(enableJournal, description);
     MonitoredTask proxy = (MonitoredTask) Proxy.newProxyInstance(stat.getClass().getClassLoader(),
       new Class<?>[] { MonitoredTask.class }, new PassthroughInvocationHandler<>(stat));
     TaskAndWeakRefPair pair = new TaskAndWeakRefPair(stat, proxy);
@@ -109,8 +108,7 @@ public class TaskMonitor {
   }
 
   public synchronized MonitoredRPCHandler createRPCStatus(String description) {
-    MonitoredRPCHandler stat = new MonitoredRPCHandlerImpl();
-    stat.setDescription(description);
+    MonitoredRPCHandler stat = new MonitoredRPCHandlerImpl(description);
     MonitoredRPCHandler proxy =
       (MonitoredRPCHandler) Proxy.newProxyInstance(stat.getClass().getClassLoader(),
         new Class<?>[] { MonitoredRPCHandler.class }, new PassthroughInvocationHandler<>(stat));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestCallRunner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestCallRunner.java
@@ -81,7 +81,7 @@ public class TestCallRunner {
 
     TraceUtil.trace(() -> {
       CallRunner cr = new CallRunner(mockRpcServer, mockCall);
-      cr.setStatus(new MonitoredRPCHandlerImpl());
+      cr.setStatus(new MonitoredRPCHandlerImpl("test"));
       cr.run();
     }, testName.getMethodName());
 
@@ -101,7 +101,7 @@ public class TestCallRunner {
 
     TraceUtil.trace(() -> {
       CallRunner cr = new CallRunner(mockRpcServer, mockCall);
-      cr.setStatus(new MonitoredRPCHandlerImpl());
+      cr.setStatus(new MonitoredRPCHandlerImpl("test"));
       cr.run();
     }, testName.getMethodName());
     Mockito.verify(mockCall, Mockito.times(1)).cleanup();
@@ -116,7 +116,7 @@ public class TestCallRunner {
 
     TraceUtil.trace(() -> {
       CallRunner cr = new CallRunner(mockRpcServer, mockCall);
-      cr.setStatus(new MonitoredRPCHandlerImpl());
+      cr.setStatus(new MonitoredRPCHandlerImpl("test"));
       cr.drop();
     }, testName.getMethodName());
     Mockito.verify(mockCall, Mockito.times(1)).cleanup();
@@ -142,7 +142,7 @@ public class TestCallRunner {
 
     TraceUtil.trace(() -> {
       CallRunner cr = new CallRunner(mockRpcServer, mockCall);
-      cr.setStatus(new MonitoredRPCHandlerImpl());
+      cr.setStatus(new MonitoredRPCHandlerImpl("test"));
       cr.drop();
     }, testName.getMethodName());
     Mockito.verify(mockCall, Mockito.times(1)).cleanup();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestFifoRpcScheduler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestFifoRpcScheduler.java
@@ -113,7 +113,7 @@ public class TestFifoRpcScheduler {
 
     for (int i = totalCallMethods; i > 0; i--) {
       CallRunner task = createMockTask();
-      task.setStatus(new MonitoredRPCHandlerImpl());
+      task.setStatus(new MonitoredRPCHandlerImpl("test"));
 
       if (!scheduler.dispatch(task)) {
         unableToDispatch++;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
@@ -109,7 +109,7 @@ public class TestSimpleRpcScheduler {
     scheduler.init(CONTEXT);
     scheduler.start();
     CallRunner task = createMockTask();
-    task.setStatus(new MonitoredRPCHandlerImpl());
+    task.setStatus(new MonitoredRPCHandlerImpl("test"));
     scheduler.dispatch(task);
     verify(task, timeout(10000)).run();
     scheduler.stop();
@@ -164,7 +164,7 @@ public class TestSimpleRpcScheduler {
     int totalCallMethods = 10;
     for (int i = totalCallMethods; i > 0; i--) {
       CallRunner task = createMockTask();
-      task.setStatus(new MonitoredRPCHandlerImpl());
+      task.setStatus(new MonitoredRPCHandlerImpl("test"));
       scheduler.dispatch(task);
     }
 
@@ -205,7 +205,7 @@ public class TestSimpleRpcScheduler {
       }
     };
     for (CallRunner task : tasks) {
-      task.setStatus(new MonitoredRPCHandlerImpl());
+      task.setStatus(new MonitoredRPCHandlerImpl("test"));
       doAnswer(answerToRun).when(task).run();
     }
 
@@ -524,7 +524,7 @@ public class TestSimpleRpcScheduler {
 
   private void doAnswerTaskExecution(final CallRunner callTask, final ArrayList<Integer> results,
     final int value, final int sleepInterval) {
-    callTask.setStatus(new MonitoredRPCHandlerImpl());
+    callTask.setStatus(new MonitoredRPCHandlerImpl("test"));
     doAnswer(new Answer<Object>() {
       @Override
       public Object answer(InvocationOnMock invocation) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -54,6 +54,8 @@ public class TestTaskMonitor {
     TaskMonitor tm = new TaskMonitor(new Configuration());
     assertTrue("Task monitor should start empty", tm.getTasks().isEmpty());
 
+
+
     // Make a task and fetch it back out
     MonitoredTask task = tm.createStatus("Test task");
     MonitoredTask taskFromTm = tm.getTasks().get(0);
@@ -62,6 +64,8 @@ public class TestTaskMonitor {
     assertEquals(task.getDescription(), taskFromTm.getDescription());
     assertEquals(-1, taskFromTm.getCompletionTimestamp());
     assertEquals(MonitoredTask.State.RUNNING, taskFromTm.getState());
+    assertEquals(task.getStatus(), taskFromTm.getStatus());
+    assertEquals("status unset", taskFromTm.getStatus());
 
     // Mark it as finished
     task.markComplete("Finished!");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -54,8 +54,6 @@ public class TestTaskMonitor {
     TaskMonitor tm = new TaskMonitor(new Configuration());
     assertTrue("Task monitor should start empty", tm.getTasks().isEmpty());
 
-
-
     // Make a task and fetch it back out
     MonitoredTask task = tm.createStatus("Test task");
     MonitoredTask taskFromTm = tm.getTasks().get(0);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -228,7 +228,7 @@ public class TestTaskMonitor {
 
   @Test
   public void testClone() throws Exception {
-    MonitoredRPCHandlerImpl monitor = new MonitoredRPCHandlerImpl();
+    MonitoredRPCHandlerImpl monitor = new MonitoredRPCHandlerImpl("test");
     monitor.abort("abort RPC");
     TestParam testParam = new TestParam("param1");
     monitor.setRPC("method1", new Object[] { testParam }, 0);


### PR DESCRIPTION
~Simple null check to prevent the following spam when a task does not have a status.~ 

Simple changes to prevent NPE spam in hmaster logs 
- Initialize the status and description when new MonitoredTasks are created 
- Do not allow null statuses or descriptions to be set

```
[RpcServer.default.FPBQ.Fifo.handler=29,queue=2,port=60000] ERROR org.apache.hadoop.hbase.ipc.RpcServer: Unexpected throwable object  
java.lang.NullPointerException    
at org.apache.hadoop.hbase.shaded.protobuf.generated.ClusterStatusProtos$ServerTask$Builder.setStatus(ClusterStatusProtos.java:14352)    
at org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil.toServerTask(ProtobufUtil.java:3565)    
at org.apache.hadoop.hbase.ClusterMetricsBuilder.lambda$toClusterStatus$4(ClusterMetricsBuilder.java:80)    
at java.base/java.util.stream.ReferencePipeline$3$1.accept(ReferencePipeline.java:195)    
at java.base/java.util.ArrayList$ArrayListSpliterator.forEachRemaining(ArrayList.java:1655)    
at java.base/java.util.stream.AbstractPipeline.copyInto(AbstractPipeline.java:484)    
at java.base/java.util.stream.AbstractPipeline.wrapAndCopyInto(AbstractPipeline.java:474)    
at java.base/java.util.stream.ReduceOps$ReduceOp.evaluateSequential(ReduceOps.java:913)    
at java.base/java.util.stream.AbstractPipeline.evaluate(AbstractPipeline.java:234)    
at java.base/java.util.stream.ReferencePipeline.collect(ReferencePipeline.java:578)    
at org.apache.hadoop.hbase.ClusterMetricsBuilder.toClusterStatus(ClusterMetricsBuilder.java:80)    
at org.apache.hadoop.hbase.master.MasterRpcServices.getClusterStatus(MasterRpcServices.java:980)    
at org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos$MasterService$2.callBlockingMethod(MasterProtos.java)    
at org.apache.hadoop.hbase.ipc.RpcServer.call(RpcServer.java:385)    
at org.apache.hadoop.hbase.ipc.CallRunner.run(CallRunner.java:124)    
at org.apache.hadoop.hbase.ipc.RpcHandler.run(RpcHandler.java:102)    
at org.apache.hadoop.hbase.ipc.RpcHandler.run(RpcHandler.java:82) 

``` 