### PR TITLE
HBASE-27408 Improve BucketAllocatorException log to always include HFile name

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -1045,13 +1045,19 @@ public class BucketCache implements BlockCache, HeapSize {
         final HFileContext fileContext = ((HFileBlock) re.getData()).getHFileContext();
         final String columnFamily = Bytes.toString(fileContext.getColumnFamily());
         final String tableName = Bytes.toString(fileContext.getTableName());
-        if (tableName != null && columnFamily != null) {
+        if (tableName != null) {
           sb.append(" Table: ");
           sb.append(tableName);
+        }
+        if (columnFamily != null) {
           sb.append(" CF: ");
           sb.append(columnFamily);
-          sb.append(" HFile: ");
+        }
+        sb.append(" HFile: ");
+        if (fileContext.getHFileName() != null) {
           sb.append(fileContext.getHFileName());
+        } else {
+          sb.append(re.getKey());
         }
       } else {
         sb.append(" HFile: ");


### PR DESCRIPTION
This is just a very simple logging change to ensure that we always print as much info as we have available.

The biggest actual affect is that the `HFile:` section will now always be printed. The other components are optional and in my experience only available in HFileWriter _not_ HFileReader. So I think they'd only show up if cacheOnWrite is enabled and fails to allocate a block while writing blocks to a storefile. In my experience I've never seen them show up, because we don't have cacheOnWrite enabled.

The [original implementation](https://github.com/apache/hbase/pull/3840/files?diff=split&w=0#diff-b75abcdb76c582e16144df3a9bf2ddbc8fd0814c06190c33503a2c1cb365273cL1012) had a similar fallback which was lost in the most recent cleanup.