### PR TITLE
HBASE-27768 Race conditions in BlockingRpcConnection

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
@@ -357,7 +357,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
         Thread.currentThread().interrupt();
 
         String msg = "Interrupted while waiting for work";
-        LOG.debug(msg);
+
         // If we were interrupted by closeConn, it would have set thread to null.
         // We are synchronized here and if we somehow got interrupted without setting thread to
         // null, we want to make sure the connection is closed since the read thread would be dead.
@@ -365,7 +365,10 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
         // This guards against the case where a call to setupIOStreams got the synchronized lock
         // first after closeConn, thus changing the thread to a new thread.
         if (isCurrentThreadExpected()) {
+          LOG.debug(msg + ", closing connection");
           closeConn(new InterruptedIOException(msg));
+        } else {
+          LOG.debug(msg);
         }
 
         return false;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
@@ -43,6 +43,7 @@ import java.util.Queue;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.security.sasl.SaslException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.CellScanner;
@@ -95,6 +96,13 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
   @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "IS2_INCONSISTENT_SYNC",
       justification = "We are always under lock actually")
   private Thread thread;
+
+  // Used for ensuring two reader threads don't run over each other. Should only be used
+  // in reader thread run() method, to avoid deadlocks with synchronization on BlockingRpcConnection
+  private final Object readerThreadLock = new Object();
+
+  // Used to suffix the threadName in a way that we can differentiate them in logs/thread dumps.
+  private final AtomicInteger attempts = new AtomicInteger();
 
   // connected socket. protected for writing UT.
   protected Socket socket = null;
@@ -323,6 +331,17 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
       if (thread == null) {
         return false;
       }
+
+      // If closeConn is called while we are in the readResponse method, it's possible that a new
+      // call to setupIOStreams comes in and creates a new value for "thread" before readResponse
+      // finishes. Once readResponse finishes, it will come in here and thread will be non-null
+      // above, but pointing at a new thread. In that case, we should end to avoid a situation
+      // where two threads are forever competing for the same socket.
+      if (!isCurrentThreadExpected()) {
+        LOG.debug("Thread replaced by new connection thread. Ending waitForWork loop.");
+        return false;
+      }
+
       if (!calls.isEmpty()) {
         return true;
       }
@@ -336,6 +355,20 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
       } catch (InterruptedException e) {
         // Restore interrupt status
         Thread.currentThread().interrupt();
+
+        String msg = "Interrupted while waiting for work";
+        LOG.debug(msg);
+        // If we were interrupted by closeConn, it would have set thread to null.
+        // We are synchronized here and if we somehow got interrupted without setting thread to
+        // null, we want to make sure the connection is closed since the read thread would be dead.
+        // Rather than do a null check here, we check if the current thread is the expected thread.
+        // This guards against the case where a call to setupIOStreams got the synchronized lock
+        // first after closeConn, thus changing the thread to a new thread.
+        if (isCurrentThreadExpected()) {
+          closeConn(new InterruptedIOException(msg));
+        }
+
+        return false;
       }
     }
   }
@@ -343,13 +376,24 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
   @Override
   public void run() {
     if (LOG.isTraceEnabled()) {
-      LOG.trace(threadName + ": starting");
+      LOG.trace("starting");
     }
-    while (waitForWork()) {
-      readResponse();
+
+    // We have a synchronization here because it's possible in error scenarios for a new
+    // thread to be started while readResponse is still reading on the socket. We don't want
+    // two threads to be reading from the same socket/inputstream.
+    // The below calls can synchronize on "BlockingRpcConnection.this".
+    // We should not synchronize on readerThreadLock anywhere else, to avoid deadlocks
+    synchronized (readerThreadLock) {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("started");
+      }
+      while (waitForWork()) {
+        readResponse();
+      }
     }
     if (LOG.isTraceEnabled()) {
-      LOG.trace(threadName + ": stopped");
+      LOG.trace("stopped");
     }
   }
 
@@ -522,7 +566,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
     }
 
     // start the receiver thread after the socket connection has been set up
-    thread = new Thread(this, threadName);
+    thread = new Thread(this, threadName + " (attempt: " + attempts.incrementAndGet() + ")");
     thread.setDaemon(true);
     thread.start();
   }
@@ -629,7 +673,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
         call.callStats.setRequestSizeBytes(write(this.out, requestHeader, call.param, cellBlock));
       } catch (Throwable t) {
         if (LOG.isTraceEnabled()) {
-          LOG.trace("Error while writing {}", call.toShortString());
+          LOG.trace("Error while writing {}", call.toShortString(), t);
         }
         IOException e = IPCUtil.toIOE(t);
         closeConn(e);
@@ -716,14 +760,31 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
         // since we expect certain responses to not make it by the specified
         // {@link ConnectionId#rpcTimeout}.
         if (LOG.isTraceEnabled()) {
-          LOG.trace("ignored", e);
+          LOG.trace("ignored ex for call {}", call, e);
         }
       } else {
         synchronized (this) {
-          closeConn(e);
+          // The exception we received may have been caused by another thread closing
+          // this connection. It's possible that before getting to this point, a new connection was
+          // created. In that case, it doesn't help and can actually hurt to close again here.
+          if (isCurrentThreadExpected()) {
+            LOG.debug("Closing connection after error in call {}", call, e);
+            closeConn(e);
+          }
         }
       }
     }
+  }
+
+  /**
+   * For use in the reader thread, tests if the current reader thread is the one expected to be
+   * running. When closeConn is called, the reader thread is expected to end. setupIOStreams then
+   * creates a new thread and updates the thread pointer. At that point, the new thread should be
+   * the only one running. We use this method to guard against cases where the old thread may be
+   * erroneously running or closing the connection in error states.
+   */
+  private boolean isCurrentThreadExpected() {
+    return thread == Thread.currentThread();
   }
 
   @Override


### PR DESCRIPTION
The basic idea here is we should usually have two threads: the main thread and a reader thread. Writes come through the main thread, which also handles calling setupIOStreams if the connection is not yet made. The reader thread is continually polling for work, calling `readResponse()` when calls are found. The writer methods are all synchronized, while the reader thread is not. The reader thread uses a `waitForWork()` poll method, which is itself synchronized.

If an exception occurs while writing a request, `closeConn` will be called. This interrupts and nulls out the reader `thread`, along with the socket and streams, and fails all calls that were pending read. The next write to come in will go through `setupIOStreams()`, which will create new sockets/streams and start a new reader thread.

In an ideal world, when `closeConn` is called, the reader thread will be waiting on the `wait()` call in `waitForWork()`. In that case, it's likely (not guaranteed) that when the thread is interrupted by `closeConn` the `wait()` will finish and the first check in `waitForWork()` will be true (`thread == null`). In that case, the reader thread will properly end.

Synchronization order is unspecified. So it's possible that while the existing `writeRequest`/`closeConn` was running, another write came in and was waiting on the monitor. When the original call releases the monitor, the new write comes in and since the socket is null, goes through `setupIOStreams()`.  In this case, when the `wait()` finishes in `waitForWork()` it will check for `thread == null` and the thread _will not_ be null. It will have changed to a new thread, not the current thread.

This can also occur if closeConn is called while we are in `readResponse()`, which is not synchronized at all. The same scenario can happen where a new write can come in after `closeConn` which creates a new thread before readResponse finishes. So it'll go into waitForWork() and see that thread is not null, and then the old reader thread never dies.

----

A larger refactor is probably in order here, if BlockingRpcConnection weren't being replaced. As it is, I solved this issue by adding two things:

1. Add a check for isCurrentThreadExpected, which checks if `Thread.currentThread()` is equal to `thread`. I added this check in three places where better handling is necessary:
    1. In the waitForWork loop, if thread != null. We should check that thread is also the current thread, otherwise we need to exit.
    1. When handling InterruptedException. In this case we want to call closeConn if the interrupt itself didn't come from closeConn. For example, if the process is ending or an external actor interrupted us.
    1. In readResponse, when deciding whether to closeConn when an error occurs. I've seen some cases where we end up unnecessarily closing and restarting the same connection thread multiple times because closeConn causes readResponse to fail, but in the meantime a new connection thread was created. The readResponse failure calls closeConn again even though the new connection is ok.
1. Synchronize the reader threads, so that two reader threads can't read from the same socket. This causes corruption and other oddities.

----

I don't really see any specific tests for BlockingRpcConnection, beyond TestBlockingIPC. I don't really know how I'd add a new test for this logic given our setup. Currently I'm working on doing some manual testing of this change in our environment with a live cluster and lots of multigets.