### PR TITLE
HBASE-27528 log duplication issues in MasterRpcServices.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -2809,13 +2809,6 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
             mergeExistingPermissions);
         }
         server.cpHost.postGrant(perm, mergeExistingPermissions);
-        User caller = RpcServer.getRequestUser().orElse(null);
-        if (AUDITLOG.isTraceEnabled()) {
-          // audit log should store permission changes in addition to auth results
-          String remoteAddress = RpcServer.getRemoteAddress().map(InetAddress::toString).orElse("");
-          AUDITLOG.trace("User {} (remote address: {}) granted permission {}", caller,
-            remoteAddress, perm);
-        }
         return GrantResponse.getDefaultInstance();
       } else {
         throw new DoNotRetryIOException(
@@ -2839,13 +2832,6 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
           PermissionStorage.removeUserPermission(server.getConfiguration(), userPermission, table);
         }
         server.cpHost.postRevoke(userPermission);
-        User caller = RpcServer.getRequestUser().orElse(null);
-        if (AUDITLOG.isTraceEnabled()) {
-          // audit log should record all permission changes
-          String remoteAddress = RpcServer.getRemoteAddress().map(InetAddress::toString).orElse("");
-          AUDITLOG.trace("User {} (remote address: {}) revoked permission {}", caller,
-            remoteAddress, userPermission);
-        }
         return RevokeResponse.getDefaultInstance();
       } else {
         throw new DoNotRetryIOException(


### PR DESCRIPTION
[HBASE-27528](https://issues.apache.org/jira/browse/HBASE-27528) MasterRpcServices record audit log in privileged operations **(grant, revoke)**.
```java
  public RevokeResponse revoke(RpcController controller, RevokeRequest request)
    throws ServiceException {
    try {
      ......
        server.cpHost.preRevoke(userPermission); // has audit log in AccessChecker
       ...... // removeUserPermission
        User caller = RpcServer.getRequestUser().orElse(null);
        if (AUDITLOG.isTraceEnabled()) {
          String remoteAddress = RpcServer.getRemoteAddress().map(InetAddress::toString).orElse("");
          AUDITLOG.trace("User {} (remote address: {}) revoked permission {}", caller,
            remoteAddress, userPermission); // duplicate auditlog
        }
        ......
  }
```
but I found a path from `server.cpHost.preRevoke(userPermission);` to `AccessChecker audit log`
(`preRevoke -> MasterCoprocessorHost.preRevoke -> AccessController.preRevoke -> preGrantOrRevoke -> accessChecker.requireXXXPermission -> logResult -> AUDITLOG.trace...`), which caused **log duplication**: 
```java
public void requireGlobalPermission(User user, String request, Action perm, String namespace)
    throws IOException {
    AuthResult authResult;
    if (authManager.authorizeUserGlobal(user, perm)) {
      authResult = AuthResult.allow(request, "Global check allowed", user, perm, null);
      authResult.getParams().setNamespace(namespace);
      logResult(authResult);
    } else {
      authResult = AuthResult.deny(request, "Global check failed", user, perm, null);
      authResult.getParams().setNamespace(namespace);
      logResult(authResult);
      throw new AccessDeniedException(
        "Insufficient permissions for user '" + (user != null ? user.getShortName() : "null")
          + "' (global, action=" + perm.toString() + ")");
    }
  }
```
the `logResult` auditlog contain all the infomation recorded by `MasterRpcServices.revoke` (`user, remote address, permission`) : 
```java
  public static void logResult(AuthResult result) {
    if (AUDITLOG.isTraceEnabled()) {
      User user = result.getUser();
      UserGroupInformation ugi = user != null ? user.getUGI() : null;
      AUDITLOG.trace(
        "Access {} for user {}; reason: {}; remote address: {}; request: {}; context: {};"
          + "auth method: {}",
        (result.isAllowed() ? "allowed" : "denied"),
        (user != null ? user.getShortName() : "UNKNOWN"), result.getReason(),
        RpcServer.getRemoteAddress().map(InetAddress::toString).orElse(""), result.getRequest(),
        result.toContextString(), ugi != null ? ugi.getAuthenticationMethod() : "UNKNOWN");
    }
  }
```
Since **AccessChecker** integrates auditlogs for **permission check**, I'll delete the log in MasterRpcServices.
And grant has the same problem.