### PR TITLE
HBASE-27496 Optionally limit the cumulative size of normalization plans produced by SimpleRegionNormalizer

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/MergeNormalizationPlan.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/MergeNormalizationPlan.java
@@ -59,6 +59,15 @@ final class MergeNormalizationPlan implements NormalizationPlan {
   }
 
   @Override
+  public long getPlanSizeMb() {
+    long total = 0;
+    for (NormalizationTarget target : normalizationTargets) {
+      total += target.getRegionSizeMb();
+    }
+    return total;
+  }
+
+  @Override
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
       .append("normalizationTargets", normalizationTargets).toString();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/NormalizationPlan.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/NormalizationPlan.java
@@ -34,4 +34,6 @@ public interface NormalizationPlan {
 
   /** Returns the type of this plan */
   PlanType getType();
+
+  long getPlanSizeMb();
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/RegionNormalizerWorker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/RegionNormalizerWorker.java
@@ -251,7 +251,10 @@ class RegionNormalizerWorker implements PropagatingConfigurationObserver, Runnab
       }
       if (maybeTruncatedPlans.size() != plans.size()) {
         LOG.debug(
-          "Truncating list of normalization plans that RegionNormalizerWorker will process because of {}. Original list had {} plan(s), new list has {} plan(s). Original list covered regions with cumulative size {} mb, new list covers regions with cumulative size {} mb.",
+          "Truncating list of normalization plans that RegionNormalizerWorker will process "
+            + "because of {}. Original list had {} plan(s), new list has {} plan(s). "
+            + "Original list covered regions with cumulative size {} mb, "
+            + "new list covers regions with cumulative size {} mb.",
           CUMULATIVE_SIZE_LIMIT_MB_KEY, plans.size(), maybeTruncatedPlans.size(),
           totalCumulativeSizeMb, truncatedCumulativeSizeMb);
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.master.normalizer;
 
+import static org.apache.hadoop.hbase.master.normalizer.RegionNormalizerWorker.CUMULATIVE_SIZE_LIMIT_MB_KEY;
+import static org.apache.hadoop.hbase.master.normalizer.RegionNormalizerWorker.DEFAULT_CUMULATIVE_SIZE_LIMIT_MB;
 import static org.apache.hbase.thirdparty.org.apache.commons.collections4.CollectionUtils.isEmpty;
 
 import java.time.Instant;
@@ -79,8 +81,6 @@ class SimpleRegionNormalizer implements RegionNormalizer, ConfigurationObserver 
   static final int DEFAULT_MERGE_MIN_REGION_AGE_DAYS = 3;
   static final String MERGE_MIN_REGION_SIZE_MB_KEY = "hbase.normalizer.merge.min_region_size.mb";
   static final int DEFAULT_MERGE_MIN_REGION_SIZE_MB = 0;
-  static final String CUMULATIVE_SIZE_LIMIT_MB_KEY = "hbase.normalizer.plans_size_limit.mb";
-  static final long DEFAULT_CUMULATIVE_SIZE_LIMIT_MB = Long.MAX_VALUE;
 
   private MasterServices masterServices;
   private NormalizerConfiguration normalizerConfiguration;
@@ -534,8 +534,6 @@ class SimpleRegionNormalizer implements RegionNormalizer, ConfigurationObserver 
         currentConfiguration.getMergeMinRegionAge(), mergeMinRegionAge);
       logConfigurationUpdated(MERGE_MIN_REGION_SIZE_MB_KEY,
         currentConfiguration.getMergeMinRegionSizeMb(), mergeMinRegionSizeMb);
-      logConfigurationUpdated(CUMULATIVE_SIZE_LIMIT_MB_KEY,
-        currentConfiguration.getCumulativePlansSizeLimitMb(), cumulativePlansSizeLimitMb);
     }
 
     public Configuration getConf() {
@@ -599,7 +597,7 @@ class SimpleRegionNormalizer implements RegionNormalizer, ConfigurationObserver 
       return mergeMinRegionSizeMb;
     }
 
-    public long getCumulativePlansSizeLimitMb() {
+    private long getCumulativePlansSizeLimitMb() {
       return cumulativePlansSizeLimitMb;
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SplitNormalizationPlan.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SplitNormalizationPlan.java
@@ -46,6 +46,11 @@ final class SplitNormalizationPlan implements NormalizationPlan {
   }
 
   @Override
+  public long getPlanSizeMb() {
+    return splitTarget.getRegionSizeMb();
+  }
+
+  @Override
   public String toString() {
     return new ToStringBuilder(this, ToStringStyle.SHORT_PREFIX_STYLE)
       .append("splitTarget", splitTarget).toString();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
@@ -18,8 +18,7 @@
 package org.apache.hadoop.hbase.master.normalizer;
 
 import static java.lang.String.format;
-import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.CUMULATIVE_MERGE_SIZE_LIMIT_MB_KEY;
-import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.CUMULATIVE_SPLIT_SIZE_LIMIT_MB_KEY;
+import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.CUMULATIVE_SIZE_LIMIT_MB_KEY;
 import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.DEFAULT_MERGE_MIN_REGION_AGE_DAYS;
 import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.MERGE_ENABLED_KEY;
 import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.MERGE_MIN_REGION_AGE_DAYS_KEY;
@@ -613,35 +612,34 @@ public class TestSimpleRegionNormalizer {
   @Test
   public void testMergeSizeLimit() {
     conf.setBoolean(SPLIT_ENABLED_KEY, false);
-    conf.setLong(CUMULATIVE_MERGE_SIZE_LIMIT_MB_KEY, 5);
+    conf.setLong(CUMULATIVE_SIZE_LIMIT_MB_KEY, 5);
     final TableName tableName = name.getTableName();
     final List<RegionInfo> regionInfos = createRegionInfos(tableName, 6);
-    final Map<byte[], Integer> regionSizes =
-      createRegionSizesMap(regionInfos,1, 1, 1, 1, 1, 1);
+    final Map<byte[], Integer> regionSizes = createRegionSizesMap(regionInfos, 1, 1, 1, 1, 1, 1);
     setupMocksForNormalizer(regionSizes, regionInfos);
     when(tableDescriptor.getNormalizerTargetRegionSize()).thenReturn(2L);
 
     assertTrue(normalizer.isMergeEnabled());
     assertFalse(normalizer.isSplitEnabled());
-    assertThat(normalizer.computePlansForTable(tableDescriptor),
-      hasSize(2)); // creates 2 merge plans, even though there are 3 otherwise eligible pairs of regions
+    // creates 2 merge plans, even though there are 3 otherwise eligible pairs of regions
+    assertThat(normalizer.computePlansForTable(tableDescriptor), hasSize(2));
   }
 
   @Test
   public void testSplitSizeLimit() {
     conf.setBoolean(MERGE_ENABLED_KEY, false);
-    conf.setLong(CUMULATIVE_SPLIT_SIZE_LIMIT_MB_KEY, 10);
+    conf.setLong(CUMULATIVE_SIZE_LIMIT_MB_KEY, 10);
     final TableName tableName = name.getTableName();
     final List<RegionInfo> regionInfos = createRegionInfos(tableName, 4);
-    final Map<byte[], Integer> regionSizes =
-      createRegionSizesMap(regionInfos, 3, 3, 3, 3);
+    final Map<byte[], Integer> regionSizes = createRegionSizesMap(regionInfos, 3, 3, 3, 3);
     setupMocksForNormalizer(regionSizes, regionInfos);
     when(tableDescriptor.getNormalizerTargetRegionSize()).thenReturn(1L);
 
     assertTrue(normalizer.isSplitEnabled());
     assertFalse(normalizer.isMergeEnabled());
-    assertThat(normalizer.computePlansForTable(tableDescriptor),
-      hasSize(3));  // the plan includes only 3 regions, even though the table has 4 otherwise split-eligible regions
+    // the plan includes only 3 regions, even though the table has 4 otherwise split-eligible
+    // regions
+    assertThat(normalizer.computePlansForTable(tableDescriptor), hasSize(3));
   }
 
   @SuppressWarnings("MockitoCast")

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.master.normalizer;
 
 import static java.lang.String.format;
-import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.CUMULATIVE_SIZE_LIMIT_MB_KEY;
+import static org.apache.hadoop.hbase.master.normalizer.RegionNormalizerWorker.CUMULATIVE_SIZE_LIMIT_MB_KEY;
 import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.DEFAULT_MERGE_MIN_REGION_AGE_DAYS;
 import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.MERGE_ENABLED_KEY;
 import static org.apache.hadoop.hbase.master.normalizer.SimpleRegionNormalizer.MERGE_MIN_REGION_AGE_DAYS_KEY;


### PR DESCRIPTION
This PR adds the new setting `hbase.normalizer.plans_size_limit.mb`. This setting limit the number of plans processed by RegionNormalizerWorker, by forcing it to stop processing plans once the cumulative region size limits are exceeded.