### PR TITLE
HBASE-27648 CopyOnWriteArrayMap does not honor contract of ConcurrentMap.putIfAbsent

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/types/CopyOnWriteArrayMap.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/types/CopyOnWriteArrayMap.java
@@ -332,7 +332,8 @@ public class CopyOnWriteArrayMap<K, V> extends AbstractMap<K, V>
     if (index < 0) {
       COWEntry<K, V> newEntry = new COWEntry<>(key, value);
       this.holder = current.insert(-(index + 1), newEntry);
-      return value;
+      // putIfAbsent contract requires returning null if no previous entry exists
+      return null;
     }
     return current.entries[index].getValue();
   }

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/types/TestCopyOnWriteMaps.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/types/TestCopyOnWriteMaps.java
@@ -41,6 +41,7 @@ public class TestCopyOnWriteMaps {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestCopyOnWriteMaps.class);
 
+  private static final int MAX_INITIAL_ENTRIES = 10_000;
   private static final int MAX_RAND = 10 * 1000 * 1000;
   private ConcurrentNavigableMap<Long, Long> m;
   private ConcurrentSkipListMap<Long, Long> csm;
@@ -50,7 +51,7 @@ public class TestCopyOnWriteMaps {
     m = new CopyOnWriteArrayMap<>();
     csm = new ConcurrentSkipListMap<>();
 
-    for (long i = 0; i < 10000; i++) {
+    for (long i = 0; i < MAX_INITIAL_ENTRIES; i++) {
       long o = ThreadLocalRandom.current().nextLong(MAX_RAND);
       m.put(i, o);
       csm.put(i, o);
@@ -58,6 +59,18 @@ public class TestCopyOnWriteMaps {
     long o = ThreadLocalRandom.current().nextLong(MAX_RAND);
     m.put(0L, o);
     csm.put(0L, o);
+  }
+
+  @Test
+  public void testPutIfAbsent() {
+    long key = MAX_INITIAL_ENTRIES * 2;
+    long val = ThreadLocalRandom.current().nextLong(MAX_RAND);
+    // initial call should return null, then should return previous value
+    assertNull(m.putIfAbsent(key, val));
+    assertEquals(val, (long) m.putIfAbsent(key, val * 2));
+    // test same with csm so we ensure similar semantics
+    assertNull(csm.putIfAbsent(key, val));
+    assertEquals(val, (long) csm.putIfAbsent(key, val * 2));
   }
 
   @Test


### PR DESCRIPTION
See javadoc of putIfAbsent:

> `@return` the previous value associated with the specified key, or null if there was no mapping for the key. (A null return can also indicate that the map previously associated null with the key, if the implementation supports null values.)

New test verifies putIfAbsent semantics on both CopyOnWriteArrayMap and ConcurrentSkipListMap so we can see that other ConcurrentMap implementations follow this contract. I've also read the code of a few others.