### PR TITLE
HBASE-27810 HBCK throws RejectedExecutionException when closing ZooKeeper resources

### DIFF
--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKWatcher.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKWatcher.java
@@ -604,7 +604,9 @@ public class ZKWatcher implements Watcher, Abortable, Closeable {
     LOG.debug(prefix("Received ZooKeeper Event, " + "type=" + event.getType() + ", " + "state="
       + event.getState() + ", " + "path=" + event.getPath()));
     final String spanName = ZKWatcher.class.getSimpleName() + "-" + identifier;
-    zkEventProcessor.execute(TraceUtil.tracedRunnable(() -> processEvent(event), spanName));
+    if (!zkEventProcessor.isShutdown()) {
+      zkEventProcessor.execute(TraceUtil.tracedRunnable(() -> processEvent(event), spanName));
+    }
   }
 
   // Connection management


### PR DESCRIPTION
Check if the executor has already been shut down before submitting new job.
I'm not sure if catching `RejectedExecutionException` would be a better approach here. I'm open for suggestions.

Find more details in the Jira ticket.