### PR TITLE
HBASE-27494: Fix missing meta cache dropping exception metrics

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRequestFutureImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRequestFutureImpl.java
@@ -912,6 +912,10 @@ class AsyncRequestFutureImpl<CResult> implements AsyncRequestFuture {
     if (ClientExceptionsUtil.isMetaClearingException(regionException)) {
       // We want to make sure to clear the cache in case there were location-related exceptions.
       // We don't to clear the cache for every possible exception that comes through, however.
+      MetricsConnection metrics = asyncProcess.connection.getConnectionMetrics();
+      if (metrics != null){
+        metrics.incrCacheDroppingExceptions(regionException);
+      }
       asyncProcess.connection.clearCaches(server);
     }
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRequestFutureImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRequestFutureImpl.java
@@ -913,7 +913,7 @@ class AsyncRequestFutureImpl<CResult> implements AsyncRequestFuture {
       // We want to make sure to clear the cache in case there were location-related exceptions.
       // We don't to clear the cache for every possible exception that comes through, however.
       MetricsConnection metrics = asyncProcess.connection.getConnectionMetrics();
-      if (metrics != null){
+      if (metrics != null) {
         metrics.incrCacheDroppingExceptions(regionException);
       }
       asyncProcess.connection.clearCaches(server);


### PR DESCRIPTION
In this one instance, the meta cache dropping exception metric is not tracked. 

cc: @bbeaudreault 