### PR TITLE
HBASE-27744 Update compression dependencies

### DIFF
--- a/hbase-resource-bundle/src/main/resources/supplemental-models.xml
+++ b/hbase-resource-bundle/src/main/resources/supplemental-models.xml
@@ -2406,6 +2406,19 @@ Copyright (c) 2007-2017 The JRuby project
   <supplement>
     <project>
       <groupId>com.aayushatharva.brotli4j</groupId>
+      <artifactId>service</artifactId>
+      <licenses>
+        <license>
+          <name>Apache License, Version 2.0</name>
+          <url>http://www.apache.org/licenses/LICENSE-2.0.txt</url>
+          <distribution>repo</distribution>
+        </license>
+      </licenses>
+    </project>
+  </supplement>
+  <supplement>
+    <project>
+      <groupId>com.aayushatharva.brotli4j</groupId>
       <artifactId>native-windows-x86_64</artifactId>
       <licenses>
         <license>

--- a/pom.xml
+++ b/pom.xml
@@ -880,12 +880,12 @@
     <spotless.version>2.27.2</spotless.version>
     <maven-site.version>3.12.0</maven-site.version>
     <!-- compression -->
-    <aircompressor.version>0.21</aircompressor.version>
-    <brotli4j.version>1.8.0</brotli4j.version>
+    <aircompressor.version>0.24</aircompressor.version>
+    <brotli4j.version>1.11.0</brotli4j.version>
     <lz4.version>1.8.0</lz4.version>
-    <snappy.version>1.1.8.4</snappy.version>
+    <snappy.version>1.1.9.1</snappy.version>
     <xz.version>1.9</xz.version>
-    <zstd-jni.version>1.5.0-4</zstd-jni.version>
+    <zstd-jni.version>1.5.4-2</zstd-jni.version>
     <hbase-thirdparty.version>4.1.4</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>


### PR DESCRIPTION
Update compression codec dependencies:

 - aircompressor 0.21 -> 0.24
 - brotli4j 1.8.0 -> 1.11.0
 - snappy 1.1.8.4 -> 1.1.9.1
 - zstd-jni 1.5.0-4 -> 1.5.4-2

and add a new supplemental model for new brotli4j dependency.