### PR TITLE
HBASE-27529 Provide RS coproc ability to attach WAL extended attributes to mutations at replication sink

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
@@ -154,4 +154,19 @@ public interface RegionServerObserver {
     Mutation mutation) throws IOException {
 
   }
+
+  /**
+   * This will be called after replication sink mutations are executed on the sink table as part of
+   * batch call.
+   * @param ctx      the environment to interact with the framework and region server.
+   * @param walEntry wal entry from which mutation is formed.
+   * @param mutation mutation to be applied at sink cluster.
+   * @throws IOException if something goes wrong.
+   */
+  default void postReplicationSinkBatchMutate(
+    ObserverContext<RegionServerCoprocessorEnvironment> ctx, AdminProtos.WALEntry walEntry,
+    Mutation mutation) throws IOException {
+
+  }
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
@@ -19,9 +19,12 @@ package org.apache.hadoop.hbase.coprocessor;
 
 import java.io.IOException;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.replication.ReplicationEndpoint;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos;
 
 /**
  * Defines coprocessor hooks for interacting with operations on the
@@ -136,5 +139,19 @@ public interface RegionServerObserver {
    */
   default void postExecuteProcedures(ObserverContext<RegionServerCoprocessorEnvironment> ctx)
     throws IOException {
+  }
+
+  /**
+   * This will be called before replication sink mutations are executed on the sink table as part of
+   * batch call.
+   * @param ctx      the environment to interact with the framework and region server.
+   * @param walEntry wal entry from which mutation is formed.
+   * @param mutation mutation to be applied at sink cluster.
+   * @throws IOException if something goes wrong.
+   */
+  default void preReplicationSinkBatchMutate(
+    ObserverContext<RegionServerCoprocessorEnvironment> ctx, AdminProtos.WALEntry walEntry,
+    Mutation mutation) throws IOException {
+
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerCoprocessorHost.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerCoprocessorHost.java
@@ -22,6 +22,7 @@ import java.lang.reflect.InvocationTargetException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.SharedConnection;
 import org.apache.hadoop.hbase.coprocessor.BaseEnvironment;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
@@ -39,6 +40,8 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.protobuf.Service;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos;
 
 @InterfaceAudience.Private
 public class RegionServerCoprocessorHost
@@ -162,6 +165,16 @@ public class RegionServerCoprocessorHost
       @Override
       public void call(RegionServerObserver observer) throws IOException {
         observer.postReplicateLogEntries(this);
+      }
+    });
+  }
+
+  public void preReplicationSinkBatchMutate(AdminProtos.WALEntry walEntry, Mutation mutation)
+    throws IOException {
+    execOperation(coprocEnvironments.isEmpty() ? null : new RegionServerObserverOperation() {
+      @Override
+      public void call(RegionServerObserver observer) throws IOException {
+        observer.preReplicationSinkBatchMutate(this, walEntry, mutation);
       }
     });
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerCoprocessorHost.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerCoprocessorHost.java
@@ -179,6 +179,16 @@ public class RegionServerCoprocessorHost
     });
   }
 
+  public void postReplicationSinkBatchMutate(AdminProtos.WALEntry walEntry, Mutation mutation)
+    throws IOException {
+    execOperation(coprocEnvironments.isEmpty() ? null : new RegionServerObserverOperation() {
+      @Override
+      public void call(RegionServerObserver observer) throws IOException {
+        observer.postReplicationSinkBatchMutate(this, walEntry, mutation);
+      }
+    });
+  }
+
   public ReplicationEndpoint postCreateReplicationEndPoint(final ReplicationEndpoint endpoint)
     throws IOException {
     if (this.coprocEnvironments.isEmpty()) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/ReplicationSinkServiceImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/ReplicationSinkServiceImpl.java
@@ -28,6 +28,8 @@ import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.ScheduledChore;
 import org.apache.hadoop.hbase.Server;
 import org.apache.hadoop.hbase.Stoppable;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.regionserver.RegionServerCoprocessorHost;
 import org.apache.hadoop.hbase.regionserver.ReplicationSinkService;
 import org.apache.hadoop.hbase.replication.regionserver.ReplicationLoad;
 import org.apache.hadoop.hbase.replication.regionserver.ReplicationSink;
@@ -57,8 +59,12 @@ public class ReplicationSinkServiceImpl implements ReplicationSinkService {
   public void replicateLogEntries(List<AdminProtos.WALEntry> entries, CellScanner cells,
     String replicationClusterId, String sourceBaseNamespaceDirPath,
     String sourceHFileArchiveDirPath) throws IOException {
+    RegionServerCoprocessorHost rsServerHost = null;
+    if (server instanceof HRegionServer) {
+      rsServerHost = ((HRegionServer) server).getRegionServerCoprocessorHost();
+    }
     this.replicationSink.replicateEntries(entries, cells, replicationClusterId,
-      sourceBaseNamespaceDirPath, sourceHFileArchiveDirPath);
+      sourceBaseNamespaceDirPath, sourceHFileArchiveDirPath, rsServerHost);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/ReplicationSinkServiceImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/ReplicationSinkServiceImpl.java
@@ -59,12 +59,8 @@ public class ReplicationSinkServiceImpl implements ReplicationSinkService {
   public void replicateLogEntries(List<AdminProtos.WALEntry> entries, CellScanner cells,
     String replicationClusterId, String sourceBaseNamespaceDirPath,
     String sourceHFileArchiveDirPath) throws IOException {
-    RegionServerCoprocessorHost rsServerHost = null;
-    if (server instanceof HRegionServer) {
-      rsServerHost = ((HRegionServer) server).getRegionServerCoprocessorHost();
-    }
     this.replicationSink.replicateEntries(entries, cells, replicationClusterId,
-      sourceBaseNamespaceDirPath, sourceHFileArchiveDirPath, rsServerHost);
+      sourceBaseNamespaceDirPath, sourceHFileArchiveDirPath);
   }
 
   @Override
@@ -78,7 +74,11 @@ public class ReplicationSinkServiceImpl implements ReplicationSinkService {
 
   @Override
   public void startReplicationService() throws IOException {
-    this.replicationSink = new ReplicationSink(this.conf);
+    RegionServerCoprocessorHost rsServerHost = null;
+    if (server instanceof HRegionServer) {
+      rsServerHost = ((HRegionServer) server).getRegionServerCoprocessorHost();
+    }
+    this.replicationSink = new ReplicationSink(this.conf, rsServerHost);
     this.server.getChoreService().scheduleChore(new ReplicationStatisticsChore(
       "ReplicationSinkStatistics", server, (int) TimeUnit.SECONDS.toMillis(statsPeriodInSecond)));
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
@@ -114,13 +114,17 @@ public class ReplicationSink {
   private final int rowSizeWarnThreshold;
   private boolean replicationSinkTrackerEnabled;
 
+  private final RegionServerCoprocessorHost rsServerHost;
+
   /**
    * Create a sink for replication
    * @param conf conf object
    * @throws IOException thrown when HDFS goes bad or bad file name
    */
-  public ReplicationSink(Configuration conf) throws IOException {
+  public ReplicationSink(Configuration conf, RegionServerCoprocessorHost rsServerHost)
+    throws IOException {
     this.conf = HBaseConfiguration.create(conf);
+    this.rsServerHost = rsServerHost;
     rowSizeWarnThreshold =
       conf.getInt(HConstants.BATCH_ROWS_THRESHOLD_NAME, HConstants.BATCH_ROWS_THRESHOLD_DEFAULT);
     replicationSinkTrackerEnabled = conf.getBoolean(REPLICATION_SINK_TRACKER_ENABLED_KEY,
@@ -186,12 +190,11 @@ public class ReplicationSink {
    * @param sourceBaseNamespaceDirPath Path that point to the source cluster base namespace
    *                                   directory
    * @param sourceHFileArchiveDirPath  Path that point to the source cluster hfile archive directory
-   * @param rsServerHost               regionserver coproc host.
    * @throws IOException If failed to replicate the data
    */
   public void replicateEntries(List<WALEntry> entries, final CellScanner cells,
     String replicationClusterId, String sourceBaseNamespaceDirPath,
-    String sourceHFileArchiveDirPath, RegionServerCoprocessorHost rsServerHost) throws IOException {
+    String sourceHFileArchiveDirPath) throws IOException {
     if (entries.isEmpty()) {
       return;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
@@ -219,6 +219,7 @@ public class ReplicationSink {
         Cell previousCell = null;
         Mutation mutation = null;
         int count = entry.getAssociatedCellCount();
+        List<WALProtos.Attribute> attributeList = entry.getKey().getExtendedAttributesList();
         for (int i = 0; i < count; i++) {
           // Throw index out of bounds if our cell count is off
           if (!cells.advance()) {
@@ -265,6 +266,11 @@ public class ReplicationSink {
               mutation.setClusterIds(clusterIds);
               mutation.setAttribute(ReplicationUtils.REPLICATION_ATTR_NAME,
                 HConstants.EMPTY_BYTE_ARRAY);
+              if (attributeList != null) {
+                for (WALProtos.Attribute attribute : attributeList) {
+                  mutation.setAttribute(attribute.getKey(), attribute.getValue().toByteArray());
+                }
+              }
               addToHashMultiMap(rowMap, table, clusterIds, mutation);
             }
             if (CellUtil.isDelete(cell)) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
@@ -179,11 +179,14 @@ public class ReplicationSink {
   /**
    * Replicate this array of entries directly into the local cluster using the native client. Only
    * operates against raw protobuf type saving on a conversion from pb to pojo.
+   * @param entries                    WAL entries to be replicated.
+   * @param cells                      cell scanner for iteration.
    * @param replicationClusterId       Id which will uniquely identify source cluster FS client
    *                                   configurations in the replication configuration directory
    * @param sourceBaseNamespaceDirPath Path that point to the source cluster base namespace
    *                                   directory
    * @param sourceHFileArchiveDirPath  Path that point to the source cluster hfile archive directory
+   * @param rsServerHost               regionserver coproc host.
    * @throws IOException If failed to replicate the data
    */
   public void replicateEntries(List<WALEntry> entries, final CellScanner cells,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSink.java
@@ -227,7 +227,6 @@ public class ReplicationSink {
         Cell previousCell = null;
         Mutation mutation = null;
         int count = entry.getAssociatedCellCount();
-        List<WALProtos.Attribute> attributeList = entry.getKey().getExtendedAttributesList();
         for (int i = 0; i < count; i++) {
           // Throw index out of bounds if our cell count is off
           if (!cells.advance()) {
@@ -275,6 +274,8 @@ public class ReplicationSink {
               mutation.setAttribute(ReplicationUtils.REPLICATION_ATTR_NAME,
                 HConstants.EMPTY_BYTE_ARRAY);
               if (this.conf.getBoolean(HBASE_REPLICATION_SINK_ATTRIBUTES_WAL_TO_MUTATIONS, false)) {
+                List<WALProtos.Attribute> attributeList =
+                  entry.getKey().getExtendedAttributesList();
                 attachWALExtendedAttributesToMutation(mutation, attributeList);
               }
               addToHashMultiMap(rowMap, table, clusterIds, mutation);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithWALExtendedAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithWALExtendedAttributes.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.RegionObserver;
 import org.apache.hadoop.hbase.regionserver.MiniBatchOperationInProgress;
+import org.apache.hadoop.hbase.replication.regionserver.ReplicationSink;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -125,6 +126,7 @@ public class TestReplicationWithWALExtendedAttributes {
     conf2.setStrings(HConstants.REPLICATION_CODEC_CONF_KEY, KeyValueCodecWithTags.class.getName());
     conf2.setStrings(CoprocessorHost.USER_REGION_COPROCESSOR_CONF_KEY,
       TestCoprocessorForWALAnnotationAtSink.class.getName());
+    conf2.setBoolean(ReplicationSink.HBASE_REPLICATION_SINK_ATTRIBUTES_WAL_TO_MUTATIONS, true);
 
     utility2 = new HBaseTestingUtil(conf2);
     utility2.setZkCluster(miniZK);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithWALExtendedAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithWALExtendedAttributes.java
@@ -282,6 +282,15 @@ public class TestReplicationWithWALExtendedAttributes {
       attachWALExtendedAttributesToMutation(mutation, attributeList);
     }
 
+    @Override
+    public void postReplicationSinkBatchMutate(
+      ObserverContext<RegionServerCoprocessorEnvironment> ctx, AdminProtos.WALEntry walEntry,
+      Mutation mutation) throws IOException {
+      RegionServerObserver.super.postReplicationSinkBatchMutate(ctx, walEntry, mutation);
+      LOG.info("WALEntry extended attributes: {}", walEntry.getKey().getExtendedAttributesList());
+      LOG.info("Mutation attributes: {}", mutation.getAttributesMap());
+    }
+
     private void attachWALExtendedAttributesToMutation(Mutation mutation,
       List<WALProtos.Attribute> attributeList) {
       if (attributeList != null) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithWALExtendedAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithWALExtendedAttributes.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.replication;
+
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.codec.KeyValueCodecWithTags;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.RegionObserver;
+import org.apache.hadoop.hbase.regionserver.MiniBatchOperationInProgress;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.ReplicationTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.wal.WALEdit;
+import org.apache.hadoop.hbase.wal.WALKey;
+import org.apache.hadoop.hbase.zookeeper.MiniZooKeeperCluster;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.io.Closeables;
+
+@Category({ ReplicationTests.class, MediumTests.class })
+public class TestReplicationWithWALExtendedAttributes {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestReplicationWithWALExtendedAttributes.class);
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestReplicationWithWALExtendedAttributes.class);
+
+  private static Configuration conf1 = HBaseConfiguration.create();
+
+  private static Admin replicationAdmin;
+
+  private static Connection connection1;
+
+  private static Table htable1;
+  private static Table htable2;
+
+  private static HBaseTestingUtil utility1;
+  private static HBaseTestingUtil utility2;
+  private static final long SLEEP_TIME = 500;
+  private static final int NB_RETRIES = 10;
+
+  private static final TableName TABLE_NAME = TableName.valueOf("TestReplicationWithWALAnnotation");
+  private static final byte[] FAMILY = Bytes.toBytes("f");
+  private static final byte[] ROW = Bytes.toBytes("row");
+  private static final byte[] ROW2 = Bytes.toBytes("row2");
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    conf1.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/1");
+    conf1.setInt("replication.source.size.capacity", 10240);
+    conf1.setLong("replication.source.sleepforretries", 100);
+    conf1.setInt("hbase.regionserver.maxlogs", 10);
+    conf1.setLong("hbase.master.logcleaner.ttl", 10);
+    conf1.setInt("zookeeper.recovery.retry", 1);
+    conf1.setInt("zookeeper.recovery.retry.intervalmill", 10);
+    conf1.setLong(HConstants.THREAD_WAKE_FREQUENCY, 100);
+    conf1.setInt("replication.stats.thread.period.seconds", 5);
+    conf1.setBoolean("hbase.tests.use.shortcircuit.reads", false);
+    conf1.setStrings(HConstants.REPLICATION_CODEC_CONF_KEY, KeyValueCodecWithTags.class.getName());
+    conf1.setStrings(CoprocessorHost.USER_REGION_COPROCESSOR_CONF_KEY,
+      TestCoprocessorForWALAnnotationAtSource.class.getName());
+
+    utility1 = new HBaseTestingUtil(conf1);
+    utility1.startMiniZKCluster();
+    MiniZooKeeperCluster miniZK = utility1.getZkCluster();
+    // Have to reget conf1 in case zk cluster location different
+    // than default
+    conf1 = utility1.getConfiguration();
+    LOG.info("Setup first Zk");
+
+    // Base conf2 on conf1 so it gets the right zk cluster.
+    Configuration conf2 = HBaseConfiguration.create(conf1);
+    conf2.setInt("hfile.format.version", 3);
+    conf2.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/2");
+    conf2.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 6);
+    conf2.setBoolean("hbase.tests.use.shortcircuit.reads", false);
+    conf2.setStrings(HConstants.REPLICATION_CODEC_CONF_KEY, KeyValueCodecWithTags.class.getName());
+    conf2.setStrings(CoprocessorHost.USER_REGION_COPROCESSOR_CONF_KEY,
+      TestCoprocessorForWALAnnotationAtSink.class.getName());
+
+    utility2 = new HBaseTestingUtil(conf2);
+    utility2.setZkCluster(miniZK);
+
+    LOG.info("Setup second Zk");
+    utility1.startMiniCluster(2);
+    utility2.startMiniCluster(2);
+
+    connection1 = ConnectionFactory.createConnection(conf1);
+    replicationAdmin = connection1.getAdmin();
+    ReplicationPeerConfig rpc =
+      ReplicationPeerConfig.newBuilder().setClusterKey(utility2.getClusterKey()).build();
+    replicationAdmin.addReplicationPeer("2", rpc);
+
+    TableDescriptor tableDescriptor = TableDescriptorBuilder.newBuilder(TABLE_NAME)
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(FAMILY).setMaxVersions(3)
+        .setScope(HConstants.REPLICATION_SCOPE_GLOBAL).build())
+      .build();
+    try (Connection conn = ConnectionFactory.createConnection(conf1);
+      Admin admin = conn.getAdmin()) {
+      admin.createTable(tableDescriptor, HBaseTestingUtil.KEYS_FOR_HBA_CREATE_TABLE);
+    }
+    try (Connection conn = ConnectionFactory.createConnection(conf2);
+      Admin admin = conn.getAdmin()) {
+      admin.createTable(tableDescriptor, HBaseTestingUtil.KEYS_FOR_HBA_CREATE_TABLE);
+    }
+    htable1 = utility1.getConnection().getTable(TABLE_NAME);
+    htable2 = utility2.getConnection().getTable(TABLE_NAME);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    Closeables.close(replicationAdmin, true);
+    Closeables.close(connection1, true);
+    utility2.shutdownMiniCluster();
+    utility1.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testReplicationWithWALExtendedAttributes() throws Exception {
+    Put put = new Put(ROW);
+    put.addColumn(FAMILY, ROW, ROW);
+
+    htable1 = utility1.getConnection().getTable(TABLE_NAME);
+    htable1.put(put);
+
+    Put put2 = new Put(ROW2);
+    put2.addColumn(FAMILY, ROW2, ROW2);
+
+    htable1.batch(Collections.singletonList(put2), new Object[1]);
+
+    assertGetValues(new Get(ROW), ROW);
+    assertGetValues(new Get(ROW2), ROW2);
+  }
+
+  private static void assertGetValues(Get get, byte[] value)
+    throws IOException, InterruptedException {
+    for (int i = 0; i < NB_RETRIES; i++) {
+      if (i == NB_RETRIES - 1) {
+        fail("Waited too much time for put replication");
+      }
+      Result res = htable2.get(get);
+      if (res.isEmpty()) {
+        LOG.info("Row not available");
+        Thread.sleep(SLEEP_TIME);
+      } else {
+        assertArrayEquals(value, res.value());
+        break;
+      }
+    }
+  }
+
+  public static class TestCoprocessorForWALAnnotationAtSource
+    implements RegionCoprocessor, RegionObserver {
+
+    @Override
+    public Optional<RegionObserver> getRegionObserver() {
+      return Optional.of(this);
+    }
+
+    @Override
+    public void preWALAppend(ObserverContext<RegionCoprocessorEnvironment> ctx, WALKey key,
+      WALEdit edit) throws IOException {
+      key.addExtendedAttribute("extendedAttr1", Bytes.toBytes("Value of Extended attribute 01"));
+      key.addExtendedAttribute("extendedAttr2", Bytes.toBytes("Value of Extended attribute 02"));
+    }
+  }
+
+  public static class TestCoprocessorForWALAnnotationAtSink
+    implements RegionCoprocessor, RegionObserver {
+
+    @Override
+    public Optional<RegionObserver> getRegionObserver() {
+      return Optional.of(this);
+    }
+
+    @Override
+    public void prePut(ObserverContext<RegionCoprocessorEnvironment> c, Put put, WALEdit edit)
+      throws IOException {
+      String attrVal1 = Bytes.toString(put.getAttribute("extendedAttr1"));
+      String attrVal2 = Bytes.toString(put.getAttribute("extendedAttr2"));
+      if (attrVal1 == null || attrVal2 == null) {
+        throw new IOException("Failed to retrieve WAL annotations");
+      }
+      if (
+        attrVal1.equals("Value of Extended attribute 01")
+          && attrVal2.equals("Value of Extended attribute 02")
+      ) {
+        return;
+      }
+      throw new IOException("Failed to retrieve WAL annotations..");
+    }
+
+    @Override
+    public void preBatchMutate(ObserverContext<RegionCoprocessorEnvironment> c,
+      MiniBatchOperationInProgress<Mutation> miniBatchOp) throws IOException {
+      String attrVal1 = Bytes.toString(miniBatchOp.getOperation(0).getAttribute("extendedAttr1"));
+      String attrVal2 = Bytes.toString(miniBatchOp.getOperation(0).getAttribute("extendedAttr2"));
+      if (attrVal1 == null || attrVal2 == null) {
+        throw new IOException("Failed to retrieve WAL annotations");
+      }
+      if (
+        attrVal1.equals("Value of Extended attribute 01")
+          && attrVal2.equals("Value of Extended attribute 02")
+      ) {
+        return;
+      }
+      throw new IOException("Failed to retrieve WAL annotations..");
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSink.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestReplicationSink.java
@@ -167,7 +167,7 @@ public class TestReplicationSink {
       entries.add(createEntry(TABLE_NAME1, i, KeyValue.Type.Put, cells));
     }
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-      replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+      replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
     Scan scan = new Scan();
     ResultScanner scanRes = table1.getScanner(scan);
     assertEquals(BATCH_SIZE, scanRes.next(BATCH_SIZE).length);
@@ -184,7 +184,7 @@ public class TestReplicationSink {
       entries.add(createEntry(TABLE_NAME1, i, KeyValue.Type.Put, cells));
     }
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells), replicationClusterId,
-      baseNamespaceDir, hfileArchiveDir);
+      baseNamespaceDir, hfileArchiveDir, null);
 
     entries = new ArrayList<>(BATCH_SIZE);
     cells = new ArrayList<>();
@@ -194,7 +194,7 @@ public class TestReplicationSink {
     }
 
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-      replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+      replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
     Scan scan = new Scan();
     ResultScanner scanRes = table1.getScanner(scan);
     assertEquals(BATCH_SIZE / 2, scanRes.next(BATCH_SIZE).length);
@@ -208,7 +208,7 @@ public class TestReplicationSink {
       entries.add(createEntry(TABLE_NAME1, i, KeyValue.Type.Put, cells));
     }
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells), replicationClusterId,
-      baseNamespaceDir, hfileArchiveDir);
+      baseNamespaceDir, hfileArchiveDir, null);
 
     ResultScanner resultScanner = table1.getScanner(new Scan());
     int totalRows = 0;
@@ -224,7 +224,7 @@ public class TestReplicationSink {
         i % 2 != 0 ? KeyValue.Type.Put : KeyValue.Type.DeleteColumn, cells));
     }
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells), replicationClusterId,
-      baseNamespaceDir, hfileArchiveDir);
+      baseNamespaceDir, hfileArchiveDir, null);
     resultScanner = table1.getScanner(new Scan());
     totalRows = 0;
     while (resultScanner.next() != null) {
@@ -245,7 +245,7 @@ public class TestReplicationSink {
     }
 
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-      replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+      replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
     Scan scan = new Scan();
     ResultScanner scanRes = table2.getScanner(scan);
     for (Result res : scanRes) {
@@ -268,7 +268,7 @@ public class TestReplicationSink {
       entries.add(createEntry(TABLE_NAME1, i, KeyValue.Type.Put, cells));
     }
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-      replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+      replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
     entries = new ArrayList<>(3);
     cells = new ArrayList<>();
     entries.add(createEntry(TABLE_NAME1, 0, KeyValue.Type.DeleteColumn, cells));
@@ -276,7 +276,7 @@ public class TestReplicationSink {
     entries.add(createEntry(TABLE_NAME1, 2, KeyValue.Type.DeleteColumn, cells));
 
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-      replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+      replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
 
     Scan scan = new Scan();
     ResultScanner scanRes = table1.getScanner(scan);
@@ -299,7 +299,7 @@ public class TestReplicationSink {
       entries.add(createEntry(TABLE_NAME1, i, KeyValue.Type.Put, cells));
     }
     SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-      replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+      replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
     Get get = new Get(Bytes.toBytes(1));
     Result res = table1.get(get);
     assertEquals(0, res.size());
@@ -315,7 +315,7 @@ public class TestReplicationSink {
     }
     try {
       SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-        replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+        replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
       Assert.fail("Should re-throw TableNotFoundException.");
     } catch (TableNotFoundException e) {
     }
@@ -329,7 +329,7 @@ public class TestReplicationSink {
         admin.disableTable(TABLE_NAME1);
         try {
           SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-            replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+            replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
           Assert.fail("Should re-throw RetriesExhaustedWithDetailsException.");
         } catch (RetriesExhaustedException e) {
         } finally {
@@ -410,7 +410,7 @@ public class TestReplicationSink {
     }
     // 7. Replicate the bulk loaded entry
     SINK.replicateEntries(entries, CellUtil.createCellScanner(edit.getCells().iterator()),
-      replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+      replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
     try (ResultScanner scanner = table1.getScanner(new Scan())) {
       // 8. Assert data is replicated
       assertEquals(numRows, scanner.next(numRows).length);
@@ -433,7 +433,7 @@ public class TestReplicationSink {
     cells.clear(); // cause IndexOutOfBoundsException
     try {
       SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-        replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+        replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
       Assert.fail("Should re-throw ArrayIndexOutOfBoundsException.");
     } catch (ArrayIndexOutOfBoundsException e) {
       errorCount++;
@@ -448,7 +448,7 @@ public class TestReplicationSink {
     }
     try {
       SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-        replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+        replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
       Assert.fail("Should re-throw TableNotFoundException.");
     } catch (TableNotFoundException e) {
       errorCount++;
@@ -466,7 +466,7 @@ public class TestReplicationSink {
         admin.disableTable(TABLE_NAME1);
         try {
           SINK.replicateEntries(entries, CellUtil.createCellScanner(cells.iterator()),
-            replicationClusterId, baseNamespaceDir, hfileArchiveDir);
+            replicationClusterId, baseNamespaceDir, hfileArchiveDir, null);
           Assert.fail("Should re-throw IOException.");
         } catch (IOException e) {
           errorCount++;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
@@ -159,7 +159,7 @@ public class TestWALEntrySinkFilter {
       }
     };
     // Call our sink.
-    sink.replicateEntries(entries, cellScanner, null, null, null);
+    sink.replicateEntries(entries, cellScanner, null, null, null, null);
     // Check what made it through and what was filtered.
     assertTrue(FILTERED.get() > 0);
     assertTrue(UNFILTERED.get() > 0);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
@@ -113,7 +113,7 @@ public class TestWALEntrySinkFilter {
       IfTimeIsGreaterThanBOUNDARYWALEntrySinkFilterImpl.class, WALEntrySinkFilter.class);
     conf.setClass(ClusterConnectionFactory.HBASE_SERVER_CLUSTER_CONNECTION_IMPL,
       DevNullAsyncClusterConnection.class, AsyncClusterConnection.class);
-    ReplicationSink sink = new ReplicationSink(conf);
+    ReplicationSink sink = new ReplicationSink(conf, null);
     // Create some dumb walentries.
     List<AdminProtos.WALEntry> entries = new ArrayList<>();
     AdminProtos.WALEntry.Builder entryBuilder = AdminProtos.WALEntry.newBuilder();
@@ -159,7 +159,7 @@ public class TestWALEntrySinkFilter {
       }
     };
     // Call our sink.
-    sink.replicateEntries(entries, cellScanner, null, null, null, null);
+    sink.replicateEntries(entries, cellScanner, null, null, null);
     // Check what made it through and what was filtered.
     assertTrue(FILTERED.get() > 0);
     assertTrue(UNFILTERED.get() > 0);


### PR DESCRIPTION
HBase provides coproc ability to enhance WALKey attributes (a.k.a. WAL annotations) in order for the replication sink cluster to build required metadata with the mutations. The endpoint is preWALAppend(). This ability was provided by HBASE-22622. The map of extended attributes is optional and hence not directly used by hbase internally. 

For any hbase downstreamers to build CDC (Change Data Capture) like functionality, it might required additional metadata in addition to the ones being used by hbase already (replication scope, list of cluster ids, seq id, table name, region id etc). For instance, Phoenix uses many additional attributes like tenant id, schema name, table type etc.
We already have this extended map of attributes available in WAL protobuf, to provide us the capability to (de)serialize it. While creating new ReplicateWALEntryRequest from the list of WAL entires, we are able to serialize the additional attributes. Similarly, at the replication sink side, the deserialized WALEntry has the extended attributes available.

At the sink cluster, we should be able to attach the deserialized extended attributes to the newly generated mutations so that the peer cluster can utilize the mutation attributes to re-build required metadata.