### PR TITLE
HBASE-27857 Fix timeout exception handling in HBaseClassTestRule

### DIFF
--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/HBaseClassTestRule.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/HBaseClassTestRule.java
@@ -162,7 +162,7 @@ public final class HBaseClassTestRule implements TestRule {
 
   @Override
   public Statement apply(Statement base, Description description) {
-    return timeout.apply(systemExitRule.apply(base, description), description);
+    return systemExitRule.apply(timeout.apply(base, description), description);
   }
 
 }


### PR DESCRIPTION
HBaseClassTestRule applies a timeout and a system exit rule to tests. The timeout rule throws an exception if it hits the timeout threshold. Since the timeout rule is applied after the system exit rule, the system exit rule does not see the exception and does not re-enable the system exit behavior which can cause maven to hang on some tests.

This change applies the timeout rule before the system exit rule so that normal system exit can be restored before the surefire forked node is shutdown.