### PR TITLE
HBASE-27876: Only generate SBOM when releasing

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2905,19 +2905,6 @@
           </formats>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.cyclonedx</groupId>
-        <artifactId>cyclonedx-maven-plugin</artifactId>
-        <version>2.7.6</version>
-        <executions>
-          <execution>
-            <goals>
-              <goal>makeBom</goal>
-            </goals>
-            <phase>package</phase>
-          </execution>
-        </executions>
-      </plugin>
     </plugins>
     <extensions>
       <extension>
@@ -3486,6 +3473,19 @@
                 <version>${extra.enforcer.version}</version>
               </dependency>
             </dependencies>
+          </plugin>
+          <plugin>
+            <groupId>org.cyclonedx</groupId>
+            <artifactId>cyclonedx-maven-plugin</artifactId>
+            <version>2.7.6</version>
+            <executions>
+              <execution>
+                <goals>
+                  <goal>makeBom</goal>
+                </goals>
+                <phase>package</phase>
+              </execution>
+            </executions>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION
See details: [HBASE-27876](https://issues.apache.org/jira/browse/HBASE-27876)

I tested following commands.

```
$ mvn clean install -DskipTests
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
...
$ ls target/
hbase-3.0.0-alpha-4-SNAPSHOT-site.xml  maven-shared-archive-resources
```

```
$ mvn clean install -DskipTests -Prelease
[INFO] ------------------------------------------------------------------------
[INFO] BUILD SUCCESS
[INFO] ------------------------------------------------------------------------
...
$ ls target/
bom.json  bom.xml  hbase-3.0.0-alpha-4-SNAPSHOT-site.xml  maven-shared-archive-resources  rat.txt
```