### PR TITLE
HBASE-27558 Scan quotas and limits should account for total block IO

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.io;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
@@ -279,8 +280,8 @@ public class HalfStoreFileReader extends StoreFileReader {
       }
 
       @Override
-      public int getCurrentBlockSizeOnce() {
-        return this.delegate.getCurrentBlockSizeOnce();
+      public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+        this.delegate.recordBlockSize(blockSizeConsumer);
       }
     };
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hbase.io;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
@@ -280,7 +280,7 @@ public class HalfStoreFileReader extends StoreFileReader {
       }
 
       @Override
-      public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+      public void recordBlockSize(IntConsumer blockSizeConsumer) {
         this.delegate.recordBlockSize(blockSizeConsumer);
       }
     };

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -277,6 +277,11 @@ public class HalfStoreFileReader extends StoreFileReader {
       public void shipped() throws IOException {
         this.delegate.shipped();
       }
+
+      @Override
+      public int getCurrentBlockSizeOnce() {
+        return this.delegate.getCurrentBlockSizeOnce();
+      }
     };
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -420,12 +421,11 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     }
 
     @Override
-    public int getCurrentBlockSizeOnce() {
-      if (providedCurrentBlockSize || curBlock == null) {
-        return 0;
+    public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+      if (!providedCurrentBlockSize && curBlock != null) {
+        providedCurrentBlockSize = true;
+        blockSizeConsumer.accept(curBlock.getUncompressedSizeWithoutHeader());
       }
-      providedCurrentBlockSize = true;
-      return curBlock.getUncompressedSizeWithoutHeader();
     }
 
     // Returns the #bytes in HFile for the current cell. Used to skip these many bytes in current

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -27,7 +27,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Optional;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -421,7 +421,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     }
 
     @Override
-    public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+    public void recordBlockSize(IntConsumer blockSizeConsumer) {
       if (!providedCurrentBlockSize && curBlock != null) {
         providedCurrentBlockSize = true;
         blockSizeConsumer.accept(curBlock.getUncompressedSizeWithoutHeader());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -337,7 +337,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     // RegionScannerImpl#handleException). Call the releaseIfNotCurBlock() to release the
     // unreferenced block please.
     protected HFileBlock curBlock;
-    // Whether we returned a result for curBlock's size in getCurrentBlockSizeOnce().
+    // Whether we returned a result for curBlock's size in recordBlockSize().
     // gets reset whenever curBlock is changed.
     private boolean providedCurrentBlockSize = false;
     // Previous blocks that were used in the course of the read

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java
@@ -140,4 +140,10 @@ public interface HFileScanner extends Shipper, Closeable {
    */
   @Override
   void close();
+
+  /**
+   * Returns the block size in bytes for the current block. Will only return a value once per block,
+   * otherwise 0. Used for calculating block IO in ScannerContext.
+   */
+  int getCurrentBlockSizeOnce();
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hbase.io.hfile;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.regionserver.Shipper;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -147,5 +147,5 @@ public interface HFileScanner extends Shipper, Closeable {
    * Implementations should ensure that blockSizeConsumer is only called once per block.
    * @param blockSizeConsumer to be called with block size in bytes, once per block.
    */
-  void recordBlockSize(Consumer<Integer> blockSizeConsumer);
+  void recordBlockSize(IntConsumer blockSizeConsumer);
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileScanner.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.io.hfile;
 import java.io.Closeable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.function.Consumer;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.regionserver.Shipper;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -142,8 +143,9 @@ public interface HFileScanner extends Shipper, Closeable {
   void close();
 
   /**
-   * Returns the block size in bytes for the current block. Will only return a value once per block,
-   * otherwise 0. Used for calculating block IO in ScannerContext.
+   * Record the size of the current block in bytes, passing as an argument to the blockSizeConsumer.
+   * Implementations should ensure that blockSizeConsumer is only called once per block.
+   * @param blockSizeConsumer to be called with block size in bytes, once per block.
    */
-  int getCurrentBlockSizeOnce();
+  void recordBlockSize(Consumer<Integer> blockSizeConsumer);
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
@@ -22,7 +22,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.regionserver.ScannerContext.NextState;
@@ -106,7 +106,7 @@ public class KeyValueHeap extends NonReversedNonLazyKeyValueScanner
   }
 
   @Override
-  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+  public void recordBlockSize(IntConsumer blockSizeConsumer) {
     this.current.recordBlockSize(blockSizeConsumer);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
@@ -105,6 +105,11 @@ public class KeyValueHeap extends NonReversedNonLazyKeyValueScanner
   }
 
   @Override
+  public int getCurrentBlockSizeOnce() {
+    return this.current.getCurrentBlockSizeOnce();
+  }
+
+  @Override
   public Cell next() throws IOException {
     if (this.current == null) {
       return null;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueHeap.java
@@ -22,6 +22,7 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.PriorityQueue;
+import java.util.function.Consumer;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.regionserver.ScannerContext.NextState;
@@ -105,8 +106,8 @@ public class KeyValueHeap extends NonReversedNonLazyKeyValueScanner
   }
 
   @Override
-  public int getCurrentBlockSizeOnce() {
-    return this.current.getCurrentBlockSizeOnce();
+  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+    this.current.recordBlockSize(blockSizeConsumer);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueScanner.java
@@ -126,6 +126,12 @@ public interface KeyValueScanner extends Shipper, Closeable {
   boolean isFileScanner();
 
   /**
+   * Returns the block size in bytes for the current block. Will only return a value once per block,
+   * otherwise 0. Used for calculating block IO in ScannerContext.
+   */
+  int getCurrentBlockSizeOnce();
+
+  /**
    * @return the file path if this is a file scanner, otherwise null.
    * @see #isFileScanner()
    */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueScanner.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.regionserver;
 
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.function.Consumer;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
@@ -126,10 +127,11 @@ public interface KeyValueScanner extends Shipper, Closeable {
   boolean isFileScanner();
 
   /**
-   * Returns the block size in bytes for the current block. Will only return a value once per block,
-   * otherwise 0. Used for calculating block IO in ScannerContext.
+   * Record the size of the current block in bytes, passing as an argument to the blockSizeConsumer.
+   * Implementations should ensure that blockSizeConsumer is only called once per block.
+   * @param blockSizeConsumer to be called with block size in bytes, once per block.
    */
-  int getCurrentBlockSizeOnce();
+  void recordBlockSize(Consumer<Integer> blockSizeConsumer);
 
   /**
    * @return the file path if this is a file scanner, otherwise null.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/KeyValueScanner.java
@@ -19,7 +19,7 @@ package org.apache.hadoop.hbase.regionserver;
 
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
@@ -131,7 +131,7 @@ public interface KeyValueScanner extends Shipper, Closeable {
    * Implementations should ensure that blockSizeConsumer is only called once per block.
    * @param blockSizeConsumer to be called with block size in bytes, once per block.
    */
-  void recordBlockSize(Consumer<Integer> blockSizeConsumer);
+  void recordBlockSize(IntConsumer blockSizeConsumer);
 
   /**
    * @return the file path if this is a file scanner, otherwise null.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.regionserver;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
@@ -64,9 +65,8 @@ public abstract class NonLazyKeyValueScanner implements KeyValueScanner {
   }
 
   @Override
-  public int getCurrentBlockSizeOnce() {
-    // No block size by default.
-    return 0;
+  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+    // do nothing
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
@@ -64,6 +64,12 @@ public abstract class NonLazyKeyValueScanner implements KeyValueScanner {
   }
 
   @Override
+  public int getCurrentBlockSizeOnce() {
+    // No block size by default.
+    return 0;
+  }
+
+  @Override
   public Path getFilePath() {
     // Not a file by default.
     return null;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/NonLazyKeyValueScanner.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.regionserver;
 
 import java.io.IOException;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
@@ -65,7 +65,7 @@ public abstract class NonLazyKeyValueScanner implements KeyValueScanner {
   }
 
   @Override
-  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+  public void recordBlockSize(IntConsumer blockSizeConsumer) {
     // do nothing
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
@@ -610,9 +610,11 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
           return scannerContext.setScannerState(NextState.NO_MORE_VALUES).hasMoreValues();
         }
         if (!shouldStop) {
-          // Read nothing as the cells were filtered, but still need to check time limit.
-          // We also check size limit because we might have read blocks in getting to this point.
-          if (scannerContext.checkAnyLimitReached(limitScope)) {
+          // We check size limit because we might have read blocks in the nextRow call above, or
+          // in the call populateResults call. Only scans with hasFilterRow should reach this point,
+          // and for those scans which filter row _cells_ this is the only place we can actually
+          // enforce that the scan does not exceed limits since it bypasses all other checks above.
+          if (scannerContext.checkSizeLimit(limitScope)) {
             return true;
           }
           continue;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionScannerImpl.java
@@ -503,7 +503,8 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
           results.clear();
 
           // Read nothing as the rowkey was filtered, but still need to check time limit
-          if (scannerContext.checkTimeLimit(limitScope)) {
+          // We also check size limit because we might have read blocks in getting to this point.
+          if (scannerContext.checkAnyLimitReached(limitScope)) {
             return true;
           }
           continue;
@@ -561,8 +562,9 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
           // This row was totally filtered out, if this is NOT the last row,
           // we should continue on. Otherwise, nothing else to do.
           if (!shouldStop) {
-            // Read nothing as the cells was filtered, but still need to check time limit
-            if (scannerContext.checkTimeLimit(limitScope)) {
+            // Read nothing as the cells was filtered, but still need to check time limit.
+            // We also check size limit because we might have read blocks in getting to this point.
+            if (scannerContext.checkAnyLimitReached(limitScope)) {
               return true;
             }
             continue;
@@ -608,6 +610,11 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
           return scannerContext.setScannerState(NextState.NO_MORE_VALUES).hasMoreValues();
         }
         if (!shouldStop) {
+          // Read nothing as the cells were filtered, but still need to check time limit.
+          // We also check size limit because we might have read blocks in getting to this point.
+          if (scannerContext.checkAnyLimitReached(limitScope)) {
+            return true;
+          }
           continue;
         }
       }
@@ -705,13 +712,21 @@ class RegionScannerImpl implements RegionScanner, Shipper, RpcCallback {
 
   protected boolean nextRow(ScannerContext scannerContext, Cell curRowCell) throws IOException {
     assert this.joinedContinuationRow == null : "Trying to go to next row during joinedHeap read.";
+
+    // Enable skipping row mode, which disables limits and skips tracking progress for all
+    // but block size. We keep tracking block size because skipping a row in this way
+    // might involve reading blocks along the way.
+    scannerContext.setSkippingRow(true);
+
     Cell next;
     while ((next = this.storeHeap.peek()) != null && CellUtil.matchingRows(next, curRowCell)) {
       // Check for thread interrupt status in case we have been signaled from
       // #interruptRegionOperation.
       region.checkInterrupt();
-      this.storeHeap.next(MOCKED_LIST);
+      this.storeHeap.next(MOCKED_LIST, scannerContext);
     }
+
+    scannerContext.setSkippingRow(false);
     resetFilters();
 
     // Calling the hook in CP which allows it to do a fast forward

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
@@ -287,6 +287,11 @@ public class SegmentScanner implements KeyValueScanner {
   }
 
   @Override
+  public int getCurrentBlockSizeOnce() {
+    return 0;
+  }
+
+  @Override
   public Path getFilePath() {
     return null;
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hbase.regionserver;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.SortedSet;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
@@ -288,7 +288,7 @@ public class SegmentScanner implements KeyValueScanner {
   }
 
   @Override
-  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+  public void recordBlockSize(IntConsumer blockSizeConsumer) {
     // do nothing
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SegmentScanner.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.regionserver;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.SortedSet;
+import java.util.function.Consumer;
 import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
@@ -287,8 +288,8 @@ public class SegmentScanner implements KeyValueScanner {
   }
 
   @Override
-  public int getCurrentBlockSizeOnce() {
-    return 0;
+  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+    // do nothing
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -26,7 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.concurrent.atomic.LongAdder;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
@@ -452,7 +452,7 @@ public class StoreFileScanner implements KeyValueScanner {
   }
 
   @Override
-  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+  public void recordBlockSize(IntConsumer blockSizeConsumer) {
     hfs.recordBlockSize(blockSizeConsumer);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -451,6 +451,11 @@ public class StoreFileScanner implements KeyValueScanner {
   }
 
   @Override
+  public int getCurrentBlockSizeOnce() {
+    return hfs.getCurrentBlockSizeOnce();
+  }
+
+  @Override
   public Path getFilePath() {
     return reader.getHFileReader().getPath();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Optional;
 import java.util.PriorityQueue;
 import java.util.concurrent.atomic.LongAdder;
+import java.util.function.Consumer;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
@@ -451,8 +452,8 @@ public class StoreFileScanner implements KeyValueScanner {
   }
 
   @Override
-  public int getCurrentBlockSizeOnce() {
-    return hfs.getCurrentBlockSizeOnce();
+  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+    hfs.recordBlockSize(blockSizeConsumer);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -613,7 +613,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
           scannerContext.returnImmediately();
         }
 
-        scannerContext.incrementBlockProgress(heap.getCurrentBlockSizeOnce());
+        heap.recordBlockSize(scannerContext::incrementBlockProgress);
 
         prevCell = cell;
         scannerContext.setLastPeekedCell(cell);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -569,7 +569,7 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
     }
 
     // Clear progress away unless invoker has indicated it should be kept.
-    if (!scannerContext.getKeepProgress()) {
+    if (!scannerContext.getKeepProgress() && !scannerContext.getSkippingRow()) {
       scannerContext.clearProgress();
     }
 
@@ -612,6 +612,9 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
           // here, we still need to scan all the qualifiers before returning...
           scannerContext.returnImmediately();
         }
+
+        scannerContext.incrementBlockProgress(heap.getCurrentBlockSizeOnce());
+
         prevCell = cell;
         scannerContext.setLastPeekedCell(cell);
         topChanged = false;
@@ -749,6 +752,13 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
 
           default:
             throw new RuntimeException("UNEXPECTED");
+        }
+
+        // One last chance to break due to size limit. The INCLUDE* cases above already check
+        // limit and continue. For the various filtered cases, we need to check because block
+        // size limit may have been exceeded even if we don't add cells to result list.
+        if (scannerContext.checkSizeLimit(LimitScope.BETWEEN_CELLS)) {
+          return scannerContext.setScannerState(NextState.MORE_VALUES).hasMoreValues();
         }
       } while ((cell = this.heap.peek()) != null);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileReaderImpl.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileReaderImpl.java
@@ -87,7 +87,7 @@ public class TestHFileReaderImpl {
    * Test that we only count block size once per block while scanning
    */
   @Test
-  public void testGetCurrentBlockSizeOnce() throws IOException {
+  public void testRecordBlockSize() throws IOException {
     Path p = makeNewFile();
     FileSystem fs = TEST_UTIL.getTestFileSystem();
     Configuration conf = TEST_UTIL.getConfiguration();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
@@ -113,4 +113,9 @@ public class DelegatingKeyValueScanner implements KeyValueScanner {
   public Cell getNextIndexedKey() {
     return delegate.getNextIndexedKey();
   }
+
+  @Override
+  public int getCurrentBlockSizeOnce() {
+    return delegate.getCurrentBlockSizeOnce();
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.regionserver;
 
 import java.io.IOException;
-import java.util.function.Consumer;
+import java.util.function.IntConsumer;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Scan;
@@ -116,7 +116,7 @@ public class DelegatingKeyValueScanner implements KeyValueScanner {
   }
 
   @Override
-  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+  public void recordBlockSize(IntConsumer blockSizeConsumer) {
     delegate.recordBlockSize(blockSizeConsumer);
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DelegatingKeyValueScanner.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.regionserver;
 
 import java.io.IOException;
+import java.util.function.Consumer;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.client.Scan;
@@ -115,7 +116,7 @@ public class DelegatingKeyValueScanner implements KeyValueScanner {
   }
 
   @Override
-  public int getCurrentBlockSizeOnce() {
-    return delegate.getCurrentBlockSizeOnce();
+  public void recordBlockSize(Consumer<Integer> blockSizeConsumer) {
+    delegate.recordBlockSize(blockSizeConsumer);
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScannerBlockSizeLimits.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScannerBlockSizeLimits.java
@@ -1,0 +1,253 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashSet;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CompareOperator;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionLocator;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.ResultScanner;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.metrics.ScanMetrics;
+import org.apache.hadoop.hbase.filter.BinaryComparator;
+import org.apache.hadoop.hbase.filter.ColumnPaginationFilter;
+import org.apache.hadoop.hbase.filter.QualifierFilter;
+import org.apache.hadoop.hbase.filter.RowFilter;
+import org.apache.hadoop.hbase.filter.SkipFilter;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ LargeTests.class })
+public class TestScannerBlockSizeLimits {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestScannerBlockSizeLimits.class);
+
+  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private static final TableName TABLE = TableName.valueOf("TestScannerBlockSizeLimits");
+  private static final byte[] FAMILY1 = Bytes.toBytes("0");
+  private static final byte[] FAMILY2 = Bytes.toBytes("1");
+
+  private static final byte[] DATA = new byte[1000];
+  private static final byte[][] FAMILIES = new byte[][] { FAMILY1, FAMILY2 };
+
+  private static final byte[] COLUMN1 = Bytes.toBytes(0);
+  private static final byte[] COLUMN2 = Bytes.toBytes(1);
+  private static final byte[] COLUMN3 = Bytes.toBytes(2);
+  private static final byte[] COLUMN4 = Bytes.toBytes(4);
+  private static final byte[] COLUMN5 = Bytes.toBytes(5);
+
+  private static final byte[][] COLUMNS = new byte[][] { COLUMN1, COLUMN2 };
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.setInt(HConstants.HBASE_SERVER_SCANNER_MAX_RESULT_SIZE_KEY, 4200);
+    TEST_UTIL.startMiniCluster(1);
+    TEST_UTIL.createTable(TABLE, FAMILIES, 1, 2048);
+    createTestData();
+  }
+
+  private static void createTestData() throws IOException, InterruptedException {
+    RegionLocator locator = TEST_UTIL.getConnection().getRegionLocator(TABLE);
+    String regionName = locator.getAllRegionLocations().get(0).getRegion().getEncodedName();
+    HRegion region = TEST_UTIL.getRSForFirstRegionInTable(TABLE).getRegion(regionName);
+
+    for (int i = 1; i < 10; i++) {
+      // 5 columns per row, in 2 families
+      // Each column value is 1000 bytes, which is enough to fill a full block with row and header.
+      // So 5 blocks per row.
+      Put put = new Put(Bytes.toBytes(i));
+      for (int j = 0; j < 6; j++) {
+        put.addColumn(FAMILY1, Bytes.toBytes(j), DATA);
+      }
+
+      put.addColumn(FAMILY2, COLUMN1, DATA);
+
+      region.put(put);
+
+      if (i % 2 == 0) {
+        region.flush(true);
+      }
+    }
+
+    // we've created 10 storefiles at this point, 5 per family
+    region.flush(true);
+
+  }
+
+  /**
+   * Simplest test that ensures we don't count block sizes too much. These 2 requested cells are in
+   * the same block, so should be returned in 1 request. If we mis-counted blocks, it'd come in 2
+   * requests.
+   */
+  @Test
+  public void testSingleBlock() throws IOException {
+    Table table = TEST_UTIL.getConnection().getTable(TABLE);
+
+    ResultScanner scanner =
+      table.getScanner(getBaseScan().withStartRow(Bytes.toBytes(1)).withStopRow(Bytes.toBytes(2))
+        .addColumn(FAMILY1, COLUMN1).addColumn(FAMILY1, COLUMN2).setReadType(Scan.ReadType.STREAM));
+
+    ScanMetrics metrics = scanner.getScanMetrics();
+
+    scanner.next(100);
+
+    assertEquals(1, metrics.countOfRowsScanned.get());
+    assertEquals(1, metrics.countOfRPCcalls.get());
+  }
+
+  /**
+   * Tests that we check size limit after filterRowKey. When filterRowKey, we call nextRow to skip
+   * to next row. This should be efficient in this case, but we still need to check size limits
+   * after each row is processed. So in this test, we accumulate some block IO reading row 1, then
+   * skip row 2 and should return early at that point. The next rpc call starts with row3 blocks
+   * loaded, so can return the whole row in one rpc. If we were not checking size limits, we'd have
+   * been able to load an extra row 3 cell into the first rpc and thus split row 3 across multiple
+   * Results.
+   */
+  @Test
+  public void testCheckLimitAfterFilterRowKey() throws IOException {
+
+    Table table = TEST_UTIL.getConnection().getTable(TABLE);
+
+    ResultScanner scanner = table.getScanner(getBaseScan().addColumn(FAMILY1, COLUMN1)
+      .addColumn(FAMILY1, COLUMN2).addColumn(FAMILY1, COLUMN3).addFamily(FAMILY2)
+      .setFilter(new RowFilter(CompareOperator.NOT_EQUAL, new BinaryComparator(Bytes.toBytes(2)))));
+
+    boolean foundRow3 = false;
+    for (Result result : scanner) {
+      Set<Integer> rows = new HashSet<>();
+      for (Cell cell : result.rawCells()) {
+        rows.add(Bytes.toInt(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength()));
+      }
+      if (rows.contains(3)) {
+        assertFalse("expected row3 to come all in one result, but found it in two results",
+          foundRow3);
+        assertEquals(1, rows.size());
+        foundRow3 = true;
+      }
+    }
+    ScanMetrics metrics = scanner.getScanMetrics();
+
+    // 4 blocks per row, so 36 blocks. We can scan 3 blocks per RPC, which is 12 RPCs. But we can
+    // skip 1 row, so skip 2 RPCs.
+    assertEquals(10, metrics.countOfRPCcalls.get());
+  }
+
+  /**
+   * After RegionScannerImpl.populateResults, row filters are run. If row is excluded, nextRow() is
+   * called which might accumulate more block IO. Validates that in this case we still honor block
+   * limits.
+   */
+  @Test
+  public void testCheckLimitAfterFilteringRowCells() throws IOException {
+    Table table = TEST_UTIL.getConnection().getTable(TABLE);
+
+    ResultScanner scanner = table.getScanner(getBaseScan().withStartRow(Bytes.toBytes(1), true)
+      .addColumn(FAMILY1, COLUMN1).addColumn(FAMILY1, COLUMN2).setReadType(Scan.ReadType.STREAM)
+      .setFilter(new SkipFilter(new QualifierFilter(CompareOperator.EQUAL,
+        new BinaryComparator(Bytes.toBytes("dasfasf"))))));
+
+    // Our filter doesn't end up matching any real columns, so expect only cursors
+    for (Result result : scanner) {
+      assertTrue(result.isCursor());
+    }
+
+    ScanMetrics metrics = scanner.getScanMetrics();
+
+    // scanning over 9 rows, filtering on 2 contiguous columns each, so 9 blocks total
+    // limited to 4200 bytes per which is enough for 3 blocks (exceed limit after loading 3rd)
+    // so that's 3 RPC and the last RPC pulls the cells loaded by the last block
+    assertEquals(4, metrics.countOfRPCcalls.get());
+  }
+
+  /**
+   * At the end of the loop in StoreScanner, we do one more check of size limits. This is to catch
+   * block size being exceeded while filtering cells within a store. Test to ensure that we do that,
+   * otherwise we'd see no cursors below.
+   */
+  @Test
+  public void testCheckLimitAfterFilteringCell() throws IOException {
+    Table table = TEST_UTIL.getConnection().getTable(TABLE);
+
+    ResultScanner scanner = table.getScanner(getBaseScan()
+      .setFilter(new QualifierFilter(CompareOperator.EQUAL, new BinaryComparator(COLUMN2))));
+
+    int cursors = 0;
+    for (Result result : scanner) {
+      if (result.isCursor()) {
+        cursors++;
+      }
+    }
+    ScanMetrics metrics = scanner.getScanMetrics();
+
+    // We will return 9 rows, but also 2 cursors because we exceed the scan size limit partway
+    // through. So that accounts for 11 rpcs.
+    assertEquals(2, cursors);
+    assertEquals(11, metrics.countOfRPCcalls.get());
+  }
+
+  /**
+   * Tests that when we seek over blocks we dont include them in the block size of the request
+   */
+  @Test
+  public void testSeekNextUsingHint() throws IOException {
+    Table table = TEST_UTIL.getConnection().getTable(TABLE);
+
+    ResultScanner scanner = table.getScanner(
+      getBaseScan().addFamily(FAMILY1).setFilter(new ColumnPaginationFilter(1, COLUMN5)));
+
+    scanner.next(100);
+    ScanMetrics metrics = scanner.getScanMetrics();
+
+    // We have to read the first cell/block of each row, then can skip to the last block. So that's
+    // 2 blocks per row to read (18 total). Our max scan size is enough to read 3 blocks per RPC,
+    // plus one final RPC to finish region.
+    assertEquals(7, metrics.countOfRPCcalls.get());
+  }
+
+  /**
+   * We enable cursors and partial results to give us more granularity over counting of results, and
+   * we enable STREAM so that no auto switching from pread to stream occurs -- this throws off the
+   * rpc counts.
+   */
+  private Scan getBaseScan() {
+    return new Scan().setScanMetricsEnabled(true).setNeedCursorResult(true)
+      .setAllowPartialResults(true).setReadType(Scan.ReadType.STREAM);
+  }
+}


### PR DESCRIPTION
I've deployed this on a test cluster and verified that it helps to reduce excess retained blocks due to heavily filtered scans. It is nice to have a upper limit on the cost of a scan, whether filtered or unfiltered and equally applying to both.