### PR TITLE
HBASE-27810 HBCK throws RejectedExecutionException when closing ZooKeeper resources (branch-2.4)

### DIFF
--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKWatcher.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKWatcher.java
@@ -599,7 +599,9 @@ public class ZKWatcher implements Watcher, Abortable, Closeable {
   public void process(WatchedEvent event) {
     LOG.debug(prefix("Received ZooKeeper Event, " + "type=" + event.getType() + ", " + "state="
       + event.getState() + ", " + "path=" + event.getPath()));
-    zkEventProcessor.submit(() -> processEvent(event));
+    if (!zkEventProcessor.isShutdown()) {
+      zkEventProcessor.submit(() -> processEvent(event));
+    }
   }
 
   // Connection management


### PR DESCRIPTION
cc @meszibalu 