### PR TITLE
HBASE-27492 support through all day offPeak to cover all the usage scenario

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/OffPeakHours.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/OffPeakHours.java
@@ -46,7 +46,7 @@ public abstract class OffPeakHours {
 
   /**
    * @param startHour inclusive
-   * @param endHour   exclusive
+   * @param endHour   inclusive
    */
   public static OffPeakHours getInstance(int startHour, int endHour) {
     if (startHour == -1 && endHour == -1) {
@@ -84,7 +84,7 @@ public abstract class OffPeakHours {
 
     /**
      * @param startHour inclusive
-     * @param endHour   exclusive
+     * @param endHour   inclusive
      */
     OffPeakHoursImpl(int startHour, int endHour) {
       this.startHour = startHour;
@@ -99,7 +99,7 @@ public abstract class OffPeakHours {
     @Override
     public boolean isOffPeakHour(int targetHour) {
       if (startHour <= endHour) {
-        return startHour <= targetHour && targetHour < endHour;
+        return startHour <= targetHour && targetHour <= endHour;
       }
       return targetHour < endHour || startHour <= targetHour;
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestOffPeakHours.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestOffPeakHours.java
@@ -49,6 +49,8 @@ public class TestOffPeakHours {
   private int hourPlusOne;
   private int hourMinusOne;
   private int hourMinusTwo;
+  private int hourAllDayStart;
+  private int hourAllDayEnd;
   private Configuration conf;
 
   @Before
@@ -57,6 +59,8 @@ public class TestOffPeakHours {
     hourPlusOne = ((hourOfDay + 1) % 24);
     hourMinusOne = ((hourOfDay - 1 + 24) % 24);
     hourMinusTwo = ((hourOfDay - 2 + 24) % 24);
+    hourAllDayStart = 0;
+    hourAllDayEnd = 23;
     conf = testUtil.getConfiguration();
   }
 
@@ -81,5 +85,15 @@ public class TestOffPeakHours {
     conf.setLong(CompactionConfiguration.HBASE_HSTORE_OFFPEAK_END_HOUR, hourMinusOne);
     OffPeakHours target = OffPeakHours.getInstance(conf);
     assertFalse(target.isOffPeakHour(hourOfDay));
+  }
+
+  @Test
+  public void testSetPeakHourAllDay() {
+    conf.setLong(CompactionConfiguration.HBASE_HSTORE_OFFPEAK_START_HOUR, hourAllDayStart);
+    conf.setLong(CompactionConfiguration.HBASE_HSTORE_OFFPEAK_END_HOUR, hourAllDayEnd);
+    OffPeakHours target = OffPeakHours.getInstance(conf);
+    assertTrue(target.isOffPeakHour(hourAllDayStart));
+    assertTrue(target.isOffPeakHour(hourOfDay));
+    assertTrue(target.isOffPeakHour(hourAllDayEnd));
   }
 }


### PR DESCRIPTION
fix the bug for scenario not cover all the usage

I just want all day 0-24 offpeak, I cannot just change my configuration to achieve it, no peak configuration here.
I cannot set hbase.offpeak.end.hour=24, because not vailded.

support through all day offPeak to cover all the usage scenario only when including the end hour 23

