### PR TITLE
HBASE-27714 WALEntryStreamTestBase creates a new HBTU in startCluster…

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStreamTestBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStreamTestBase.java
@@ -130,7 +130,6 @@ public abstract class WALEntryStreamTestBase {
   protected final MultiVersionConcurrencyControl mvcc = new MultiVersionConcurrencyControl();
 
   protected static void startCluster() throws Exception {
-    TEST_UTIL = new HBaseTestingUtil();
     CONF = TEST_UTIL.getConfiguration();
     CONF.setLong("replication.source.sleepforretries", 10);
     TEST_UTIL.startMiniDFSCluster(3);


### PR DESCRIPTION
… method which causes all sub classes are testing default configurations