### PR TITLE
HBASE-27649 WALPlayer does not properly dedupe overridden cell versions

### DIFF
--- a/hbase-backup/pom.xml
+++ b/hbase-backup/pom.xml
@@ -29,7 +29,6 @@
   <artifactId>hbase-backup</artifactId>
   <name>Apache HBase - Backup</name>
   <description>Backup for HBase</description>
-  <!-- trigger build -->
   <dependencies>
     <!-- Intra-project dependencies -->
     <dependency>

--- a/hbase-backup/pom.xml
+++ b/hbase-backup/pom.xml
@@ -29,6 +29,7 @@
   <artifactId>hbase-backup</artifactId>
   <name>Apache HBase - Backup</name>
   <description>Backup for HBase</description>
+  <!-- trigger build -->
   <dependencies>
     <!-- Intra-project dependencies -->
     <dependency>

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
@@ -352,6 +352,11 @@ public class BackupManager implements Closeable {
   public ArrayList<BackupImage> getAncestors(BackupInfo backupInfo, TableName table)
     throws IOException {
     ArrayList<BackupImage> ancestors = getAncestors(backupInfo);
+    return filterAncestorsForTable(ancestors, table);
+  }
+
+  public static ArrayList<BackupImage> filterAncestorsForTable(ArrayList<BackupImage> ancestors,
+    TableName table) {
     ArrayList<BackupImage> tableAncestors = new ArrayList<>();
     for (BackupImage image : ancestors) {
       if (image.hasTable(table)) {

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackup.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackup.java
@@ -130,6 +130,8 @@ public class TestIncrementalBackup extends TestBackupBase {
       byte[] name = regions.get(0).getRegionInfo().getRegionName();
       long startSplitTime = EnvironmentEdgeManager.currentTime();
       try {
+        // todo: this fails, and itd be nice if we could really add a split so we can prove
+        // that our new splits passthrough works (expect split to disappear once we restore)
         admin.splitRegionAsync(name).get();
       } catch (Exception e) {
         // although split fail, this may not affect following check in current API,

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/ExtendedCellSerialization.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/ExtendedCellSerialization.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.mapreduce;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.hadoop.hbase.ExtendedCell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.KeyValueUtil;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.io.serializer.Deserializer;
+import org.apache.hadoop.io.serializer.Serialization;
+import org.apache.hadoop.io.serializer.Serializer;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Similar to CellSerialization, but includes the sequenceId from an ExtendedCell. This is necessary
+ * so that CellSortReducer can sort by sequenceId, if applicable. Note that these two serializations
+ * are not compatible -- data serialized by CellSerialization cannot be deserialized with
+ * ExtendedCellSerialization and vice versa. This is ok for {@link HFileOutputFormat2} because the
+ * serialization is not actually used for the actual written HFiles, just intermediate data (between
+ * mapper and reducer of a single job).
+ */
+@InterfaceAudience.Private
+public class ExtendedCellSerialization implements Serialization<ExtendedCell> {
+  @Override
+  public boolean accept(Class<?> c) {
+    return ExtendedCell.class.isAssignableFrom(c);
+  }
+
+  @Override
+  public ExtendedCellDeserializer getDeserializer(Class<ExtendedCell> t) {
+    return new ExtendedCellDeserializer();
+  }
+
+  @Override
+  public ExtendedCellSerializer getSerializer(Class<ExtendedCell> c) {
+    return new ExtendedCellSerializer();
+  }
+
+  public static class ExtendedCellDeserializer implements Deserializer<ExtendedCell> {
+    private DataInputStream dis;
+
+    @Override
+    public void close() throws IOException {
+      this.dis.close();
+    }
+
+    @Override
+    public KeyValue deserialize(ExtendedCell ignore) throws IOException {
+      KeyValue kv = KeyValueUtil.create(this.dis);
+      PrivateCellUtil.setSequenceId(kv, this.dis.readLong());
+      return kv;
+    }
+
+    @Override
+    public void open(InputStream is) throws IOException {
+      this.dis = new DataInputStream(is);
+    }
+  }
+
+  public static class ExtendedCellSerializer implements Serializer<ExtendedCell> {
+    private DataOutputStream dos;
+
+    @Override
+    public void close() throws IOException {
+      this.dos.close();
+    }
+
+    @Override
+    public void open(OutputStream os) throws IOException {
+      this.dos = new DataOutputStream(os);
+    }
+
+    @Override
+    public void serialize(ExtendedCell kv) throws IOException {
+      dos.writeInt(PrivateCellUtil.estimatedSerializedSizeOf(kv) - Bytes.SIZEOF_INT);
+      PrivateCellUtil.writeCell(kv, dos, true);
+      dos.writeLong(kv.getSequenceId());
+    }
+  }
+}

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -125,7 +125,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
 
   protected static final byte[] tableSeparator = Bytes.toBytes(";");
 
-  protected static byte[] combineTableNameSuffix(byte[] tableName, byte[] suffix) {
+  public static byte[] combineTableNameSuffix(byte[] tableName, byte[] suffix) {
     return Bytes.add(tableName, tableSeparator, suffix);
   }
 
@@ -881,9 +881,16 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
    * Configure <code>job</code> with a TotalOrderPartitioner, partitioning against
    * <code>splitPoints</code>. Cleans up the partitions file after job exists.
    */
-  static void configurePartitioner(Job job, List<ImmutableBytesWritable> splitPoints,
+  public static void configurePartitioner(Job job, List<ImmutableBytesWritable> splitPoints,
     boolean writeMultipleTables) throws IOException {
     Configuration conf = job.getConfiguration();
+    // todo: need to think if there's a better way
+    if (conf.get(job.getJobName() + ".wrotePartitions") != null) {
+      LOG.info("Already configured partitions, skipping... {}", splitPoints);
+      return;
+    }
+    LOG.info("Configuring partitions {}", splitPoints);
+    conf.set(job.getJobName() + ".wrotePartitions", "true");
     // create the partitions file
     FileSystem fs = FileSystem.get(conf);
     String hbaseTmpFsDir =

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -30,6 +30,7 @@ import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -158,6 +159,15 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
   static final String OUTPUT_TABLE_NAME_CONF_KEY = "hbase.mapreduce.hfileoutputformat.table.name";
   static final String MULTI_TABLE_HFILEOUTPUTFORMAT_CONF_KEY =
     "hbase.mapreduce.use.multi.table.hfileoutputformat";
+
+  /**
+   * ExtendedCell and ExtendedCellSerialization are InterfaceAudience.Private. We expose this config
+   * package-private for internal usage for jobs like WALPlayer which need to use features of
+   * ExtendedCell.
+   */
+  static final String EXTENDED_CELL_SERIALIZATION_ENABLED_KEY =
+    "hbase.mapreduce.hfileoutputformat.extendedcell.enabled";
+  static final boolean EXTENDED_CELL_SERIALIZATION_ENABLED_DEFULT = false;
 
   public static final String REMOTE_CLUSTER_CONF_PREFIX = "hbase.hfileoutputformat.remote.cluster.";
   public static final String REMOTE_CLUSTER_ZOOKEEPER_QUORUM_CONF_KEY =
@@ -619,12 +629,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
       LOG.warn("Unknown map output value type:" + job.getMapOutputValueClass());
     }
 
-    // Order matters here. Hadoop's SerializationFactory runs through serializations in the order
-    // they are registered. Register ExtendedCellSerialization before CellSerialization because both
-    // work for ExtendedCells but ExtendedCellSerialization handles them properly.
-    conf.setStrings("io.serializations", conf.get("io.serializations"),
-      MutationSerialization.class.getName(), ResultSerialization.class.getName(),
-      ExtendedCellSerialization.class.getName(), CellSerialization.class.getName());
+    mergeSerializations(conf);
 
     if (conf.getBoolean(LOCALITY_SENSITIVE_CONF_KEY, DEFAULT_LOCALITY_SENSITIVE)) {
       LOG.info("bulkload locality sensitive enabled");
@@ -671,6 +676,33 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
     TableMapReduceUtil.addDependencyJars(job);
     TableMapReduceUtil.initCredentials(job);
     LOG.info("Incremental output configured for tables: " + StringUtils.join(allTableNames, ","));
+  }
+
+  private static void mergeSerializations(Configuration conf) {
+    List<String> serializations = new ArrayList<>();
+
+    // add any existing values that have been set
+    String[] existing = conf.getStrings("io.serializations");
+    if (existing != null) {
+      Collections.addAll(serializations, existing);
+    }
+
+    serializations.add(MutationSerialization.class.getName());
+    serializations.add(ResultSerialization.class.getName());
+
+    // Add ExtendedCellSerialization, if configured. Order matters here. Hadoop's
+    // SerializationFactory runs through serializations in the order they are registered.
+    // We want to register ExtendedCellSerialization before CellSerialization because both
+    // work for ExtendedCells but only ExtendedCellSerialization handles them properly.
+    if (
+      conf.getBoolean(EXTENDED_CELL_SERIALIZATION_ENABLED_KEY,
+        EXTENDED_CELL_SERIALIZATION_ENABLED_DEFULT)
+    ) {
+      serializations.add(ExtendedCellSerialization.class.getName());
+    }
+    serializations.add(CellSerialization.class.getName());
+
+    conf.setStrings("io.serializations", serializations.toArray(new String[0]));
   }
 
   public static void configureIncrementalLoadMap(Job job, TableDescriptor tableDescriptor)

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -619,9 +619,12 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
       LOG.warn("Unknown map output value type:" + job.getMapOutputValueClass());
     }
 
+    // Order matters here. Hadoop's SerializationFactory runs through serializations in the order
+    // they are registered. Register ExtendedCellSerialization before CellSerialization because both
+    // work for ExtendedCells but ExtendedCellSerialization handles them properly.
     conf.setStrings("io.serializations", conf.get("io.serializations"),
       MutationSerialization.class.getName(), ResultSerialization.class.getName(),
-      CellSerialization.class.getName());
+      ExtendedCellSerialization.class.getName(), CellSerialization.class.getName());
 
     if (conf.getBoolean(LOCALITY_SENSITIVE_CONF_KEY, DEFAULT_LOCALITY_SENSITIVE)) {
       LOG.info("bulkload locality sensitive enabled");

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -316,6 +316,10 @@ public class WALPlayer extends Configured implements Tool {
     if (hfileOutPath != null) {
       LOG.debug("add incremental job :" + hfileOutPath + " from " + inputDirs);
 
+      // WALPlayer needs ExtendedCellSerialization so that sequenceId can be propagated when
+      // sorting cells in CellSortReducer
+      conf.setBoolean(HFileOutputFormat2.EXTENDED_CELL_SERIALIZATION_ENABLED_KEY, true);
+
       // the bulk HFile case
       List<TableName> tableNames = getTableNameList(tables);
 

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -80,12 +80,17 @@ public class WALPlayer extends Configured implements Tool {
   protected static final String tableSeparator = ";";
 
   private final static String JOB_NAME_CONF_KEY = "mapreduce.job.name";
+  private List<ImmutableBytesWritable> splits;
 
   public WALPlayer() {
   }
 
   protected WALPlayer(final Configuration c) {
     super(c);
+  }
+
+  public void setSplits(List<ImmutableBytesWritable> splits) {
+    this.splits = splits;
   }
 
   /**
@@ -320,6 +325,10 @@ public class WALPlayer extends Configured implements Tool {
       // sorting cells in CellSortReducer
       job.getConfiguration().setBoolean(HFileOutputFormat2.EXTENDED_CELL_SERIALIZATION_ENABLED_KEY,
         true);
+
+      if (splits != null) {
+        HFileOutputFormat2.configurePartitioner(job, splits, true);
+      }
 
       // the bulk HFile case
       List<TableName> tableNames = getTableNameList(tables);

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -318,7 +318,8 @@ public class WALPlayer extends Configured implements Tool {
 
       // WALPlayer needs ExtendedCellSerialization so that sequenceId can be propagated when
       // sorting cells in CellSortReducer
-      conf.setBoolean(HFileOutputFormat2.EXTENDED_CELL_SERIALIZATION_ENABLED_KEY, true);
+      job.getConfiguration().setBoolean(HFileOutputFormat2.EXTENDED_CELL_SERIALIZATION_ENABLED_KEY,
+        true);
 
       // the bulk HFile case
       List<TableName> tableNames = getTableNameList(tables);

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
@@ -17,6 +17,10 @@
  */
 package org.apache.hadoop.hbase.mapreduce;
 
+import static org.hamcrest.CoreMatchers.equalTo;
+import static org.hamcrest.CoreMatchers.notNullValue;
+import static org.hamcrest.CoreMatchers.nullValue;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -190,15 +194,12 @@ public class TestWALPlayer {
     Get g = new Get(row);
     Result result = table.get(g);
     byte[] value = CellUtil.cloneValue(result.getColumnLatestCell(family, column1));
-    assertTrue(
-      "Expected " + Bytes.toStringBinary(column1) + " latest value to be equal to lastVal="
-        + Bytes.toStringBinary(lastVal) + " but was " + Bytes.toStringBinary(value),
-      Bytes.equals(lastVal, value));
+    assertThat(Bytes.toStringBinary(value), equalTo(Bytes.toStringBinary(lastVal)));
 
     table = TEST_UTIL.truncateTable(tableName);
     g = new Get(row);
     result = table.get(g);
-    assertTrue("expected row to be empty after truncate but got " + result, result.isEmpty());
+    assertThat(result.listCells(), nullValue());
 
     BulkLoadHFiles.create(configuration).bulkLoad(tableName,
       new Path(outPath, tableName.getNamespaceAsString() + "/" + tableName.getNameAsString()));
@@ -206,10 +207,9 @@ public class TestWALPlayer {
     g = new Get(row);
     result = table.get(g);
     value = CellUtil.cloneValue(result.getColumnLatestCell(family, column1));
-    assertTrue(
-      "Expected " + Bytes.toStringBinary(column1) + " latest value to be equal to lastVal="
-        + Bytes.toStringBinary(lastVal) + " but was " + Bytes.toStringBinary(value),
-      Bytes.equals(lastVal, value));
+
+    assertThat(result.listCells(), notNullValue());
+    assertThat(Bytes.toStringBinary(value), equalTo(Bytes.toStringBinary(lastVal)));
   }
 
   /**

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
@@ -177,7 +177,7 @@ public class TestWALPlayer {
     String walInputDir = new Path(cluster.getMaster().getMasterFileSystem().getWALRootDir(),
       HConstants.HREGION_LOGDIR_NAME).toString();
 
-    Configuration configuration = TEST_UTIL.getConfiguration();
+    Configuration configuration = new Configuration(TEST_UTIL.getConfiguration());
     String outPath = "/tmp/" + name.getMethodName();
     configuration.set(WALPlayer.BULK_OUTPUT_CONF_KEY, outPath);
     configuration.setBoolean(WALPlayer.MULTI_TABLES_SUPPORT, true);

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
@@ -54,6 +54,7 @@ import org.apache.hadoop.hbase.testclassification.MapReduceTests;
 import org.apache.hadoop.hbase.tool.BulkLoadHFiles;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.LauncherSecurityManager;
 import org.apache.hadoop.hbase.util.MapReduceExtendedCell;
 import org.apache.hadoop.hbase.wal.WAL;
@@ -147,7 +148,7 @@ public class TestWALPlayer {
     final byte[] row = Bytes.toBytes("row");
     Table table = TEST_UTIL.createTable(tableName, family);
 
-    long now = System.currentTimeMillis();
+    long now = EnvironmentEdgeManager.currentTime();
     // put a row into the first table
     Put p = new Put(row);
     p.addColumn(family, column1, now, column1);


### PR DESCRIPTION
This seems simple enough from a compatibility perspective. I'm adding a new `io.serializations`, but it should not matter for HFileOutputFormat2 whose output is actually written by StoreFileWriter. It'll only be used in the intermediate output, so is safe to change between deploys.

I chose to create a new ExtendedCellSerialization because it seemed the cleanest way to encapsulate, since others may have used CellSerialization in other contexts. The alternative would be to make CellSerialization implement Configurable, and use that to inject some new configuration which defaults to false. It felt better to skip needing to add a new configuration.

EDIT: I decided to wrap this in a conditional so its exposed to WALPlayer only for now. I realized that someone could have a job which reads Cells from some other sequence file they had created. A job configured by HFileOutputFormat2 would fail to read those if ExtendedCellSerialization were added. So adding to just WALPlayer preserves compatibility, since that job is end-to-end.