### PR TITLE
HBASE-27227 Long running heavily filtered scans hold up too many ByteBuffAllocator buffers

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileInputFormat.java
@@ -90,7 +90,7 @@ public class HFileInputFormat extends FileInputFormat<NullWritable, Cell> {
 
       // The file info must be loaded before the scanner can be used.
       // This seems like a bug in HBase, but it's easily worked around.
-      this.scanner = in.getScanner(conf, false, false);
+      this.scanner = in.getScanner(conf, false, false, false);
 
     }
 

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
@@ -470,7 +470,7 @@ public class TestHFileOutputFormat2 {
         LocatedFileStatus keyFileStatus = iterator.next();
         HFile.Reader reader =
           HFile.createReader(fs, keyFileStatus.getPath(), new CacheConfig(conf), true, conf);
-        HFileScanner scanner = reader.getScanner(conf, false, false, false);
+        HFileScanner scanner = reader.getScanner(conf, false, false, false, false);
 
         kvCount += reader.getEntries();
         scanner.seekTo();
@@ -516,7 +516,7 @@ public class TestHFileOutputFormat2 {
         LocatedFileStatus keyFileStatus = iterator.next();
         HFile.Reader reader =
           HFile.createReader(fs, keyFileStatus.getPath(), new CacheConfig(conf), true, conf);
-        HFileScanner scanner = reader.getScanner(conf, false, false, false);
+        HFileScanner scanner = reader.getScanner(conf, false, false, false, false);
         scanner.seekTo();
         Cell cell = scanner.getCell();
         List<Tag> tagsFromCell = PrivateCellUtil.getTags(cell);

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTSVWithVisibilityLabels.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTSVWithVisibilityLabels.java
@@ -466,7 +466,7 @@ public class TestImportTSVWithVisibilityLabels implements Configurable {
   private static int getKVCountFromHfile(FileSystem fs, Path p) throws IOException {
     Configuration conf = util.getConfiguration();
     HFile.Reader reader = HFile.createReader(fs, p, new CacheConfig(conf), true, conf);
-    HFileScanner scanner = reader.getScanner(conf, false, false);
+    HFileScanner scanner = reader.getScanner(conf, false, false, false);
     scanner.seekTo();
     int count = 0;
     do {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTsv.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTsv.java
@@ -545,7 +545,7 @@ public class TestImportTsv implements Configurable {
   private static int getKVCountFromHfile(FileSystem fs, Path p) throws IOException {
     Configuration conf = util.getConfiguration();
     HFile.Reader reader = HFile.createReader(fs, p, new CacheConfig(conf), true, conf);
-    HFileScanner scanner = reader.getScanner(conf, false, false);
+    HFileScanner scanner = reader.getScanner(conf, false, false, false);
     scanner.seekTo();
     int count = 0;
     do {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -92,8 +92,8 @@ public class HalfStoreFileReader extends StoreFileReader {
 
   @Override
   public HFileScanner getScanner(final boolean cacheBlocks, final boolean pread,
-    final boolean isCompaction) {
-    final HFileScanner s = super.getScanner(cacheBlocks, pread, isCompaction);
+    final boolean isCompaction, boolean checkpointingEnabled) {
+    final HFileScanner s = super.getScanner(cacheBlocks, pread, isCompaction, checkpointingEnabled);
     return new HFileScanner() {
       final HFileScanner delegate = s;
       public boolean atEnd = false;
@@ -325,7 +325,7 @@ public class HalfStoreFileReader extends StoreFileReader {
   @Override
   public Optional<Cell> getFirstKey() {
     if (!firstKeySeeked) {
-      HFileScanner scanner = getScanner(true, true, false);
+      HFileScanner scanner = getScanner(true, true, false, false);
       try {
         if (scanner.seekTo()) {
           this.firstKey = Optional.ofNullable(scanner.getKey());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -283,6 +283,10 @@ public class HalfStoreFileReader extends StoreFileReader {
         this.delegate.checkpoint(state);
       }
 
+      @Override
+      public void retainBlock() {
+        this.delegate.retainBlock();
+      }
     };
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -277,6 +277,12 @@ public class HalfStoreFileReader extends StoreFileReader {
       public void shipped() throws IOException {
         this.delegate.shipped();
       }
+
+      @Override
+      public void checkpoint(State state) {
+        this.delegate.checkpoint(state);
+      }
+
     };
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -390,7 +390,7 @@ public final class HFile {
     CellComparator getComparator();
 
     HFileScanner getScanner(Configuration conf, boolean cacheBlocks, boolean pread,
-      boolean isCompaction);
+      boolean isCompaction, boolean checkpointingEnabled);
 
     HFileBlock getMetaBlock(String metaBlockName, boolean cacheBlock) throws IOException;
 
@@ -420,7 +420,8 @@ public final class HFile {
 
     HFileBlockIndex.ByteArrayKeyBlockIndexReader getMetaBlockIndexReader();
 
-    HFileScanner getScanner(Configuration conf, boolean cacheBlocks, boolean pread);
+    HFileScanner getScanner(Configuration conf, boolean cacheBlocks, boolean pread,
+      boolean checkpointingEnabled);
 
     /**
      * Retrieves general Bloom filter metadata as appropriate for each {@link HFile} version. Knows

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -2070,7 +2070,8 @@ public class HFileBlock implements Cacheable {
     return createBuilder(blk, newBuf).build();
   }
 
-  static HFileBlock deepCloneOnHeap(HFileBlock blk) {
+  // Publicly visible for access in tests
+  public static HFileBlock deepCloneOnHeap(HFileBlock blk) {
     ByteBuff deepCloned = ByteBuff.wrap(ByteBuffer.wrap(blk.buf.toBytes(0, blk.buf.limit())));
     return createBuilder(blk, deepCloned).build();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -310,7 +310,7 @@ public class HFilePrettyPrinter extends Configured implements Tool {
 
     if (verbose || printKey || checkRow || checkFamily || printStats || checkMobIntegrity) {
       // scan over file and read key/value's and check if requested
-      HFileScanner scanner = reader.getScanner(getConf(), false, false, false);
+      HFileScanner scanner = reader.getScanner(getConf(), false, false, false, false);
       fileStats = new KeyValueStatsCollector();
       boolean shouldScanKeysValues;
       if (this.isSeekToRow && !Bytes.equals(row, reader.getFirstRowKey().orElse(null))) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -341,7 +341,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     // any blocks accumulated in the fetching of a row, if that row is thrown away due to filterRow.
     private int lastCheckpointIndex = -1;
 
-    // Updated by retainBlock, when a cell is included from the current block. Is reset whenever
+    // Updated by retainBlock(), when a cell is included from the current block. Is reset whenever
     // curBlock gets updated. Only honored when lastCheckpointIndex >= 0, meaning a checkpoint
     // has occurred.
     private boolean shouldRetainBlock = false;
@@ -1096,6 +1096,10 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
       lastCheckpointIndex = prevBlocks.size();
     }
 
+    /**
+     * Sets state so that when curBlock is finished, it gets added onto prevBlocks. Otherwise, we
+     * eagerly release the block when checkpointing is enabled.
+     */
     @Override
     public void retainBlock() {
       shouldRetainBlock = true;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/procedure2/store/region/HFileProcedurePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/procedure2/store/region/HFileProcedurePrettyPrinter.java
@@ -137,7 +137,7 @@ public class HFileProcedurePrettyPrinter extends AbstractHBaseTool {
     out.println("Scanning -> " + file);
     FileSystem fs = file.getFileSystem(conf);
     try (HFile.Reader reader = HFile.createReader(fs, file, CacheConfig.DISABLED, true, conf);
-      HFileScanner scanner = reader.getScanner(conf, false, false, false)) {
+      HFileScanner scanner = reader.getScanner(conf, false, false, false, false)) {
       if (procId != null) {
         if (
           scanner.seekTo(PrivateCellUtil.createFirstOnRow(Bytes.toBytes(procId.longValue()))) != -1

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
@@ -543,9 +543,9 @@ public class HStoreFile implements StoreFile {
    * Must be called after initReader.
    */
   public StoreFileScanner getPreadScanner(boolean cacheBlocks, long readPt, long scannerOrder,
-    boolean canOptimizeForNonNullColumn) {
+    boolean canOptimizeForNonNullColumn, boolean checkpointingEnabled) {
     return getReader().getStoreFileScanner(cacheBlocks, true, false, readPt, scannerOrder,
-      canOptimizeForNonNullColumn);
+      canOptimizeForNonNullColumn, checkpointingEnabled);
   }
 
   /**
@@ -554,10 +554,10 @@ public class HStoreFile implements StoreFile {
    * Must be called after initReader.
    */
   public StoreFileScanner getStreamScanner(boolean canUseDropBehind, boolean cacheBlocks,
-    boolean isCompaction, long readPt, long scannerOrder, boolean canOptimizeForNonNullColumn)
-    throws IOException {
+    boolean isCompaction, long readPt, long scannerOrder, boolean canOptimizeForNonNullColumn,
+    boolean checkpointingEnabled) throws IOException {
     return createStreamReader(canUseDropBehind).getStoreFileScanner(cacheBlocks, false,
-      isCompaction, readPt, scannerOrder, canOptimizeForNonNullColumn);
+      isCompaction, readPt, scannerOrder, canOptimizeForNonNullColumn, checkpointingEnabled);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
@@ -440,4 +440,12 @@ public class KeyValueHeap extends NonReversedNonLazyKeyValueScanner
       }
     }
   }
+
+  @Override
+  public void retainBlock() {
+    if (current != null) {
+      current.retainBlock();
+    }
+
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
@@ -420,4 +420,24 @@ public class KeyValueHeap extends NonReversedNonLazyKeyValueScanner
       }
     }
   }
+
+  @Override
+  public void checkpoint(State state) {
+    if (current != null) {
+      current.checkpoint(state);
+    }
+    if (this.heap != null) {
+      for (KeyValueScanner scanner : this.heap) {
+        scanner.checkpoint(state);
+      }
+    }
+    // Also checkpoint any scanners for delayed close. These would be exhausted scanners,
+    // which may contain blocks that were totally filtered during a request. If so, the checkpoint
+    // will release them.
+    if (scannersForDelayedClose != null) {
+      for (KeyValueScanner scanner : scannersForDelayedClose) {
+        scanner.checkpoint(state);
+      }
+    }
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
@@ -78,4 +78,9 @@ public abstract class NonLazyKeyValueScanner implements KeyValueScanner {
   public void shipped() throws IOException {
     // do nothing
   }
+
+  @Override
+  public void checkpoint(State state) {
+    // do nothing
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
@@ -83,4 +83,9 @@ public abstract class NonLazyKeyValueScanner implements KeyValueScanner {
   public void checkpoint(State state) {
     // do nothing
   }
+
+  @Override
+  public void retainBlock() {
+    // do nothing
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
@@ -799,6 +799,11 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
   }
 
   @Override
+  public void retainBlock() {
+    // do nothing. this is really only called in StoreScanner
+  }
+
+  @Override
   public void run() throws IOException {
     // This is the RPC callback method executed. We do the close in of the scanner in this
     // callback

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
@@ -144,12 +144,6 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
       region.smallestReadPointCalcLock.unlock(ReadPointCalculationLock.LockType.RECORDING_LOCK);
     }
     initializeScanners(scan, additionalScanners);
-
-    // set initial checkpoint, which enables eager releasing in all StoreScanners. StoreScanner
-    // calls retainBlock() if a cell is included, and HFileReaderImpl releases exhausted blocks
-    // if retainBlock() was never called. Additionally below we will do more checkpointing if
-    // filters are included on the scan.
-    checkpoint(State.START);
   }
 
   private void initializeScanners(Scan scan, List<KeyValueScanner> additionalScanners)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
@@ -314,6 +314,11 @@ public class SegmentScanner implements KeyValueScanner {
     // do nothing
   }
 
+  @Override
+  public void retainBlock() {
+    // do nothing
+  }
+
   // debug method
   @Override
   public String toString() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
@@ -309,6 +309,11 @@ public class SegmentScanner implements KeyValueScanner {
     // do nothing
   }
 
+  @Override
+  public void checkpoint(State state) {
+    // do nothing
+  }
+
   // debug method
   @Override
   public String toString() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/Shipper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/Shipper.java
@@ -52,4 +52,12 @@ public interface Shipper {
    * {@link #checkpoint(State)}. Calling again with {@link State#START} will reset the pointers.
    */
   void checkpoint(State state);
+
+  /**
+   * Used by upstream callers to notify the shipper that the current block should be retained for
+   * shipping when {@link #shipped()} or {@link #checkpoint(State)} are called. Otherwise, the block
+   * will be released immediately once it's no longer needed. Only has an effect after
+   * {@link #checkpoint(State)} has been called at least once.
+   */
+  void retainBlock();
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileReader.java
@@ -139,11 +139,17 @@ public class StoreFileReader {
    *                                    {@link KeyValueScanner#getScannerOrder()}.
    * @param canOptimizeForNonNullColumn {@code true} if we can make sure there is no null column,
    *                                    otherwise {@code false}. This is a hint for optimization.
+   * @param checkpointingEnabled        if true, blocks will only be retained as they are iterated
+   *                                    if {@link Shipper#retainBlock()} is called. Further,
+   *                                    {@link Shipper#checkpoint(Shipper.State)} is enabled so
+   *                                    blocks can be released early at safe checkpoints.
    * @return a scanner
    */
   public StoreFileScanner getStoreFileScanner(boolean cacheBlocks, boolean pread,
-    boolean isCompaction, long readPt, long scannerOrder, boolean canOptimizeForNonNullColumn) {
-    return new StoreFileScanner(this, getScanner(cacheBlocks, pread, isCompaction), !isCompaction,
+    boolean isCompaction, long readPt, long scannerOrder, boolean canOptimizeForNonNullColumn,
+    boolean checkpointingEnabled) {
+    return new StoreFileScanner(this,
+      getScanner(cacheBlocks, pread, isCompaction, checkpointingEnabled), !isCompaction,
       reader.hasMVCCInfo(), readPt, scannerOrder, canOptimizeForNonNullColumn);
   }
 
@@ -190,7 +196,7 @@ public class StoreFileReader {
    */
   @Deprecated
   public HFileScanner getScanner(boolean cacheBlocks, boolean pread) {
-    return getScanner(cacheBlocks, pread, false);
+    return getScanner(cacheBlocks, pread, false, false);
   }
 
   /**
@@ -203,8 +209,9 @@ public class StoreFileReader {
    * @see <a href="https://issues.apache.org/jira/browse/HBASE-15296">HBASE-15296</a>
    */
   @Deprecated
-  public HFileScanner getScanner(boolean cacheBlocks, boolean pread, boolean isCompaction) {
-    return reader.getScanner(conf, cacheBlocks, pread, isCompaction);
+  public HFileScanner getScanner(boolean cacheBlocks, boolean pread, boolean isCompaction,
+    boolean checkpointingEnabled) {
+    return reader.getScanner(conf, cacheBlocks, pread, isCompaction, checkpointingEnabled);
   }
 
   public void close(boolean evictOnClose) throws IOException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -563,4 +563,9 @@ public class StoreFileScanner implements KeyValueScanner {
   public void checkpoint(State state) {
     this.hfs.checkpoint(state);
   }
+
+  @Override
+  public void retainBlock() {
+    this.hfs.retainBlock();
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -558,4 +558,9 @@ public class StoreFileScanner implements KeyValueScanner {
   public void shipped() throws IOException {
     this.hfs.shipped();
   }
+
+  @Override
+  public void checkpoint(State state) {
+    this.hfs.checkpoint(state);
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -799,11 +799,6 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
       if (count > 0 && matcher.isUserScan()) {
         // if true increment memstore metrics, if not the mixed one
         updateMetricsStore(onlyFromMemstore);
-      } else if (count == 0 && checkpointed) {
-        // If we returned nothing, it means the row has been filtered for this store. If we've
-        // previously checkpointed, we can call checkpoint again here to release any blocks we may
-        // have scanned in reaching this point.
-        checkpoint(State.FILTERED);
       }
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -661,6 +661,10 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
             // also update metric accordingly
             if (this.countPerRow > storeOffset) {
               outResult.add(cell);
+              // call retainBlock since we are including this cell in the result
+              // we only want to retain blocks that are backing cells that we include.
+              // if the cell is filtered upstream, it will be released by checkpoint.
+              this.heap.retainBlock();
 
               // Update local tracking information
               count++;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -770,7 +770,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
         .build();
       halfWriter = new StoreFileWriter.Builder(conf, cacheConf, fs).withFilePath(outFile)
         .withBloomType(bloomFilterType).withFileContext(hFileContext).build();
-      HFileScanner scanner = halfReader.getScanner(false, false, false);
+      HFileScanner scanner = halfReader.getScanner(false, false, false, false);
       scanner.seekTo();
       do {
         halfWriter.append(scanner.getCell());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CompressionTest.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CompressionTest.java
@@ -132,7 +132,7 @@ public class CompressionTest {
     Cell cc = null;
     HFile.Reader reader = HFile.createReader(fs, path, CacheConfig.DISABLED, true, conf);
     try {
-      HFileScanner scanner = reader.getScanner(conf, false, true);
+      HFileScanner scanner = reader.getScanner(conf, false, true, false);
       scanner.seekTo(); // position to the start of file
       // Scanner does not do Cells yet. Do below for now till fixed.
       cc = scanner.getCell();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HFilePerformanceEvaluation.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HFilePerformanceEvaluation.java
@@ -408,7 +408,7 @@ public class HFilePerformanceEvaluation {
     @Override
     void setUp() throws Exception {
       super.setUp();
-      this.scanner = this.reader.getScanner(conf, false, false);
+      this.scanner = this.reader.getScanner(conf, false, false, false);
       this.scanner.seekTo();
     }
 
@@ -437,7 +437,7 @@ public class HFilePerformanceEvaluation {
 
     @Override
     void doRow(int i) throws Exception {
-      HFileScanner scanner = this.reader.getScanner(conf, false, true);
+      HFileScanner scanner = this.reader.getScanner(conf, false, true, false);
       byte[] b = getRandomRow();
       if (scanner.seekTo(createCell(b)) < 0) {
         LOG.info("Not able to seekTo " + new String(b));
@@ -462,7 +462,7 @@ public class HFilePerformanceEvaluation {
 
     @Override
     void doRow(int i) throws Exception {
-      HFileScanner scanner = this.reader.getScanner(conf, false, false);
+      HFileScanner scanner = this.reader.getScanner(conf, false, false, false);
       byte[] b = getRandomRow();
       // System.out.println("Random row: " + new String(b));
       Cell c = createCell(b);
@@ -500,7 +500,7 @@ public class HFilePerformanceEvaluation {
 
     @Override
     void doRow(int i) throws Exception {
-      HFileScanner scanner = this.reader.getScanner(conf, false, true);
+      HFileScanner scanner = this.reader.getScanner(conf, false, true, false);
       byte[] gaussianRandomRowBytes = getGaussianRandomRowBytes();
       scanner.seekTo(createCell(gaussianRandomRowBytes));
       for (int ii = 0; ii < 30; ii++) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/compress/HFileTestBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/compress/HFileTestBase.java
@@ -85,7 +85,7 @@ public class HFileTestBase {
     HFileScanner scanner = null;
     HFile.Reader reader = HFile.createReader(FS, path, cacheConf, true, conf);
     try {
-      scanner = reader.getScanner(conf, false, false);
+      scanner = reader.getScanner(conf, false, false, false);
       assertTrue("Initial seekTo failed", scanner.seekTo());
       do {
         Cell kv = scanner.getCell();
@@ -105,7 +105,7 @@ public class HFileTestBase {
     LOG.info("Random seeking with " + fileContext);
     reader = HFile.createReader(FS, path, cacheConf, true, conf);
     try {
-      scanner = reader.getScanner(conf, false, true);
+      scanner = reader.getScanner(conf, false, true, false);
       assertTrue("Initial seekTo failed", scanner.seekTo());
       for (i = 0; i < 100; i++) {
         KeyValue kv = testKvs.get(rand.nextInt(testKvs.size()));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheOnWrite.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheOnWrite.java
@@ -270,7 +270,7 @@ public class TestCacheOnWrite {
         .withIncludesTags(useTags).build();
     final boolean cacheBlocks = false;
     final boolean pread = false;
-    HFileScanner scanner = reader.getScanner(conf, cacheBlocks, pread);
+    HFileScanner scanner = reader.getScanner(conf, cacheBlocks, pread, false);
     assertTrue(testDescription, scanner.seekTo());
 
     long offset = 0;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
@@ -655,7 +655,7 @@ public class TestHFile {
     System.out.println(cacheConf.toString());
     // Load up the index.
     // Get a scanner that caches and that does not use pread.
-    HFileScanner scanner = reader.getScanner(conf, true, false);
+    HFileScanner scanner = reader.getScanner(conf, true, false, false);
     // Align scanner at start of the file.
     scanner.seekTo();
     readAllRecords(scanner);
@@ -742,7 +742,7 @@ public class TestHFile {
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, mFile).build();
     Reader reader = createReaderFromStream(context, cacheConf, conf);
     // No data -- this should return false.
-    assertFalse(reader.getScanner(conf, false, false).seekTo());
+    assertFalse(reader.getScanner(conf, false, false, false).seekTo());
     someReadingWithMetaBlock(reader);
     fs.delete(mFile, true);
     reader.close();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
@@ -612,7 +612,7 @@ public class TestHFileBlockIndex {
       LOG.info("Last key: " + Bytes.toStringBinary(keys[NUM_KV - 1]));
 
       for (boolean pread : new boolean[] { false, true }) {
-        HFileScanner scanner = reader.getScanner(conf, true, pread);
+        HFileScanner scanner = reader.getScanner(conf, true, pread, false);
         for (int i = 0; i < NUM_KV; ++i) {
           checkSeekTo(keys, scanner, i);
           checkKeyValue("i=" + i, keys[i], values[i],
@@ -731,7 +731,7 @@ public class TestHFileBlockIndex {
 
     HFile.Reader reader = HFile.createReader(fs, hfPath, cacheConf, true, conf);
     // Scanner doesn't do Cells yet. Fix.
-    HFileScanner scanner = reader.getScanner(conf, true, true);
+    HFileScanner scanner = reader.getScanner(conf, true, true, false);
     for (int i = 0; i < keys.size(); ++i) {
       scanner.seekTo(ExtendedCellBuilderFactory.create(CellBuilderType.DEEP_COPY)
         .setRow(keys.get(i)).setFamily(HConstants.EMPTY_BYTE_ARRAY)

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileEncryption.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileEncryption.java
@@ -241,7 +241,7 @@ public class TestHFileEncryption {
         try {
           FixedFileTrailer trailer = reader.getTrailer();
           assertNotNull(trailer.getEncryptionKey());
-          scanner = reader.getScanner(conf, false, false);
+          scanner = reader.getScanner(conf, false, false, false);
           assertTrue("Initial seekTo failed", scanner.seekTo());
           do {
             Cell kv = scanner.getCell();
@@ -261,7 +261,7 @@ public class TestHFileEncryption {
         Random rand = ThreadLocalRandom.current();
         reader = HFile.createReader(fs, path, cacheConf, true, conf);
         try {
-          scanner = reader.getScanner(conf, false, true);
+          scanner = reader.getScanner(conf, false, true, false);
           assertTrue("Initial seekTo failed", scanner.seekTo());
           for (i = 0; i < 100; i++) {
             KeyValue kv = testKvs.get(rand.nextInt(testKvs.size()));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileInlineToRootChunkConversion.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileInlineToRootChunkConversion.java
@@ -91,7 +91,7 @@ public class TestHFileInlineToRootChunkConversion {
 
     HFile.Reader reader = HFile.createReader(fs, hfPath, cacheConf, true, conf);
     // Scanner doesn't do Cells yet. Fix.
-    HFileScanner scanner = reader.getScanner(conf, true, true);
+    HFileScanner scanner = reader.getScanner(conf, true, true, false);
     for (int i = 0; i < keys.size(); ++i) {
       scanner.seekTo(ExtendedCellBuilderFactory.create(CellBuilderType.DEEP_COPY)
         .setRow(keys.get(i)).setFamily(HConstants.EMPTY_BYTE_ARRAY)

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileReaderImpl.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileReaderImpl.java
@@ -86,6 +86,7 @@ public class TestHFileReaderImpl {
     return ncTFile;
   }
 
+  @SuppressWarnings("checkstyle:EmptyBlock")
   @Test
   public void testRetainBlock() throws IOException {
     // use very small blocksize to force every cell to be a different block. this gives us

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileScannerImplReferenceCount.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileScannerImplReferenceCount.java
@@ -196,7 +196,7 @@ public class TestHFileScannerImplReferenceCount {
     // We've build a HFile tree with index = 16.
     Assert.assertEquals(16, reader.getTrailer().getNumDataIndexLevels());
 
-    HFileScannerImpl scanner = (HFileScannerImpl) reader.getScanner(conf, true, true, false);
+    HFileScannerImpl scanner = (HFileScannerImpl) reader.getScanner(conf, true, true, false, false);
     HFileBlock block1 = reader.getDataBlockIndexReader()
       .loadDataBlockWithScanInfo(firstCell, null, true, true, false, DataBlockEncoding.NONE, reader)
       .getHFileBlock();
@@ -279,7 +279,7 @@ public class TestHFileScannerImplReferenceCount {
     // We've build a HFile tree with index = 16.
     Assert.assertEquals(16, reader.getTrailer().getNumDataIndexLevels());
 
-    HFileScannerImpl scanner = (HFileScannerImpl) reader.getScanner(conf, true, true, false);
+    HFileScannerImpl scanner = (HFileScannerImpl) reader.getScanner(conf, true, true, false, false);
     HFileBlock block1 = reader.getDataBlockIndexReader()
       .loadDataBlockWithScanInfo(firstCell, null, true, true, false, DataBlockEncoding.NONE, reader)
       .getHFileBlock();
@@ -408,7 +408,7 @@ public class TestHFileScannerImplReferenceCount {
     // We've build a HFile tree with index = 16.
     Assert.assertEquals(16, reader.getTrailer().getNumDataIndexLevels());
 
-    HFileScannerImpl scanner = (HFileScannerImpl) reader.getScanner(conf, true, true, false);
+    HFileScannerImpl scanner = (HFileScannerImpl) reader.getScanner(conf, true, true, false, false);
     HFileBlock block1 = reader.getDataBlockIndexReader()
       .loadDataBlockWithScanInfo(firstCell, null, true, true, false, DataBlockEncoding.NONE, reader)
       .getHFileBlock();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileSeek.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileSeek.java
@@ -176,7 +176,7 @@ public class TestHFileSeek {
     Reader reader = TestHFile.createReaderFromStream(context, new CacheConfig(conf), conf);
     KeySampler kSampler = new KeySampler(rng, ((KeyValue) reader.getFirstKey().get()).getKey(),
       ((KeyValue) reader.getLastKey().get()).getKey(), keyLenGen);
-    HFileScanner scanner = reader.getScanner(conf, false, USE_PREAD);
+    HFileScanner scanner = reader.getScanner(conf, false, USE_PREAD, false);
     BytesWritable key = new BytesWritable();
     timer.reset();
     timer.start();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestReseekTo.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestReseekTo.java
@@ -109,7 +109,7 @@ public class TestReseekTo {
 
     HFile.Reader reader = HFile.createReader(TEST_UTIL.getTestFileSystem(), ncTFile, cacheConf,
       true, TEST_UTIL.getConfiguration());
-    HFileScanner scanner = reader.getScanner(TEST_UTIL.getConfiguration(), false, true);
+    HFileScanner scanner = reader.getScanner(TEST_UTIL.getConfiguration(), false, true, false);
 
     scanner.seekTo();
     for (int i = 0; i < keyList.size(); i++) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestSeekBeforeWithInlineBlocks.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestSeekBeforeWithInlineBlocks.java
@@ -142,7 +142,7 @@ public class TestSeekBeforeWithInlineBlocks {
           // Check that we can seekBefore in either direction and with both pread
           // enabled and disabled
           for (boolean pread : new boolean[] { false, true }) {
-            HFileScanner scanner = reader.getScanner(conf, true, pread);
+            HFileScanner scanner = reader.getScanner(conf, true, pread, false);
             checkNoSeekBefore(cells, scanner, 0);
             for (int i = 1; i < NUM_KV; i++) {
               checkSeekBefore(cells, scanner, i);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestSeekTo.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestSeekTo.java
@@ -149,7 +149,7 @@ public class TestSeekTo {
     FileSystem fs = TEST_UTIL.getTestFileSystem();
     Configuration conf = TEST_UTIL.getConfiguration();
     HFile.Reader reader = HFile.createReader(fs, p, new CacheConfig(conf), true, conf);
-    HFileScanner scanner = reader.getScanner(conf, false, true);
+    HFileScanner scanner = reader.getScanner(conf, false, true, false);
     assertFalse(scanner.seekBefore(toKV("a", tagUsage)));
 
     assertFalse(scanner.seekBefore(toKV("c", tagUsage)));
@@ -207,7 +207,7 @@ public class TestSeekTo {
     FileSystem fs = TEST_UTIL.getTestFileSystem();
     Configuration conf = TEST_UTIL.getConfiguration();
     HFile.Reader reader = HFile.createReader(fs, p, new CacheConfig(conf), true, conf);
-    HFileScanner scanner = reader.getScanner(conf, false, true);
+    HFileScanner scanner = reader.getScanner(conf, false, true, false);
     assertFalse(scanner.seekBefore(toKV("a", tagUsage)));
     assertFalse(scanner.seekBefore(toKV("b", tagUsage)));
     assertFalse(scanner.seekBefore(toKV("c", tagUsage)));
@@ -301,7 +301,7 @@ public class TestSeekTo {
     Configuration conf = TEST_UTIL.getConfiguration();
     HFile.Reader reader = HFile.createReader(fs, p, new CacheConfig(conf), true, conf);
     assertEquals(2, reader.getDataBlockIndexReader().getRootBlockCount());
-    HFileScanner scanner = reader.getScanner(conf, false, true);
+    HFileScanner scanner = reader.getScanner(conf, false, true, false);
     // lies before the start of the file.
     assertEquals(-1, scanner.seekTo(toKV("a", tagUsage)));
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DataBlockEncodingTool.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DataBlockEncodingTool.java
@@ -587,7 +587,7 @@ public class DataBlockEncodingTool {
     StoreFileReader reader = hsf.getReader();
     reader.loadFileInfo();
     KeyValueScanner scanner =
-      reader.getStoreFileScanner(true, true, false, hsf.getMaxMemStoreTS(), 0, false);
+      reader.getStoreFileScanner(true, true, false, hsf.getMaxMemStoreTS(), 0, false, false);
     USE_TAG = reader.getHFileReader().getFileContext().isIncludesTags();
     // run the utilities
     DataBlockEncodingTool comp = new DataBlockEncodingTool(conf, compressionName);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
@@ -40,6 +40,11 @@ public class DelegatingKeyValueScanner implements KeyValueScanner {
   }
 
   @Override
+  public void retainBlock() {
+    delegate.retainBlock();
+  }
+
+  @Override
   public Cell peek() {
     return delegate.peek();
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
@@ -35,6 +35,11 @@ public class DelegatingKeyValueScanner implements KeyValueScanner {
   }
 
   @Override
+  public void checkpoint(State state) {
+    delegate.checkpoint(state);
+  }
+
+  @Override
   public Cell peek() {
     return delegate.peek();
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/EncodedSeekPerformanceTest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/EncodedSeekPerformanceTest.java
@@ -62,7 +62,7 @@ public class EncodedSeekPerformanceTest {
       cacheConf, BloomType.NONE, true);
     storeFile.initReader();
     StoreFileReader reader = storeFile.getReader();
-    StoreFileScanner scanner = reader.getStoreFileScanner(true, false, false, 0, 0, false);
+    StoreFileScanner scanner = reader.getStoreFileScanner(true, false, false, 0, 0, false, false);
     Cell current;
 
     scanner.seek(KeyValue.LOWESTKEY);
@@ -93,7 +93,7 @@ public class EncodedSeekPerformanceTest {
     long totalSize = 0;
 
     StoreFileReader reader = storeFile.getReader();
-    StoreFileScanner scanner = reader.getStoreFileScanner(true, false, false, 0, 0, false);
+    StoreFileScanner scanner = reader.getStoreFileScanner(true, false, false, 0, 0, false, false);
 
     long startReadingTime = System.nanoTime();
     Cell current;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/MockHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/MockHStoreFile.java
@@ -152,17 +152,17 @@ public class MockHStoreFile extends HStoreFile {
 
   @Override
   public StoreFileScanner getPreadScanner(boolean cacheBlocks, long readPt, long scannerOrder,
-    boolean canOptimizeForNonNullColumn) {
+    boolean canOptimizeForNonNullColumn, boolean checkpointingEnabled) {
     return getReader().getStoreFileScanner(cacheBlocks, true, false, readPt, scannerOrder,
-      canOptimizeForNonNullColumn);
+      canOptimizeForNonNullColumn, false);
   }
 
   @Override
   public StoreFileScanner getStreamScanner(boolean canUseDropBehind, boolean cacheBlocks,
-    boolean isCompaction, long readPt, long scannerOrder, boolean canOptimizeForNonNullColumn)
-    throws IOException {
+    boolean isCompaction, long readPt, long scannerOrder, boolean canOptimizeForNonNullColumn,
+    boolean checkpointingEnabled) throws IOException {
     return getReader().getStoreFileScanner(cacheBlocks, false, isCompaction, readPt, scannerOrder,
-      canOptimizeForNonNullColumn);
+      canOptimizeForNonNullColumn, false);
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCacheOnWriteInSchema.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCacheOnWriteInSchema.java
@@ -233,7 +233,7 @@ public class TestCacheOnWriteInSchema {
     HFile.Reader reader = sf.getReader().getHFileReader();
     try {
       // Open a scanner with (on read) caching disabled
-      HFileScanner scanner = reader.getScanner(conf, false, false);
+      HFileScanner scanner = reader.getScanner(conf, false, false, false);
       assertTrue(testDescription, scanner.seekTo());
       // Cribbed from io.hfile.TestCacheOnWrite
       long offset = 0;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompoundBloomFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompoundBloomFilter.java
@@ -201,7 +201,7 @@ public class TestCompoundBloomFilter {
     sf.initReader();
     StoreFileReader r = sf.getReader();
     final boolean pread = true; // does not really matter
-    StoreFileScanner scanner = r.getStoreFileScanner(true, pread, false, 0, 0, false);
+    StoreFileScanner scanner = r.getStoreFileScanner(true, pread, false, 0, 0, false, false);
 
     {
       // Test for false negatives (not allowed).

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEndToEndSplitTransaction.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEndToEndSplitTransaction.java
@@ -133,7 +133,7 @@ public class TestEndToEndSplitTransaction {
           .filter(s -> s.isReference() && !scanner.containsKey(r.getRegionInfo().getEncodedName()))
           .forEach(sf -> {
             StoreFileReader reader = ((HStoreFile) sf).getReader();
-            reader.getStoreFileScanner(true, false, false, 0, 0, false);
+            reader.getStoreFileScanner(true, false, false, 0, 0, false, false);
             scanner.put(r.getRegionInfo().getEncodedName(), reader);
             LOG.info("Got reference to file = " + sf.getPath() + ",for region = "
               + r.getRegionInfo().getEncodedName());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
@@ -1799,10 +1799,10 @@ public class TestHStore {
     public List<KeyValueScanner> getScanners(List<HStoreFile> files, boolean cacheBlocks,
       boolean usePread, boolean isCompaction, ScanQueryMatcher matcher, byte[] startRow,
       boolean includeStartRow, byte[] stopRow, boolean includeStopRow, long readPt,
-      boolean includeMemstoreScanner) throws IOException {
+      boolean includeMemstoreScanner, boolean checkpointingEnabled) throws IOException {
       hook.getScanners(this);
       return super.getScanners(files, cacheBlocks, usePread, isCompaction, matcher, startRow, true,
-        stopRow, false, readPt, includeMemstoreScanner);
+        stopRow, false, readPt, includeMemstoreScanner, checkpointingEnabled);
     }
 
     @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -578,7 +578,7 @@ public class TestHStoreFile {
 
   private static StoreFileScanner getStoreFileScanner(StoreFileReader reader, boolean cacheBlocks,
     boolean pread) {
-    return reader.getStoreFileScanner(cacheBlocks, pread, false, 0, 0, false);
+    return reader.getStoreFileScanner(cacheBlocks, pread, false, 0, 0, false, false);
   }
 
   private static final String localFormatter = "%010d";

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRowPrefixBloomFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRowPrefixBloomFilter.java
@@ -131,7 +131,7 @@ public class TestRowPrefixBloomFilter {
   }
 
   private static StoreFileScanner getStoreFileScanner(StoreFileReader reader) {
-    return reader.getStoreFileScanner(false, false, false, 0, 0, false);
+    return reader.getStoreFileScanner(false, false, false, 0, 0, false, false);
   }
 
   private void writeStoreFile(final Path f, BloomType bt, int expKeys) throws IOException {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileScannerWithTagCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileScannerWithTagCompression.java
@@ -88,7 +88,7 @@ public class TestStoreFileScannerWithTagCompression {
     storeFileInfo.initHFileInfo(context);
     StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
     storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
-    StoreFileScanner s = reader.getStoreFileScanner(false, false, false, 0, 0, false);
+    StoreFileScanner s = reader.getStoreFileScanner(false, false, false, 0, 0, false, false);
     try {
       // Now do reseek with empty KV to position to the beginning of the file
       KeyValue k = KeyValueUtil.createFirstOnRow(Bytes.toBytes("k2"));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
@@ -66,6 +66,7 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
+import org.mockito.Mockito;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -1091,5 +1092,104 @@ public class TestStoreScanner {
       assertTrue(fileScanner.closed);
       assertFalse(memStoreScanner.closed);
     }
+  }
+
+  @Test
+  public void testCheckpointNewScannersAfterFlush() throws IOException {
+    List<KeyValueScanner> scanners = scanFixture(kvs);
+    List<KeyValueScanner> otherScanners = new ArrayList<>();
+
+    // We want to increment this counter anything checkpoint is called on these new scanners
+    AtomicInteger checkpointed = new AtomicInteger();
+    for (KeyValueScanner scanner : scanFixture(kvs)) {
+      KeyValueScanner mockedScanner = Mockito.spy(scanner);
+      Mockito.doAnswer(invocationOnMock -> checkpointed.incrementAndGet()).when(mockedScanner)
+        .checkpoint(Shipper.State.START);
+      otherScanners.add(mockedScanner);
+    }
+
+    HStore mockStore = Mockito.mock(HStore.class);
+    Mockito.when(mockStore.getScanners(Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(),
+      Mockito.anyBoolean(), Mockito.anyBoolean(), Mockito.any(), Mockito.any(), Mockito.any(),
+      Mockito.anyLong(), Mockito.anyBoolean())).thenReturn(otherScanners);
+    Mockito.when(mockStore.getComparator()).thenReturn(CellComparator.getInstance());
+
+    HStoreFile mockedFile = Mockito.mock(HStoreFile.class);
+
+    try (StoreScanner scan =
+      new StoreScanner(mockStore, new Scan(), scanInfo, getCols("a", "d"), scanners)) {
+      scan.updateReaders(Collections.singletonList(mockedFile), Collections.emptyList());
+      List<Cell> results = new ArrayList<>();
+      scan.next(results);
+    }
+
+    // no checkpoint should occur, because the StoreScanner itself has not been checkpointed
+    assertEquals(0, checkpointed.get());
+
+    try (StoreScanner scan =
+      new StoreScanner(mockStore, new Scan(), scanInfo, getCols("a", "d"), scanners)) {
+      scan.checkpoint(Shipper.State.START);
+      scan.updateReaders(Collections.singletonList(mockedFile), Collections.emptyList());
+      List<Cell> results = new ArrayList<>();
+      scan.next(results);
+    }
+
+    // StoreScanner has been checkpointed, so checkpoint should occur on new scanners
+    assertEquals(otherScanners.size(), checkpointed.get());
+  }
+
+  @Test
+  public void testCheckpointAfterSwitchToStreamRead() throws IOException {
+    Configuration confForStream = new Configuration(CONF);
+    confForStream.setInt(StoreScanner.STORESCANNER_PREAD_MAX_BYTES, 0);
+    // Same as the usual scanInfo in this class, but with pread max bytes set low so we trigger
+    // switch to stream below
+    ScanInfo scanInfoForStream = new ScanInfo(confForStream, CF, scanInfo.getMinVersions(),
+      scanInfo.getMaxVersions(), scanInfo.getTtl(), scanInfo.getKeepDeletedCells(),
+      HConstants.DEFAULT_BLOCKSIZE, scanInfo.getTimeToPurgeDeletes(), scanInfo.getComparator(),
+      scanInfo.isNewVersionBehavior());
+
+    List<KeyValueScanner> scanners = scanFixture(kvs);
+    List<KeyValueScanner> otherScanners = new ArrayList<>();
+
+    // We want to increment this counter anything checkpoint is called on these new scanners
+    AtomicInteger checkpointed = new AtomicInteger();
+    for (KeyValueScanner scanner : scanFixture(kvs)) {
+      KeyValueScanner mockedScanner = Mockito.spy(scanner);
+      Mockito.doAnswer(invocationOnMock -> checkpointed.incrementAndGet()).when(mockedScanner)
+        .checkpoint(Shipper.State.START);
+      otherScanners.add(mockedScanner);
+    }
+
+    HStore mockStore = Mockito.mock(HStore.class);
+    Mockito
+      .when(mockStore.recreateScanners(Mockito.any(), Mockito.anyBoolean(), Mockito.anyBoolean(),
+        Mockito.anyBoolean(), Mockito.any(), Mockito.any(), Mockito.anyBoolean(), Mockito.any(),
+        Mockito.anyBoolean(), Mockito.anyLong(), Mockito.anyBoolean()))
+      .thenReturn(otherScanners);
+    Mockito.when(mockStore.getComparator()).thenReturn(CellComparator.getInstance());
+
+    try (StoreScanner scan =
+      new StoreScanner(mockStore, new Scan(), scanInfoForStream, getCols("a", "d"), scanners)) {
+      List<Cell> results = new ArrayList<>();
+      scan.next(results);
+      scan.trySwitchToStreamRead();
+      scan.next(results);
+    }
+
+    // no checkpoint should occur, because the StoreScanner itself has not been checkpointed
+    assertEquals(0, checkpointed.get());
+
+    try (StoreScanner scan =
+      new StoreScanner(mockStore, new Scan(), scanInfoForStream, getCols("a", "d"), scanners)) {
+      scan.checkpoint(Shipper.State.START);
+      List<Cell> results = new ArrayList<>();
+      scan.next(results);
+      scan.trySwitchToStreamRead();
+      scan.next(results);
+    }
+
+    // StoreScanner has been checkpointed, so checkpoint should occur on new scanners
+    assertEquals(otherScanners.size(), checkpointed.get());
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestCompactor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestCompactor.java
@@ -65,7 +65,7 @@ public class TestCompactor {
     when(r.getBloomFilterType()).thenReturn(BloomType.NONE);
     when(r.getHFileReader()).thenReturn(mock(HFile.Reader.class));
     when(r.getStoreFileScanner(anyBoolean(), anyBoolean(), anyBoolean(), anyLong(), anyLong(),
-      anyBoolean())).thenReturn(mock(StoreFileScanner.class));
+      anyBoolean(), false)).thenReturn(mock(StoreFileScanner.class));
     when(sf.getReader()).thenReturn(r);
     when(sf.getMaxSequenceId()).thenReturn(maxSequenceId);
     return sf;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestCompactor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestCompactor.java
@@ -65,7 +65,7 @@ public class TestCompactor {
     when(r.getBloomFilterType()).thenReturn(BloomType.NONE);
     when(r.getHFileReader()).thenReturn(mock(HFile.Reader.class));
     when(r.getStoreFileScanner(anyBoolean(), anyBoolean(), anyBoolean(), anyLong(), anyLong(),
-      anyBoolean(), false)).thenReturn(mock(StoreFileScanner.class));
+      anyBoolean(), anyBoolean())).thenReturn(mock(StoreFileScanner.class));
     when(sf.getReader()).thenReturn(r);
     when(sf.getMaxSequenceId()).thenReturn(maxSequenceId);
     return sf;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestStripeCompactionPolicy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestStripeCompactionPolicy.java
@@ -874,7 +874,7 @@ public class TestStripeCompactionPolicy {
     when(r.getBloomFilterType()).thenReturn(BloomType.NONE);
     when(r.getHFileReader()).thenReturn(mock(HFile.Reader.class));
     when(r.getStoreFileScanner(anyBoolean(), anyBoolean(), anyBoolean(), anyLong(), anyLong(),
-      anyBoolean())).thenReturn(mock(StoreFileScanner.class));
+      anyBoolean(), false)).thenReturn(mock(StoreFileScanner.class));
     when(sf.getReader()).thenReturn(r);
     when(sf.getBulkLoadTimestamp()).thenReturn(OptionalLong.empty());
     when(r.getMaxTimestamp()).thenReturn(TimeRange.INITIAL_MAX_TIMESTAMP);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestStripeCompactionPolicy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/compactions/TestStripeCompactionPolicy.java
@@ -874,7 +874,7 @@ public class TestStripeCompactionPolicy {
     when(r.getBloomFilterType()).thenReturn(BloomType.NONE);
     when(r.getHFileReader()).thenReturn(mock(HFile.Reader.class));
     when(r.getStoreFileScanner(anyBoolean(), anyBoolean(), anyBoolean(), anyLong(), anyLong(),
-      anyBoolean(), false)).thenReturn(mock(StoreFileScanner.class));
+      anyBoolean(), anyBoolean())).thenReturn(mock(StoreFileScanner.class));
     when(sf.getReader()).thenReturn(r);
     when(sf.getBulkLoadTimestamp()).thenReturn(OptionalLong.empty());
     when(r.getMaxTimestamp()).thenReturn(TimeRange.INITIAL_MAX_TIMESTAMP);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/tool/TestBulkLoadHFiles.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/tool/TestBulkLoadHFiles.java
@@ -612,7 +612,7 @@ public class TestBulkLoadHFiles {
     Configuration conf = util.getConfiguration();
     HFile.Reader reader =
       HFile.createReader(p.getFileSystem(conf), p, new CacheConfig(conf), true, conf);
-    HFileScanner scanner = reader.getScanner(conf, false, false);
+    HFileScanner scanner = reader.getScanner(conf, false, false, false);
     scanner.seekTo();
     int count = 0;
     do {


### PR DESCRIPTION
- HFileReaderImpl retains all blocks scanned for a request into a `prevBlocks` list. These blocks are currently only ever released in `shipped()` or `close()`.
- Large scans with narrow filters or sparse scans can retain many blocks that contain no cells needed for the request results.
- Here we introduce a checkpoint system which allows us to release those blocks when it's determined that they are not needed.
- We start a checkpoint each time a row is fetched in RegionScannerImpl, by calling `checkpoint(State.START)`. This sets state in StoreScanner and HFileReaderImpl.
- In StoreScanner, we call `retainBlock()` whenever a cell is added to the result list. This causes the block to be added to prevBlocks once it's fully scanned, otherwise it gets eagerly released. If no cells are pulled from a block at this level, we can easily immediately release it.
- If cells are retained but then the row ends up fully filtered, we call `checkpoint(State.FILTERED)`, which releases any blocks accumulated since the last checkpoint. This accounts for cases where filters clear the result list after being applied.
  - There are 3 places where a row can be fully filtered in RegionScannerImpl:
    - When a row is filtered due to `filterRowKey`.
    - When all cells have been accumulated but then filtered due to `filterRowCells` or `filterRow`.
    - When no cells have been returned after checking both storeHeap and joinedHeap.
- When checkpoint is called in RegionScannerImpl, it fans out to all StoreScanners in the heap (and delayed close scanners). Similarly, when checkpoint is called in StoreScanner, it fans out to all StoreFileScanners in its heap (and delayed close scanners). StoreFileScanner propagates the checkpoint into HFileReaderImpl. The goal here is to checkpoint all HFileReaderImpls, including those in delayed close state because they may have had blocks filtered prior to close.
- Additionally, StoreScanner will sometimes open new StoreFileScanners (due to reopen after flush or switching to stream read). If the StoreScanner had been checkpointed previously, we checkpoint these new scanners after open. This sets them up to be ready for another checkpoint next time a row is filtered.

I've added extensive tests in TestBlockEvictionFromClient. These verify the expected number of retained block for various filter cases, ensures the returned results are accurate, and additionally forces block cache corruption on any early released blocks. The corruption would cause the test to fail if any necessary blocks were wrongly released, because the rpc shipper tries serializing cells from buffers whose content has changed.

I also added unit tests to StoreScanner and HFileReaderImpl for the relevant smaller changes there.