### PR TITLE
HBASE-27655: Remove the empty path annotation from ClusterMetricsReso…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/http/api_v1/cluster_metrics/resource/ClusterMetricsResource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/http/api_v1/cluster_metrics/resource/ClusterMetricsResource.java
@@ -61,7 +61,6 @@ public class ClusterMetricsResource {
   }
 
   @GET
-  @Path("/")
   public ClusterMetrics getBaseMetrics() throws ExecutionException, InterruptedException {
     final EnumSet<Option> fields =
       EnumSet.of(Option.HBASE_VERSION, Option.CLUSTER_ID, Option.MASTER, Option.BACKUP_MASTERS);


### PR DESCRIPTION
…urce

https://issues.apache.org/jira/browse/HBASE-27655

We don't need a `Path` annotation if I understand correctly.
- https://docs.oracle.com/javaee/7/api/javax/ws/rs/Path.html
- https://stackoverflow.com/questions/33513654/warning-the-subresource-method-contains-empty-path-annotation