### PR TITLE
Add supplement for com.aayushatharva.brotli4j:native-osx-aarch64

### DIFF
--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
@@ -3449,6 +3449,19 @@ Copyright (c) 2007-2017 The JRuby project
   <supplement>
     <project>
       <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>native-osx-aarch64</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </project>
+  </supplement>
+  <supplement>
+    <project>
+      <groupId>com.aayushatharva.brotli4j</groupId>
       <artifactId>native-windows-x86_64</artifactId>
       <licenses>
         <license>


### PR DESCRIPTION
Add supplement for com.aayushatharva.brotli4j:native-osx-aarch64 licence information. https://issues.apache.org/jira/browse/HBASE-27723