### PR TITLE
Upgrade commons-validator to 1.7

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -809,7 +809,7 @@
     <avro.version>1.11.0</avro.version>
     <caffeine.version>2.8.1</caffeine.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <commons-validator.version>1.6</commons-validator.version>
+    <commons-validator.version>1.7</commons-validator.version>
     <commons-io.version>2.11.0</commons-io.version>
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-math.version>3.6.1</commons-math.version>


### PR DESCRIPTION
Upgrade commons-validator to 1.7 to address CVE-2014-0114 and CVE-2019-10086 brought in by commons-beanutils 1.9.2