### PR TITLE
HBASE-27896 Disable hdfs readahead for pread reads

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileInfo.java
@@ -73,7 +73,7 @@ public class StoreFileInfo implements Configurable {
     Pattern.compile(String.format("^(%s|%s)\\.(.+)$", HFILE_NAME_REGEX, HFileLink.LINK_NAME_REGEX));
 
   public static final String STORE_FILE_READER_NO_READAHEAD = "hbase.store.reader.no-readahead";
-  public static final boolean DEFAULT_STORE_FILE_READER_NO_READAHEAD = false;
+  public static final boolean DEFAULT_STORE_FILE_READER_NO_READAHEAD = true;
 
   // Configuration
   private Configuration conf;


### PR DESCRIPTION
I left the option in place, but just changed the default. If desired, I could just remove the option as well. I can't think of a case where it would be good to enable, am just trying to preserve compatibility if anyone has set it.