### PR TITLE
HBASE-27872 xerial's snappy-java requires GLIBC >= 2.32

### DIFF
--- a/hbase-compression/hbase-compression-snappy/src/main/java/org/apache/hadoop/hbase/io/compress/xerial/SnappyCodec.java
+++ b/hbase-compression/hbase-compression-snappy/src/main/java/org/apache/hadoop/hbase/io/compress/xerial/SnappyCodec.java
@@ -31,6 +31,8 @@ import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.Compressor;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.xerial.snappy.Snappy;
 
 /**
@@ -43,8 +45,24 @@ public class SnappyCodec implements Configurable, CompressionCodec {
 
   public static final String SNAPPY_BUFFER_SIZE_KEY = "hbase.io.compress.snappy.buffersize";
 
+  private static final Logger LOG = LoggerFactory.getLogger(SnappyCodec.class);
   private Configuration conf;
   private int bufferSize;
+  private static boolean loaded = false;
+
+  static {
+    try {
+      Snappy.getNativeLibraryVersion();
+      loaded = true;
+    } catch (Throwable t) {
+      LOG.error("The Snappy native libraries could not be loaded", t);
+    }
+  }
+
+  /** Return true if the native shared libraries were loaded; false otherwise. */
+  public static boolean isLoaded() {
+    return loaded;
+  }
 
   public SnappyCodec() {
     conf = new Configuration();

--- a/hbase-compression/hbase-compression-snappy/src/main/java/org/apache/hadoop/hbase/io/compress/xerial/SnappyCodec.java
+++ b/hbase-compression/hbase-compression-snappy/src/main/java/org/apache/hadoop/hbase/io/compress/xerial/SnappyCodec.java
@@ -49,12 +49,14 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   private Configuration conf;
   private int bufferSize;
   private static boolean loaded = false;
+  private static Throwable loadError;
 
   static {
     try {
       Snappy.getNativeLibraryVersion();
       loaded = true;
     } catch (Throwable t) {
+      loadError = t;
       LOG.error("The Snappy native libraries could not be loaded", t);
     }
   }
@@ -65,6 +67,9 @@ public class SnappyCodec implements Configurable, CompressionCodec {
   }
 
   public SnappyCodec() {
+    if (!isLoaded()) {
+      throw new RuntimeException("Snappy codec could not be loaded", loadError);
+    }
     conf = new Configuration();
     bufferSize = getBufferSize(conf);
   }

--- a/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestHFileCompressionSnappy.java
+++ b/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestHFileCompressionSnappy.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.io.compress.xerial;
 
+import static org.junit.Assume.assumeTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
@@ -29,8 +31,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Category({ IOTests.class, SmallTests.class })
 public class TestHFileCompressionSnappy extends HFileTestBase {
@@ -39,15 +39,11 @@ public class TestHFileCompressionSnappy extends HFileTestBase {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestHFileCompressionSnappy.class);
 
-  private static final Logger LOG = LoggerFactory.getLogger(TestHFileCompressionSnappy.class);
   private static Configuration conf;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      LOG.warn("Snappy codec cannot be loaded. Test will not execute.");
-      return;
-    }
+    assumeTrue(SnappyCodec.isLoaded());
     conf = TEST_UTIL.getConfiguration();
     conf.set(Compression.SNAPPY_CODEC_CLASS_KEY, SnappyCodec.class.getCanonicalName());
     Compression.Algorithm.SNAPPY.reload(conf);
@@ -56,9 +52,6 @@ public class TestHFileCompressionSnappy extends HFileTestBase {
 
   @Test
   public void test() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      return;
-    }
     Path path =
       new Path(TEST_UTIL.getDataTestDir(), HBaseTestingUtil.getRandomUUID().toString() + ".hfile");
     doTest(conf, path, Compression.Algorithm.SNAPPY);

--- a/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestHFileCompressionSnappy.java
+++ b/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestHFileCompressionSnappy.java
@@ -29,6 +29,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Category({ IOTests.class, SmallTests.class })
 public class TestHFileCompressionSnappy extends HFileTestBase {
@@ -37,10 +39,15 @@ public class TestHFileCompressionSnappy extends HFileTestBase {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestHFileCompressionSnappy.class);
 
+  private static final Logger LOG = LoggerFactory.getLogger(TestHFileCompressionSnappy.class);
   private static Configuration conf;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      LOG.warn("Snappy codec cannot be loaded. Test will not execute.");
+      return;
+    }
     conf = TEST_UTIL.getConfiguration();
     conf.set(Compression.SNAPPY_CODEC_CLASS_KEY, SnappyCodec.class.getCanonicalName());
     Compression.Algorithm.SNAPPY.reload(conf);
@@ -49,6 +56,9 @@ public class TestHFileCompressionSnappy extends HFileTestBase {
 
   @Test
   public void test() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      return;
+    }
     Path path =
       new Path(TEST_UTIL.getDataTestDir(), HBaseTestingUtil.getRandomUUID().toString() + ".hfile");
     doTest(conf, path, Compression.Algorithm.SNAPPY);

--- a/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestSnappyCodec.java
+++ b/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestSnappyCodec.java
@@ -20,9 +20,12 @@ package org.apache.hadoop.hbase.io.compress.xerial;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.io.compress.CompressionTestBase;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Category(SmallTests.class)
 public class TestSnappyCodec extends CompressionTestBase {
@@ -31,13 +34,29 @@ public class TestSnappyCodec extends CompressionTestBase {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestSnappyCodec.class);
 
+  private static final Logger LOG = LoggerFactory.getLogger(TestSnappyCodec.class);
+
+  @BeforeClass
+  public static void setupClass() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      LOG.warn("Snappy codec cannot be loaded. Test will not execute.");
+      return;
+    }
+  }
+
   @Test
   public void testSnappyCodecSmall() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      return;
+    }
     codecSmallTest(new SnappyCodec());
   }
 
   @Test
   public void testSnappyCodecLarge() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      return;
+    }
     codecLargeTest(new SnappyCodec(), 1.1); // poor compressability
     codecLargeTest(new SnappyCodec(), 2);
     codecLargeTest(new SnappyCodec(), 10); // very high compressability
@@ -45,6 +64,9 @@ public class TestSnappyCodec extends CompressionTestBase {
 
   @Test
   public void testSnappyCodecVeryLarge() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      return;
+    }
     codecVeryLargeTest(new SnappyCodec(), 3); // like text
   }
 

--- a/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestSnappyCodec.java
+++ b/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestSnappyCodec.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.io.compress.xerial;
 
+import static org.junit.Assume.assumeTrue;
+
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.io.compress.CompressionTestBase;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
@@ -24,8 +26,6 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Category(SmallTests.class)
 public class TestSnappyCodec extends CompressionTestBase {
@@ -34,29 +34,18 @@ public class TestSnappyCodec extends CompressionTestBase {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestSnappyCodec.class);
 
-  private static final Logger LOG = LoggerFactory.getLogger(TestSnappyCodec.class);
-
   @BeforeClass
   public static void setupClass() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      LOG.warn("Snappy codec cannot be loaded. Test will not execute.");
-      return;
-    }
+    assumeTrue(SnappyCodec.isLoaded());
   }
 
   @Test
   public void testSnappyCodecSmall() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      return;
-    }
     codecSmallTest(new SnappyCodec());
   }
 
   @Test
   public void testSnappyCodecLarge() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      return;
-    }
     codecLargeTest(new SnappyCodec(), 1.1); // poor compressability
     codecLargeTest(new SnappyCodec(), 2);
     codecLargeTest(new SnappyCodec(), 10); // very high compressability
@@ -64,9 +53,6 @@ public class TestSnappyCodec extends CompressionTestBase {
 
   @Test
   public void testSnappyCodecVeryLarge() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      return;
-    }
     codecVeryLargeTest(new SnappyCodec(), 3); // like text
   }
 

--- a/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestWALCompressionSnappy.java
+++ b/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestWALCompressionSnappy.java
@@ -33,9 +33,13 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Category({ RegionServerTests.class, MediumTests.class })
 public class TestWALCompressionSnappy extends CompressedWALTestBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestWALCompressionSnappy.class);
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
@@ -46,6 +50,10 @@ public class TestWALCompressionSnappy extends CompressedWALTestBase {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      LOG.warn("Snappy codec cannot be loaded. Test will not execute.");
+      return;
+    }
     Configuration conf = TEST_UTIL.getConfiguration();
     conf.set(Compression.SNAPPY_CODEC_CLASS_KEY, SnappyCodec.class.getCanonicalName());
     Compression.Algorithm.SNAPPY.reload(conf);
@@ -57,11 +65,17 @@ public class TestWALCompressionSnappy extends CompressedWALTestBase {
 
   @AfterClass
   public static void tearDown() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      return;
+    }
     TEST_UTIL.shutdownMiniCluster();
   }
 
   @Test
   public void test() throws Exception {
+    if (!SnappyCodec.isLoaded()) {
+      return;
+    }
     TableName tableName = TableName.valueOf(name.getMethodName().replaceAll("[^a-zA-Z0-9]", "_"));
     doTest(tableName);
   }

--- a/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestWALCompressionSnappy.java
+++ b/hbase-compression/hbase-compression-snappy/src/test/java/org/apache/hadoop/hbase/io/compress/xerial/TestWALCompressionSnappy.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.io.compress.xerial;
 
+import static org.junit.Assume.assumeTrue;
+
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HConstants;
@@ -33,13 +35,9 @@ import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @Category({ RegionServerTests.class, MediumTests.class })
 public class TestWALCompressionSnappy extends CompressedWALTestBase {
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestWALCompressionSnappy.class);
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
@@ -50,10 +48,7 @@ public class TestWALCompressionSnappy extends CompressedWALTestBase {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      LOG.warn("Snappy codec cannot be loaded. Test will not execute.");
-      return;
-    }
+    assumeTrue(SnappyCodec.isLoaded());
     Configuration conf = TEST_UTIL.getConfiguration();
     conf.set(Compression.SNAPPY_CODEC_CLASS_KEY, SnappyCodec.class.getCanonicalName());
     Compression.Algorithm.SNAPPY.reload(conf);
@@ -65,17 +60,11 @@ public class TestWALCompressionSnappy extends CompressedWALTestBase {
 
   @AfterClass
   public static void tearDown() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      return;
-    }
     TEST_UTIL.shutdownMiniCluster();
   }
 
   @Test
   public void test() throws Exception {
-    if (!SnappyCodec.isLoaded()) {
-      return;
-    }
     TableName tableName = TableName.valueOf(name.getMethodName().replaceAll("[^a-zA-Z0-9]", "_"));
     doTest(tableName);
   }


### PR DESCRIPTION
We need to add a native library load check with a helpful error message if xerial snappy fails to initialize due to a too old glibc or similar reason, and disable the unit test if the native library fails to load.