### PR TITLE
HBASE-27862:HMaster.getCompactionState's return result about table compaction state is not quite right

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -4158,8 +4158,8 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         RegionMetrics regionMetrics = sl.getRegionMetrics().get(regionInfo.getRegionName());
         if (regionMetrics == null) {
           String regionName = regionInfo.getRegionNameAsString();
-          LOG.error("Can not get compaction details for region: " + regionName +
-            ", it may be disabled or in transition.");
+          LOG.error("Can not get compaction details for the region: " + regionName +
+            " , it may be disabled or in transition.");
           notOnlineRegions.add(regionName);
           continue;
         }


### PR DESCRIPTION
1. The table compaction state should be NONE if all of those regions is online and is not compacting.
2. The Table compaction state should be null if one of those regions is not online and others is not compacting.  null means that the table compaction state we obtained is UNKOWN.
3. The Table compaction state should be minor/major when there are regions which is compacting

Jira: [HBASE-27862](https://issues.apache.org/jira/browse/HBASE-27862)