### PR TITLE
HBASE-27726 Handling of ruby shell SyntaxError exceptions

### DIFF
--- a/hbase-shell/src/main/ruby/irb/hirb.rb
+++ b/hbase-shell/src/main/ruby/irb/hirb.rb
@@ -118,6 +118,8 @@ module IRB
           rescue Interrupt => exc
           rescue SystemExit, SignalException
             raise
+          rescue SyntaxError => exc
+            raise exc unless @interactive
           rescue NameError => exc
             raise exc unless @interactive
             # HBASE-26880: Ignore NameError to prevent exiting Shell on mistyped commands.


### PR DESCRIPTION
This PR is with respect to handling of SyntaxError exception in case we pass non-ascii characters in ruby shell.

The error scenario is explained in the below example :
hbase:002:0> create 't2', 'cf'
2023-03-14 04:54:50,061 INFO  [main] client.HBaseAdmin: Operation: CREATE, Table Name: default:t2, procId: 2140 completed
Created table t2
Took 1.1503 seconds
=> Hbase::Table - t2
hbase:003:0> alter 't2', NAME ⇒ 'cf', VERSIONS ⇒ 5
SyntaxError: (hbase):3: syntax error, unexpected tIDENTIFIER
alter 't2', NAME ⇒ 'cf', VERSIONS ⇒ 5
                 ^~~
                      eval at org/jruby/RubyKernel.java:1091
                  evaluate at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/irb/workspace.rb:85
                  evaluate at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/irb/context.rb:385
                eval_input at uri:classloader:/irb/hirb.rb:115
             signal_status at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/irb.rb:647
                eval_input at uri:classloader:/irb/hirb.rb:112
  each_top_level_statement at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/irb/ruby-lex.rb:246
                      loop at org/jruby/RubyKernel.java:1507
  each_top_level_statement at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/irb/ruby-lex.rb:232
                     catch at org/jruby/RubyKernel.java:1237
  each_top_level_statement at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/irb/ruby-lex.rb:231
                eval_input at uri:classloader:/irb/hirb.rb:111
                       run at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/irb.rb:428
                     catch at org/jruby/RubyKernel.java:1237
                       run at uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/irb.rb:427
<main> at classpath:/jar-bootstrap.rb:226

**EXPECTED RESULT :** 

It should throw compilation error instead of exiting
The image attached below gives the exception in case we pass non-ascii character in alter command

<img width="980" alt="Screenshot 2023-03-28 at 11 18 09 AM" src="https://user-images.githubusercontent.com/32217578/228140573-ef0dcca2-eef3-41d9-9e86-8dacf6569458.png">
