### PR TITLE
Revert "HBASE-27539 Encapsulate and centralise access to ref count th…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.io;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
@@ -30,7 +31,6 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
-import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileReader;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -69,12 +69,13 @@ public class HalfStoreFileReader extends StoreFileReader {
    * @param fileInfo  HFile info
    * @param cacheConf CacheConfig
    * @param r         original reference file (contains top or bottom)
+   * @param refCount  reference count
    * @param conf      Configuration
    */
   public HalfStoreFileReader(final ReaderContext context, final HFileInfo fileInfo,
-    final CacheConfig cacheConf, final Reference r, StoreFileInfo storeFileInfo,
+    final CacheConfig cacheConf, final Reference r, AtomicInteger refCount,
     final Configuration conf) throws IOException {
-    super(context, fileInfo, cacheConf, storeFileInfo, conf);
+    super(context, fileInfo, cacheConf, refCount, conf);
     // This is not actual midkey for this half-file; its just border
     // around which we split top and bottom. Have to look in files to find
     // actual last and first keys for bottom and top halves. Half-files don't

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
@@ -349,12 +349,12 @@ public class HStoreFile implements StoreFile {
   }
 
   public int getRefCount() {
-    return fileInfo.getRefCount();
+    return fileInfo.refCount.get();
   }
 
   /** Returns true if the file is still used in reads */
   public boolean isReferencedInReads() {
-    int rc = fileInfo.getRefCount();
+    int rc = fileInfo.refCount.get();
     assert rc >= 0; // we should not go negative.
     return rc > 0;
   }
@@ -653,11 +653,11 @@ public class HStoreFile implements StoreFile {
   }
 
   long increaseRefCount() {
-    return this.fileInfo.increaseRefCount();
+    return this.fileInfo.refCount.incrementAndGet();
   }
 
   long decreaseRefCount() {
-    return this.fileInfo.decreaseRefCount();
+    return this.fileInfo.refCount.decrementAndGet();
   }
 
   static void increaseStoreFilesRefeCount(Collection<HStoreFile> storeFiles) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileInfo.java
@@ -107,7 +107,7 @@ public class StoreFileInfo implements Configurable {
   // Counter that is incremented every time a scanner is created on the
   // store file. It is decremented when the scan on the store file is
   // done.
-  private final AtomicInteger refCount = new AtomicInteger(0);
+  final AtomicInteger refCount = new AtomicInteger(0);
 
   /**
    * Create a Store File Info
@@ -274,13 +274,12 @@ public class StoreFileInfo implements Configurable {
     return this.hdfsBlocksDistribution;
   }
 
-  public StoreFileReader createReader(ReaderContext context, CacheConfig cacheConf)
-    throws IOException {
+  StoreFileReader createReader(ReaderContext context, CacheConfig cacheConf) throws IOException {
     StoreFileReader reader = null;
     if (this.reference != null) {
-      reader = new HalfStoreFileReader(context, hfileInfo, cacheConf, reference, this, conf);
+      reader = new HalfStoreFileReader(context, hfileInfo, cacheConf, reference, refCount, conf);
     } else {
-      reader = new StoreFileReader(context, hfileInfo, cacheConf, this, conf);
+      reader = new StoreFileReader(context, hfileInfo, cacheConf, refCount, conf);
     }
     return reader;
   }
@@ -650,7 +649,7 @@ public class StoreFileInfo implements Configurable {
     return this.noReadahead;
   }
 
-  public HFileInfo getHFileInfo() {
+  HFileInfo getHFileInfo() {
     return hfileInfo;
   }
 
@@ -680,18 +679,6 @@ public class StoreFileInfo implements Configurable {
 
   public void initHFileInfo(ReaderContext context) throws IOException {
     this.hfileInfo = new HFileInfo(context, conf);
-  }
-
-  int getRefCount() {
-    return this.refCount.get();
-  }
-
-  int increaseRefCount() {
-    return this.refCount.incrementAndGet();
-  }
-
-  int decreaseRefCount() {
-    return this.refCount.decrementAndGet();
   }
 
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileWriter.java
@@ -402,7 +402,7 @@ public class StoreFileWriter implements CellSink, ShipperListener {
    * @param dir Directory to create file in.
    * @return random filename inside passed <code>dir</code>
    */
-  public static Path getUniqueFile(final FileSystem fs, final Path dir) throws IOException {
+  static Path getUniqueFile(final FileSystem fs, final Path dir) throws IOException {
     if (!fs.getFileStatus(dir).isDirectory()) {
       throw new IOException("Expecting " + dir.toString() + " to be a directory");
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/LoadIncrementalHFiles.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/LoadIncrementalHFiles.java
@@ -1168,11 +1168,10 @@ public class LoadIncrementalHFiles extends Configured implements Tool {
     StoreFileWriter halfWriter = null;
     try {
       ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, inFile).build();
-      StoreFileInfo storeFileInfo =
-        new StoreFileInfo(conf, fs, fs.getFileStatus(inFile), reference);
-      storeFileInfo.initHFileInfo(context);
-      halfReader = (HalfStoreFileReader) storeFileInfo.createReader(context, cacheConf);
-      storeFileInfo.getHFileInfo().initMetaAndIndex(halfReader.getHFileReader());
+      HFileInfo hfile = new HFileInfo(context, conf);
+      halfReader =
+        new HalfStoreFileReader(context, hfile, cacheConf, reference, new AtomicInteger(0), conf);
+      hfile.initMetaAndIndex(halfReader.getHFileReader());
       Map<byte[], byte[]> fileInfo = halfReader.loadFileInfo();
 
       int blocksize = familyDescriptor.getBlocksize();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/TestHalfStoreFileReader.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/TestHalfStoreFileReader.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -38,10 +39,10 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
-import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.testclassification.IOTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -117,12 +118,10 @@ public class TestHalfStoreFileReader {
   private void doTestOfScanAndReseek(Path p, FileSystem fs, Reference bottom, CacheConfig cacheConf)
     throws IOException {
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, p).build();
-    StoreFileInfo storeFileInfo =
-      new StoreFileInfo(TEST_UTIL.getConfiguration(), fs, fs.getFileStatus(p), bottom);
-    storeFileInfo.initHFileInfo(context);
-    final HalfStoreFileReader halfreader =
-      (HalfStoreFileReader) storeFileInfo.createReader(context, cacheConf);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(halfreader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, TEST_UTIL.getConfiguration());
+    final HalfStoreFileReader halfreader = new HalfStoreFileReader(context, fileInfo, cacheConf,
+      bottom, new AtomicInteger(0), TEST_UTIL.getConfiguration());
+    fileInfo.initMetaAndIndex(halfreader.getHFileReader());
     halfreader.loadFileInfo();
     final HFileScanner scanner = halfreader.getScanner(false, false);
 
@@ -215,12 +214,10 @@ public class TestHalfStoreFileReader {
   private Cell doTestOfSeekBefore(Path p, FileSystem fs, Reference bottom, Cell seekBefore,
     CacheConfig cacheConfig) throws IOException {
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, p).build();
-    StoreFileInfo storeFileInfo =
-      new StoreFileInfo(TEST_UTIL.getConfiguration(), fs, fs.getFileStatus(p), bottom);
-    storeFileInfo.initHFileInfo(context);
-    final HalfStoreFileReader halfreader =
-      (HalfStoreFileReader) storeFileInfo.createReader(context, cacheConfig);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(halfreader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, TEST_UTIL.getConfiguration());
+    final HalfStoreFileReader halfreader = new HalfStoreFileReader(context, fileInfo, cacheConfig,
+      bottom, new AtomicInteger(0), TEST_UTIL.getConfiguration());
+    fileInfo.initMetaAndIndex(halfreader.getHFileReader());
     halfreader.loadFileInfo();
     final HFileScanner scanner = halfreader.getScanner(false, false);
     scanner.seekBefore(seekBefore);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -38,6 +38,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.TreeSet;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -69,6 +70,7 @@ import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
 import org.apache.hadoop.hbase.io.hfile.HFileDataBlockEncoder;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
@@ -109,7 +111,7 @@ public class TestHStoreFile {
   private static final Logger LOG = LoggerFactory.getLogger(TestHStoreFile.class);
   private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
   private CacheConfig cacheConf = new CacheConfig(TEST_UTIL.getConfiguration());
-  private static Path ROOT_DIR = TEST_UTIL.getDataTestDir("TestStoreFile");
+  private static String ROOT_DIR = TEST_UTIL.getDataTestDir("TestStoreFile").toString();
   private static final ChecksumType CKTYPE = ChecksumType.CRC32C;
   private static final int CKBYTES = 512;
   private static String TEST_FAMILY = "cf";
@@ -565,10 +567,10 @@ public class TestHStoreFile {
     writer.close();
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
-    storeFileInfo.initHFileInfo(context);
-    StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, conf);
+    StoreFileReader reader =
+      new StoreFileReader(context, fileInfo, cacheConf, new AtomicInteger(0), conf);
+    fileInfo.initMetaAndIndex(reader.getHFileReader());
     reader.loadFileInfo();
     reader.loadBloomfilter();
     StoreFileScanner scanner = getStoreFileScanner(reader, false, false);
@@ -613,10 +615,7 @@ public class TestHStoreFile {
     conf.setBoolean(BloomFilterFactory.IO_STOREFILE_BLOOM_ENABLED, true);
 
     // write the file
-    if (!fs.exists(ROOT_DIR)) {
-      fs.mkdirs(ROOT_DIR);
-    }
-    Path f = StoreFileWriter.getUniqueFile(fs, ROOT_DIR);
+    Path f = new Path(ROOT_DIR, name.getMethodName());
     HFileContext meta = new HFileContextBuilder().withBlockSize(BLOCKSIZE_SMALL)
       .withChecksumType(CKTYPE).withBytesPerCheckSum(CKBYTES).build();
     // Make a store file and write data to it.
@@ -632,10 +631,7 @@ public class TestHStoreFile {
     float err = conf.getFloat(BloomFilterFactory.IO_STOREFILE_BLOOM_ERROR_RATE, 0);
 
     // write the file
-    if (!fs.exists(ROOT_DIR)) {
-      fs.mkdirs(ROOT_DIR);
-    }
-    Path f = StoreFileWriter.getUniqueFile(fs, ROOT_DIR);
+    Path f = new Path(ROOT_DIR, name.getMethodName());
 
     HFileContext meta = new HFileContextBuilder().withBlockSize(BLOCKSIZE_SMALL)
       .withChecksumType(CKTYPE).withBytesPerCheckSum(CKBYTES).build();
@@ -654,10 +650,10 @@ public class TestHStoreFile {
     writer.close();
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
-    storeFileInfo.initHFileInfo(context);
-    StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, conf);
+    StoreFileReader reader =
+      new StoreFileReader(context, fileInfo, cacheConf, new AtomicInteger(0), conf);
+    fileInfo.initMetaAndIndex(reader.getHFileReader());
     reader.loadFileInfo();
     reader.loadBloomfilter();
 
@@ -693,11 +689,7 @@ public class TestHStoreFile {
   @Test
   public void testReseek() throws Exception {
     // write the file
-    if (!fs.exists(ROOT_DIR)) {
-      fs.mkdirs(ROOT_DIR);
-    }
-    Path f = StoreFileWriter.getUniqueFile(fs, ROOT_DIR);
-
+    Path f = new Path(ROOT_DIR, name.getMethodName());
     HFileContext meta = new HFileContextBuilder().withBlockSize(8 * 1024).build();
     // Make a store file and write data to it.
     StoreFileWriter writer = new StoreFileWriter.Builder(conf, cacheConf, this.fs).withFilePath(f)
@@ -707,10 +699,10 @@ public class TestHStoreFile {
     writer.close();
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
-    storeFileInfo.initHFileInfo(context);
-    StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, conf);
+    StoreFileReader reader =
+      new StoreFileReader(context, fileInfo, cacheConf, new AtomicInteger(0), conf);
+    fileInfo.initMetaAndIndex(reader.getHFileReader());
 
     // Now do reseek with empty KV to position to the beginning of the file
 
@@ -741,13 +733,9 @@ public class TestHStoreFile {
     // 2nd for loop for every column (2*colCount)
     float[] expErr = { 2 * rowCount * colCount * err, 2 * rowCount * 2 * colCount * err };
 
-    if (!fs.exists(ROOT_DIR)) {
-      fs.mkdirs(ROOT_DIR);
-    }
     for (int x : new int[] { 0, 1 }) {
       // write the file
-      Path f = StoreFileWriter.getUniqueFile(fs, ROOT_DIR);
-
+      Path f = new Path(ROOT_DIR, name.getMethodName() + x);
       HFileContext meta = new HFileContextBuilder().withBlockSize(BLOCKSIZE_SMALL)
         .withChecksumType(CKTYPE).withBytesPerCheckSum(CKBYTES).build();
       // Make a store file and write data to it.
@@ -771,10 +759,10 @@ public class TestHStoreFile {
       ReaderContext context =
         new ReaderContextBuilder().withFilePath(f).withFileSize(fs.getFileStatus(f).getLen())
           .withFileSystem(fs).withInputStreamWrapper(new FSDataInputStreamWrapper(fs, f)).build();
-      StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
-      storeFileInfo.initHFileInfo(context);
-      StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
-      storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+      HFileInfo fileInfo = new HFileInfo(context, conf);
+      StoreFileReader reader =
+        new StoreFileReader(context, fileInfo, cacheConf, new AtomicInteger(0), conf);
+      fileInfo.initMetaAndIndex(reader.getHFileReader());
       reader.loadFileInfo();
       reader.loadBloomfilter();
       StoreFileScanner scanner = getStoreFileScanner(reader, false, false);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRowPrefixBloomFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRowPrefixBloomFilter.java
@@ -24,6 +24,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -36,6 +37,7 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
 import org.apache.hadoop.hbase.log.HBaseMarkers;
@@ -178,18 +180,15 @@ public class TestRowPrefixBloomFilter {
     float expErr = 2 * prefixRowCount * suffixRowCount * err;
     int expKeys = fixedLengthExpKeys;
     // write the file
-    if (!fs.exists(testDir)) {
-      fs.mkdirs(testDir);
-    }
-    Path f = StoreFileWriter.getUniqueFile(fs, testDir);
+    Path f = new Path(testDir, name.getMethodName());
     writeStoreFile(f, bt, expKeys);
 
     // read the file
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
-    storeFileInfo.initHFileInfo(context);
-    StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, conf);
+    StoreFileReader reader =
+      new StoreFileReader(context, fileInfo, cacheConf, new AtomicInteger(0), conf);
+    fileInfo.initMetaAndIndex(reader.getHFileReader());
     reader.loadFileInfo();
     reader.loadBloomfilter();
 
@@ -252,17 +251,14 @@ public class TestRowPrefixBloomFilter {
     FileSystem fs = FileSystem.getLocal(conf);
     int expKeys = fixedLengthExpKeys;
     // write the file
-    if (!fs.exists(testDir)) {
-      fs.mkdirs(testDir);
-    }
-    Path f = StoreFileWriter.getUniqueFile(fs, testDir);
+    Path f = new Path(testDir, name.getMethodName());
     writeStoreFile(f, bt, expKeys);
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
-    storeFileInfo.initHFileInfo(context);
-    StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, conf);
+    StoreFileReader reader =
+      new StoreFileReader(context, fileInfo, cacheConf, new AtomicInteger(0), conf);
+    fileInfo.initMetaAndIndex(reader.getHFileReader());
     reader.loadFileInfo();
     reader.loadBloomfilter();
 
@@ -308,17 +304,14 @@ public class TestRowPrefixBloomFilter {
     FileSystem fs = FileSystem.getLocal(conf);
     int expKeys = fixedLengthExpKeys;
     // write the file
-    if (!fs.exists(testDir)) {
-      fs.mkdirs(testDir);
-    }
-    Path f = StoreFileWriter.getUniqueFile(fs, testDir);
+    Path f = new Path(testDir, name.getMethodName());
     writeStoreFile(f, bt, expKeys);
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
-    storeFileInfo.initHFileInfo(context);
-    StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, conf);
+    StoreFileReader reader =
+      new StoreFileReader(context, fileInfo, cacheConf, new AtomicInteger(0), conf);
+    fileInfo.initMetaAndIndex(reader.getHFileReader());
     reader.loadFileInfo();
     reader.loadBloomfilter();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileScannerWithTagCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileScannerWithTagCompression.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -37,6 +38,7 @@ import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
@@ -58,7 +60,8 @@ public class TestStoreFileScannerWithTagCompression {
   private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
   private static Configuration conf = TEST_UTIL.getConfiguration();
   private static CacheConfig cacheConf = new CacheConfig(TEST_UTIL.getConfiguration());
-  private static Path ROOT_DIR = TEST_UTIL.getDataTestDir("TestStoreFileScannerWithTagCompression");
+  private static String ROOT_DIR =
+    TEST_UTIL.getDataTestDir("TestStoreFileScannerWithTagCompression").toString();
   private static FileSystem fs = null;
 
   @BeforeClass
@@ -70,10 +73,7 @@ public class TestStoreFileScannerWithTagCompression {
   @Test
   public void testReseek() throws Exception {
     // write the file
-    if (!fs.exists(ROOT_DIR)) {
-      fs.mkdirs(ROOT_DIR);
-    }
-    Path f = StoreFileWriter.getUniqueFile(fs, ROOT_DIR);
+    Path f = new Path(ROOT_DIR, "testReseek");
     HFileContext meta = new HFileContextBuilder().withBlockSize(8 * 1024).withIncludesTags(true)
       .withCompressTags(true).withDataBlockEncoding(DataBlockEncoding.PREFIX).build();
     // Make a store file and write data to it.
@@ -84,10 +84,10 @@ public class TestStoreFileScannerWithTagCompression {
     writer.close();
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
-    storeFileInfo.initHFileInfo(context);
-    StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
-    storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+    HFileInfo fileInfo = new HFileInfo(context, conf);
+    StoreFileReader reader =
+      new StoreFileReader(context, fileInfo, cacheConf, new AtomicInteger(0), conf);
+    fileInfo.initMetaAndIndex(reader.getHFileReader());
     StoreFileScanner s = reader.getStoreFileScanner(false, false, false, 0, 0, false);
     try {
       // Now do reseek with empty KV to position to the beginning of the file


### PR DESCRIPTION
…rough StoreFileInfo (#4939)"

This reverts commit 1e53e1e486119654f68cf4acf025cdf8fe40482a.

Revert reason: the change in StoreFileReader breaks the API backward compatibility for the next branch-2.5 patch release