### PR TITLE
HBASE-27799: RpcThrottlingException wait interval message is misleading between 0-1s

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/RpcThrottlingException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/RpcThrottlingException.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hbase.quotas;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
 import org.apache.hadoop.hbase.HBaseIOException;
-import org.apache.hadoop.util.StringUtils;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -135,12 +134,29 @@ public class RpcThrottlingException extends HBaseIOException {
   }
 
   private static String stringFromMillis(long millis) {
-    if (millis >= 1000) {
-      return StringUtils.formatTime(millis);
-    } else {
-      // StringUtils#formatTime doesn't support millis
-      return millis + "ms";
+    StringBuilder buf = new StringBuilder();
+    long hours = millis / (60 * 60 * 1000);
+    long rem = (millis % (60 * 60 * 1000));
+    long minutes = rem / (60 * 1000);
+    rem = rem % (60 * 1000);
+    long seconds = rem / 1000;
+    long milliseconds = rem % 1000;
+
+    if (hours != 0) {
+      buf.append(hours);
+      buf.append("hrs, ");
     }
+    if (minutes != 0) {
+      buf.append(minutes);
+      buf.append("mins, ");
+    }
+    if (seconds != 0) {
+      buf.append(seconds);
+      buf.append("sec, ");
+    }
+    buf.append(milliseconds);
+    buf.append("ms");
+    return buf.toString();
   }
 
   private static long timeFromString(String timeDiff) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/RpcThrottlingException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/RpcThrottlingException.java
@@ -162,13 +162,8 @@ public class RpcThrottlingException extends HBaseIOException {
 
   // Visible for TestRpcThrottlingException
   protected static long timeFromString(String timeDiff) {
-    Pattern pattern;
-    if (timeDiff.contains("ms")) {
-      pattern = Pattern.compile("^(?:(\\d+)hrs, )?(?:(\\d+)mins, )?(?:(\\d+)sec, )?(?:(\\d+)ms)?");
-    } else {
-      // legacy pattern. see HBASE-27799 which added millis to this String
-      pattern = Pattern.compile("^(?:(\\d+)hrs, )?(?:(\\d+)mins, )?(?:(\\d+)sec)?");
-    }
+    Pattern pattern =
+      Pattern.compile("^(?:(\\d+)hrs, )?(?:(\\d+)mins, )?(?:(\\d+)sec.{0,2})?(?:(\\d+)ms)?");
     long[] factors = new long[] { 60 * 60 * 1000, 60 * 1000, 1000, 1 };
     Matcher m = pattern.matcher(timeDiff);
     if (m.find()) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/RpcThrottlingException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/RpcThrottlingException.java
@@ -145,11 +145,11 @@ public class RpcThrottlingException extends HBaseIOException {
 
     if (hours != 0) {
       buf.append(hours);
-      buf.append("hrs, ");
+      buf.append(hours > 1 ? "hrs, " : "hr, ");
     }
     if (minutes != 0) {
       buf.append(minutes);
-      buf.append("mins, ");
+      buf.append(minutes > 1 ? "mins, " : "min, ");
     }
     if (seconds != 0) {
       buf.append(seconds);
@@ -163,7 +163,7 @@ public class RpcThrottlingException extends HBaseIOException {
   // Visible for TestRpcThrottlingException
   protected static long timeFromString(String timeDiff) {
     Pattern pattern =
-      Pattern.compile("^(?:(\\d+)hrs, )?(?:(\\d+)mins, )?(?:(\\d+)sec.{0,2})?(?:(\\d+)ms)?");
+      Pattern.compile("^(?:(\\d+)hrs?, )?(?:(\\d+)mins?, )?(?:(\\d+)sec[, ]{0,2})?(?:(\\d+)ms)?");
     long[] factors = new long[] { 60 * 60 * 1000, 60 * 1000, 1000, 1 };
     Matcher m = pattern.matcher(timeDiff);
     if (m.find()) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/RpcThrottlingException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/RpcThrottlingException.java
@@ -130,8 +130,17 @@ public class RpcThrottlingException extends HBaseIOException {
 
   private static void throwThrottlingException(final Type type, final long waitInterval)
     throws RpcThrottlingException {
-    String msg = MSG_TYPE[type.ordinal()] + MSG_WAIT + StringUtils.formatTime(waitInterval);
+    String msg = MSG_TYPE[type.ordinal()] + MSG_WAIT + stringFromMillis(waitInterval);
     throw new RpcThrottlingException(type, waitInterval, msg);
+  }
+
+  private static String stringFromMillis(long millis) {
+    if (millis >= 1000) {
+      return StringUtils.formatTime(millis);
+    } else {
+      // StringUtils#formatTime doesn't support millis
+      return millis + "ms";
+    }
   }
 
   private static long timeFromString(String timeDiff) {

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.quotas;
+
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ SmallTests.class })
+public class TestRpcThrottlingException {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestRpcThrottlingException.class);
+
+  @Test
+  public void itHandles1sWaitIntervalMessage() {
+    try {
+      RpcThrottlingException.throwNumReadRequestsExceeded(1000);
+    } catch (RpcThrottlingException e) {
+      assertTrue(e.getMessage().contains("wait 1sec"));
+    }
+  }
+
+  @Test
+  public void itHandles50msWaitIntervalMessage() {
+    try {
+      RpcThrottlingException.throwNumReadRequestsExceeded(50);
+    } catch (RpcThrottlingException e) {
+      assertTrue(e.getMessage().contains("wait 50ms"));
+    }
+  }
+
+  @Test
+  public void itHandles1min1sWaitIntervalMessage() {
+    try {
+      RpcThrottlingException.throwNumReadRequestsExceeded(61_000);
+    } catch (RpcThrottlingException e) {
+      assertTrue(e.getMessage().contains("wait 1mins, 1sec"));
+    }
+  }
+
+}

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
@@ -35,10 +35,11 @@ public class TestRpcThrottlingException {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestRpcThrottlingException.class);
 
-  private static final Map<String,
-    Long> STR_TO_MS_NEW_FORMAT = ImmutableMap.<String, Long> builder().put("0ms", 0L)
-      .put("50ms", 50L).put("1sec, 1ms", 1001L).put("1min, 5sec, 15ms", 65_015L)
-      .put("5mins, 2sec, 0ms", 302000L).put("1hr, 3mins, 5sec, 1ms", 3785001L).build();
+  private static final Map<String, Long> STR_TO_MS_NEW_FORMAT =
+    ImmutableMap.<String, Long> builder().put("0ms", 0L).put("50ms", 50L).put("1sec, 1ms", 1001L)
+      .put("1min, 5sec, 15ms", 65_015L).put("5mins, 2sec, 0ms", 302000L)
+      .put("1hr, 3mins, 5sec, 1ms", 3785001L).put("1hr, 5sec, 1ms", 3605001L)
+      .put("1hr, 0ms", 3600000L).put("1hr, 1min, 1ms", 3660001L).build();
   private static final Map<String,
     Long> STR_TO_MS_LEGACY_FORMAT = ImmutableMap.<String, Long> builder().put("0sec", 0L)
       .put("1sec", 1000L).put("2sec", 2000L).put("1mins, 5sec", 65_000L).put("5mins, 2sec", 302000L)

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.quotas;
 
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
@@ -36,6 +37,7 @@ public class TestRpcThrottlingException {
   public void itHandlesSecWaitIntervalMessage() {
     try {
       RpcThrottlingException.throwNumReadRequestsExceeded(1001);
+      fail();
     } catch (RpcThrottlingException e) {
       assertTrue(e.getMessage().contains("wait 1sec, 1ms"));
     }
@@ -45,6 +47,7 @@ public class TestRpcThrottlingException {
   public void itHandlesMsWaitIntervalMessage() {
     try {
       RpcThrottlingException.throwNumReadRequestsExceeded(50);
+      fail();
     } catch (RpcThrottlingException e) {
       assertTrue(e.getMessage().contains("wait 50ms"));
     }
@@ -54,6 +57,7 @@ public class TestRpcThrottlingException {
   public void itHandlesMinWaitIntervalMessage() {
     try {
       RpcThrottlingException.throwNumReadRequestsExceeded(65_015);
+      fail();
     } catch (RpcThrottlingException e) {
       assertTrue(e.getMessage().contains("wait 1mins, 5sec, 15ms"));
     }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.quotas;
 
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -61,6 +62,18 @@ public class TestRpcThrottlingException {
     } catch (RpcThrottlingException e) {
       assertTrue(e.getMessage().contains("wait 1mins, 5sec, 15ms"));
     }
+  }
+
+  @Test
+  public void itConvertsMillisToString() {
+    String output = RpcThrottlingException.stringFromMillis(6500);
+    assertEquals("6sec, 500ms", output);
+  }
+
+  @Test
+  public void itConvertsStringToMillis() {
+    long millis = RpcThrottlingException.timeFromString("5mins, 2sec, 0ms");
+    assertEquals(millis, 302000);
   }
 
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
@@ -33,16 +33,16 @@ public class TestRpcThrottlingException {
     HBaseClassTestRule.forClass(TestRpcThrottlingException.class);
 
   @Test
-  public void itHandles1sWaitIntervalMessage() {
+  public void itHandlesSecWaitIntervalMessage() {
     try {
-      RpcThrottlingException.throwNumReadRequestsExceeded(1000);
+      RpcThrottlingException.throwNumReadRequestsExceeded(1001);
     } catch (RpcThrottlingException e) {
-      assertTrue(e.getMessage().contains("wait 1sec"));
+      assertTrue(e.getMessage().contains("wait 1sec, 1ms"));
     }
   }
 
   @Test
-  public void itHandles50msWaitIntervalMessage() {
+  public void itHandlesMsWaitIntervalMessage() {
     try {
       RpcThrottlingException.throwNumReadRequestsExceeded(50);
     } catch (RpcThrottlingException e) {
@@ -51,11 +51,11 @@ public class TestRpcThrottlingException {
   }
 
   @Test
-  public void itHandles1min1sWaitIntervalMessage() {
+  public void itHandlesMinWaitIntervalMessage() {
     try {
-      RpcThrottlingException.throwNumReadRequestsExceeded(61_000);
+      RpcThrottlingException.throwNumReadRequestsExceeded(65_015);
     } catch (RpcThrottlingException e) {
-      assertTrue(e.getMessage().contains("wait 1mins, 1sec"));
+      assertTrue(e.getMessage().contains("wait 1mins, 5sec, 15ms"));
     }
   }
 

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/quotas/TestRpcThrottlingException.java
@@ -76,4 +76,16 @@ public class TestRpcThrottlingException {
     assertEquals(millis, 302000);
   }
 
+  @Test
+  public void itConvertsLegacyStringSecToMillis() {
+    long millis = RpcThrottlingException.timeFromString("5sec");
+    assertEquals(millis, 5000);
+  }
+
+  @Test
+  public void itConvertsLegacyStringHourMinSecToMillis2() {
+    long millis = RpcThrottlingException.timeFromString("1hrs, 3mins, 5sec");
+    assertEquals(millis, 3785000);
+  }
+
 }


### PR DESCRIPTION
`StringUtils#formatTime` will round down millis which can produce misleading error messages on RpcThrottlingExceptions with wait intervals between 0 and 1 second. This PR simply adds support expressing sub-second wait intervals 

@bbeaudreault 