### PR TITLE
HBASE-27710 ByteBuff ref counting is too expensive for on-heap buffers

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/nio/RefCnt.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/nio/RefCnt.java
@@ -59,6 +59,13 @@ public class RefCnt extends AbstractReferenceCounted {
     this.leak = recycler == ByteBuffAllocator.NONE ? null : detector.track(this);
   }
 
+  /**
+   * Returns true if this refCnt has a recycler.
+   */
+  public boolean hasRecycler() {
+    return recycler != ByteBuffAllocator.NONE;
+  }
+
   @Override
   public ReferenceCounted retain() {
     maybeRecord();

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/TestByteBuffAllocator.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/TestByteBuffAllocator.java
@@ -221,8 +221,10 @@ public class TestByteBuffAllocator {
     assertEquals(0, buf2.refCnt());
     assertEquals(0, dup2.refCnt());
     assertEquals(0, alloc.getFreeBufferCount());
-    assertException(dup2::position);
-    assertException(buf2::position);
+    // these should not throw an exception because they are heap buffers.
+    // off-heap buffers would throw an exception if trying to call a method once released.
+    dup2.position();
+    buf2.position();
 
     // duplicate the buf1, if the dup1 released, buf1 will also be released (MultipleByteBuffer)
     ByteBuff dup1 = buf1.duplicate();

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/TestByteBuffAllocator.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/TestByteBuffAllocator.java
@@ -415,4 +415,103 @@ public class TestByteBuffAllocator {
     alloc1.allocate(1024);
     Assert.assertEquals(getHeapAllocationRatio(HEAP, HEAP, alloc1), 1024f / (1024f + 2048f), 1e-6);
   }
+
+  /**
+   * Tests that we only call the logic in checkRefCount for ByteBuff's that have a non-NONE
+   * recycler.
+   */
+  @Test
+  public void testCheckRefCountOnlyWithRecycler() {
+    TrackingSingleByteBuff singleBuff = new TrackingSingleByteBuff(ByteBuffer.allocate(1));
+    singleBuff.get();
+    assertEquals(1, singleBuff.getCheckRefCountCalls());
+    assertEquals(0, singleBuff.getRefCntCalls());
+    singleBuff = new TrackingSingleByteBuff(() -> {
+      // do nothing, just so we dont use NONE recycler
+    }, ByteBuffer.allocate(1));
+    singleBuff.get();
+    assertEquals(1, singleBuff.getCheckRefCountCalls());
+    assertEquals(1, singleBuff.getRefCntCalls());
+
+    TrackingMultiByteBuff multiBuff = new TrackingMultiByteBuff(ByteBuffer.allocate(1));
+
+    multiBuff.get();
+    assertEquals(1, multiBuff.getCheckRefCountCalls());
+    assertEquals(0, multiBuff.getRefCntCalls());
+    multiBuff = new TrackingMultiByteBuff(() -> {
+      // do nothing, just so we dont use NONE recycler
+    }, ByteBuffer.allocate(1));
+    multiBuff.get();
+    assertEquals(1, multiBuff.getCheckRefCountCalls());
+    assertEquals(1, multiBuff.getRefCntCalls());
+  }
+
+  private static class TrackingSingleByteBuff extends SingleByteBuff {
+
+    int refCntCalls = 0;
+    int checkRefCountCalls = 0;
+
+    public TrackingSingleByteBuff(ByteBuffer buf) {
+      super(buf);
+    }
+
+    public TrackingSingleByteBuff(ByteBuffAllocator.Recycler recycler, ByteBuffer buf) {
+      super(recycler, buf);
+    }
+
+    public int getRefCntCalls() {
+      return refCntCalls;
+    }
+
+    public int getCheckRefCountCalls() {
+      return checkRefCountCalls;
+    }
+
+    @Override
+    protected void checkRefCount() {
+      checkRefCountCalls++;
+      super.checkRefCount();
+    }
+
+    @Override
+    public int refCnt() {
+      refCntCalls++;
+      return super.refCnt();
+    }
+  }
+
+  private static class TrackingMultiByteBuff extends MultiByteBuff {
+
+    int refCntCalls = 0;
+    int checkRefCountCalls = 0;
+
+    public TrackingMultiByteBuff(ByteBuffer... items) {
+      super(items);
+    }
+
+    public TrackingMultiByteBuff(ByteBuffAllocator.Recycler recycler, ByteBuffer... items) {
+      super(recycler, items);
+    }
+
+    public int getRefCntCalls() {
+      return refCntCalls;
+    }
+
+    public int getCheckRefCountCalls() {
+      return checkRefCountCalls;
+    }
+
+    @Override
+    protected void checkRefCount() {
+      checkRefCountCalls++;
+      super.checkRefCount();
+    }
+
+    @Override
+    public int refCnt() {
+      refCntCalls++;
+      return super.refCnt();
+    }
+  }
+
 }

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -18,6 +18,7 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
+trigger build
 -->
   <modelVersion>4.0.0</modelVersion>
   <parent>

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -18,7 +18,6 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-trigger build
 -->
   <modelVersion>4.0.0</modelVersion>
   <parent>


### PR DESCRIPTION
This felt like the cleanest way to solve this case, but open to other opinions. Whether we need to checkRefCount is directly tied to whether we use NONE recycler.

A couple other options I considered:
- Create a new inheritance hierarchy, i.e. OnHeapSingleByteBuff, etc. This felt like it'd only complicate an already complex system.
- Update the SingleByteBuff and MultiByteBuff constructors to take a new `boolean onHeap` or `boolean shouldCheckRefCount`. This felt more error prone because it's too easy for someone to forget to pass the correct boolean value for the corresponding recycler.

I added a basic test to validate that we only call checkRefCount for non-NONE recyclers. Beyond that, I think our existing ample coverage should suffice? Let me know if you'd like to see a particular test.