### PR TITLE
HBASE-27536: improve slowlog payload

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/OnlineLogRecord.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/OnlineLogRecord.java
@@ -17,15 +17,22 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import java.util.List;
+import java.util.Optional;
 import org.apache.commons.lang3.builder.EqualsBuilder;
 import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.util.GsonUtil;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.gson.Gson;
+import org.apache.hbase.thirdparty.com.google.gson.JsonElement;
 import org.apache.hbase.thirdparty.com.google.gson.JsonObject;
+import org.apache.hbase.thirdparty.com.google.gson.JsonParser;
 import org.apache.hbase.thirdparty.com.google.gson.JsonSerializer;
 
 /**
@@ -36,13 +43,31 @@ import org.apache.hbase.thirdparty.com.google.gson.JsonSerializer;
 @InterfaceStability.Evolving
 final public class OnlineLogRecord extends LogEntry {
 
-  // used to convert object to pretty printed format
-  // used by toJsonPrettyPrint()
+  private static final Logger LOG = LoggerFactory.getLogger(OnlineLogRecord.class.getName());
+  private static final JsonElement EXCLUDED_NODE = JsonParser.parseString(HConstants.EMPTY_STRING);
+
+  private static JsonElement serializeCatchAll(Operation operation) {
+    try {
+      return JsonParser.parseString(operation.toJSON());
+    } catch (Exception e) {
+      LOG.warn("Suppressing exception during OnlineLogRecord serialization with operation {}",
+        operation, e);
+      return EXCLUDED_NODE;
+    }
+  }
+
+  private static final Gson INNER_GSON = GsonUtil.createGson().setPrettyPrinting()
+    .registerTypeAdapter(Operation.class,
+      (JsonSerializer<
+        Operation>) (operation, type, jsonSerializationContext) -> serializeCatchAll(operation))
+    .registerTypeAdapter(Optional.class,
+      (JsonSerializer<Optional<?>>) (optional, type, jsonSerializationContext) -> optional
+        .map(jsonSerializationContext::serialize).orElse(EXCLUDED_NODE))
+    .create();
   private static final Gson GSON =
     GsonUtil.createGson().setPrettyPrinting().registerTypeAdapter(OnlineLogRecord.class,
       (JsonSerializer<OnlineLogRecord>) (slowLogPayload, type, jsonSerializationContext) -> {
-        Gson gson = new Gson();
-        JsonObject jsonObj = (JsonObject) gson.toJsonTree(slowLogPayload);
+        JsonObject jsonObj = (JsonObject) INNER_GSON.toJsonTree(slowLogPayload);
         if (slowLogPayload.getMultiGetsCount() == 0) {
           jsonObj.remove("multiGetsCount");
         }
@@ -71,6 +96,10 @@ final public class OnlineLogRecord extends LogEntry {
   private final int multiGetsCount;
   private final int multiMutationsCount;
   private final int multiServiceCalls;
+  private final Optional<Scan> scan;
+  private final Optional<List<Operation>> multi;
+  private final Optional<Get> get;
+  private final Optional<Mutation> mutate;
 
   public long getStartTime() {
     return startTime;
@@ -128,11 +157,52 @@ final public class OnlineLogRecord extends LogEntry {
     return multiServiceCalls;
   }
 
-  private OnlineLogRecord(final long startTime, final int processingTime, final int queueTime,
+  /**
+   * If {@value org.apache.hadoop.hbase.HConstants#SLOW_LOG_OPERATION_MESSAGE_PAYLOAD_ENABLED} is
+   * enabled then this value may be present and should represent the Scan that produced the given
+   * {@link OnlineLogRecord}. This value should only be present if {@link #getMulti()},
+   * {@link #getGet()}, and {@link #getMutate()} are empty
+   */
+  public Optional<Scan> getScan() {
+    return scan;
+  }
+
+  /**
+   * If {@value org.apache.hadoop.hbase.HConstants#SLOW_LOG_OPERATION_MESSAGE_PAYLOAD_ENABLED} is
+   * enabled then this value may be present and should represent the MultiRequest that produced the
+   * given {@link OnlineLogRecord}. This value should only be present if {@link #getScan},
+   * {@link #getGet()}, and {@link #getMutate()} are empty
+   */
+  public Optional<List<Operation>> getMulti() {
+    return multi;
+  }
+
+  /**
+   * If {@value org.apache.hadoop.hbase.HConstants#SLOW_LOG_OPERATION_MESSAGE_PAYLOAD_ENABLED} is
+   * enabled then this value may be present and should represent the Get that produced the given
+   * {@link OnlineLogRecord}. This value should only be present if {@link #getScan()},
+   * {@link #getMulti()} ()}, and {@link #getMutate()} are empty
+   */
+  public Optional<Get> getGet() {
+    return get;
+  }
+
+  /**
+   * If {@value org.apache.hadoop.hbase.HConstants#SLOW_LOG_OPERATION_MESSAGE_PAYLOAD_ENABLED} is
+   * enabled then this value may be present and should represent the Mutation that produced the
+   * given {@link OnlineLogRecord}. This value should only be present if {@link #getScan},
+   * {@link #getMulti()} ()}, and {@link #getGet()} ()} are empty
+   */
+  public Optional<Mutation> getMutate() {
+    return mutate;
+  }
+
+  OnlineLogRecord(final long startTime, final int processingTime, final int queueTime,
     final long responseSize, final String clientAddress, final String serverClass,
     final String methodName, final String callDetails, final String param, final String regionName,
     final String userName, final int multiGetsCount, final int multiMutationsCount,
-    final int multiServiceCalls) {
+    final int multiServiceCalls, final Optional<Scan> scan, final Optional<List<Operation>> multi,
+    final Optional<Get> get, final Optional<Mutation> mutate) {
     this.startTime = startTime;
     this.processingTime = processingTime;
     this.queueTime = queueTime;
@@ -147,6 +217,10 @@ final public class OnlineLogRecord extends LogEntry {
     this.multiGetsCount = multiGetsCount;
     this.multiMutationsCount = multiMutationsCount;
     this.multiServiceCalls = multiServiceCalls;
+    this.scan = scan;
+    this.multi = multi;
+    this.get = get;
+    this.mutate = mutate;
   }
 
   public static class OnlineLogRecordBuilder {
@@ -164,6 +238,10 @@ final public class OnlineLogRecord extends LogEntry {
     private int multiGetsCount;
     private int multiMutationsCount;
     private int multiServiceCalls;
+    private Optional<Scan> scan = Optional.empty();
+    private Optional<List<Operation>> multi = Optional.empty();
+    private Optional<Get> get = Optional.empty();
+    private Optional<Mutation> mutate = Optional.empty();
 
     public OnlineLogRecordBuilder setStartTime(long startTime) {
       this.startTime = startTime;
@@ -235,10 +313,30 @@ final public class OnlineLogRecord extends LogEntry {
       return this;
     }
 
+    public OnlineLogRecordBuilder setScan(Scan scan) {
+      this.scan = Optional.of(scan);
+      return this;
+    }
+
+    public OnlineLogRecordBuilder setMulti(List<Operation> multi) {
+      this.multi = Optional.of(multi);
+      return this;
+    }
+
+    public OnlineLogRecordBuilder setGet(Get get) {
+      this.get = Optional.of(get);
+      return this;
+    }
+
+    public OnlineLogRecordBuilder setMutate(Mutation mutate) {
+      this.mutate = Optional.of(mutate);
+      return this;
+    }
+
     public OnlineLogRecord build() {
       return new OnlineLogRecord(startTime, processingTime, queueTime, responseSize, clientAddress,
         serverClass, methodName, callDetails, param, regionName, userName, multiGetsCount,
-        multiMutationsCount, multiServiceCalls);
+        multiMutationsCount, multiServiceCalls, scan, multi, get, mutate);
     }
   }
 
@@ -261,7 +359,8 @@ final public class OnlineLogRecord extends LogEntry {
       .append(multiServiceCalls, that.multiServiceCalls).append(clientAddress, that.clientAddress)
       .append(serverClass, that.serverClass).append(methodName, that.methodName)
       .append(callDetails, that.callDetails).append(param, that.param)
-      .append(regionName, that.regionName).append(userName, that.userName).isEquals();
+      .append(regionName, that.regionName).append(userName, that.userName).append(scan, that.scan)
+      .append(multi, that.multi).append(get, that.get).append(mutate, that.mutate).isEquals();
   }
 
   @Override
@@ -269,7 +368,8 @@ final public class OnlineLogRecord extends LogEntry {
     return new HashCodeBuilder(17, 37).append(startTime).append(processingTime).append(queueTime)
       .append(responseSize).append(clientAddress).append(serverClass).append(methodName)
       .append(callDetails).append(param).append(regionName).append(userName).append(multiGetsCount)
-      .append(multiMutationsCount).append(multiServiceCalls).toHashCode();
+      .append(multiMutationsCount).append(multiServiceCalls).append(scan).append(multi).append(get)
+      .append(mutate).toHashCode();
   }
 
   @Override
@@ -286,7 +386,8 @@ final public class OnlineLogRecord extends LogEntry {
       .append("callDetails", callDetails).append("param", param).append("regionName", regionName)
       .append("userName", userName).append("multiGetsCount", multiGetsCount)
       .append("multiMutationsCount", multiMutationsCount)
-      .append("multiServiceCalls", multiServiceCalls).toString();
+      .append("multiServiceCalls", multiServiceCalls).append("scan", scan).append("multi", multi)
+      .append("get", get).append("mutate", mutate).toString();
   }
 
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/SlowLogParams.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/SlowLogParams.java
@@ -23,6 +23,8 @@ import org.apache.commons.lang3.builder.HashCodeBuilder;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.yetus.audience.InterfaceAudience;
 
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
+
 /**
  * SlowLog params object that contains detailed info as params and region name : to be used for
  * filter purpose
@@ -32,15 +34,63 @@ public class SlowLogParams {
 
   private final String regionName;
   private final String params;
+  private final ClientProtos.Scan scan;
+  private final ClientProtos.MultiRequest multi;
+  private final ClientProtos.Get get;
+  private final ClientProtos.MutationProto mutate;
+
+  public SlowLogParams(String regionName, String params, ClientProtos.Scan scan) {
+    this.regionName = regionName;
+    this.params = params;
+    this.scan = scan;
+    this.multi = null;
+    this.get = null;
+    this.mutate = null;
+  }
+
+  public SlowLogParams(String regionName, String params, ClientProtos.MultiRequest multi) {
+    this.regionName = regionName;
+    this.params = params;
+    this.scan = null;
+    this.multi = multi;
+    this.get = null;
+    this.mutate = null;
+  }
+
+  public SlowLogParams(String regionName, String params, ClientProtos.Get get) {
+    this.regionName = regionName;
+    this.params = params;
+    this.scan = null;
+    this.multi = null;
+    this.get = get;
+    this.mutate = null;
+  }
+
+  public SlowLogParams(String regionName, String params, ClientProtos.MutationProto mutate) {
+    this.regionName = regionName;
+    this.params = params;
+    this.scan = null;
+    this.multi = null;
+    this.get = null;
+    this.mutate = mutate;
+  }
 
   public SlowLogParams(String regionName, String params) {
     this.regionName = regionName;
     this.params = params;
+    this.scan = null;
+    this.multi = null;
+    this.get = null;
+    this.mutate = null;
   }
 
   public SlowLogParams(String params) {
     this.regionName = StringUtils.EMPTY;
     this.params = params;
+    this.scan = null;
+    this.multi = null;
+    this.get = null;
+    this.mutate = null;
   }
 
   public String getRegionName() {
@@ -51,9 +101,26 @@ public class SlowLogParams {
     return params;
   }
 
+  public ClientProtos.Scan getScan() {
+    return scan;
+  }
+
+  public ClientProtos.MultiRequest getMulti() {
+    return multi;
+  }
+
+  public ClientProtos.Get getGet() {
+    return get;
+  }
+
+  public ClientProtos.MutationProto getMutate() {
+    return mutate;
+  }
+
   @Override
   public String toString() {
     return new ToStringBuilder(this).append("regionName", regionName).append("params", params)
+      .append("scan", scan).append("multi", multi).append("get", get).append("mutate", mutate)
       .toString();
   }
 
@@ -67,11 +134,13 @@ public class SlowLogParams {
     }
     SlowLogParams that = (SlowLogParams) o;
     return new EqualsBuilder().append(regionName, that.regionName).append(params, that.params)
-      .isEquals();
+      .append(scan, that.scan).append(multi, that.multi).append(get, that.get)
+      .append(mutate, that.mutate).isEquals();
   }
 
   @Override
   public int hashCode() {
-    return new HashCodeBuilder(17, 37).append(regionName).append(params).toHashCode();
+    return new HashCodeBuilder(17, 37).append(regionName).append(params).append(scan).append(multi)
+      .append(get).append(mutate).toHashCode();
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestOnlineLogRecord.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestOnlineLogRecord.java
@@ -1,0 +1,141 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import com.google.common.collect.ImmutableList;
+import java.util.Optional;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.filter.FirstKeyOnlyFilter;
+import org.apache.hadoop.hbase.testclassification.ClientTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.Assert;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ ClientTests.class, SmallTests.class })
+public class TestOnlineLogRecord {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestOnlineLogRecord.class);
+
+  @Test
+  public void itSerializesScan() {
+    Scan scan = new Scan();
+    scan.withStartRow(Bytes.toBytes(123));
+    scan.withStopRow(Bytes.toBytes(456));
+    String expectedOutput = "{\n" + "  \"startTime\": \"1\",\n" + "  \"processingTime\": 2,\n"
+      + "  \"queueTime\": 3,\n" + "  \"responseSize\": \"4\",\n" + "  \"multiGetsCount\": 5,\n"
+      + "  \"multiMutationsCount\": 6,\n" + "  \"multiServiceCalls\": 7,\n" + "  \"scan\": {\n"
+      + "    \"startRow\": [\n" + "      0,\n" + "      0,\n" + "      0,\n" + "      123\n"
+      + "    ],\n" + "    \"includeStartRow\": true,\n" + "    \"stopRow\": [\n" + "      0,\n"
+      + "      0,\n" + "      1,\n" + "      -56\n" + "    ],\n"
+      + "    \"includeStopRow\": false,\n" + "    \"maxVersions\": 1,\n" + "    \"batch\": -1,\n"
+      + "    \"allowPartialResults\": false,\n" + "    \"storeLimit\": -1,\n"
+      + "    \"storeOffset\": 0,\n" + "    \"caching\": -1,\n" + "    \"maxResultSize\": \"-1\",\n"
+      + "    \"cacheBlocks\": true,\n" + "    \"reversed\": false,\n" + "    \"tr\": {\n"
+      + "      \"minStamp\": \"0\",\n" + "      \"maxStamp\": \"9223372036854775807\",\n"
+      + "      \"allTime\": true\n" + "    },\n" + "    \"familyMap\": {},\n"
+      + "    \"mvccReadPoint\": \"-1\",\n" + "    \"limit\": -1,\n"
+      + "    \"readType\": \"DEFAULT\",\n" + "    \"needCursorResult\": false,\n"
+      + "    \"targetReplicaId\": -1,\n" + "    \"consistency\": \"STRONG\",\n"
+      + "    \"colFamTimeRangeMap\": {},\n" + "    \"priority\": -1\n" + "  }\n" + "}";
+    OnlineLogRecord o = new OnlineLogRecord(1, 2, 3, 4, null, null, null, null, null, null, null, 5,
+      6, 7, Optional.of(scan), Optional.empty(), Optional.empty(), Optional.empty());
+    Assert.assertEquals(o.toJsonPrettyPrint(), expectedOutput);
+  }
+
+  @Test
+  public void itSerializesMulti() {
+    Get get1 = new Get(Bytes.toBytes(123));
+    Get get2 = new Get(Bytes.toBytes(456));
+    get2.setFilter(new FirstKeyOnlyFilter());
+    String expectedOutput = "{\n" + "  \"startTime\": \"1\",\n" + "  \"processingTime\": 2,\n"
+      + "  \"queueTime\": 3,\n" + "  \"responseSize\": \"4\",\n" + "  \"multiGetsCount\": 5,\n"
+      + "  \"multiMutationsCount\": 6,\n" + "  \"multiServiceCalls\": 7,\n" + "  \"multi\": [\n"
+      + "    {\n" + "      \"row\": [\n" + "        0,\n" + "        0,\n" + "        0,\n"
+      + "        123\n" + "      ],\n" + "      \"maxVersions\": 1,\n"
+      + "      \"cacheBlocks\": true,\n" + "      \"storeLimit\": -1,\n"
+      + "      \"storeOffset\": 0,\n" + "      \"tr\": {\n" + "        \"minStamp\": \"0\",\n"
+      + "        \"maxStamp\": \"9223372036854775807\",\n" + "        \"allTime\": true\n"
+      + "      },\n" + "      \"checkExistenceOnly\": false,\n" + "      \"familyMap\": {},\n"
+      + "      \"targetReplicaId\": -1,\n" + "      \"consistency\": \"STRONG\",\n"
+      + "      \"colFamTimeRangeMap\": {},\n" + "      \"priority\": -1\n" + "    },\n" + "    {\n"
+      + "      \"row\": [\n" + "        0,\n" + "        0,\n" + "        1,\n" + "        -56\n"
+      + "      ],\n" + "      \"maxVersions\": 1,\n" + "      \"cacheBlocks\": true,\n"
+      + "      \"storeLimit\": -1,\n" + "      \"storeOffset\": 0,\n" + "      \"tr\": {\n"
+      + "        \"minStamp\": \"0\",\n" + "        \"maxStamp\": \"9223372036854775807\",\n"
+      + "        \"allTime\": true\n" + "      },\n" + "      \"checkExistenceOnly\": false,\n"
+      + "      \"familyMap\": {},\n" + "      \"filter\": {\n" + "        \"foundKV\": false\n"
+      + "      },\n" + "      \"targetReplicaId\": -1,\n" + "      \"consistency\": \"STRONG\",\n"
+      + "      \"colFamTimeRangeMap\": {},\n" + "      \"priority\": -1\n" + "    }\n" + "  ]\n"
+      + "}";
+    OnlineLogRecord o = new OnlineLogRecord(1, 2, 3, 4, null, null, null, null, null, null, null, 5,
+      6, 7, Optional.empty(),
+      Optional.of(ImmutableList.<Operation> builder().add(get1).add(get2).build()),
+      Optional.empty(), Optional.empty());
+    Assert.assertEquals(o.toJsonPrettyPrint(), expectedOutput);
+  }
+
+  @Test
+  public void itSerializesGet() {
+    Get get = new Get(Bytes.toBytes(123));
+    String expectedOutput = "{\n" + "  \"startTime\": \"1\",\n" + "  \"processingTime\": 2,\n"
+      + "  \"queueTime\": 3,\n" + "  \"responseSize\": \"4\",\n" + "  \"multiGetsCount\": 5,\n"
+      + "  \"multiMutationsCount\": 6,\n" + "  \"multiServiceCalls\": 7,\n" + "  \"get\": {\n"
+      + "    \"row\": [\n" + "      0,\n" + "      0,\n" + "      0,\n" + "      123\n" + "    ],\n"
+      + "    \"maxVersions\": 1,\n" + "    \"cacheBlocks\": true,\n" + "    \"storeLimit\": -1,\n"
+      + "    \"storeOffset\": 0,\n" + "    \"tr\": {\n" + "      \"minStamp\": \"0\",\n"
+      + "      \"maxStamp\": \"9223372036854775807\",\n" + "      \"allTime\": true\n" + "    },\n"
+      + "    \"checkExistenceOnly\": false,\n" + "    \"familyMap\": {},\n"
+      + "    \"targetReplicaId\": -1,\n" + "    \"consistency\": \"STRONG\",\n"
+      + "    \"colFamTimeRangeMap\": {},\n" + "    \"priority\": -1\n" + "  }\n" + "}";
+    OnlineLogRecord o = new OnlineLogRecord(1, 2, 3, 4, null, null, null, null, null, null, null, 5,
+      6, 7, Optional.empty(), Optional.empty(), Optional.of(get), Optional.empty());
+    Assert.assertEquals(o.toJsonPrettyPrint(), expectedOutput);
+  }
+
+  @Test
+  public void itSerializesMutate() {
+    Mutation mutate = new Put(Bytes.toBytes(123)).addColumn(Bytes.toBytes(456), Bytes.toBytes(789),
+      Bytes.toBytes(0));
+    String expectedOutput = "{\n" + "  \"startTime\": \"1\",\n" + "  \"processingTime\": 2,\n"
+      + "  \"queueTime\": 3,\n" + "  \"responseSize\": \"4\",\n" + "  \"multiGetsCount\": 5,\n"
+      + "  \"multiMutationsCount\": 6,\n" + "  \"multiServiceCalls\": 7,\n" + "  \"mutate\": {\n"
+      + "    \"row\": [\n" + "      0,\n" + "      0,\n" + "      0,\n" + "      123\n" + "    ],\n"
+      + "    \"ts\": \"9223372036854775807\",\n" + "    \"durability\": \"USE_DEFAULT\",\n"
+      + "    \"familyMap\": {\n" + "      \"[B@1a6e431\": [\n" + "        {\n"
+      + "          \"bytes\": [\n" + "            0,\n" + "            0,\n" + "            0,\n"
+      + "            24,\n" + "            0,\n" + "            0,\n" + "            0,\n"
+      + "            4,\n" + "            0,\n" + "            4,\n" + "            0,\n"
+      + "            0,\n" + "            0,\n" + "            123,\n" + "            4,\n"
+      + "            0,\n" + "            0,\n" + "            1,\n" + "            -56,\n"
+      + "            0,\n" + "            0,\n" + "            3,\n" + "            21,\n"
+      + "            127,\n" + "            -1,\n" + "            -1,\n" + "            -1,\n"
+      + "            -1,\n" + "            -1,\n" + "            -1,\n" + "            -1,\n"
+      + "            4,\n" + "            0,\n" + "            0,\n" + "            0,\n"
+      + "            0\n" + "          ],\n" + "          \"offset\": 0,\n"
+      + "          \"length\": 36,\n" + "          \"seqId\": \"0\"\n" + "        }\n" + "      ]\n"
+      + "    },\n" + "    \"priority\": -1\n" + "  }\n" + "}";
+    OnlineLogRecord o = new OnlineLogRecord(1, 2, 3, 4, null, null, null, null, null, null, null, 5,
+      6, 7, Optional.empty(), Optional.empty(), Optional.empty(), Optional.of(mutate));
+    Assert.assertEquals(o.toJsonPrettyPrint(), expectedOutput);
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1564,6 +1564,10 @@ public final class HConstants {
   // Default 10 mins.
   public static final int DEFAULT_SLOW_LOG_SYS_TABLE_CHORE_DURATION = 10 * 60 * 1000;
 
+  public static final String SLOW_LOG_OPERATION_MESSAGE_PAYLOAD_ENABLED =
+    "hbase.slowlog.operation.message.payload.enabled";
+  public static final boolean SLOW_LOG_OPERATION_MESSAGE_PAYLOAD_ENABLED_DEFAULT = false;
+
   public static final String SHELL_TIMESTAMP_FORMAT_EPOCH_KEY =
     "hbase.shell.timestamp.format.epoch";
 

--- a/hbase-protocol-shaded/src/main/protobuf/server/region/TooSlowLog.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/region/TooSlowLog.proto
@@ -27,6 +27,8 @@ option java_outer_classname = "TooSlowLog";
 option java_generate_equals_and_hash = true;
 option optimize_for = SPEED;
 
+import "client/Client.proto";
+
 message SlowLogPayload {
   required int64 start_time = 1;
   required int32 processing_time = 2;
@@ -43,6 +45,10 @@ message SlowLogPayload {
   optional int32 multi_mutations = 13 [default = 0];
   optional int32 multi_service_calls = 14 [default = 0];
   required Type type = 15;
+  optional Scan scan = 16;
+  optional MultiRequest multi = 17;
+  optional Get get = 18;
+  optional MutationProto mutate = 19;
 
   // SLOW_LOG is RPC call slow in nature whereas LARGE_LOG is RPC call quite large.
   // Majority of times, slow logs are also large logs and hence, ALL is combination of


### PR DESCRIPTION
Related Jira: https://issues.apache.org/jira/browse/HBASE-27536

I've loaded the server changes onto a test host and verified the following two states:
* `hbase.regionserver.slowlog.operation.json.enabled` == false results in an empty string for `operationJson`
* `hbase.regionserver.slowlog.operation.json.enabled` == true results in an `operationJson` as expected.

Here's a picture of the entire `OnlineLogEntry` for a `Mutate` example:
![Screen Shot 2022-12-22 at 1 27 59 PM](https://user-images.githubusercontent.com/21689053/209202941-02324316-cffd-4a84-b027-4ffc397abcfd.png)

And here's a copy of the `operationJson` for a `Scan` example:
```
{
  "filter": "PageFilter 25",
  "startRow": "P\\x00\\x00\\x00",
  "stopRow": "`\\x00\\x00\\x00",
  "batch": -1,
  "cacheBlocks": false,
  "totalColumns": 0,
  "maxResultSize": "4194304",
  "families": {},
  "caching": 2147483647,
  "maxVersions": 1,
  "timeRange": [
    "0",
    "9223372036854775807"
  ]
}
```