### PR TITLE
HBASE-27736 HFileSystem.getLocalFs is not used

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/fs/HFileSystem.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/fs/HFileSystem.java
@@ -452,13 +452,6 @@ public class HFileSystem extends FilterFileSystem {
   }
 
   /**
-   * Wrap a LocalFileSystem within a HFileSystem.
-   */
-  static public FileSystem getLocalFs(Configuration conf) throws IOException {
-    return new HFileSystem(FileSystem.getLocal(conf));
-  }
-
-  /**
    * The org.apache.hadoop.fs.FilterFileSystem does not yet support createNonRecursive. This is a
    * hadoop bug and when it is fixed in Hadoop, this definition will go away.
    */


### PR DESCRIPTION
HFileSystem::getLocalFs useless，and can be remove