### PR TITLE
HBASE-27657: Connection and Request Attributes

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdminRequestRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdminRequestRetryingCaller.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.client;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.ipc.HBaseRpcController;
@@ -44,7 +45,7 @@ public class AsyncAdminRequestRetryingCaller<T> extends AsyncRpcRetryingCaller<T
     long pauseNs, long pauseNsForServerOverloaded, int maxAttempts, long operationTimeoutNs,
     long rpcTimeoutNs, int startLogErrorsCnt, ServerName serverName, Callable<T> callable) {
     super(retryTimer, conn, priority, pauseNs, pauseNsForServerOverloaded, maxAttempts,
-      operationTimeoutNs, rpcTimeoutNs, startLogErrorsCnt);
+      operationTimeoutNs, rpcTimeoutNs, startLogErrorsCnt, Collections.emptyMap());
     this.serverName = serverName;
     this.callable = callable;
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
@@ -31,6 +31,7 @@ import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 import io.opentelemetry.api.trace.Span;
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
@@ -127,6 +128,11 @@ public class AsyncConnectionImpl implements AsyncConnection {
 
   public AsyncConnectionImpl(Configuration conf, ConnectionRegistry registry, String clusterId,
     SocketAddress localAddress, User user) {
+    this(conf, registry, clusterId, localAddress, user, null);
+  }
+
+  public AsyncConnectionImpl(Configuration conf, ConnectionRegistry registry, String clusterId,
+    SocketAddress localAddress, User user, Map<String, byte[]> connectionAttributes) {
     this.conf = conf;
     this.user = user;
     this.metricsScope = MetricsConnection.getScope(conf, clusterId, this);
@@ -142,8 +148,8 @@ public class AsyncConnectionImpl implements AsyncConnection {
     } else {
       this.metrics = Optional.empty();
     }
-    this.rpcClient =
-      RpcClientFactory.createClient(conf, clusterId, localAddress, metrics.orElse(null));
+    this.rpcClient = RpcClientFactory.createClient(conf, clusterId, localAddress,
+      metrics.orElse(null), connectionAttributes);
     this.rpcControllerFactory = RpcControllerFactory.instantiate(conf);
     this.rpcTimeout =
       (int) Math.min(Integer.MAX_VALUE, TimeUnit.NANOSECONDS.toMillis(connConf.getRpcTimeoutNs()));

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
@@ -31,6 +31,7 @@ import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 import io.opentelemetry.api.trace.Span;
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
@@ -128,7 +129,7 @@ public class AsyncConnectionImpl implements AsyncConnection {
 
   public AsyncConnectionImpl(Configuration conf, ConnectionRegistry registry, String clusterId,
     SocketAddress localAddress, User user) {
-    this(conf, registry, clusterId, localAddress, user, null);
+    this(conf, registry, clusterId, localAddress, user, Collections.emptyMap());
   }
 
   public AsyncConnectionImpl(Configuration conf, ConnectionRegistry registry, String clusterId,

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncMasterRequestRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncMasterRequestRpcRetryingCaller.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.exceptions.ClientExceptionsUtil;
 import org.apache.hadoop.hbase.ipc.HBaseRpcController;
@@ -47,7 +48,7 @@ public class AsyncMasterRequestRpcRetryingCaller<T> extends AsyncRpcRetryingCall
     Callable<T> callable, int priority, long pauseNs, long pauseNsForServerOverloaded,
     int maxRetries, long operationTimeoutNs, long rpcTimeoutNs, int startLogErrorsCnt) {
     super(retryTimer, conn, priority, pauseNs, pauseNsForServerOverloaded, maxRetries,
-      operationTimeoutNs, rpcTimeoutNs, startLogErrorsCnt);
+      operationTimeoutNs, rpcTimeoutNs, startLogErrorsCnt, Collections.emptyMap());
     this.callable = callable;
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRpcRetryingCaller.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hbase.client.ConnectionUtils.translateException;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
@@ -78,7 +79,7 @@ public abstract class AsyncRpcRetryingCaller<T> {
 
   public AsyncRpcRetryingCaller(Timer retryTimer, AsyncConnectionImpl conn, int priority,
     long pauseNs, long pauseNsForServerOverloaded, int maxAttempts, long operationTimeoutNs,
-    long rpcTimeoutNs, int startLogErrorsCnt) {
+    long rpcTimeoutNs, int startLogErrorsCnt, Map<String, byte[]> requestAttributes) {
     this.retryTimer = retryTimer;
     this.conn = conn;
     this.priority = priority;
@@ -89,6 +90,7 @@ public abstract class AsyncRpcRetryingCaller<T> {
     this.future = new CompletableFuture<>();
     this.controller = conn.rpcControllerFactory.newController();
     this.controller.setPriority(priority);
+    this.controller.setRequestAttributes(requestAttributes);
     this.exceptions = new ArrayList<>();
     this.startNs = System.nanoTime();
     this.pauseManager =

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncScanSingleRegionRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncScanSingleRegionRpcRetryingCaller.java
@@ -31,6 +31,7 @@ import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.OptionalLong;
 import java.util.concurrent.CompletableFuture;
@@ -316,7 +317,7 @@ class AsyncScanSingleRegionRpcRetryingCaller {
     AdvancedScanResultConsumer consumer, Interface stub, HRegionLocation loc,
     boolean isRegionServerRemote, int priority, long scannerLeaseTimeoutPeriodNs, long pauseNs,
     long pauseNsForServerOverloaded, int maxAttempts, long scanTimeoutNs, long rpcTimeoutNs,
-    int startLogErrorsCnt) {
+    int startLogErrorsCnt, Map<String, byte[]> requestAttributes) {
     this.retryTimer = retryTimer;
     this.conn = conn;
     this.scan = scan;
@@ -341,6 +342,7 @@ class AsyncScanSingleRegionRpcRetryingCaller {
     this.priority = priority;
     this.controller = conn.rpcControllerFactory.newController();
     this.controller.setPriority(priority);
+    this.controller.setRequestAttributes(requestAttributes);
     this.exceptions = new ArrayList<>();
     this.pauseManager =
       new HBaseServerExceptionPauseManager(pauseNs, pauseNsForServerOverloaded, scanTimeoutNs);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncServerRequestRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncServerRequestRpcRetryingCaller.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.client;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
@@ -49,7 +50,7 @@ public class AsyncServerRequestRpcRetryingCaller<T> extends AsyncRpcRetryingCall
     long pauseNs, long pauseNsForServerOverloaded, int maxAttempts, long operationTimeoutNs,
     long rpcTimeoutNs, int startLogErrorsCnt, ServerName serverName, Callable<T> callable) {
     super(retryTimer, conn, HConstants.NORMAL_QOS, pauseNs, pauseNsForServerOverloaded, maxAttempts,
-      operationTimeoutNs, rpcTimeoutNs, startLogErrorsCnt);
+      operationTimeoutNs, rpcTimeoutNs, startLogErrorsCnt, Collections.emptyMap());
     this.serverName = serverName;
     this.callable = callable;
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncSingleRequestRpcRetryingCaller.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncSingleRequestRpcRetryingCaller.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.client;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.HRegionLocation;
@@ -57,9 +58,10 @@ class AsyncSingleRequestRpcRetryingCaller<T> extends AsyncRpcRetryingCaller<T> {
   public AsyncSingleRequestRpcRetryingCaller(Timer retryTimer, AsyncConnectionImpl conn,
     TableName tableName, byte[] row, int replicaId, RegionLocateType locateType,
     Callable<T> callable, int priority, long pauseNs, long pauseNsForServerOverloaded,
-    int maxAttempts, long operationTimeoutNs, long rpcTimeoutNs, int startLogErrorsCnt) {
+    int maxAttempts, long operationTimeoutNs, long rpcTimeoutNs, int startLogErrorsCnt,
+    Map<String, byte[]> requestAttributes) {
     super(retryTimer, conn, priority, pauseNs, pauseNsForServerOverloaded, maxAttempts,
-      operationTimeoutNs, rpcTimeoutNs, startLogErrorsCnt);
+      operationTimeoutNs, rpcTimeoutNs, startLogErrorsCnt, requestAttributes);
     this.tableName = tableName;
     this.row = row;
     this.replicaId = replicaId;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
+import org.apache.commons.lang3.NotImplementedException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.CompareOperator;
 import org.apache.hadoop.hbase.TableName;
@@ -115,7 +116,9 @@ public interface AsyncTable<C extends ScanResultConsumerBase> {
    * Get the map of request attributes
    * @return a map of request attributes supplied by the client
    */
-  Map<String, byte[]> getRequestAttributes();
+  default Map<String, byte[]> getRequestAttributes() {
+    throw new NotImplementedException("Add an implementation!");
+  }
 
   /**
    * Test for the existence of columns in the table, as specified by the Get.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hbase.client.ConnectionUtils.toCheckExistenceOnl
 import static org.apache.hadoop.hbase.util.FutureUtils.allOf;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -109,6 +110,8 @@ public interface AsyncTable<C extends ScanResultConsumerBase> {
    * @return scan rpc timeout in the specified time unit
    */
   long getScanTimeout(TimeUnit unit);
+
+  Map<String, byte[]> getRequestAttributes();
 
   /**
    * Test for the existence of columns in the table, as specified by the Get.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
@@ -111,6 +111,10 @@ public interface AsyncTable<C extends ScanResultConsumerBase> {
    */
   long getScanTimeout(TimeUnit unit);
 
+  /**
+   * Get the map of request attributes
+   * @return a map of request attributes supplied by the client
+   */
   Map<String, byte[]> getRequestAttributes();
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilder.java
@@ -144,6 +144,11 @@ public interface AsyncTableBuilder<C extends ScanResultConsumerBase> {
   AsyncTableBuilder<C> setRequestAttributes(Map<String, byte[]> requestAttributes);
 
   /**
+   * Set a request attribute
+   */
+  AsyncTableBuilder<C> setRequestAttribute(String key, byte[] value);
+
+  /**
    * Create the {@link AsyncTable} instance.
    */
   AsyncTable<C> build();

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilder.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.ConnectionUtils.retries2Attempts;
 
-import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.HBaseServerException;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -137,11 +136,6 @@ public interface AsyncTableBuilder<C extends ScanResultConsumerBase> {
    * Set the number of retries that are allowed before we start to log.
    */
   AsyncTableBuilder<C> setStartLogErrorsCnt(int startLogErrorsCnt);
-
-  /**
-   * Sets the map of request attributes
-   */
-  AsyncTableBuilder<C> setRequestAttributes(Map<String, byte[]> requestAttributes);
 
   /**
    * Set a request attribute

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilder.java
@@ -139,7 +139,7 @@ public interface AsyncTableBuilder<C extends ScanResultConsumerBase> {
   AsyncTableBuilder<C> setStartLogErrorsCnt(int startLogErrorsCnt);
 
   /**
-   * Sets a request attribute
+   * Sets the map of request attributes
    */
   AsyncTableBuilder<C> setRequestAttributes(Map<String, byte[]> requestAttributes);
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilder.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.ConnectionUtils.retries2Attempts;
 
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.HBaseServerException;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -136,6 +137,11 @@ public interface AsyncTableBuilder<C extends ScanResultConsumerBase> {
    * Set the number of retries that are allowed before we start to log.
    */
   AsyncTableBuilder<C> setStartLogErrorsCnt(int startLogErrorsCnt);
+
+  /**
+   * Sets a request attribute
+   */
+  AsyncTableBuilder<C> setRequestAttributes(Map<String, byte[]> requestAttributes);
 
   /**
    * Create the {@link AsyncTable} instance.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilderBase.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilderBase.java
@@ -128,7 +128,14 @@ abstract class AsyncTableBuilderBase<C extends ScanResultConsumerBase>
 
   @Override
   public AsyncTableBuilder<C> setRequestAttributes(Map<String, byte[]> requestAttributes) {
-    this.requestAttributes = requestAttributes;
+    this.requestAttributes = new HashMap<>(requestAttributes.size());
+    this.requestAttributes.putAll(requestAttributes);
+    return this;
+  }
+
+  @Override
+  public AsyncTableBuilder<C> setRequestAttribute(String key, byte[] value) {
+    this.requestAttributes.put(key, value);
     return this;
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilderBase.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilderBase.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.ConnectionUtils.retries2Attempts;
 
+import java.util.HashMap;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -49,6 +51,8 @@ abstract class AsyncTableBuilderBase<C extends ScanResultConsumerBase>
   protected int maxAttempts;
 
   protected int startLogErrorsCnt;
+
+  protected Map<String, byte[]> requestAttributes = new HashMap<>();
 
   AsyncTableBuilderBase(TableName tableName, AsyncConnectionConfiguration connConf) {
     this.tableName = tableName;
@@ -119,6 +123,12 @@ abstract class AsyncTableBuilderBase<C extends ScanResultConsumerBase>
   @Override
   public AsyncTableBuilderBase<C> setStartLogErrorsCnt(int startLogErrorsCnt) {
     this.startLogErrorsCnt = startLogErrorsCnt;
+    return this;
+  }
+
+  @Override
+  public AsyncTableBuilder<C> setRequestAttributes(Map<String, byte[]> requestAttributes) {
+    this.requestAttributes = requestAttributes;
     return this;
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilderBase.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableBuilderBase.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.ConnectionUtils.retries2Attempts;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.TimeUnit;
@@ -52,7 +53,7 @@ abstract class AsyncTableBuilderBase<C extends ScanResultConsumerBase>
 
   protected int startLogErrorsCnt;
 
-  protected Map<String, byte[]> requestAttributes = new HashMap<>();
+  protected Map<String, byte[]> requestAttributes = Collections.emptyMap();
 
   AsyncTableBuilderBase(TableName tableName, AsyncConnectionConfiguration connConf) {
     this.tableName = tableName;
@@ -127,14 +128,10 @@ abstract class AsyncTableBuilderBase<C extends ScanResultConsumerBase>
   }
 
   @Override
-  public AsyncTableBuilder<C> setRequestAttributes(Map<String, byte[]> requestAttributes) {
-    this.requestAttributes = new HashMap<>(requestAttributes.size());
-    this.requestAttributes.putAll(requestAttributes);
-    return this;
-  }
-
-  @Override
   public AsyncTableBuilder<C> setRequestAttribute(String key, byte[] value) {
+    if (this.requestAttributes.isEmpty()) {
+      this.requestAttributes = new HashMap<>();
+    }
     this.requestAttributes.put(key, value);
     return this;
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableImpl.java
@@ -24,6 +24,7 @@ import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.TimeUnit;
@@ -99,6 +100,11 @@ class AsyncTableImpl implements AsyncTable<ScanResultConsumer> {
   @Override
   public long getScanTimeout(TimeUnit unit) {
     return rawTable.getScanTimeout(unit);
+  }
+
+  @Override
+  public Map<String, byte[]> getRequestAttributes() {
+    return rawTable.getRequestAttributes();
   }
 
   private <T> CompletableFuture<T> wrap(CompletableFuture<T> future) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionFactory.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionFactory.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.security.PrivilegedExceptionAction;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -217,7 +218,7 @@ public class ConnectionFactory {
    */
   public static Connection createConnection(Configuration conf, ExecutorService pool,
     final User user) throws IOException {
-    return createConnection(conf, pool, user, null);
+    return createConnection(conf, pool, user, Collections.emptyMap());
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionFactory.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionFactory.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 import java.io.IOException;
 import java.lang.reflect.Constructor;
 import java.security.PrivilegedExceptionAction;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.conf.Configuration;
@@ -216,21 +217,53 @@ public class ConnectionFactory {
    */
   public static Connection createConnection(Configuration conf, ExecutorService pool,
     final User user) throws IOException {
+    return createConnection(conf, pool, user, null);
+  }
+
+  /**
+   * Create a new Connection instance using the passed <code>conf</code> instance. Connection
+   * encapsulates all housekeeping for a connection to the cluster. All tables and interfaces
+   * created from returned connection share zookeeper connection, meta cache, and connections to
+   * region servers and masters. <br>
+   * The caller is responsible for calling {@link Connection#close()} on the returned connection
+   * instance. Typical usage:
+   *
+   * <pre>
+   * Connection connection = ConnectionFactory.createConnection(conf);
+   * Table table = connection.getTable(TableName.valueOf("table1"));
+   * try {
+   *   table.get(...);
+   *   ...
+   * } finally {
+   *   table.close();
+   *   connection.close();
+   * }
+   * </pre>
+   *
+   * @param conf                 configuration
+   * @param user                 the user the connection is for
+   * @param pool                 the thread pool to use for batch operations
+   * @param connectionAttributes attributes to be sent along to server during connection establish
+   * @return Connection object for <code>conf</code>
+   */
+  public static Connection createConnection(Configuration conf, ExecutorService pool,
+    final User user, Map<String, byte[]> connectionAttributes) throws IOException {
     Class<?> clazz = conf.getClass(ConnectionUtils.HBASE_CLIENT_CONNECTION_IMPL,
       ConnectionOverAsyncConnection.class, Connection.class);
     if (clazz != ConnectionOverAsyncConnection.class) {
       try {
         // Default HCM#HCI is not accessible; make it so before invoking.
-        Constructor<?> constructor =
-          clazz.getDeclaredConstructor(Configuration.class, ExecutorService.class, User.class);
+        Constructor<?> constructor = clazz.getDeclaredConstructor(Configuration.class,
+          ExecutorService.class, User.class, Map.class);
         constructor.setAccessible(true);
-        return user.runAs((PrivilegedExceptionAction<
-          Connection>) () -> (Connection) constructor.newInstance(conf, pool, user));
+        return user.runAs((PrivilegedExceptionAction<Connection>) () -> (Connection) constructor
+          .newInstance(conf, pool, user, connectionAttributes));
       } catch (Exception e) {
         throw new IOException(e);
       }
     } else {
-      return FutureUtils.get(createAsyncConnection(conf, user)).toConnection();
+      return FutureUtils.get(createAsyncConnection(conf, user, connectionAttributes))
+        .toConnection();
     }
   }
 
@@ -281,6 +314,27 @@ public class ConnectionFactory {
    */
   public static CompletableFuture<AsyncConnection> createAsyncConnection(Configuration conf,
     final User user) {
+    return createAsyncConnection(conf, user, null);
+  }
+
+  /**
+   * Create a new AsyncConnection instance using the passed {@code conf} and {@code user}.
+   * AsyncConnection encapsulates all housekeeping for a connection to the cluster. All tables and
+   * interfaces created from returned connection share zookeeper connection, meta cache, and
+   * connections to region servers and masters.
+   * <p>
+   * The caller is responsible for calling {@link AsyncConnection#close()} on the returned
+   * connection instance.
+   * <p>
+   * Usually you should only create one AsyncConnection instance in your code and use it everywhere
+   * as it is thread safe.
+   * @param conf                 configuration
+   * @param user                 the user the asynchronous connection is for
+   * @param connectionAttributes attributes to be sent along to server during connection establish
+   * @return AsyncConnection object wrapped by CompletableFuture
+   */
+  public static CompletableFuture<AsyncConnection> createAsyncConnection(Configuration conf,
+    final User user, Map<String, byte[]> connectionAttributes) {
     return TraceUtil.tracedFuture(() -> {
       CompletableFuture<AsyncConnection> future = new CompletableFuture<>();
       ConnectionRegistry registry = ConnectionRegistryFactory.getRegistry(conf);
@@ -300,7 +354,7 @@ public class ConnectionFactory {
         try {
           future.complete(
             user.runAs((PrivilegedExceptionAction<? extends AsyncConnection>) () -> ReflectionUtils
-              .newInstance(clazz, conf, registry, clusterId, null, user)));
+              .newInstance(clazz, conf, registry, clusterId, null, user, connectionAttributes)));
         } catch (Exception e) {
           registry.close();
           future.completeExceptionally(e);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionOverAsyncConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionOverAsyncConnection.java
@@ -193,7 +193,8 @@ class ConnectionOverAsyncConnection implements Connection {
           conn.getTableBuilder(tableName).setRpcTimeout(rpcTimeout, TimeUnit.MILLISECONDS)
             .setReadRpcTimeout(readRpcTimeout, TimeUnit.MILLISECONDS)
             .setWriteRpcTimeout(writeRpcTimeout, TimeUnit.MILLISECONDS)
-            .setOperationTimeout(operationTimeout, TimeUnit.MILLISECONDS).build(),
+            .setOperationTimeout(operationTimeout, TimeUnit.MILLISECONDS)
+            .setRequestAttributes(requestAttributes).build(),
           poolSupplier);
       }
     };

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionOverAsyncConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionOverAsyncConnection.java
@@ -189,13 +189,13 @@ class ConnectionOverAsyncConnection implements Connection {
       public Table build() {
         IOExceptionSupplier<ExecutorService> poolSupplier =
           pool != null ? () -> pool : ConnectionOverAsyncConnection.this::getBatchPool;
-        return new TableOverAsyncTable(conn,
+        AsyncTableBuilder<AdvancedScanResultConsumer> tableBuilder =
           conn.getTableBuilder(tableName).setRpcTimeout(rpcTimeout, TimeUnit.MILLISECONDS)
             .setReadRpcTimeout(readRpcTimeout, TimeUnit.MILLISECONDS)
             .setWriteRpcTimeout(writeRpcTimeout, TimeUnit.MILLISECONDS)
-            .setOperationTimeout(operationTimeout, TimeUnit.MILLISECONDS)
-            .setRequestAttributes(requestAttributes).build(),
-          poolSupplier);
+            .setOperationTimeout(operationTimeout, TimeUnit.MILLISECONDS);
+        requestAttributes.forEach(tableBuilder::setRequestAttribute);
+        return new TableOverAsyncTable(conn, tableBuilder.build(), poolSupplier);
       }
     };
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Table.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Table.java
@@ -751,4 +751,12 @@ public interface Table extends Closeable {
   default long getOperationTimeout(TimeUnit unit) {
     throw new NotImplementedException("Add an implementation!");
   }
+
+  /**
+   * Get the attributes to be submitted with requests
+   * @return map of request attributes
+   */
+  default Map<String, byte[]> getRequestAttributes() {
+    return Collections.emptyMap();
+  }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Table.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Table.java
@@ -757,6 +757,6 @@ public interface Table extends Closeable {
    * @return map of request attributes
    */
   default Map<String, byte[]> getRequestAttributes() {
-    return Collections.emptyMap();
+    throw new NotImplementedException("Add an implementation!");
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilder.java
@@ -56,9 +56,10 @@ public interface TableBuilder {
    */
   TableBuilder setWriteRpcTimeout(int timeout);
 
+  /**
+   * Sets the map of request attributes
+   */
   TableBuilder setRequestAttributes(Map<String, byte[]> requestAttributes);
-
-  Map<String, byte[]> getRequestAttributes();
 
   /**
    * Create the {@link Table} instance.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import java.util.Map;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -54,6 +55,10 @@ public interface TableBuilder {
    * Set timeout for each write(put, delete) rpc request.
    */
   TableBuilder setWriteRpcTimeout(int timeout);
+
+  TableBuilder setRequestAttributes(Map<String, byte[]> requestAttributes);
+
+  Map<String, byte[]> getRequestAttributes();
 
   /**
    * Create the {@link Table} instance.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilder.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import java.util.Map;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -55,11 +54,6 @@ public interface TableBuilder {
    * Set timeout for each write(put, delete) rpc request.
    */
   TableBuilder setWriteRpcTimeout(int timeout);
-
-  /**
-   * Sets the map of request attributes
-   */
-  TableBuilder setRequestAttributes(Map<String, byte[]> requestAttributes);
 
   /**
    * Set a request attribute

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilder.java
@@ -62,6 +62,11 @@ public interface TableBuilder {
   TableBuilder setRequestAttributes(Map<String, byte[]> requestAttributes);
 
   /**
+   * Set a request attribute
+   */
+  TableBuilder setRequestAttribute(String key, byte[] value);
+
+  /**
    * Create the {@link Table} instance.
    */
   Table build();

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilderBase.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilderBase.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
 import org.apache.hadoop.hbase.TableName;
@@ -38,7 +39,7 @@ abstract class TableBuilderBase implements TableBuilder {
 
   protected int writeRpcTimeout;
 
-  protected Map<String, byte[]> requestAttributes = new HashMap<>();
+  protected Map<String, byte[]> requestAttributes = Collections.emptyMap();
 
   TableBuilderBase(TableName tableName, ConnectionConfiguration connConf) {
     if (tableName == null) {
@@ -79,14 +80,10 @@ abstract class TableBuilderBase implements TableBuilder {
   }
 
   @Override
-  public TableBuilderBase setRequestAttributes(Map<String, byte[]> requestAttributes) {
-    this.requestAttributes = new HashMap<>(requestAttributes.size());
-    this.requestAttributes.putAll(requestAttributes);
-    return this;
-  }
-
-  @Override
   public TableBuilderBase setRequestAttribute(String key, byte[] value) {
+    if (this.requestAttributes.isEmpty()) {
+      this.requestAttributes = new HashMap<>();
+    }
     this.requestAttributes.put(key, value);
     return this;
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilderBase.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilderBase.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import java.util.HashMap;
+import java.util.Map;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -35,6 +37,8 @@ abstract class TableBuilderBase implements TableBuilder {
   protected int readRpcTimeout;
 
   protected int writeRpcTimeout;
+
+  protected Map<String, byte[]> requestAttributes = new HashMap<>();
 
   TableBuilderBase(TableName tableName, ConnectionConfiguration connConf) {
     if (tableName == null) {
@@ -72,5 +76,16 @@ abstract class TableBuilderBase implements TableBuilder {
   public TableBuilderBase setWriteRpcTimeout(int timeout) {
     this.writeRpcTimeout = timeout;
     return this;
+  }
+
+  @Override
+  public TableBuilderBase setRequestAttributes(Map<String, byte[]> requestAttributes) {
+    this.requestAttributes = requestAttributes;
+    return this;
+  }
+
+  @Override
+  public Map<String, byte[]> getRequestAttributes() {
+    return requestAttributes;
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilderBase.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilderBase.java
@@ -80,7 +80,14 @@ abstract class TableBuilderBase implements TableBuilder {
 
   @Override
   public TableBuilderBase setRequestAttributes(Map<String, byte[]> requestAttributes) {
-    this.requestAttributes = requestAttributes;
+    this.requestAttributes = new HashMap<>(requestAttributes.size());
+    this.requestAttributes.putAll(requestAttributes);
+    return this;
+  }
+
+  @Override
+  public TableBuilderBase setRequestAttribute(String key, byte[] value) {
+    this.requestAttributes.put(key, value);
     return this;
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilderBase.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableBuilderBase.java
@@ -83,9 +83,4 @@ abstract class TableBuilderBase implements TableBuilder {
     this.requestAttributes = requestAttributes;
     return this;
   }
-
-  @Override
-  public Map<String, byte[]> getRequestAttributes() {
-    return requestAttributes;
-  }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableOverAsyncTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableOverAsyncTable.java
@@ -561,6 +561,11 @@ class TableOverAsyncTable implements Table {
   }
 
   @Override
+  public Map<String, byte[]> getRequestAttributes() {
+    return table.getRequestAttributes();
+  }
+
+  @Override
   public RegionLocator getRegionLocator() throws IOException {
     return conn.toConnection().getRegionLocator(getName());
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
@@ -26,6 +26,7 @@ import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.Collection;
+import java.util.Map;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
@@ -106,6 +107,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
   private boolean running = true; // if client runs
 
   protected final Configuration conf;
+  protected final Map<String, byte[]> connectionAttributes;
   protected final String clusterId;
   protected final SocketAddress localAddr;
   protected final MetricsConnection metrics;
@@ -154,7 +156,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
    * @param metrics   the connection metrics
    */
   public AbstractRpcClient(Configuration conf, String clusterId, SocketAddress localAddr,
-    MetricsConnection metrics) {
+    MetricsConnection metrics, Map<String, byte[]> connectionAttributes) {
     this.userProvider = UserProvider.instantiate(conf);
     this.localAddr = localAddr;
     this.tcpKeepAlive = conf.getBoolean("hbase.ipc.client.tcpkeepalive", true);
@@ -167,6 +169,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
 
     this.minIdleTimeBeforeClose = conf.getInt(IDLE_TIME, 120000); // 2 minutes
     this.conf = conf;
+    this.connectionAttributes = connectionAttributes;
     this.codec = getCodec();
     this.compressor = getCompressor(conf);
     this.fallbackAllowed = conf.getBoolean(IPC_CLIENT_FALLBACK_TO_SIMPLE_AUTH_ALLOWED_KEY,
@@ -417,7 +420,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
 
       final AtomicInteger counter = concurrentCounterCache.getUnchecked(addr);
       Call call = new Call(nextCallId(), md, param, hrc.cellScanner(), returnType,
-        hrc.getCallTimeout(), hrc.getPriority(), new RpcCallback<Call>() {
+        hrc.getCallTimeout(), hrc.getPriority(), hrc.getAttributes(), new RpcCallback<Call>() {
           @Override
           public void run(Call call) {
             try (Scope scope = call.span.makeCurrent()) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcClient.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.util.Map;
 import javax.net.SocketFactory;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
@@ -41,7 +42,7 @@ public class BlockingRpcClient extends AbstractRpcClient<BlockingRpcConnection> 
    * SocketFactory
    */
   BlockingRpcClient(Configuration conf) {
-    this(conf, HConstants.CLUSTER_ID_DEFAULT, null, null);
+    this(conf, HConstants.CLUSTER_ID_DEFAULT, null, null, null);
   }
 
   /**
@@ -53,8 +54,8 @@ public class BlockingRpcClient extends AbstractRpcClient<BlockingRpcConnection> 
    * @param metrics   the connection metrics
    */
   public BlockingRpcClient(Configuration conf, String clusterId, SocketAddress localAddr,
-    MetricsConnection metrics) {
-    super(conf, clusterId, localAddr, metrics);
+    MetricsConnection metrics, Map<String, byte[]> connectionAttributes) {
+    super(conf, clusterId, localAddr, metrics, connectionAttributes);
     this.socketFactory = NetUtils.getDefaultSocketFactory(conf);
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcClient.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.Map;
 import javax.net.SocketFactory;
 import org.apache.hadoop.conf.Configuration;
@@ -42,7 +43,7 @@ public class BlockingRpcClient extends AbstractRpcClient<BlockingRpcConnection> 
    * SocketFactory
    */
   BlockingRpcClient(Configuration conf) {
-    this(conf, HConstants.CLUSTER_ID_DEFAULT, null, null, null);
+    this(conf, HConstants.CLUSTER_ID_DEFAULT, null, null, Collections.emptyMap());
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/BlockingRpcConnection.java
@@ -219,7 +219,7 @@ class BlockingRpcConnection extends RpcConnection implements Runnable {
   BlockingRpcConnection(BlockingRpcClient rpcClient, ConnectionId remoteId) throws IOException {
     super(rpcClient.conf, AbstractRpcClient.WHEEL_TIMER, remoteId, rpcClient.clusterId,
       rpcClient.userProvider.isHBaseSecurityEnabled(), rpcClient.codec, rpcClient.compressor,
-      rpcClient.metrics);
+      rpcClient.metrics, rpcClient.connectionAttributes);
     this.rpcClient = rpcClient;
     this.connectionHeaderPreamble = getConnectionHeaderPreamble();
     ConnectionHeader header = getConnectionHeader();

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/Call.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/Call.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
 
 import io.opentelemetry.api.trace.Span;
 import java.io.IOException;
+import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.builder.ToStringBuilder;
 import org.apache.commons.lang3.builder.ToStringStyle;
@@ -56,14 +57,15 @@ class Call {
   final Descriptors.MethodDescriptor md;
   final int timeout; // timeout in millisecond for this call; 0 means infinite.
   final int priority;
+  final Map<String, byte[]> attributes;
   final MetricsConnection.CallStats callStats;
   private final RpcCallback<Call> callback;
   final Span span;
   Timeout timeoutTask;
 
   Call(int id, final Descriptors.MethodDescriptor md, Message param, final CellScanner cells,
-    final Message responseDefaultType, int timeout, int priority, RpcCallback<Call> callback,
-    MetricsConnection.CallStats callStats) {
+    final Message responseDefaultType, int timeout, int priority, Map<String, byte[]> attributes,
+    RpcCallback<Call> callback, MetricsConnection.CallStats callStats) {
     this.param = param;
     this.md = md;
     this.cells = cells;
@@ -73,6 +75,7 @@ class Call {
     this.id = id;
     this.timeout = timeout;
     this.priority = priority;
+    this.attributes = attributes;
     this.callback = callback;
     this.span = Span.current();
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/Call.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/Call.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
 
 import io.opentelemetry.api.trace.Span;
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -62,6 +63,13 @@ class Call {
   private final RpcCallback<Call> callback;
   final Span span;
   Timeout timeoutTask;
+
+  Call(int id, final Descriptors.MethodDescriptor md, Message param, final CellScanner cells,
+    final Message responseDefaultType, int timeout, int priority, RpcCallback<Call> callback,
+    MetricsConnection.CallStats callStats) {
+    this(id, md, param, cells, responseDefaultType, timeout, priority, Collections.emptyMap(),
+      callback, callStats);
+  }
 
   Call(int id, final Descriptors.MethodDescriptor md, Message param, final CellScanner cells,
     final Message responseDefaultType, int timeout, int priority, Map<String, byte[]> attributes,

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/Call.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/Call.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hbase.ipc;
 
 import io.opentelemetry.api.trace.Span;
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import org.apache.commons.lang3.builder.ToStringBuilder;
@@ -63,13 +62,6 @@ class Call {
   private final RpcCallback<Call> callback;
   final Span span;
   Timeout timeoutTask;
-
-  Call(int id, final Descriptors.MethodDescriptor md, Message param, final CellScanner cells,
-    final Message responseDefaultType, int timeout, int priority, RpcCallback<Call> callback,
-    MetricsConnection.CallStats callStats) {
-    this(id, md, param, cells, responseDefaultType, timeout, priority, Collections.emptyMap(),
-      callback, callStats);
-  }
 
   Call(int id, final Descriptors.MethodDescriptor md, Message param, final CellScanner cells,
     final Message responseDefaultType, int timeout, int priority, Map<String, byte[]> attributes,

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/DelegatingHBaseRpcController.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/DelegatingHBaseRpcController.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
+import java.util.Map;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -110,6 +111,11 @@ public class DelegatingHBaseRpcController implements HBaseRpcController {
   @Override
   public boolean hasCallTimeout() {
     return delegate.hasCallTimeout();
+  }
+
+  @Override
+  public Map<String, byte[]> getAttributes() {
+    return null;
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/DelegatingHBaseRpcController.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/DelegatingHBaseRpcController.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.TableName;
@@ -115,7 +116,7 @@ public class DelegatingHBaseRpcController implements HBaseRpcController {
 
   @Override
   public Map<String, byte[]> getAttributes() {
-    return null;
+    return Collections.emptyMap();
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/DelegatingHBaseRpcController.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/DelegatingHBaseRpcController.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
-import java.util.Collections;
 import java.util.Map;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.TableName;
@@ -115,8 +114,13 @@ public class DelegatingHBaseRpcController implements HBaseRpcController {
   }
 
   @Override
-  public Map<String, byte[]> getAttributes() {
-    return Collections.emptyMap();
+  public Map<String, byte[]> getRequestAttributes() {
+    return delegate.getRequestAttributes();
+  }
+
+  @Override
+  public void setRequestAttributes(Map<String, byte[]> requestAttributes) {
+    delegate.setRequestAttributes(requestAttributes);
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcController.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcController.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
+import java.util.Map;
 import org.apache.hadoop.hbase.CellScannable;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
@@ -70,6 +71,8 @@ public interface HBaseRpcController extends RpcController, CellScannable {
   void setCallTimeout(int callTimeout);
 
   boolean hasCallTimeout();
+
+  Map<String, byte[]> getAttributes();
 
   /**
    * Set failed with an exception to pass on. For use in async rpc clients

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcController.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcController.java
@@ -72,7 +72,9 @@ public interface HBaseRpcController extends RpcController, CellScannable {
 
   boolean hasCallTimeout();
 
-  Map<String, byte[]> getAttributes();
+  Map<String, byte[]> getRequestAttributes();
+
+  void setRequestAttributes(Map<String, byte[]> requestAttributes);
 
   /**
    * Set failed with an exception to pass on. For use in async rpc clients

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcController.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcController.java
@@ -72,8 +72,14 @@ public interface HBaseRpcController extends RpcController, CellScannable {
 
   boolean hasCallTimeout();
 
+  /**
+   * Get the map of request attributes
+   */
   Map<String, byte[]> getRequestAttributes();
 
+  /**
+   * Set the map of request attributes
+   */
   void setRequestAttributes(Map<String, byte[]> requestAttributes);
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcControllerImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcControllerImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.ipc;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.hbase.CellScannable;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.CellUtil;
@@ -164,6 +165,11 @@ public class HBaseRpcControllerImpl implements HBaseRpcController {
   @Override
   public boolean hasCallTimeout() {
     return callTimeout != null;
+  }
+
+  @Override
+  public Map<String, byte[]> getAttributes() {
+    return null;
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcControllerImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcControllerImpl.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.hbase.CellScannable;
@@ -169,7 +170,7 @@ public class HBaseRpcControllerImpl implements HBaseRpcController {
 
   @Override
   public Map<String, byte[]> getAttributes() {
-    return null;
+    return Collections.emptyMap();
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcControllerImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/HBaseRpcControllerImpl.java
@@ -72,6 +72,8 @@ public class HBaseRpcControllerImpl implements HBaseRpcController {
    */
   private CellScanner cellScanner;
 
+  private Map<String, byte[]> requestAttributes = Collections.emptyMap();
+
   public HBaseRpcControllerImpl() {
     this(null, (CellScanner) null);
   }
@@ -169,8 +171,13 @@ public class HBaseRpcControllerImpl implements HBaseRpcController {
   }
 
   @Override
-  public Map<String, byte[]> getAttributes() {
-    return Collections.emptyMap();
+  public Map<String, byte[]> getRequestAttributes() {
+    return requestAttributes;
+  }
+
+  @Override
+  public void setRequestAttributes(Map<String, byte[]> requestAttributes) {
+    this.requestAttributes = requestAttributes;
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcClient.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
@@ -55,7 +56,12 @@ public class NettyRpcClient extends AbstractRpcClient<NettyRpcConnection> {
 
   public NettyRpcClient(Configuration configuration, String clusterId, SocketAddress localAddress,
     MetricsConnection metrics) {
-    super(configuration, clusterId, localAddress, metrics);
+    this(configuration, clusterId, localAddress, metrics, null);
+  }
+
+  public NettyRpcClient(Configuration configuration, String clusterId, SocketAddress localAddress,
+    MetricsConnection metrics, Map<String, byte[]> connectionAttributes) {
+    super(configuration, clusterId, localAddress, metrics, connectionAttributes);
     Pair<EventLoopGroup, Class<? extends Channel>> groupAndChannelClass =
       NettyRpcClientConfigHelper.getEventLoopConfig(conf);
     if (groupAndChannelClass == null) {
@@ -75,7 +81,7 @@ public class NettyRpcClient extends AbstractRpcClient<NettyRpcConnection> {
 
   /** Used in test only. */
   public NettyRpcClient(Configuration configuration) {
-    this(configuration, HConstants.CLUSTER_ID_DEFAULT, null, null);
+    this(configuration, HConstants.CLUSTER_ID_DEFAULT, null, null, null);
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcClient.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.Map;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
@@ -56,7 +57,7 @@ public class NettyRpcClient extends AbstractRpcClient<NettyRpcConnection> {
 
   public NettyRpcClient(Configuration configuration, String clusterId, SocketAddress localAddress,
     MetricsConnection metrics) {
-    this(configuration, clusterId, localAddress, metrics, null);
+    this(configuration, clusterId, localAddress, metrics, Collections.emptyMap());
   }
 
   public NettyRpcClient(Configuration configuration, String clusterId, SocketAddress localAddress,
@@ -81,7 +82,7 @@ public class NettyRpcClient extends AbstractRpcClient<NettyRpcConnection> {
 
   /** Used in test only. */
   public NettyRpcClient(Configuration configuration) {
-    this(configuration, HConstants.CLUSTER_ID_DEFAULT, null, null, null);
+    this(configuration, HConstants.CLUSTER_ID_DEFAULT, null, null, Collections.emptyMap());
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
@@ -104,7 +104,7 @@ class NettyRpcConnection extends RpcConnection {
   NettyRpcConnection(NettyRpcClient rpcClient, ConnectionId remoteId) throws IOException {
     super(rpcClient.conf, AbstractRpcClient.WHEEL_TIMER, remoteId, rpcClient.clusterId,
       rpcClient.userProvider.isHBaseSecurityEnabled(), rpcClient.codec, rpcClient.compressor,
-      rpcClient.metrics);
+      rpcClient.metrics, rpcClient.connectionAttributes);
     this.rpcClient = rpcClient;
     this.eventLoop = rpcClient.group.next();
     byte[] connectionHeaderPreamble = getConnectionHeaderPreamble();

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcClientFactory.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcClientFactory.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.net.SocketAddress;
+import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.MetricsConnection;
 import org.apache.hadoop.hbase.util.ReflectionUtils;
@@ -59,7 +60,7 @@ public final class RpcClientFactory {
    */
   public static RpcClient createClient(Configuration conf, String clusterId,
     MetricsConnection metrics) {
-    return createClient(conf, clusterId, null, metrics);
+    return createClient(conf, clusterId, null, metrics, null);
   }
 
   private static String getRpcClientClass(Configuration conf) {
@@ -81,10 +82,11 @@ public final class RpcClientFactory {
    * @return newly created RpcClient
    */
   public static RpcClient createClient(Configuration conf, String clusterId,
-    SocketAddress localAddr, MetricsConnection metrics) {
+    SocketAddress localAddr, MetricsConnection metrics, Map<String, byte[]> connectionAttributes) {
     String rpcClientClass = getRpcClientClass(conf);
-    return ReflectionUtils.instantiateWithCustomCtor(rpcClientClass, new Class[] {
-      Configuration.class, String.class, SocketAddress.class, MetricsConnection.class },
-      new Object[] { conf, clusterId, localAddr, metrics });
+    return ReflectionUtils.instantiateWithCustomCtor(
+      rpcClientClass, new Class[] { Configuration.class, String.class, SocketAddress.class,
+        MetricsConnection.class, Map.class },
+      new Object[] { conf, clusterId, localAddr, metrics, connectionAttributes });
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcClientFactory.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcClientFactory.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.MetricsConnection;
@@ -60,7 +61,7 @@ public final class RpcClientFactory {
    */
   public static RpcClient createClient(Configuration conf, String clusterId,
     MetricsConnection metrics) {
-    return createClient(conf, clusterId, null, metrics, null);
+    return createClient(conf, clusterId, null, metrics, Collections.emptyMap());
   }
 
   private static String getRpcClientClass(Configuration conf) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcConnection.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.ipc;
 import java.io.IOException;
 import java.net.InetSocketAddress;
 import java.net.UnknownHostException;
+import java.util.Map;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
@@ -39,11 +40,13 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hbase.thirdparty.com.google.protobuf.UnsafeByteOperations;
 import org.apache.hbase.thirdparty.io.netty.util.HashedWheelTimer;
 import org.apache.hbase.thirdparty.io.netty.util.Timeout;
 import org.apache.hbase.thirdparty.io.netty.util.TimerTask;
 
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.ConnectionHeader;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.UserInformation;
 
@@ -70,6 +73,7 @@ abstract class RpcConnection {
   protected final CompressionCodec compressor;
 
   protected final MetricsConnection metrics;
+  private final Map<String, byte[]> connectionAttributes;
 
   protected final HashedWheelTimer timeoutTimer;
 
@@ -86,12 +90,13 @@ abstract class RpcConnection {
 
   protected RpcConnection(Configuration conf, HashedWheelTimer timeoutTimer, ConnectionId remoteId,
     String clusterId, boolean isSecurityEnabled, Codec codec, CompressionCodec compressor,
-    MetricsConnection metrics) throws IOException {
+    MetricsConnection metrics, Map<String, byte[]> connectionAttributes) throws IOException {
     this.timeoutTimer = timeoutTimer;
     this.codec = codec;
     this.compressor = compressor;
     this.conf = conf;
     this.metrics = metrics;
+    this.connectionAttributes = connectionAttributes;
     User ticket = remoteId.getTicket();
     this.securityInfo = SecurityInfo.getInfo(remoteId.getServiceName());
     this.useSasl = isSecurityEnabled;
@@ -168,6 +173,14 @@ abstract class RpcConnection {
     }
     if (this.compressor != null) {
       builder.setCellBlockCompressorClass(this.compressor.getClass().getCanonicalName());
+    }
+    if (connectionAttributes != null && !connectionAttributes.isEmpty()) {
+      HBaseProtos.NameBytesPair.Builder attributeBuilder = HBaseProtos.NameBytesPair.newBuilder();
+      for (Map.Entry<String, byte[]> attribute : connectionAttributes.entrySet()) {
+        attributeBuilder.setName(attribute.getKey());
+        attributeBuilder.setValue(UnsafeByteOperations.unsafeWrap(attribute.getValue()));
+        builder.addAttribute(attributeBuilder.build());
+      }
     }
     builder.setVersionInfo(ProtobufUtil.getVersionInfo());
     boolean isCryptoAESEnable = conf.getBoolean(CRYPTO_AES_ENABLED_KEY, CRYPTO_AES_ENABLED_DEFAULT);

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestRpcBasedRegistryHedgedReads.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestRpcBasedRegistryHedgedReads.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertThrows;
 import java.io.IOException;
 import java.net.SocketAddress;
 import java.util.Collections;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -95,7 +96,7 @@ public class TestRpcBasedRegistryHedgedReads {
   public static final class RpcClientImpl implements RpcClient {
 
     public RpcClientImpl(Configuration configuration, String clusterId, SocketAddress localAddress,
-      MetricsConnection metrics) {
+      MetricsConnection metrics, Map<String, byte[]> attributes) {
     }
 
     @Override

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestTLSHandshadeFailure.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/ipc/TestTLSHandshadeFailure.java
@@ -30,6 +30,7 @@ import static org.mockito.Mockito.when;
 import java.io.IOException;
 import java.net.ServerSocket;
 import java.net.Socket;
+import java.util.Collections;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicReference;
 import org.apache.hadoop.conf.Configuration;
@@ -148,7 +149,8 @@ public class TestTLSHandshadeFailure {
       Address.fromParts("127.0.0.1", server.getLocalPort()));
     NettyRpcConnection conn = client.createConnection(id);
     BlockingRpcCallback<Call> done = new BlockingRpcCallback<>();
-    Call call = new Call(1, null, null, null, null, 0, 0, done, new CallStats());
+    Call call =
+      new Call(1, null, null, null, null, 0, 0, Collections.emptyMap(), done, new CallStats());
     HBaseRpcController hrc = new HBaseRpcControllerImpl();
     conn.sendRequest(call, hrc);
     done.get();

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
@@ -1667,9 +1667,10 @@ public class TestHFileOutputFormat2 {
 
     private final Connection delegate;
 
-    public ConfigurationCaptorConnection(Configuration conf, ExecutorService es, User user)
-      throws IOException {
-      delegate = FutureUtils.get(createAsyncConnection(conf, user)).toConnection();
+    public ConfigurationCaptorConnection(Configuration conf, ExecutorService es, User user,
+      Map<String, byte[]> connectionAttributes) throws IOException {
+      delegate =
+        FutureUtils.get(createAsyncConnection(conf, user, connectionAttributes)).toConnection();
 
       final String uuid = conf.get(UUID_KEY);
       if (uuid != null) {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestMultiTableInputFormatBase.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestMultiTableInputFormatBase.java
@@ -123,7 +123,8 @@ public class TestMultiTableInputFormatBase {
     private final Configuration configuration;
     static final AtomicInteger creations = new AtomicInteger(0);
 
-    MRSplitsConnection(Configuration conf, ExecutorService pool, User user) throws IOException {
+    MRSplitsConnection(Configuration conf, ExecutorService pool, User user,
+      Map<String, byte[]> connectionAttributes) throws IOException {
       this.configuration = conf;
       creations.incrementAndGet();
     }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormatBase.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormatBase.java
@@ -212,8 +212,8 @@ public class TestTableInputFormatBase {
       SIZE_MAP.put(Bytes.toBytes("p"), 200L * 1024L * 1024L);
     }
 
-    ConnectionForMergeTesting(Configuration conf, ExecutorService pool, User user)
-      throws IOException {
+    ConnectionForMergeTesting(Configuration conf, ExecutorService pool, User user,
+      Map<String, byte[]> connectionAttributes) throws IOException {
     }
 
     @Override

--- a/hbase-protocol-shaded/src/main/protobuf/rpc/RPC.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/rpc/RPC.proto
@@ -92,6 +92,7 @@ message ConnectionHeader {
   optional VersionInfo version_info = 5;
   // the transformation for rpc AES encryption with Apache Commons Crypto
   optional string rpc_crypto_cipher_transformation = 6;
+  repeated NameBytesPair attribute = 7;
 }
 
 // This is sent by rpc server to negotiate the data if necessary
@@ -148,6 +149,7 @@ message RequestHeader {
   // See HConstants.
   optional uint32 priority = 6;
   optional uint32 timeout = 7;
+  repeated NameBytesPair attribute = 8;
 }
 
 message ResponseHeader {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnectionImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnectionImpl.java
@@ -59,7 +59,7 @@ class AsyncClusterConnectionImpl extends AsyncConnectionImpl implements AsyncClu
 
   public AsyncClusterConnectionImpl(Configuration conf, ConnectionRegistry registry,
     String clusterId, SocketAddress localAddress, User user) {
-    super(conf, registry, clusterId, localAddress, user);
+    super(conf, registry, clusterId, localAddress, user, null);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnectionImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnectionImpl.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.client;
 
 import java.net.SocketAddress;
+import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.stream.Collectors;
@@ -59,7 +60,7 @@ class AsyncClusterConnectionImpl extends AsyncConnectionImpl implements AsyncClu
 
   public AsyncClusterConnectionImpl(Configuration conf, ConnectionRegistry registry,
     String clusterId, SocketAddress localAddress, User user) {
-    super(conf, registry, clusterId, localAddress, user, null);
+    super(conf, registry, clusterId, localAddress, user, Collections.emptyMap());
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionReplicationRetryingCaller.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionReplicationRetryingCaller.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.client;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
@@ -54,7 +55,8 @@ public class AsyncRegionReplicationRetryingCaller extends AsyncRpcRetryingCaller
     RegionInfo replica, List<Entry> entries) {
     super(retryTimer, conn, ConnectionUtils.getPriority(replica.getTable()),
       conn.connConf.getPauseNs(), conn.connConf.getPauseNsForServerOverloaded(), maxAttempts,
-      operationTimeoutNs, rpcTimeoutNs, conn.connConf.getStartLogErrorsCnt());
+      operationTimeoutNs, rpcTimeoutNs, conn.connConf.getStartLogErrorsCnt(),
+      Collections.emptyMap());
     this.replica = replica;
     this.entries = entries.toArray(new Entry[0]);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCall.java
@@ -27,6 +27,7 @@ import org.apache.hbase.thirdparty.com.google.protobuf.BlockingService;
 import org.apache.hbase.thirdparty.com.google.protobuf.Descriptors.MethodDescriptor;
 import org.apache.hbase.thirdparty.com.google.protobuf.Message;
 
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.ConnectionHeader;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.RequestHeader;
 
 /**
@@ -81,6 +82,8 @@ public interface RpcCall extends RpcCallContext {
 
   /** Returns The request header of this call. */
   RequestHeader getHeader();
+
+  ConnectionHeader getConnectionHeader();
 
   /** Returns Port of remote address in this call */
   int getRemotePort();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.ipc;
 
+import static org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.*;
+
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Scope;
@@ -205,6 +207,11 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   @Override
   public RequestHeader getHeader() {
     return this.header;
+  }
+
+  @Override
+  public ConnectionHeader getConnectionHeader() {
+    return this.connection.connectionHeader;
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hbase.ipc;
 
-import static org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.*;
-
 import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.context.Scope;
@@ -51,6 +49,7 @@ import org.apache.hbase.thirdparty.com.google.protobuf.Message;
 
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.VersionInfo;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.CellBlockMeta;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.ExceptionResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RPCProtos.RequestHeader;
@@ -210,7 +209,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   }
 
   @Override
-  public ConnectionHeader getConnectionHeader() {
+  public RPCProtos.ConnectionHeader getConnectionHeader() {
     return this.connection.connectionHeader;
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyAsyncTable.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyAsyncTable.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.client;
 
 import java.util.List;
+import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -75,6 +76,11 @@ public class DummyAsyncTable<C extends ScanResultConsumerBase> implements AsyncT
   @Override
   public long getScanTimeout(TimeUnit unit) {
     return 0;
+  }
+
+  @Override
+  public Map<String, byte[]> getRequestAttributes() {
+    return null;
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientTimeouts.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientTimeouts.java
@@ -130,7 +130,7 @@ public class TestClientTimeouts {
   public static class RandomTimeoutRpcClient extends BlockingRpcClient {
     public RandomTimeoutRpcClient(Configuration conf, String clusterId, SocketAddress localAddr,
       MetricsConnection metrics) {
-      super(conf, clusterId, localAddr, metrics);
+      super(conf, clusterId, localAddr, metrics, null);
     }
 
     // Return my own instance, one that does random timeouts

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientTimeouts.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestClientTimeouts.java
@@ -22,6 +22,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.net.SocketAddress;
 import java.net.SocketTimeoutException;
+import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
@@ -129,8 +130,8 @@ public class TestClientTimeouts {
    */
   public static class RandomTimeoutRpcClient extends BlockingRpcClient {
     public RandomTimeoutRpcClient(Configuration conf, String clusterId, SocketAddress localAddr,
-      MetricsConnection metrics) {
-      super(conf, clusterId, localAddr, metrics, null);
+      MetricsConnection metrics, Map<String, byte[]> connectionAttributes) {
+      super(conf, clusterId, localAddr, metrics, connectionAttributes);
     }
 
     // Return my own instance, one that does random timeouts

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAndConnectionAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAndConnectionAttributes.java
@@ -1,0 +1,222 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.AuthUtil;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellComparator;
+import org.apache.hadoop.hbase.CellScannable;
+import org.apache.hadoop.hbase.CellScanner;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.RegionObserver;
+import org.apache.hadoop.hbase.ipc.DelegatingHBaseRpcController;
+import org.apache.hadoop.hbase.ipc.HBaseRpcController;
+import org.apache.hadoop.hbase.ipc.RpcCall;
+import org.apache.hadoop.hbase.ipc.RpcControllerFactory;
+import org.apache.hadoop.hbase.ipc.RpcServer;
+import org.apache.hadoop.hbase.testclassification.ClientTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
+
+@Category({ ClientTests.class, MediumTests.class })
+public class TestRequestAndConnectionAttributes {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestRequestAndConnectionAttributes.class);
+
+  private static final Map<String, byte[]> CONNECTION_ATTRIBUTES = new HashMap<>();
+  static {
+    CONNECTION_ATTRIBUTES.put("clientId", Bytes.toBytes("foo"));
+  }
+  private static final Map<String, byte[]> REQUEST_ATTRIBUTES = new HashMap<>();
+
+  private static HBaseTestingUtil TEST_UTIL = null;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    TEST_UTIL = new HBaseTestingUtil();
+    TEST_UTIL.getConfiguration().set(RpcControllerFactory.CUSTOM_CONTROLLER_CONF_KEY,
+      AttributesRpcControllerFactory.class.getName());
+    TEST_UTIL.startMiniCluster(1);
+  }
+
+  @AfterClass
+  public static void afterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testConnectionAttributes() throws IOException {
+    TableName tableName = TableName.valueOf("testConnectionAttributes");
+    TEST_UTIL.createTable(tableName, new byte[][] { Bytes.toBytes("0") }, 1,
+      HConstants.DEFAULT_BLOCKSIZE, AttributesCoprocessor.class.getName());
+
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (Connection conn = ConnectionFactory.createConnection(conf, null,
+      AuthUtil.loginClient(conf), CONNECTION_ATTRIBUTES); Table table = conn.getTable(tableName)) {
+      Result result = table.get(new Get(Bytes.toBytes(0)));
+      assertEquals(REQUEST_ATTRIBUTES.size() + CONNECTION_ATTRIBUTES.size(), result.size());
+      for (Map.Entry<String, byte[]> attr : CONNECTION_ATTRIBUTES.entrySet()) {
+        byte[] val = result.getValue(Bytes.toBytes("c"), Bytes.toBytes(attr.getKey()));
+        assertEquals(Bytes.toStringBinary(attr.getValue()), Bytes.toStringBinary(val));
+      }
+    }
+  }
+
+  @Test
+  public void testRequestAttributes() throws IOException {
+    TableName tableName = TableName.valueOf("testRequestAttributes");
+    TEST_UTIL.createTable(tableName, new byte[][] { Bytes.toBytes("0") }, 1,
+      HConstants.DEFAULT_BLOCKSIZE, AttributesCoprocessor.class.getName());
+
+    REQUEST_ATTRIBUTES.clear();
+    REQUEST_ATTRIBUTES.put("test1", Bytes.toBytes("a"));
+    REQUEST_ATTRIBUTES.put("test2", Bytes.toBytes("b"));
+
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (Connection conn = ConnectionFactory.createConnection(conf, null,
+      AuthUtil.loginClient(conf), CONNECTION_ATTRIBUTES); Table table = conn.getTable(tableName)) {
+
+      Result result = table.get(new Get(Bytes.toBytes(0)));
+      assertEquals(REQUEST_ATTRIBUTES.size() + CONNECTION_ATTRIBUTES.size(), result.size());
+      for (Map.Entry<String, byte[]> attr : REQUEST_ATTRIBUTES.entrySet()) {
+        byte[] val = result.getValue(Bytes.toBytes("r"), Bytes.toBytes(attr.getKey()));
+        assertEquals(Bytes.toStringBinary(attr.getValue()), Bytes.toStringBinary(val));
+      }
+
+      REQUEST_ATTRIBUTES.put("test3", Bytes.toBytes("c"));
+      result = table.get(new Get(Bytes.toBytes(0)));
+      assertEquals(REQUEST_ATTRIBUTES.size() + CONNECTION_ATTRIBUTES.size(), result.size());
+      for (Map.Entry<String, byte[]> attr : REQUEST_ATTRIBUTES.entrySet()) {
+        byte[] val = result.getValue(Bytes.toBytes("r"), Bytes.toBytes(attr.getKey()));
+        assertEquals(Bytes.toStringBinary(attr.getValue()), Bytes.toStringBinary(val));
+      }
+    }
+  }
+
+  @Test
+  public void testNoRequestAttributes() throws IOException {
+    TableName tableName = TableName.valueOf("testNoRequestAttributes");
+    TEST_UTIL.createTable(tableName, new byte[][] { Bytes.toBytes("0") }, 1,
+      HConstants.DEFAULT_BLOCKSIZE, AttributesCoprocessor.class.getName());
+
+    REQUEST_ATTRIBUTES.clear();
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (Connection conn = ConnectionFactory.createConnection(conf, null,
+      AuthUtil.loginClient(conf), CONNECTION_ATTRIBUTES)) {
+      TableBuilder tableBuilder = conn.getTableBuilder(tableName, null);
+      try (Table table = tableBuilder.build()) {
+        Result result = table.get(new Get(Bytes.toBytes(0)));
+        assertEquals(CONNECTION_ATTRIBUTES.size(), result.size());
+      }
+    }
+  }
+
+  public static class AttributesRpcControllerFactory extends RpcControllerFactory {
+
+    public AttributesRpcControllerFactory(Configuration conf) {
+      super(conf);
+    }
+
+    @Override
+    public HBaseRpcController newController() {
+      return new AttributesRpcController(super.newController());
+    }
+
+    @Override
+    public HBaseRpcController newController(CellScanner cellScanner) {
+      return new AttributesRpcController(super.newController(cellScanner));
+    }
+
+    @Override
+    public HBaseRpcController newController(RegionInfo regionInfo, CellScanner cellScanner) {
+      return new AttributesRpcController(super.newController(regionInfo, cellScanner));
+    }
+
+    @Override
+    public HBaseRpcController newController(List<CellScannable> cellIterables) {
+      return new AttributesRpcController(super.newController(cellIterables));
+    }
+
+    @Override
+    public HBaseRpcController newController(RegionInfo regionInfo,
+      List<CellScannable> cellIterables) {
+      return new AttributesRpcController(super.newController(regionInfo, cellIterables));
+    }
+  }
+
+  public static class AttributesRpcController extends DelegatingHBaseRpcController {
+
+    public AttributesRpcController(HBaseRpcController delegate) {
+      super(delegate);
+    }
+
+    @Override
+    public Map<String, byte[]> getAttributes() {
+      return REQUEST_ATTRIBUTES;
+    }
+  }
+
+  public static class AttributesCoprocessor implements RegionObserver, RegionCoprocessor {
+
+    @Override
+    public Optional<RegionObserver> getRegionObserver() {
+      return Optional.of(this);
+    }
+
+    @Override
+    public void preGetOp(ObserverContext<RegionCoprocessorEnvironment> c, Get get,
+      List<Cell> result) throws IOException {
+      RpcCall rpcCall = RpcServer.getCurrentCall().get();
+      for (HBaseProtos.NameBytesPair attr : rpcCall.getHeader().getAttributeList()) {
+        result.add(c.getEnvironment().getCellBuilder().clear().setRow(get.getRow())
+          .setFamily(Bytes.toBytes("r")).setQualifier(Bytes.toBytes(attr.getName()))
+          .setValue(attr.getValue().toByteArray()).setType(Cell.Type.Put).setTimestamp(1).build());
+      }
+      for (HBaseProtos.NameBytesPair attr : rpcCall.getConnectionHeader().getAttributeList()) {
+        result.add(c.getEnvironment().getCellBuilder().clear().setRow(get.getRow())
+          .setFamily(Bytes.toBytes("c")).setQualifier(Bytes.toBytes(attr.getName()))
+          .setValue(attr.getValue().toByteArray()).setType(Cell.Type.Put).setTimestamp(1).build());
+      }
+      result.sort(CellComparator.getInstance());
+      c.bypass();
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAndConnectionAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAndConnectionAttributes.java
@@ -21,7 +21,6 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
-import com.google.common.collect.ImmutableList;
 import java.io.IOException;
 import java.util.Arrays;
 import java.util.HashMap;
@@ -57,6 +56,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableList;
 
 import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAndConnectionAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAndConnectionAttributes.java
@@ -126,8 +126,8 @@ public class TestRequestAndConnectionAttributes {
     try (
       Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
         CONNECTION_ATTRIBUTES);
-      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
-        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      Table table = configureRequestAttributes(
+        conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)).build()) {
 
       table.get(new Get(Bytes.toBytes(0)));
     }
@@ -144,8 +144,8 @@ public class TestRequestAndConnectionAttributes {
     try (
       Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
         CONNECTION_ATTRIBUTES);
-      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
-        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      Table table = configureRequestAttributes(
+        conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)).build()) {
       List<Get> gets = ImmutableList.of(new Get(Bytes.toBytes(0)), new Get(Bytes.toBytes(1)));
       table.get(gets);
     }
@@ -162,8 +162,8 @@ public class TestRequestAndConnectionAttributes {
     try (
       Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
         CONNECTION_ATTRIBUTES);
-      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
-        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      Table table = configureRequestAttributes(
+        conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)).build()) {
 
       table.exists(new Get(Bytes.toBytes(0)));
     }
@@ -180,8 +180,8 @@ public class TestRequestAndConnectionAttributes {
     try (
       Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
         CONNECTION_ATTRIBUTES);
-      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
-        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      Table table = configureRequestAttributes(
+        conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)).build()) {
       ResultScanner scanner = table.getScanner(new Scan());
       scanner.next();
     }
@@ -197,8 +197,8 @@ public class TestRequestAndConnectionAttributes {
     try (
       Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
         CONNECTION_ATTRIBUTES);
-      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
-        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      Table table = configureRequestAttributes(
+        conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)).build()) {
       Put put = new Put(Bytes.toBytes("a"));
       put.addColumn(REQUEST_ATTRIBUTES_TEST_TABLE_CF, Bytes.toBytes("c"), Bytes.toBytes("v"));
       table.put(put);
@@ -215,8 +215,8 @@ public class TestRequestAndConnectionAttributes {
     try (
       Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
         CONNECTION_ATTRIBUTES);
-      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
-        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      Table table = configureRequestAttributes(
+        conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)).build()) {
       Put put = new Put(Bytes.toBytes("a"));
       put.addColumn(REQUEST_ATTRIBUTES_TEST_TABLE_CF, Bytes.toBytes("c"), Bytes.toBytes("v"));
       table.put(put);
@@ -249,6 +249,11 @@ public class TestRequestAndConnectionAttributes {
     for (int i = 0; i < j; i++) {
       REQUEST_ATTRIBUTES.put(String.valueOf(i), Bytes.toBytes(UUID.randomUUID().toString()));
     }
+  }
+
+  private static TableBuilder configureRequestAttributes(TableBuilder tableBuilder) {
+    REQUEST_ATTRIBUTES.forEach(tableBuilder::setRequestAttribute);
+    return tableBuilder;
   }
 
   public static class AttributesCoprocessor implements RegionObserver, RegionCoprocessor {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAndConnectionAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAndConnectionAttributes.java
@@ -18,18 +18,24 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
 
+import com.google.common.collect.ImmutableList;
 import java.io.IOException;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.UUID;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.AuthUtil;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
-import org.apache.hadoop.hbase.CellScannable;
-import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
@@ -38,15 +44,15 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.RegionObserver;
-import org.apache.hadoop.hbase.ipc.DelegatingHBaseRpcController;
-import org.apache.hadoop.hbase.ipc.HBaseRpcController;
 import org.apache.hadoop.hbase.ipc.RpcCall;
-import org.apache.hadoop.hbase.ipc.RpcControllerFactory;
 import org.apache.hadoop.hbase.ipc.RpcServer;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.wal.WALEdit;
 import org.junit.AfterClass;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -66,20 +72,31 @@ public class TestRequestAndConnectionAttributes {
     CONNECTION_ATTRIBUTES.put("clientId", Bytes.toBytes("foo"));
   }
   private static final Map<String, byte[]> REQUEST_ATTRIBUTES = new HashMap<>();
+  private static final ExecutorService EXECUTOR_SERVICE = Executors.newFixedThreadPool(100);
+  private static final AtomicBoolean REQUEST_ATTRIBUTES_VALIDATED = new AtomicBoolean(false);
+  private static final byte[] REQUEST_ATTRIBUTES_TEST_TABLE_CF = Bytes.toBytes("0");
+  private static final TableName REQUEST_ATTRIBUTES_TEST_TABLE =
+    TableName.valueOf("testRequestAttributes");
 
   private static HBaseTestingUtil TEST_UTIL = null;
 
   @BeforeClass
   public static void setUp() throws Exception {
     TEST_UTIL = new HBaseTestingUtil();
-    TEST_UTIL.getConfiguration().set(RpcControllerFactory.CUSTOM_CONTROLLER_CONF_KEY,
-      AttributesRpcControllerFactory.class.getName());
     TEST_UTIL.startMiniCluster(1);
+    TEST_UTIL.createTable(REQUEST_ATTRIBUTES_TEST_TABLE,
+      new byte[][] { REQUEST_ATTRIBUTES_TEST_TABLE_CF }, 1, HConstants.DEFAULT_BLOCKSIZE,
+      AttributesCoprocessor.class.getName());
   }
 
   @AfterClass
   public static void afterClass() throws Exception {
     TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Before
+  public void setup() {
+    REQUEST_ATTRIBUTES_VALIDATED.getAndSet(false);
   }
 
   @Test
@@ -92,7 +109,7 @@ public class TestRequestAndConnectionAttributes {
     try (Connection conn = ConnectionFactory.createConnection(conf, null,
       AuthUtil.loginClient(conf), CONNECTION_ATTRIBUTES); Table table = conn.getTable(tableName)) {
       Result result = table.get(new Get(Bytes.toBytes(0)));
-      assertEquals(REQUEST_ATTRIBUTES.size() + CONNECTION_ATTRIBUTES.size(), result.size());
+      assertEquals(CONNECTION_ATTRIBUTES.size(), result.size());
       for (Map.Entry<String, byte[]> attr : CONNECTION_ATTRIBUTES.entrySet()) {
         byte[] val = result.getValue(Bytes.toBytes("c"), Bytes.toBytes(attr.getKey()));
         assertEquals(Bytes.toStringBinary(attr.getValue()), Bytes.toStringBinary(val));
@@ -101,39 +118,115 @@ public class TestRequestAndConnectionAttributes {
   }
 
   @Test
-  public void testRequestAttributes() throws IOException {
-    TableName tableName = TableName.valueOf("testRequestAttributes");
-    TEST_UTIL.createTable(tableName, new byte[][] { Bytes.toBytes("0") }, 1,
-      HConstants.DEFAULT_BLOCKSIZE, AttributesCoprocessor.class.getName());
-
-    REQUEST_ATTRIBUTES.clear();
-    REQUEST_ATTRIBUTES.put("test1", Bytes.toBytes("a"));
-    REQUEST_ATTRIBUTES.put("test2", Bytes.toBytes("b"));
+  public void testRequestAttributesGet() throws IOException {
+    addRandomRequestAttributes();
 
     Configuration conf = TEST_UTIL.getConfiguration();
-    try (Connection conn = ConnectionFactory.createConnection(conf, null,
-      AuthUtil.loginClient(conf), CONNECTION_ATTRIBUTES); Table table = conn.getTable(tableName)) {
+    try (
+      Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
+        CONNECTION_ATTRIBUTES);
+      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
+        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
 
-      Result result = table.get(new Get(Bytes.toBytes(0)));
-      assertEquals(REQUEST_ATTRIBUTES.size() + CONNECTION_ATTRIBUTES.size(), result.size());
-      for (Map.Entry<String, byte[]> attr : REQUEST_ATTRIBUTES.entrySet()) {
-        byte[] val = result.getValue(Bytes.toBytes("r"), Bytes.toBytes(attr.getKey()));
-        assertEquals(Bytes.toStringBinary(attr.getValue()), Bytes.toStringBinary(val));
-      }
-
-      REQUEST_ATTRIBUTES.put("test3", Bytes.toBytes("c"));
-      result = table.get(new Get(Bytes.toBytes(0)));
-      assertEquals(REQUEST_ATTRIBUTES.size() + CONNECTION_ATTRIBUTES.size(), result.size());
-      for (Map.Entry<String, byte[]> attr : REQUEST_ATTRIBUTES.entrySet()) {
-        byte[] val = result.getValue(Bytes.toBytes("r"), Bytes.toBytes(attr.getKey()));
-        assertEquals(Bytes.toStringBinary(attr.getValue()), Bytes.toStringBinary(val));
-      }
+      table.get(new Get(Bytes.toBytes(0)));
     }
+
+    assertTrue(REQUEST_ATTRIBUTES_VALIDATED.get());
+  }
+
+  @Test
+  public void testRequestAttributesMultiGet() throws IOException {
+    assertFalse(REQUEST_ATTRIBUTES_VALIDATED.get());
+    addRandomRequestAttributes();
+
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (
+      Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
+        CONNECTION_ATTRIBUTES);
+      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
+        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      List<Get> gets = ImmutableList.of(new Get(Bytes.toBytes(0)), new Get(Bytes.toBytes(1)));
+      table.get(gets);
+    }
+
+    assertTrue(REQUEST_ATTRIBUTES_VALIDATED.get());
+  }
+
+  @Test
+  public void testRequestAttributesExists() throws IOException {
+    assertFalse(REQUEST_ATTRIBUTES_VALIDATED.get());
+    addRandomRequestAttributes();
+
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (
+      Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
+        CONNECTION_ATTRIBUTES);
+      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
+        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+
+      table.exists(new Get(Bytes.toBytes(0)));
+    }
+
+    assertTrue(REQUEST_ATTRIBUTES_VALIDATED.get());
+  }
+
+  @Test
+  public void testRequestAttributesScan() throws IOException {
+    assertFalse(REQUEST_ATTRIBUTES_VALIDATED.get());
+    addRandomRequestAttributes();
+
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (
+      Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
+        CONNECTION_ATTRIBUTES);
+      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
+        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      ResultScanner scanner = table.getScanner(new Scan());
+      scanner.next();
+    }
+    assertTrue(REQUEST_ATTRIBUTES_VALIDATED.get());
+  }
+
+  @Test
+  public void testRequestAttributesPut() throws IOException {
+    assertFalse(REQUEST_ATTRIBUTES_VALIDATED.get());
+    addRandomRequestAttributes();
+
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (
+      Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
+        CONNECTION_ATTRIBUTES);
+      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
+        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      Put put = new Put(Bytes.toBytes("a"));
+      put.addColumn(REQUEST_ATTRIBUTES_TEST_TABLE_CF, Bytes.toBytes("c"), Bytes.toBytes("v"));
+      table.put(put);
+    }
+    assertTrue(REQUEST_ATTRIBUTES_VALIDATED.get());
+  }
+
+  @Test
+  public void testRequestAttributesMultiPut() throws IOException {
+    assertFalse(REQUEST_ATTRIBUTES_VALIDATED.get());
+    addRandomRequestAttributes();
+
+    Configuration conf = TEST_UTIL.getConfiguration();
+    try (
+      Connection conn = ConnectionFactory.createConnection(conf, null, AuthUtil.loginClient(conf),
+        CONNECTION_ATTRIBUTES);
+      Table table = conn.getTableBuilder(REQUEST_ATTRIBUTES_TEST_TABLE, EXECUTOR_SERVICE)
+        .setRequestAttributes(REQUEST_ATTRIBUTES).build()) {
+      Put put = new Put(Bytes.toBytes("a"));
+      put.addColumn(REQUEST_ATTRIBUTES_TEST_TABLE_CF, Bytes.toBytes("c"), Bytes.toBytes("v"));
+      table.put(put);
+    }
+    assertTrue(REQUEST_ATTRIBUTES_VALIDATED.get());
   }
 
   @Test
   public void testNoRequestAttributes() throws IOException {
-    TableName tableName = TableName.valueOf("testNoRequestAttributes");
+    assertFalse(REQUEST_ATTRIBUTES_VALIDATED.get());
+    TableName tableName = TableName.valueOf("testNoRequestAttributesScan");
     TEST_UTIL.createTable(tableName, new byte[][] { Bytes.toBytes("0") }, 1,
       HConstants.DEFAULT_BLOCKSIZE, AttributesCoprocessor.class.getName());
 
@@ -143,54 +236,17 @@ public class TestRequestAndConnectionAttributes {
       AuthUtil.loginClient(conf), CONNECTION_ATTRIBUTES)) {
       TableBuilder tableBuilder = conn.getTableBuilder(tableName, null);
       try (Table table = tableBuilder.build()) {
-        Result result = table.get(new Get(Bytes.toBytes(0)));
-        assertEquals(CONNECTION_ATTRIBUTES.size(), result.size());
+        table.get(new Get(Bytes.toBytes(0)));
+        assertTrue(REQUEST_ATTRIBUTES_VALIDATED.get());
       }
     }
   }
 
-  public static class AttributesRpcControllerFactory extends RpcControllerFactory {
-
-    public AttributesRpcControllerFactory(Configuration conf) {
-      super(conf);
-    }
-
-    @Override
-    public HBaseRpcController newController() {
-      return new AttributesRpcController(super.newController());
-    }
-
-    @Override
-    public HBaseRpcController newController(CellScanner cellScanner) {
-      return new AttributesRpcController(super.newController(cellScanner));
-    }
-
-    @Override
-    public HBaseRpcController newController(RegionInfo regionInfo, CellScanner cellScanner) {
-      return new AttributesRpcController(super.newController(regionInfo, cellScanner));
-    }
-
-    @Override
-    public HBaseRpcController newController(List<CellScannable> cellIterables) {
-      return new AttributesRpcController(super.newController(cellIterables));
-    }
-
-    @Override
-    public HBaseRpcController newController(RegionInfo regionInfo,
-      List<CellScannable> cellIterables) {
-      return new AttributesRpcController(super.newController(regionInfo, cellIterables));
-    }
-  }
-
-  public static class AttributesRpcController extends DelegatingHBaseRpcController {
-
-    public AttributesRpcController(HBaseRpcController delegate) {
-      super(delegate);
-    }
-
-    @Override
-    public Map<String, byte[]> getAttributes() {
-      return REQUEST_ATTRIBUTES;
+  private void addRandomRequestAttributes() {
+    REQUEST_ATTRIBUTES.clear();
+    int j = Math.max(2, (int) (10 * Math.random()));
+    for (int i = 0; i < j; i++) {
+      REQUEST_ATTRIBUTES.put(String.valueOf(i), Bytes.toBytes(UUID.randomUUID().toString()));
     }
   }
 
@@ -204,6 +260,9 @@ public class TestRequestAndConnectionAttributes {
     @Override
     public void preGetOp(ObserverContext<RegionCoprocessorEnvironment> c, Get get,
       List<Cell> result) throws IOException {
+      validateRequestAttributes();
+
+      // for connection attrs test
       RpcCall rpcCall = RpcServer.getCurrentCall().get();
       for (HBaseProtos.NameBytesPair attr : rpcCall.getHeader().getAttributeList()) {
         result.add(c.getEnvironment().getCellBuilder().clear().setRow(get.getRow())
@@ -217,6 +276,36 @@ public class TestRequestAndConnectionAttributes {
       }
       result.sort(CellComparator.getInstance());
       c.bypass();
+    }
+
+    @Override
+    public boolean preScannerNext(ObserverContext<RegionCoprocessorEnvironment> c,
+      InternalScanner s, List<Result> result, int limit, boolean hasNext) throws IOException {
+      validateRequestAttributes();
+      return hasNext;
+    }
+
+    @Override
+    public void prePut(ObserverContext<RegionCoprocessorEnvironment> c, Put put, WALEdit edit)
+      throws IOException {
+      validateRequestAttributes();
+    }
+
+    private void validateRequestAttributes() {
+      RpcCall rpcCall = RpcServer.getCurrentCall().get();
+      List<HBaseProtos.NameBytesPair> attrs = rpcCall.getHeader().getAttributeList();
+      if (attrs.size() != REQUEST_ATTRIBUTES.size()) {
+        return;
+      }
+      for (HBaseProtos.NameBytesPair attr : attrs) {
+        if (!REQUEST_ATTRIBUTES.containsKey(attr.getName())) {
+          return;
+        }
+        if (!Arrays.equals(REQUEST_ATTRIBUTES.get(attr.getName()), attr.getValue().toByteArray())) {
+          return;
+        }
+      }
+      REQUEST_ATTRIBUTES_VALIDATED.getAndSet(true);
     }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcClientLeaks.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcClientLeaks.java
@@ -72,7 +72,7 @@ public class TestRpcClientLeaks {
 
     public MyRpcClientImpl(Configuration conf, String clusterId, SocketAddress address,
       MetricsConnection metrics) {
-      super(conf, clusterId, address, metrics);
+      super(conf, clusterId, address, metrics, null);
     }
 
     @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcClientLeaks.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcClientLeaks.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.fail;
 import java.io.IOException;
 import java.net.Socket;
 import java.net.SocketAddress;
+import java.util.Map;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.hadoop.conf.Configuration;
@@ -71,8 +72,8 @@ public class TestRpcClientLeaks {
     }
 
     public MyRpcClientImpl(Configuration conf, String clusterId, SocketAddress address,
-      MetricsConnection metrics) {
-      super(conf, clusterId, address, metrics, null);
+      MetricsConnection metrics, Map<String, byte[]> connectionAttributes) {
+      super(conf, clusterId, address, metrics, connectionAttributes);
     }
 
     @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcServerSlowConnectionSetup.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcServerSlowConnectionSetup.java
@@ -124,7 +124,7 @@ public class TestRpcServerSlowConnectionSetup {
     int callId = 10;
     Call call = new Call(callId, TestProtobufRpcProto.getDescriptor().findMethodByName("ping"),
       EmptyRequestProto.getDefaultInstance(), null, EmptyResponseProto.getDefaultInstance(), 1000,
-      HConstants.NORMAL_QOS, null, MetricsConnection.newCallStats());
+      HConstants.NORMAL_QOS, null, null, MetricsConnection.newCallStats());
     RequestHeader requestHeader = IPCUtil.buildRequestHeader(call, null);
     dos.writeInt(IPCUtil.getTotalSizeWhenWrittenDelimited(requestHeader, call.param));
     requestHeader.writeDelimitedTo(dos);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
@@ -632,6 +632,7 @@ public class TestNamedQueueRecorder {
     return getRpcCall(userName, Optional.of(forcedParamIndex));
   }
 
+  @SuppressWarnings("checkstyle:methodlength")
   private static RpcCall getRpcCall(String userName, Optional<Integer> forcedParamIndex) {
     RpcCall rpcCall = new RpcCall() {
       @Override
@@ -666,7 +667,6 @@ public class TestNamedQueueRecorder {
 
       @Override
       public void setStartTime(long startTime) {
-
       }
 
       @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
@@ -695,6 +695,11 @@ public class TestNamedQueueRecorder {
       }
 
       @Override
+      public RPCProtos.ConnectionHeader getConnectionHeader() {
+        return null;
+      }
+
+      @Override
       public int getRemotePort() {
         return 0;
       }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
@@ -221,6 +221,11 @@ public class TestRegionProcedureStore extends RegionProcedureStoreTestBase {
       }
 
       @Override
+      public RPCProtos.ConnectionHeader getConnectionHeader() {
+        return null;
+      }
+
+      @Override
       public int getRemotePort() {
         return 0;
       }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
@@ -158,6 +158,7 @@ public class TestRegionProcedureStore extends RegionProcedureStoreTestBase {
     RpcServer.setCurrentCall(null);
   }
 
+  @SuppressWarnings("checkstyle:methodlength")
   private RpcCall newRpcCallWithDeadline() {
     return new RpcCall() {
       @Override

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
@@ -323,6 +323,12 @@ public class ThriftConnection implements Connection {
       }
 
       @Override
+      public TableBuilder setRequestAttributes(Map<String, byte[]> requestAttributes) {
+        this.setRequestAttributes(requestAttributes);
+        return this;
+      }
+
+      @Override
       public Table build() {
         try {
           Pair<THBaseService.Client, TTransport> client = clientBuilder.getClient();

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
@@ -323,7 +323,7 @@ public class ThriftConnection implements Connection {
       }
 
       @Override
-      public TableBuilder setRequestAttributes(Map<String, byte[]> requestAttributes) {
+      public TableBuilder setRequestAttribute(String key, byte[] value) {
         return this;
       }
 

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
@@ -324,7 +324,6 @@ public class ThriftConnection implements Connection {
 
       @Override
       public TableBuilder setRequestAttributes(Map<String, byte[]> requestAttributes) {
-        this.setRequestAttributes(requestAttributes);
         return this;
       }
 

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
@@ -89,8 +89,8 @@ public class ThriftConnection implements Connection {
   private int operationTimeout;
   private int connectTimeout;
 
-  public ThriftConnection(Configuration conf, ExecutorService pool, final User user)
-    throws IOException {
+  public ThriftConnection(Configuration conf, ExecutorService pool, final User user,
+    Map<String, byte[]> connectionAttributes) throws IOException {
     this.conf = conf;
     this.user = user;
     this.host = conf.get(Constants.HBASE_THRIFT_SERVER_NAME);


### PR DESCRIPTION
[Here's an initial design doc](https://docs.google.com/document/d/1cGEmUn2kAPhn_Q18DvAOhigtCbnQ8ia6oV4OvMb5DyU/edit?usp=sharing)

I'm hoping to get feedback on the design proposed above.

Currently we have the ability to set Operation attributes, via Get.setAttribute, etc. It would be useful to be able to set attributes at the request and connection level.

These levels can result in less duplication. For example, send some attributes once per connection instead of for every one of the millions of requests a connection might send. Or send once for the request, instead of duplicating on every operation in a multi request.

Additionally, the Connection and RequestHeader are more globally available on the server side. Both can be accessed via RpcServer.getCurrentCall(), which is useful in various integration points – coprocessors, custom queues, quotas, slow log, etc. Operation attributes are harder to access because you need to parse the raw Message into the appropriate type to get access to the getter.

This PR introduces two new avenues for providing attributes:
* passing in a map of connection attributes to `ConnectionFactory#createConnection`
* passing in a request attribute to `TableBuilder#setRequestAttribute`

We've also added end-to-end tests for both systems.

cc @bbeaudreault @hgromer @saijmo @eab148 @bozzkar