### PR TITLE
HBASE-27921: Bump up jruby to 9.4.2.0 and related joni and jcodings to 2.1.48 and 1.0.58 respectively

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -553,6 +553,8 @@ if [ "$COMMAND" = "shell" ] ; then
     # We want jruby to consume these things rather than our bootstrap script;
     # jruby will look for the env variable 'JRUBY_OPTS'.
     JRUBY_OPTS="${JRUBY_OPTS} -X+O"
+    # jruby outputs "warning: parentheses after method name is interpreted as an argument list" in shell
+    JRUBY_OPTS="${JRUBY_OPTS} -W0"
     export JRUBY_OPTS
     # hbase-shell.jar contains a 'jar-bootstrap.rb'
     # for more info see

--- a/pom.xml
+++ b/pom.xml
@@ -830,7 +830,7 @@
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
     <glassfish.jsp.version>2.3.2</glassfish.jsp.version>
     <glassfish.el.version>3.0.1-b08</glassfish.el.version>
-    <jruby.version>9.3.9.0</jruby.version>
+    <jruby.version>9.4.2.0</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
     <opentelemetry.version>1.15.0</opentelemetry.version>
@@ -847,8 +847,8 @@
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <jettison.version>1.5.4</jettison.version>
     <!--Make sure these joni/jcodings are compatible with the versions used by jruby-->
-    <joni.version>2.1.43</joni.version>
-    <jcodings.version>1.0.57</jcodings.version>
+    <joni.version>2.1.48</joni.version>
+    <jcodings.version>1.0.58</jcodings.version>
     <spy.version>2.12.2</spy.version>
     <bouncycastle.version>1.70</bouncycastle.version>
     <skyscreamer.version>1.5.1</skyscreamer.version>


### PR DESCRIPTION
**MOTIVATION**
Current version of `jruby` (9.3.9.0) has `snakeyaml` dependency version `1.33` which is affected by critical CVE https://cve.mitre.org/cgi-bin/cvename.cgi?name=CVE-2022-1471

**SOLUTION**
- Upgrading `jruby` to the latest version; `9.4.2.0`
- Upgrading related `joni` and `jcodings` to `2.1.48` and `1.0.58` respectively
- Adding `-W0` option to `JRUBY_OPTS` as it outputs below warning when `hbase` shell is launched;
```
uri:classloader:/META-INF/jruby.home/lib/ruby/stdlib/rubygems/core_ext/kernel_require.rb:85: warning: parentheses after method name is interpreted as an argument list, not a decomposed argument
```

**CHECKS**
- Launched HBase shell.
- Executed unit tests without cluster;
```
[INFO] Running org.apache.hadoop.hbase.client.TestShellNoCluster
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 0.041 s - in org.apache.hadoop.hbase.client.TestShellNoCluster
[INFO] Running org.apache.hadoop.hbase.client.TestTableShell
[INFO] Tests run: 1, Failures: 0, Errors: 0, Skipped: 0, Time elapsed: 25.595 s - in org.apache.hadoop.hbase.client.TestTableShell
```
- No more vulnerable `snakeyaml` dependency;
```
> jar -tvf ./lib/jruby-complete-* | grep -i snake
     0 Wed Mar 08 16:02:56 UTC 2023 META-INF/jruby.home/lib/ruby/stdlib/org/snakeyaml/
    22 Wed Mar 08 10:02:04 UTC 2023 META-INF/jruby.home/lib/ruby/stdlib/org/snakeyaml/.jrubydir
     0 Wed Mar 08 16:02:56 UTC 2023 META-INF/jruby.home/lib/ruby/stdlib/org/snakeyaml/snakeyaml-engine/
    34 Wed Mar 08 10:02:04 UTC 2023 META-INF/jruby.home/lib/ruby/stdlib/org/snakeyaml/snakeyaml-engine/.jrubydir
     0 Wed Mar 08 16:02:56 UTC 2023 META-INF/jruby.home/lib/ruby/stdlib/org/snakeyaml/snakeyaml-engine/2.6/
    30 Wed Mar 08 10:02:04 UTC 2023 META-INF/jruby.home/lib/ruby/stdlib/org/snakeyaml/snakeyaml-engine/2.6/.jrubydir
292124 Wed Mar 08 10:02:04 UTC 2023 META-INF/jruby.home/lib/ruby/stdlib/org/snakeyaml/snakeyaml-engine/2.6/snakeyaml-engine-2.6.jar
   305 Wed Mar 08 10:02:04 UTC 2023 META-INF/jruby.home/lib/ruby/stdlib/org/snakeyaml/snakeyaml-engine/maven-metadata-local.xml
>
```