### PR TITLE
HBASE-27762 Include EventType and ProcedureV2 pid in logging via MDC (addendum)

### DIFF
--- a/conf/log4j2.properties
+++ b/conf/log4j2.properties
@@ -25,7 +25,7 @@ appender.console.type = Console
 appender.console.target = SYSTEM_ERR
 appender.console.name = console
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ISO8601} %-5p [%t (%X)] %c{2}: %.1000m%n
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t%notEmpty{ %X}] %c{2}: %.1000m%n
 
 # Daily Rolling File Appender
 appender.DRFA.type = RollingFile

--- a/hbase-logging/src/test/resources/log4j2.properties
+++ b/hbase-logging/src/test/resources/log4j2.properties
@@ -26,7 +26,7 @@ appender.console.target = SYSTEM_ERR
 appender.console.name = Console
 appender.console.maxSize = 1G
 appender.console.layout.type = PatternLayout
-appender.console.layout.pattern = %d{ISO8601} %-5p [%t (%X)] %C{2}(%L): %m%n
+appender.console.layout.pattern = %d{ISO8601} %-5p [%t%notEmpty{ %X}] %C{2}(%L): %m%n
 
 rootLogger = INFO,Console
 


### PR DESCRIPTION
Make use of `%notEmpty` pattern with MDC logging. Will function as expected once we upgrade to Log4J 2.21.0+.