### PR TITLE
HBASE-27838 Update zstd-jni from version 1.5.4-2 -> 1.5.5-2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -885,7 +885,7 @@
     <lz4.version>1.8.0</lz4.version>
     <snappy.version>1.1.9.1</snappy.version>
     <xz.version>1.9</xz.version>
-    <zstd-jni.version>1.5.4-2</zstd-jni.version>
+    <zstd-jni.version>1.5.5-2</zstd-jni.version>
     <hbase-thirdparty.version>4.1.4</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>


### PR DESCRIPTION
Release notes for the underlying zstd 1.5.5 library: https://github.com/facebook/zstd/releases/tag/v1.5.5

This version includes a fix that prevented zstd-jni from running on s390x on common linux distros.