### PR TITLE
HBASE-28011 : The logStats about LruBlockCache is not accurate

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
@@ -1017,10 +1017,11 @@ public class LruBlockCache implements FirstLevelBlockCache {
     // Log size
     long usedSize = heapSize();
     long freeSize = maxSize - usedSize;
-    LruBlockCache.LOG.info("usedSize=" + StringUtils.byteDesc(usedSize) + ", " + "freeSize="
-      + StringUtils.byteDesc(freeSize) + ", " + "max=" + StringUtils.byteDesc(this.maxSize) + ", "
-      + "blockCount=" + getBlockCount() + ", " + "accesses=" + stats.getRequestCount() + ", "
-      + "hits=" + stats.getHitCount() + ", " + "hitRatio="
+    LruBlockCache.LOG.info("totalSize=" + StringUtils.byteDesc(maxSize) + ", " + "usedSize="
+      + StringUtils.byteDesc(usedSize) + ", " + "freeSize=" + StringUtils.byteDesc(freeSize) + ", "
+      + "max=" + StringUtils.byteDesc(this.maxSize) + ", " + "blockCount=" + getBlockCount() + ", "
+      + "accesses=" + stats.getRequestCount() + ", " + "hits=" + stats.getHitCount() + ", "
+      + "hitRatio="
       + (stats.getHitCount() == 0
         ? "0"
         : (StringUtils.formatPercent(stats.getHitRatio(), 2) + ", "))

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
@@ -1015,9 +1015,9 @@ public class LruBlockCache implements FirstLevelBlockCache {
 
   public void logStats() {
     // Log size
-    long totalSize = heapSize();
-    long freeSize = maxSize - totalSize;
-    LruBlockCache.LOG.info("totalSize=" + StringUtils.byteDesc(totalSize) + ", " + "freeSize="
+    long usedSize = heapSize();
+    long freeSize = maxSize - usedSize;
+    LruBlockCache.LOG.info("usedSize=" + StringUtils.byteDesc(usedSize) + ", " + "freeSize="
       + StringUtils.byteDesc(freeSize) + ", " + "max=" + StringUtils.byteDesc(this.maxSize) + ", "
       + "blockCount=" + getBlockCount() + ", " + "accesses=" + stats.getRequestCount() + ", "
       + "hits=" + stats.getHitCount() + ", " + "hitRatio="


### PR DESCRIPTION
Details see: [HBASE-28011](https://issues.apache.org/jira/browse/HBASE-28011)

Apply this commit, LruBlockCache.logStats would print info,as follow:  

```
INFO  [LruBlockCacheStatsExecutor] hfile.LruBlockCache: totalSize=3.20 GB, usedSize=2.41 MB, freeSize=3.20 GB, max=3.20 GB, blockCount=4, accesses=13, hits=9, hitRatio=69.23%, , cachingAccesses=13, cachingHits=9, cachingHitsRatio=69.23%, evictions=29, evicted=0, evictedPerRun=0.0
```