### PR TITLE
HBASE-27001 The deleted variable cannot be printed out

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/CleanerChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/CleanerChore.java
@@ -478,7 +478,7 @@ public abstract class CleanerChore<T extends FileCleanerDelegate> extends Schedu
       LOG.info("unexpected exception: ", e);
       deleted = false;
     }
-    LOG.trace("Finish deleting {} under {}, deleted=", type, dir, deleted);
+    LOG.trace("Finish deleting {} under {}, deleted = {}", type, dir, deleted);
     return deleted;
   }
 }


### PR DESCRIPTION
* The deleted variable cannot be printed out, add it

Co-authored-by: selina.yan <selina.yan@huolala.cn>

Signed-off-by: Pankaj Kumar<pankajkumar@apache.org>
(cherry picked from commit b8558d30d0027d031ce6dec8b2ba0243c3a58554)