### PR TITLE
HBASE-27937 Update getting_started to fix typo

### DIFF
--- a/src/main/asciidoc/_chapters/getting_started.adoc
+++ b/src/main/asciidoc/_chapters/getting_started.adoc
@@ -371,13 +371,13 @@ The following command starts four additional RegionServers, running on sequentia
 +
 ----
 
-$ .bin/local-regionservers.sh start 2 3 4 5
+$ ./bin/local-regionservers.sh start 2 3 4 5
 ----
 +
 To stop a RegionServer manually, use the `local-regionservers.sh` command with the `stop` parameter and the offset of the server to stop.
 +
 ----
-$ .bin/local-regionservers.sh stop 3
+$ ./bin/local-regionservers.sh stop 3
 ----
 
 . Stop HBase.


### PR DESCRIPTION
Fix typo of quck start doc HBASE-27937