### PR TITLE
HBASE-27708 CPU hot-spot resolving User subject

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/security/User.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/security/User.java
@@ -55,12 +55,6 @@ public abstract class User {
 
   protected UserGroupInformation ugi;
 
-  /**
-   * Lazily-populated cache value of this instance's {@link #toString()} value. Computing this
-   * value is expensive. See HBASE-27708.
-   */
-  private String toString = null;
-
   public UserGroupInformation getUGI() {
     return ugi;
   }
@@ -158,10 +152,7 @@ public abstract class User {
 
   @Override
   public String toString() {
-    if (toString == null) {
-      toString = ugi.toString();
-    }
-    return toString;
+    return ugi.toString();
   }
 
   /** Returns the {@code User} instance within current execution context. */
@@ -279,20 +270,28 @@ public abstract class User {
   public static final class SecureHadoopUser extends User {
     private String shortName;
     private LoadingCache<String, String[]> cache;
+    /**
+     * Cache value of this instance's {@link #toString()} value. Computing this value is expensive.
+     * Assumes the UGI is never updated. See HBASE-27708.
+     */
+    private final String toString;
 
     public SecureHadoopUser() throws IOException {
       ugi = UserGroupInformation.getCurrentUser();
       this.cache = null;
+      this.toString = ugi.toString();
     }
 
     public SecureHadoopUser(UserGroupInformation ugi) {
       this.ugi = ugi;
       this.cache = null;
+      this.toString = ugi.toString();
     }
 
     public SecureHadoopUser(UserGroupInformation ugi, LoadingCache<String, String[]> cache) {
       this.ugi = ugi;
       this.cache = cache;
+      this.toString = ugi.toString();
     }
 
     @Override
@@ -327,6 +326,11 @@ public abstract class User {
     public <T> T runAs(PrivilegedExceptionAction<T> action)
       throws IOException, InterruptedException {
       return ugi.doAs(action);
+    }
+
+    @Override
+    public String toString() {
+      return toString;
     }
 
     /**

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/security/User.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/security/User.java
@@ -55,6 +55,11 @@ public abstract class User {
 
   protected UserGroupInformation ugi;
 
+  /**
+   * Lazily-populated cache value of this instance's {@link #toString()} value.
+   */
+  private String toString = null;
+
   public UserGroupInformation getUGI() {
     return ugi;
   }
@@ -152,7 +157,10 @@ public abstract class User {
 
   @Override
   public String toString() {
-    return ugi.toString();
+    if (toString == null) {
+      toString = ugi.toString();
+    }
+    return toString;
   }
 
   /** Returns the {@code User} instance within current execution context. */

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/security/User.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/security/User.java
@@ -56,7 +56,8 @@ public abstract class User {
   protected UserGroupInformation ugi;
 
   /**
-   * Lazily-populated cache value of this instance's {@link #toString()} value.
+   * Lazily-populated cache value of this instance's {@link #toString()} value. Computing this
+   * value is expensive. See HBASE-27708.
    */
   private String toString = null;
 


### PR DESCRIPTION
Implementation follows that of those who came before -- nothing fancy, no locking or memory barriers.

Having the UGI as a protected, non-final property on an abstract class is a nightmare.