### PR TITLE
HBASE-27758 Inconsistent synchronization in MetricsUserSourceImpl

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsUserSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsUserSourceImpl.java
@@ -137,16 +137,14 @@ public class MetricsUserSourceImpl implements MetricsUserSource {
 
   @Override
   public void register() {
-    synchronized (this) {
-      getHisto = registry.newTimeHistogram(userGetKey);
-      scanTimeHisto = registry.newTimeHistogram(userScanTimeKey);
-      putHisto = registry.newTimeHistogram(userPutKey);
-      deleteHisto = registry.newTimeHistogram(userDeleteKey);
-      incrementHisto = registry.newTimeHistogram(userIncrementKey);
-      appendHisto = registry.newTimeHistogram(userAppendKey);
-      replayHisto = registry.newTimeHistogram(userReplayKey);
-      blockBytesScannedCount = registry.newCounter(userBlockBytesScannedKey, "", 0);
-    }
+    getHisto = registry.newTimeHistogram(userGetKey);
+    scanTimeHisto = registry.newTimeHistogram(userScanTimeKey);
+    putHisto = registry.newTimeHistogram(userPutKey);
+    deleteHisto = registry.newTimeHistogram(userDeleteKey);
+    incrementHisto = registry.newTimeHistogram(userIncrementKey);
+    appendHisto = registry.newTimeHistogram(userAppendKey);
+    replayHisto = registry.newTimeHistogram(userReplayKey);
+    blockBytesScannedCount = registry.newCounter(userBlockBytesScannedKey, "", 0);
   }
 
   @Override
@@ -162,16 +160,14 @@ public class MetricsUserSourceImpl implements MetricsUserSource {
       LOG.debug("Removing user Metrics for user: " + user);
     }
 
-    synchronized (this) {
-      registry.removeMetric(userGetKey);
-      registry.removeMetric(userScanTimeKey);
-      registry.removeMetric(userPutKey);
-      registry.removeMetric(userDeleteKey);
-      registry.removeMetric(userIncrementKey);
-      registry.removeMetric(userAppendKey);
-      registry.removeMetric(userReplayKey);
-      registry.removeMetric(userBlockBytesScannedKey);
-    }
+    registry.removeMetric(userGetKey);
+    registry.removeMetric(userScanTimeKey);
+    registry.removeMetric(userPutKey);
+    registry.removeMetric(userDeleteKey);
+    registry.removeMetric(userIncrementKey);
+    registry.removeMetric(userAppendKey);
+    registry.removeMetric(userReplayKey);
+    registry.removeMetric(userBlockBytesScannedKey);
   }
 
   @Override


### PR DESCRIPTION
Spotbugs complains because, for example, the assignment of `appendHisto` is synchronized but the actual usage in `updateAppend` is not. The first thought might be to synchronize all of the methods, but that would be detrimental to performance and unnecessary since these metrics are already thread safe.

The synchronization of register/deregister was added as part of the LossyCounting stuff for user metrics. So its possible under extreme conditions for the LossyCounting thread to deregister a user source which is currently being registered. So it's important to synchronize the actual metric creation/removal, more than anything else.

There is only one caller of `register/deregister`, here in  [MetricsUserAggregateSourceImpl](https://github.com/apache/hbase/blob/master/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsUserAggregateSourceImpl.java#L50-L87).  Note that it's already synchronized. So I think the synchronization here is redundant. Further, I don't think the synchronization here is even effective since it's synchronizing access to `registry` which could be used in other instances of MetricsUserSourceImpl.