### PR TITLE
HBASE-27553: add row param to mutation slow logs

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -2163,7 +2163,8 @@ public final class ProtobufUtil {
       }
     } else if (message instanceof MutationProto) {
       MutationProto mutationProto = (MutationProto) message;
-      String params = "type= " + mutationProto.getMutateType().toString();
+      String params = "type= " + mutationProto.getMutateType().toString() + ", row= "
+        + getStringForByteString(mutationProto.getRow());
       return new SlowLogParams(params);
     } else if (message instanceof GetRequest) {
       GetRequest getRequest = (GetRequest) message;
@@ -2182,7 +2183,8 @@ public final class ProtobufUtil {
     } else if (message instanceof MutateRequest) {
       MutateRequest mutateRequest = (MutateRequest) message;
       String regionName = getStringForByteString(mutateRequest.getRegion().getValue());
-      String params = "region= " + regionName;
+      String params = "region= " + regionName + ", row= "
+        + getStringForByteString(mutateRequest.getMutation().getRow());
       return new SlowLogParams(regionName, params);
     } else if (message instanceof CoprocessorServiceRequest) {
       CoprocessorServiceRequest coprocessorServiceRequest = (CoprocessorServiceRequest) message;


### PR DESCRIPTION
Per conversation in [HBASE-27553](https://issues.apache.org/jira/browse/HBASE-27553), we could provide the related row in the params blob for mutation slow logs. This should be useful information for the debugger reading the logs.

cc @bbeaudreault @hgromer @saijmo @eab148 @bozzkar