### PR TITLE
HBASE-27746 Check if the file system supports storage policy before invoking setStoragePolicy()

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
@@ -41,6 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
+import static org.apache.hadoop.fs.CommonPathCapabilities.FS_STORAGEPOLICY;
 
 /**
  * Utility methods for interacting with the underlying file system.
@@ -514,6 +515,11 @@ public final class CommonFSUtils {
   private static void invokeSetStoragePolicy(final FileSystem fs, final Path path,
     final String storagePolicy) throws IOException {
     Exception toThrow = null;
+
+    if (!fs.hasPathCapability(path, FS_STORAGEPOLICY)) {
+      LOG.debug("The file system does not support storage policy.");
+      return;
+    }
 
     try {
       fs.setStoragePolicy(path, storagePolicy);

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/CommonFSUtils.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.util;
 
+import static org.apache.hadoop.fs.CommonPathCapabilities.FS_STORAGEPOLICY;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URI;
@@ -41,7 +43,6 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
-import static org.apache.hadoop.fs.CommonPathCapabilities.FS_STORAGEPOLICY;
 
 /**
  * Utility methods for interacting with the underlying file system.

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestFSUtils.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestFSUtils.java
@@ -26,6 +26,8 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.URI;
+import java.net.URISyntaxException;
 import java.util.List;
 import java.util.Random;
 import org.apache.hadoop.conf.Configuration;
@@ -415,8 +417,9 @@ public class TestFSUtils {
    * Note: currently the default policy is set to defer to HDFS and this case is to verify the
    * logic, will need to remove the check if the default policy is changed
    */
-  private void verifyNoHDFSApiInvocationForDefaultPolicy() {
+  private void verifyNoHDFSApiInvocationForDefaultPolicy() throws URISyntaxException, IOException {
     FileSystem testFs = new AlwaysFailSetStoragePolicyFileSystem();
+    testFs.initialize(new URI("hdfs://localhost/"), conf);
     // There should be no exception thrown when setting to default storage policy, which indicates
     // the HDFS API hasn't been called
     try {


### PR DESCRIPTION
Simply check and ignore silently if the underlying FS does not support storage policy.

the hasPathCapability() API is Hadoop 3.2 and above. So do not cherrypick this change to HBase 2.x or lower.