### PR TITLE
HBASE-27843 If moveAndClose fails HFileArchiver should delete any incomplete archive side changes

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/backup/HFileArchiver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/backup/HFileArchiver.java
@@ -570,6 +570,11 @@ public class HFileArchiver {
         success = true;
       } catch (IOException e) {
         success = false;
+        // When HFiles are placed on a filesystem other than HDFS a rename operation can be a
+        // non-atomic file copy operation. It can take a long time to copy a large hfile and if
+        // interrupted there may be a partially copied file present at the destination. We must
+        // remove the partially copied file, if any, or otherwise the archive operation will fail
+        // indefinitely from this point.
         LOG.warn("Failed to archive " + currentFile + " on try #" + i, e);
         try {
           fs.delete(archiveFile, false);
@@ -578,7 +583,7 @@ public class HFileArchiver {
         } catch (IOException ee) {
           // Complain about other IO exceptions
           LOG.warn("Failed to clean up from failure to archive " + currentFile + " on try #" + i,
-            e);
+            ee);
         }
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/backup/HFileArchiver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/backup/HFileArchiver.java
@@ -569,8 +569,17 @@ public class HFileArchiver {
           + " because it does not exist! Skipping and continuing on.", fnfe);
         success = true;
       } catch (IOException e) {
-        LOG.warn("Failed to archive " + currentFile + " on try #" + i, e);
         success = false;
+        LOG.warn("Failed to archive " + currentFile + " on try #" + i, e);
+        try {
+          fs.delete(archiveFile, false);
+        } catch (FileNotFoundException fnfe) {
+          // This case is fine.
+        } catch (IOException ee) {
+          // Complain about other IO exceptions
+          LOG.warn("Failed to clean up from failure to archive " + currentFile + " on try #" + i,
+            e);
+        }
       }
     }
 


### PR DESCRIPTION
When HFiles are placed on a filesystem other than HDFS a rename operation can be a non-atomic file copy operation. It can take a long time to copy a large hfile and if interrupted there may be a partially copied file present at the destination. If we fail to “rename” the files into the archive we will continue to fail indefinitely. Before larger changes are considered, perhaps to StoreFileTracker, we should mitigate this problem.