### PR TITLE
HBASE-27688 HFile splitting occurs during bulkload, the CREATE_TIME_TS of hfileinfo is 0

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -88,6 +88,7 @@ import org.apache.hadoop.hbase.regionserver.StoreUtils;
 import org.apache.hadoop.hbase.security.UserProvider;
 import org.apache.hadoop.hbase.security.token.FsDelegationToken;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSVisitor;
 import org.apache.hadoop.hbase.util.FutureUtils;
 import org.apache.hadoop.hbase.util.Pair;
@@ -577,6 +578,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
     return UUID.randomUUID().toString().replaceAll("-", "");
   }
 
+
   private List<LoadQueueItem> splitStoreFile(LoadQueueItem item, TableDescriptor tableDesc,
     byte[] splitKey) throws IOException {
     Path hfilePath = item.getFilePath();
@@ -767,7 +769,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
         .withChecksumType(StoreUtils.getChecksumType(conf))
         .withBytesPerCheckSum(StoreUtils.getBytesPerChecksum(conf)).withBlockSize(blocksize)
         .withDataBlockEncoding(familyDescriptor.getDataBlockEncoding()).withIncludesTags(true)
-        .build();
+        .withCreateTime(EnvironmentEdgeManager.currentTime()).build();
       halfWriter = new StoreFileWriter.Builder(conf, cacheConf, fs).withFilePath(outFile)
         .withBloomType(bloomFilterType).withFileContext(hFileContext).build();
       HFileScanner scanner = halfReader.getScanner(false, false, false);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -578,7 +578,6 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
     return UUID.randomUUID().toString().replaceAll("-", "");
   }
 
-
   private List<LoadQueueItem> splitStoreFile(LoadQueueItem item, TableDescriptor tableDesc,
     byte[] splitKey) throws IOException {
     Path hfilePath = item.getFilePath();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -197,14 +197,11 @@ public final class FSUtils {
     if (fs instanceof HFileSystem) {
       FileSystem backingFs = ((HFileSystem) fs).getBackingFs();
       if (backingFs instanceof DistributedFileSystem) {
-        // Try to use the favoredNodes version via reflection to allow backwards-
-        // compatibility.
         short replication = Short.parseShort(conf.get(ColumnFamilyDescriptorBuilder.DFS_REPLICATION,
           String.valueOf(ColumnFamilyDescriptorBuilder.DEFAULT_DFS_REPLICATION)));
-        DistributedFileSystem dfs = (DistributedFileSystem) backingFs;
         DistributedFileSystem.HdfsDataOutputStreamBuilder builder =
-          dfs.createFile(path).recursive().permission(perm).create().overwrite(true)
-            .bufferSize(CommonFSUtils.getDefaultBufferSize(backingFs))
+          ((DistributedFileSystem) backingFs).createFile(path).recursive().permission(perm).create()
+            .overwrite(true).bufferSize(CommonFSUtils.getDefaultBufferSize(backingFs))
             .replication(
               replication > 0 ? replication : CommonFSUtils.getDefaultReplication(backingFs, path))
             .blockSize(CommonFSUtils.getDefaultBlockSize(backingFs, path));
@@ -213,6 +210,7 @@ public final class FSUtils {
         }
         return builder.build();
       }
+
     }
     return CommonFSUtils.create(fs, path, perm, true);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -85,7 +85,6 @@ import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
 import org.apache.hadoop.hdfs.protocol.LocatedBlock;
 import org.apache.hadoop.io.IOUtils;
 import org.apache.hadoop.ipc.RemoteException;
-import org.apache.hadoop.util.Progressable;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -203,17 +202,16 @@ public final class FSUtils {
         short replication = Short.parseShort(conf.get(ColumnFamilyDescriptorBuilder.DFS_REPLICATION,
           String.valueOf(ColumnFamilyDescriptorBuilder.DEFAULT_DFS_REPLICATION)));
         try {
-              DistributedFileSystem dfs = (DistributedFileSystem) backingFs;
-              DistributedFileSystem.HdfsDataOutputStreamBuilder builder =
-                dfs.createFile(path).permission(perm).create()
-                   .overwrite(true)
-                   .bufferSize(CommonFSUtils.getDefaultBufferSize(backingFs))
-                   .replication(replication > 0 ? replication : CommonFSUtils.getDefaultReplication(backingFs, path))
-                   .blockSize(CommonFSUtils.getDefaultBlockSize(backingFs, path))
-                   .favoredNodes(favoredNodes)
-                   .recursive();
-              return builder.build();
-        }catch (IllegalArgumentException | SecurityException  e) {
+          DistributedFileSystem dfs = (DistributedFileSystem) backingFs;
+          DistributedFileSystem.HdfsDataOutputStreamBuilder builder = dfs.createFile(path)
+            .permission(perm).create().overwrite(true)
+            .bufferSize(CommonFSUtils.getDefaultBufferSize(backingFs))
+            .replication(
+              replication > 0 ? replication : CommonFSUtils.getDefaultReplication(backingFs, path))
+            .blockSize(CommonFSUtils.getDefaultBlockSize(backingFs, path))
+            .favoredNodes(favoredNodes).recursive();
+          return builder.build();
+        } catch (IllegalArgumentException | SecurityException e) {
           LOG.debug("DFS Client does not support most favored nodes create; using default create");
           LOG.trace("Ignoring; use default create", e);
         }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -208,8 +208,11 @@ public final class FSUtils {
             .bufferSize(CommonFSUtils.getDefaultBufferSize(backingFs))
             .replication(
               replication > 0 ? replication : CommonFSUtils.getDefaultReplication(backingFs, path))
-            .blockSize(CommonFSUtils.getDefaultBlockSize(backingFs, path))
-            .favoredNodes(favoredNodes).recursive();
+            .blockSize(CommonFSUtils.getDefaultBlockSize(backingFs, path));
+          if (favoredNodes != null) {
+            builder.favoredNodes(favoredNodes);
+          }
+          builder.recursive();
           return builder.build();
         } catch (IllegalArgumentException | SecurityException e) {
           LOG.debug("DFS Client does not support most favored nodes create; using default create");

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -200,13 +200,13 @@ public final class FSUtils {
         short replication = Short.parseShort(conf.get(ColumnFamilyDescriptorBuilder.DFS_REPLICATION,
           String.valueOf(ColumnFamilyDescriptorBuilder.DEFAULT_DFS_REPLICATION)));
         DistributedFileSystem.HdfsDataOutputStreamBuilder builder =
-          ((DistributedFileSystem) backingFs).createFile(path).recursive().permission(perm).create()
-            .overwrite(true).bufferSize(CommonFSUtils.getDefaultBufferSize(backingFs))
-            .replication(
-              replication > 0 ? replication : CommonFSUtils.getDefaultReplication(backingFs, path))
-            .blockSize(CommonFSUtils.getDefaultBlockSize(backingFs, path));
+          ((DistributedFileSystem) backingFs).createFile(path).recursive().permission(perm)
+            .create();
         if (favoredNodes != null) {
           builder.favoredNodes(favoredNodes);
+        }
+        if (replication > 0) {
+          builder.replication(replication);
         }
         return builder.build();
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -201,23 +201,17 @@ public final class FSUtils {
         // compatibility.
         short replication = Short.parseShort(conf.get(ColumnFamilyDescriptorBuilder.DFS_REPLICATION,
           String.valueOf(ColumnFamilyDescriptorBuilder.DEFAULT_DFS_REPLICATION)));
-        try {
-          DistributedFileSystem dfs = (DistributedFileSystem) backingFs;
-          DistributedFileSystem.HdfsDataOutputStreamBuilder builder = dfs.createFile(path)
-            .permission(perm).create().overwrite(true)
+        DistributedFileSystem dfs = (DistributedFileSystem) backingFs;
+        DistributedFileSystem.HdfsDataOutputStreamBuilder builder =
+          dfs.createFile(path).recursive().permission(perm).create().overwrite(true)
             .bufferSize(CommonFSUtils.getDefaultBufferSize(backingFs))
             .replication(
               replication > 0 ? replication : CommonFSUtils.getDefaultReplication(backingFs, path))
             .blockSize(CommonFSUtils.getDefaultBlockSize(backingFs, path));
-          if (favoredNodes != null) {
-            builder.favoredNodes(favoredNodes);
-          }
-          builder.recursive();
-          return builder.build();
-        } catch (IllegalArgumentException | SecurityException e) {
-          LOG.debug("DFS Client does not support most favored nodes create; using default create");
-          LOG.trace("Ignoring; use default create", e);
+        if (favoredNodes != null) {
+          builder.favoredNodes(favoredNodes);
         }
+        return builder.build();
       }
     }
     return CommonFSUtils.create(fs, path, perm, true);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/tool/TestBulkLoadHFiles.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/tool/TestBulkLoadHFiles.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
-import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
@@ -647,17 +646,12 @@ public class TestBulkLoadHFiles {
 
   private void verifyHFileCreateTimeTS(Path p) throws IOException {
     Configuration conf = util.getConfiguration();
-    HFile.Reader reader =
-      HFile.createReader(p.getFileSystem(conf), p, new CacheConfig(conf), true, conf);
-    final HFileInfo hFileInfo = reader.getHFileInfo();
-    final long fileCreateTime = hFileInfo.getHFileContext().getFileCreateTime();
-    try {
-      reader.close();
-      MatcherAssert.assertThat(fileCreateTime, greaterThan(0L));
-    } catch (IOException e) {
-      fail("Failed due to exception");
-    }
 
+    try (HFile.Reader reader =
+      HFile.createReader(p.getFileSystem(conf), p, new CacheConfig(conf), true, conf)) {
+      long fileCreateTime = reader.getHFileInfo().getHFileContext().getFileCreateTime();
+      MatcherAssert.assertThat(fileCreateTime, greaterThan(0L));
+    }
   }
 
   private void addStartEndKeysForTest(TreeMap<byte[], Integer> map, byte[] first, byte[] last) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/tool/TestBulkLoadHFiles.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/tool/TestBulkLoadHFiles.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.tool;
 
 import static org.apache.hadoop.hbase.HBaseTestingUtil.countRows;
+import static org.hamcrest.Matchers.greaterThan;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
@@ -64,6 +65,7 @@ import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.HFileTestUtil;
+import org.hamcrest.MatcherAssert;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -649,8 +651,12 @@ public class TestBulkLoadHFiles {
       HFile.createReader(p.getFileSystem(conf), p, new CacheConfig(conf), true, conf);
     final HFileInfo hFileInfo = reader.getHFileInfo();
     final long fileCreateTime = hFileInfo.getHFileContext().getFileCreateTime();
-    reader.close();
-    assertTrue(fileCreateTime != 0);
+    try {
+      reader.close();
+      MatcherAssert.assertThat(fileCreateTime, greaterThan(0L));
+    } catch (IOException e) {
+      fail("Failed due to exception");
+    }
 
   }
 


### PR DESCRIPTION
JIRA:[HBASE-27688](https://issues.apache.org/jira/browse/HBASE-27688)
If HFile splitting occurs during bulkload, the CREATE_TIME_TS of hfileinfo =0,When HFile is copied after splitting, CREATE_TIME_TS of the original file is not copied。