### PR TITLE
HBASE-27676 Scan handlers in the RPC executor should match at least o…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RWQueueRpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RWQueueRpcExecutor.java
@@ -79,11 +79,13 @@ public class RWQueueRpcExecutor extends RpcExecutor {
     int readQueues = calcNumReaders(this.numCallQueues, callqReadShare);
     int readHandlers = Math.max(readQueues, calcNumReaders(handlerCount, callqReadShare));
 
-    int scanQueues = Math.max(0, (int) Math.floor(readQueues * callqScanShare));
     int scanHandlers = Math.max(0, (int) Math.floor(readHandlers * callqScanShare));
+    int scanQueues =
+      scanHandlers > 0 ? Math.max(1, (int) Math.floor(readQueues * callqScanShare)) : 0;
 
-    if ((readQueues - scanQueues) > 0) {
-      readQueues -= scanQueues;
+    if (scanQueues > 0) {
+      // if scanQueues > 0, the handler count of read should > 0, then we make readQueues >= 1
+      readQueues = Math.max(1, readQueues - scanQueues);
       readHandlers -= scanHandlers;
     } else {
       scanQueues = 0;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRpcSchedulerFactory.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRpcSchedulerFactory.java
@@ -68,6 +68,18 @@ public class TestRpcSchedulerFactory {
   }
 
   @Test
+  public void testRWQWithoutReadShare() {
+    // Set some configs just to see how it changes the scheduler. Can't assert the settings had
+    // an effect. Just eyeball the log.
+    this.conf.setDouble(RWQueueRpcExecutor.CALL_QUEUE_READ_SHARE_CONF_KEY, 0);
+    this.conf.setDouble(RpcExecutor.CALL_QUEUE_HANDLER_FACTOR_CONF_KEY, 0.5);
+    this.conf.setDouble(RWQueueRpcExecutor.CALL_QUEUE_SCAN_SHARE_CONF_KEY, 0);
+    RpcSchedulerFactory factory = new SimpleRpcSchedulerFactory();
+    RpcScheduler rpcScheduler = factory.create(this.conf, null, null);
+    assertTrue(rpcScheduler.getClass().equals(SimpleRpcScheduler.class));
+  }
+
+  @Test
   public void testFifo() {
     RpcSchedulerFactory factory = new FifoRpcSchedulerFactory();
     RpcScheduler rpcScheduler = factory.create(this.conf, null, null);


### PR DESCRIPTION
…ne scan queues

This issue is try to avoid NO scan queues for some scan handlers. 
For example, if we set hbase.regionserver.handler.count=150, hbase.ipc.server.callqueue.scan.ratio=0.1, hbase.ipc.server.callqueue.read.ratio=0.5, hbase.ipc.server.callqueue.handler.factor=0.1, then there will be 150*0.5*0.1=7 scan handlers, but there are 150*0.1*0.5*0.1=0 scan RPC queues.
When there are no scan rpc queues, all the scan and get requests will be dispatched to the read rpc queues, while we we thought they had been dealt with separately, since the scan handler count is not 0. When there are not enough handlers for large scan requests under this circumstance, the small get requests will be blocked in the rpc queues.