### PR TITLE
HBASE-27534 Addendum fix test crash

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestTooLargeLog.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestTooLargeLog.java
@@ -36,9 +36,11 @@ import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.ServerType;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -61,10 +63,17 @@ public class TestTooLargeLog {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
+    // Slow log needs to be enabled initially to spin up the SlowLogQueueService
     TEST_UTIL.getConfiguration().setBoolean(HConstants.SLOW_LOG_BUFFER_ENABLED_KEY, true);
-    TEST_UTIL.getConfiguration().setInt("hbase.ipc.warn.response.size", 100);
+    TEST_UTIL.getConfiguration().setInt("hbase.ipc.warn.response.size",
+      HConstants.DEFAULT_BLOCKSIZE / 2);
     TEST_UTIL.startMiniCluster(1);
     ADMIN = TEST_UTIL.getAdmin();
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
   }
 
   /**
@@ -72,16 +81,24 @@ public class TestTooLargeLog {
    * bytes scanned value through to the client.
    */
   @Test
-  public void testLogLargeBlockBytesScanned() throws IOException, InterruptedException {
+  public void testLogLargeBlockBytesScanned() throws IOException {
+    // Turn off slow log buffer for initial loadTable, because we were seeing core dump
+    // issues coming from that slow log entry. We will re-enable below.
+    HRegionServer regionServer = TEST_UTIL.getHBaseCluster().getRegionServer(0);
+    regionServer.getConfiguration().setBoolean(HConstants.SLOW_LOG_BUFFER_ENABLED_KEY, false);
+    regionServer.updateConfiguration();
+
     byte[] family = Bytes.toBytes("0");
     Table table = TEST_UTIL.createTable(TableName.valueOf("testLogLargeBlockBytesScanned"), family);
     TEST_UTIL.loadTable(table, family);
     TEST_UTIL.flush(table.getName());
 
-    Set<ServerName> server =
-      Collections.singleton(TEST_UTIL.getHBaseCluster().getRegionServer(0).getServerName());
+    Set<ServerName> server = Collections.singleton(regionServer.getServerName());
     Admin admin = TEST_UTIL.getAdmin();
-    admin.clearSlowLogResponses(server);
+
+    // Turn on slow log so we capture large scan below
+    regionServer.getConfiguration().setBoolean(HConstants.SLOW_LOG_BUFFER_ENABLED_KEY, true);
+    regionServer.updateConfiguration();
 
     Scan scan = new Scan();
     scan.setCaching(1);
@@ -90,13 +107,12 @@ public class TestTooLargeLog {
       scanner.next();
     }
 
-    List<LogEntry> entries =
-      admin.getLogEntries(server, "LARGE_LOG", ServerType.REGION_SERVER, 1, Collections.emptyMap());
+    List<LogEntry> entries = admin.getLogEntries(server, "LARGE_LOG", ServerType.REGION_SERVER, 100,
+      Collections.emptyMap());
 
     assertEquals(1, entries.size());
 
     OnlineLogRecord record = (OnlineLogRecord) entries.get(0);
-    System.out.println(record.toJsonPrettyPrint());
 
     assertTrue("expected " + record.getBlockBytesScanned() + " to be >= 100",
       record.getBlockBytesScanned() >= 100);


### PR DESCRIPTION
I can't reproduce the nightly build crash locally, so I'm hoping this will give some idea of if the fix helps.

I noticed a responseTooLarge log in the test output at the exact same millisecond as the crash (according to corresponding core dump log). The responseTooLarge is coming from the `loadTable` call, which does a giant mutate. The changes here attempt to avoid triggering a responseTooLarge for that request.