### PR TITLE
HBASE-27704 Quotas can drastically overflow configured limit

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RateLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RateLimiter.java
@@ -157,9 +157,9 @@ public abstract class RateLimiter {
     }
     // check for positive overflow
     if (avail <= Long.MAX_VALUE - refillAmount) {
-      avail = Math.max(0, Math.min(avail + refillAmount, limit));
+      avail = Math.min(avail + refillAmount, limit);
     } else {
-      avail = Math.max(0, limit);
+      avail = limit;
     }
     if (avail >= amount) {
       return true;
@@ -186,9 +186,6 @@ public abstract class RateLimiter {
 
     if (amount >= 0) {
       this.avail -= amount;
-      if (this.avail < 0) {
-        this.avail = 0;
-      }
     } else {
       if (this.avail <= Long.MAX_VALUE + amount) {
         this.avail -= amount;


### PR DESCRIPTION
Removes limits in `refill` which did not allow to go negative. 
FixedIntervalRateLimiter also needed some changes in getWaitInterval to properly match with how refilling really works.
Updated the tests to revive the original intended logic for quotas, where we really test for overconsumption.