### PR TITLE
Backport "HBASE-27762 Include EventType and ProcedureV2 pid in logging via MDC (#5145)" to branch-2.5

### DIFF
--- a/hbase-logging/src/test/resources/log4j2.properties
+++ b/hbase-logging/src/test/resources/log4j2.properties
@@ -26,7 +26,7 @@ appender.console.target = SYSTEM_ERR
 appender.console.name = Console
 appender.console.maxSize = 1G
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ISO8601} %-5p [%t (%X)] %C{2}(%L): %m%n
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t%notEmpty{ %X}] %C{2}(%L): %m%n
 
 rootLogger = INFO,Console
 

--- a/hbase-logging/src/test/resources/log4j2.properties
+++ b/hbase-logging/src/test/resources/log4j2.properties
@@ -26,7 +26,7 @@ appender.console.target = SYSTEM_ERR
 appender.console.name = Console
 appender.console.maxSize = 1G
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ISO8601} %-5p [%t] %C{2}(%L): %m%n
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t (%X)] %C{2}(%L): %m%n
 
 rootLogger = INFO,Console
 

--- a/hbase-logging/src/test/resources/log4j2.properties
+++ b/hbase-logging/src/test/resources/log4j2.properties
@@ -26,7 +26,7 @@ appender.console.target = SYSTEM_ERR
 appender.console.name = Console
 appender.console.maxSize = 1G
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ISO8601} %-5p [%t%notEmpty{ %X}] %C{2}(%L): %m%n
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t] %C{2}(%L): %m%n
 
 rootLogger = INFO,Console
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventHandler.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /**
  * Abstract base class for all HBase event handlers. Subclasses should implement the
@@ -96,12 +97,16 @@ public abstract class EventHandler implements Runnable, Comparable<EventHandler>
   public void run() {
     Span span = TraceUtil.getGlobalTracer().spanBuilder(getClass().getSimpleName())
       .setParent(Context.current().with(parent)).startSpan();
+    // assume that this is the top of an execution on a new or reused thread, that we're safe to
+    // blast any existing MDC state.
     try (Scope scope = span.makeCurrent()) {
+      MDC.put("event_type", eventType.toString());
       process();
     } catch (Throwable t) {
       handleException(t);
     } finally {
       span.end();
+      MDC.clear();
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProtos.RegionStateTransition.TransitionCode;
 
@@ -93,6 +94,7 @@ public class AssignRegionHandler extends EventHandler {
 
   @Override
   public void process() throws IOException {
+    MDC.put("pid", Long.toString(openProcId));
     HRegionServer rs = getServer();
     String encodedName = regionInfo.getEncodedName();
     byte[] encodedNameBytes = regionInfo.getEncodedNameAsBytes();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /**
  * A event handler for running procedure.
@@ -46,6 +47,7 @@ public class RSProcedureHandler extends EventHandler {
   public void process() {
     Throwable error = null;
     try {
+      MDC.put("pid", Long.toString(procId));
       callable.call();
     } catch (Throwable t) {
       LOG.error("pid=" + this.procId, t);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProtos.RegionStateTransition.TransitionCode;
 
@@ -78,6 +79,7 @@ public class UnassignRegionHandler extends EventHandler {
 
   @Override
   public void process() throws IOException {
+    MDC.put("pid", Long.toString(closeProcId));
     HRegionServer rs = getServer();
     byte[] encodedNameBytes = Bytes.toBytes(encodedName);
     Boolean previous = rs.getRegionsInTransitionInRS().putIfAbsent(encodedNameBytes, Boolean.FALSE);


### PR DESCRIPTION
Includes revert of change to `conf/log4j2.properties`.