### PR TITLE
HBASE-27848:Should fast-fail if unmatched column family exists when using ImportTsv

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/ImportTsv.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/ImportTsv.java
@@ -565,7 +565,7 @@ public class ImportTsv extends Configured implements Tool {
               }
             }
             if (unmatchedFamilies.size() > 0) {
-              String noSuchColumnFamiliesMsg = String.format("Column families: %s do not exist.", unmatchedFamilies);
+              String noSuchColumnFamiliesMsg = format("Column families: %s do not exist.", unmatchedFamilies);
               LOG.error(noSuchColumnFamiliesMsg);
               throw new NoSuchColumnFamilyException(noSuchColumnFamiliesMsg);
             }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/ImportTsv.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/ImportTsv.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.Pair;
@@ -553,6 +554,21 @@ public class ImportTsv extends Configured implements Tool {
             String errorMsg = format("Table '%s' does not exist.", tableName);
             LOG.error(errorMsg);
             throw new TableNotFoundException(errorMsg);
+          }
+          try (Table table = connection.getTable(tableName)) {
+            ArrayList<String> unmatchedFamilies = new ArrayList<>();
+            Set<String> cfSet = getColumnFamilies(columns);
+            TableDescriptor tDesc = table.getDescriptor();
+            for (String cf : cfSet) {
+              if (!tDesc.hasColumnFamily(Bytes.toBytes(cf))) {
+                unmatchedFamilies.add(cf);
+              }
+            }
+            if (unmatchedFamilies.size() > 0) {
+              String noSuchColumnFamiliesMsg = String.format("Column families: %s do not exist.", unmatchedFamilies);
+              LOG.error(noSuchColumnFamiliesMsg);
+              throw new NoSuchColumnFamilyException(noSuchColumnFamiliesMsg);
+            }
           }
           if (mapperClass.equals(TsvImporterTextMapper.class)) {
             usage(TsvImporterTextMapper.class.toString()

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/ImportTsv.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/ImportTsv.java
@@ -565,7 +565,8 @@ public class ImportTsv extends Configured implements Tool {
               }
             }
             if (unmatchedFamilies.size() > 0) {
-              String noSuchColumnFamiliesMsg = format("Column families: %s do not exist.", unmatchedFamilies);
+              String noSuchColumnFamiliesMsg =
+                format("Column families: %s do not exist.", unmatchedFamilies);
               LOG.error(noSuchColumnFamiliesMsg);
               throw new NoSuchColumnFamilyException(noSuchColumnFamiliesMsg);
             }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTsv.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTsv.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
+import org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.VerySlowMapReduceTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -239,6 +240,26 @@ public class TestImportTsv implements Configurable {
           return 0;
         }
       }, args));
+  }
+
+  @Test
+  public void testMROnNoMatchedColumnFamily() throws Exception {
+    util.createTable(tn, FAMILY);
+
+    String[] args = new String[] { tn.getNameAsString(), "/inputFile" };
+    Configuration conf = new Configuration(util.getConfiguration());
+    conf.set(ImportTsv.COLUMNS_CONF_KEY, "HBASE_ROW_KEY, FAM_ERROR:A");
+    exception.expect(NoSuchColumnFamilyException.class);
+    assertEquals("running test job configuration failed.", 0,
+      ToolRunner.run(new Configuration(util.getConfiguration()), new ImportTsv() {
+        @Override
+        public int run(String[] args) throws Exception {
+          createSubmittableJob(getConf(), args);
+          return 0;
+        }
+      }, args));
+
+    util.deleteTable(tn);
   }
 
   @Test

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTsv.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTsv.java
@@ -247,9 +247,9 @@ public class TestImportTsv implements Configurable {
     util.createTable(tn, FAMILY);
 
     String[] args = new String[] {
-      "-D" + ImportTsv.COLUMNS_CONF_KEY + "=HBASE_ROW_KEY,FAM:A,FAM01_ERROR:A,FAM01_ERROR:B,FAM02_ERROR:C",
-      tn.getNameAsString(),
-      "/inputFile" };
+      "-D" + ImportTsv.COLUMNS_CONF_KEY
+        + "=HBASE_ROW_KEY,FAM:A,FAM01_ERROR:A,FAM01_ERROR:B,FAM02_ERROR:C",
+      tn.getNameAsString(), "/inputFile" };
     exception.expect(NoSuchColumnFamilyException.class);
     assertEquals("running test job configuration failed.", 0,
       ToolRunner.run(new Configuration(util.getConfiguration()), new ImportTsv() {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTsv.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTsv.java
@@ -243,12 +243,13 @@ public class TestImportTsv implements Configurable {
   }
 
   @Test
-  public void testMROnNoMatchedColumnFamily() throws Exception {
+  public void testMRNoMatchedColumnFamily() throws Exception {
     util.createTable(tn, FAMILY);
 
-    String[] args = new String[] { tn.getNameAsString(), "/inputFile" };
-    Configuration conf = new Configuration(util.getConfiguration());
-    conf.set(ImportTsv.COLUMNS_CONF_KEY, "HBASE_ROW_KEY, FAM_ERROR:A");
+    String[] args = new String[] {
+      "-D" + ImportTsv.COLUMNS_CONF_KEY + "=HBASE_ROW_KEY,FAM:A,FAM01_ERROR:A,FAM01_ERROR:B,FAM02_ERROR:C",
+      tn.getNameAsString(),
+      "/inputFile" };
     exception.expect(NoSuchColumnFamilyException.class);
     assertEquals("running test job configuration failed.", 0,
       ToolRunner.run(new Configuration(util.getConfiguration()), new ImportTsv() {


### PR DESCRIPTION
Fix issue: [HBASE-27848](https://issues.apache.org/jira/browse/HBASE-27848)

It is better to  fast-fail before MR is submitted if we specify a error column family when using ImportTsv Tool