### PR TITLE
HBASE-27942:The description about hbase.hstore.comactionThreshold is not accurate

### DIFF
--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -812,7 +812,7 @@ possible configurations would overwhelm and obscure the important.
   <property>
     <name>hbase.hstore.compactionThreshold</name>
     <value>3</value>
-    <description> If more than this number of StoreFiles exist in any one Store
+    <description> If more than or equal to this number of StoreFiles exist in any one Store
       (one StoreFile is written per flush of MemStore), a compaction is run to rewrite all
       StoreFiles into a single StoreFile. Larger values delay compaction, but when compaction does
       occur, it takes longer to complete.</description>


### PR DESCRIPTION
Details see: [HBASE-27942](https://issues.apache.org/jira/browse/HBASE-27942)