### PR TITLE
HBASE-27819 10k RpcServer.MAX_REQUEST_SIZE is not enough in Replicati…

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestEditsDroppedWithDroppedTable.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestEditsDroppedWithDroppedTable.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.replication;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -31,11 +32,16 @@ public class TestEditsDroppedWithDroppedTable extends ReplicationDroppedTablesTe
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestEditsDroppedWithDroppedTable.class);
 
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    setupClusters(true);
+  }
+
   @Test
   public void testEditsDroppedWithDroppedTable() throws Exception {
     // Make sure by default edits for dropped tables are themselves dropped when the
     // table(s) in question have been deleted on both ends.
-    testEditsBehindDroppedTable(true, "test_dropped");
+    testEditsBehindDroppedTable("test_dropped");
   }
 
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestEditsDroppedWithDroppedTableNS.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestEditsDroppedWithDroppedTableNS.java
@@ -21,7 +21,7 @@ import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.NamespaceDescriptor;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
-import org.junit.Before;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -33,17 +33,16 @@ public class TestEditsDroppedWithDroppedTableNS extends ReplicationDroppedTables
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestEditsDroppedWithDroppedTableNS.class);
 
-  @Before
-  @Override
-  public void setUpBase() throws Exception {
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    setupClusters(true);
     // also try with a namespace
     UTIL1.getAdmin().createNamespace(NamespaceDescriptor.create("NS").build());
     UTIL2.getAdmin().createNamespace(NamespaceDescriptor.create("NS").build());
-    super.setUpBase();
   }
 
   @Test
   public void testEditsDroppedWithDroppedTableNS() throws Exception {
-    testEditsBehindDroppedTable(true, "NS:test_dropped");
+    testEditsBehindDroppedTable("NS:test_dropped");
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestEditsStuckBehindDroppedTable.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestEditsStuckBehindDroppedTable.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.replication;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -31,11 +32,15 @@ public class TestEditsStuckBehindDroppedTable extends ReplicationDroppedTablesTe
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestEditsStuckBehindDroppedTable.class);
 
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    setupClusters(false);
+  }
+
   @Test
   public void testEditsStuckBehindDroppedTable() throws Exception {
     // Sanity check Make sure by default edits for dropped tables stall the replication queue, even
     // when the table(s) in question have been deleted on both ends.
-    testEditsBehindDroppedTable(false, "test_dropped");
+    testEditsBehindDroppedTable("test_dropped");
   }
-
 }


### PR DESCRIPTION
…onDroppedTable related tests

Also modified the tests so we will only start the cluster once instead of start it in setUpBeforeClass and then restart it when running the actual test method