### PR TITLE
HBASE-27479 fix flaky test testClone in TestTaskMonitor

### DIFF
--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -333,6 +333,12 @@
       <artifactId>bcpkix-jdk15on</artifactId>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>org.skyscreamer</groupId>
+      <artifactId>jsonassert</artifactId>
+      <version>1.5.1</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
   <build>
     <!-- Make sure resources get added before they are processed by placing this first

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -336,7 +336,6 @@
     <dependency>
       <groupId>org.skyscreamer</groupId>
       <artifactId>jsonassert</artifactId>
-      <version>1.5.1</version>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -239,8 +239,8 @@ public class TestTaskMonitor {
     assertEquals(clone.getStatus(), monitor.getStatus());
     assertEquals(clone.toString(), monitor.toString());
     assertEquals(clone.toMap(), monitor.toMap());
-    JSONAssert.assertEquals(clone.toJSON(), monitor.toJSON(),true);
-    
+    JSONAssert.assertEquals(clone.toJSON(), monitor.toJSON(), true);
+
     // mark complete and make param dirty
     monitor.markComplete("complete RPC");
     testParam.setParam("dirtyParam");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -40,6 +40,7 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.skyscreamer.jsonassert.JSONAssert;
 
 @Category({ MiscTests.class, SmallTests.class })
 public class TestTaskMonitor {
@@ -238,8 +239,8 @@ public class TestTaskMonitor {
     assertEquals(clone.getStatus(), monitor.getStatus());
     assertEquals(clone.toString(), monitor.toString());
     assertEquals(clone.toMap(), monitor.toMap());
-    assertEquals(clone.toJSON(), monitor.toJSON());
-
+    JSONAssert.assertEquals(clone.toJSON(), monitor.toJSON(),true);
+    
     // mark complete and make param dirty
     monitor.markComplete("complete RPC");
     testParam.setParam("dirtyParam");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -38,9 +38,9 @@ import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.skyscreamer.jsonassert.JSONAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-import org.skyscreamer.jsonassert.JSONAssert;
 
 @Category({ MiscTests.class, SmallTests.class })
 public class TestTaskMonitor {

--- a/pom.xml
+++ b/pom.xml
@@ -827,6 +827,7 @@
     <jcodings.version>1.0.56</jcodings.version>
     <spy.version>2.12.2</spy.version>
     <bouncycastle.version>1.70</bouncycastle.version>
+    <skyscreamer.version>1.5.1</skyscreamer.version>
     <kerby.version>1.0.1</kerby.version>
     <commons-crypto.version>1.1.0</commons-crypto.version>
     <curator.version>4.2.0</curator.version>
@@ -1015,12 +1016,6 @@
         <artifactId>hbase-hadoop-compat</artifactId>
         <version>${project.version}</version>
         <type>test-jar</type>
-        <scope>test</scope>
-      </dependency>
-      <dependency>
-        <groupId>org.skyscreamer</groupId>
-        <artifactId>jsonassert</artifactId>
-        <version>1.5.1</version>
         <scope>test</scope>
       </dependency>
       <dependency>
@@ -1574,6 +1569,12 @@
         <groupId>org.bouncycastle</groupId>
         <artifactId>bcprov-jdk15on</artifactId>
         <version>${bouncycastle.version}</version>
+        <scope>test</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.skyscreamer</groupId>
+        <artifactId>jsonassert</artifactId>
+        <version>${skyscreamer.version}</version>
         <scope>test</scope>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -1018,6 +1018,11 @@
         <scope>test</scope>
       </dependency>
       <dependency>
+        <groupId>org.skyscreamer</groupId>
+        <artifactId>jsonassert</artifactId>
+        <version>1.5.1</version>
+        <scope>test</scope>
+      <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-replication</artifactId>
         <version>${project.version}</version>

--- a/pom.xml
+++ b/pom.xml
@@ -1022,6 +1022,7 @@
         <artifactId>jsonassert</artifactId>
         <version>1.5.1</version>
         <scope>test</scope>
+      </dependency>
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-replication</artifactId>


### PR DESCRIPTION
`testClone` is detected as flaky by [NonDex](https://github.com/TestingResearchIllinois/NonDex) since the origin task monitor and the cloned one are represented as JSON objects, which are in a non-deterministic order. Therefore, I used JSONAssert to check if they are equal instead.