### PR TITLE
HBASE-28012 Avoid CellUtil.cloneRow in BufferedEncodedSeeker

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/BufferedDataBlockEncoder.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/BufferedDataBlockEncoder.java
@@ -87,21 +87,100 @@ abstract class BufferedDataBlockEncoder extends AbstractDataBlockEncoder {
   // Having this as static is fine but if META is having DBE then we should
   // change this.
   public static int compareCommonRowPrefix(Cell left, Cell right, int rowCommonPrefix) {
-    return Bytes.compareTo(left.getRowArray(), left.getRowOffset() + rowCommonPrefix,
-      left.getRowLength() - rowCommonPrefix, right.getRowArray(),
-      right.getRowOffset() + rowCommonPrefix, right.getRowLength() - rowCommonPrefix);
+    if (left instanceof ByteBufferExtendedCell) {
+      ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;
+      if (right instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbRight = (ByteBufferExtendedCell) right;
+        return ByteBufferUtils.compareTo(bbLeft.getRowByteBuffer(),
+          bbLeft.getRowPosition() + rowCommonPrefix, left.getRowLength() - rowCommonPrefix,
+          bbRight.getRowByteBuffer(), bbRight.getRowPosition() + rowCommonPrefix,
+          right.getRowLength() - rowCommonPrefix);
+      } else {
+        return ByteBufferUtils.compareTo(bbLeft.getRowByteBuffer(),
+          bbLeft.getRowPosition() + rowCommonPrefix, left.getRowLength() - rowCommonPrefix,
+          right.getRowArray(), right.getRowOffset() + rowCommonPrefix,
+          right.getRowLength() - rowCommonPrefix);
+      }
+    } else {
+      if (right instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbRight = (ByteBufferExtendedCell) right;
+        return ByteBufferUtils.compareTo(left.getRowArray(), left.getRowOffset() + rowCommonPrefix,
+          left.getRowLength() - rowCommonPrefix, bbRight.getRowByteBuffer(),
+          bbRight.getRowPosition() + rowCommonPrefix, right.getRowLength() - rowCommonPrefix);
+      } else {
+        return Bytes.compareTo(left.getRowArray(), left.getRowOffset() + rowCommonPrefix,
+          left.getRowLength() - rowCommonPrefix, right.getRowArray(),
+          right.getRowOffset() + rowCommonPrefix, right.getRowLength() - rowCommonPrefix);
+      }
+    }
   }
 
   public static int compareCommonFamilyPrefix(Cell left, Cell right, int familyCommonPrefix) {
-    return Bytes.compareTo(left.getFamilyArray(), left.getFamilyOffset() + familyCommonPrefix,
-      left.getFamilyLength() - familyCommonPrefix, right.getFamilyArray(),
-      right.getFamilyOffset() + familyCommonPrefix, right.getFamilyLength() - familyCommonPrefix);
+    if (left instanceof ByteBufferExtendedCell) {
+      ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;
+      if (right instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbRight = (ByteBufferExtendedCell) right;
+        return ByteBufferUtils.compareTo(bbLeft.getFamilyByteBuffer(),
+          bbLeft.getFamilyPosition() + familyCommonPrefix,
+          left.getFamilyLength() - familyCommonPrefix, bbRight.getFamilyByteBuffer(),
+          bbRight.getFamilyPosition() + familyCommonPrefix,
+          right.getFamilyLength() - familyCommonPrefix);
+      } else {
+        return ByteBufferUtils.compareTo(bbLeft.getFamilyByteBuffer(),
+          bbLeft.getFamilyPosition() + familyCommonPrefix,
+          left.getFamilyLength() - familyCommonPrefix, right.getFamilyArray(),
+          right.getFamilyOffset() + familyCommonPrefix,
+          right.getFamilyLength() - familyCommonPrefix);
+      }
+    } else {
+      if (right instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbRight = (ByteBufferExtendedCell) right;
+        return ByteBufferUtils.compareTo(left.getFamilyArray(),
+          left.getFamilyOffset() + familyCommonPrefix, left.getFamilyLength() - familyCommonPrefix,
+          bbRight.getFamilyByteBuffer(), bbRight.getFamilyPosition() + familyCommonPrefix,
+          right.getFamilyLength() - familyCommonPrefix);
+      } else {
+        return Bytes.compareTo(left.getFamilyArray(), left.getFamilyOffset() + familyCommonPrefix,
+          left.getFamilyLength() - familyCommonPrefix, right.getFamilyArray(),
+          right.getFamilyOffset() + familyCommonPrefix,
+          right.getFamilyLength() - familyCommonPrefix);
+      }
+    }
   }
 
   public static int compareCommonQualifierPrefix(Cell left, Cell right, int qualCommonPrefix) {
-    return Bytes.compareTo(left.getQualifierArray(), left.getQualifierOffset() + qualCommonPrefix,
-      left.getQualifierLength() - qualCommonPrefix, right.getQualifierArray(),
-      right.getQualifierOffset() + qualCommonPrefix, right.getQualifierLength() - qualCommonPrefix);
+    if (left instanceof ByteBufferExtendedCell) {
+      ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;
+      if (right instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbRight = (ByteBufferExtendedCell) right;
+        return ByteBufferUtils.compareTo(bbLeft.getQualifierByteBuffer(),
+          bbLeft.getQualifierPosition() + qualCommonPrefix,
+          left.getQualifierLength() - qualCommonPrefix, bbRight.getQualifierByteBuffer(),
+          bbRight.getQualifierPosition() + qualCommonPrefix,
+          right.getQualifierLength() - qualCommonPrefix);
+      } else {
+        return ByteBufferUtils.compareTo(bbLeft.getQualifierByteBuffer(),
+          bbLeft.getQualifierPosition() + qualCommonPrefix,
+          left.getQualifierLength() - qualCommonPrefix, right.getQualifierArray(),
+          right.getQualifierOffset() + qualCommonPrefix,
+          right.getQualifierLength() - qualCommonPrefix);
+      }
+    } else {
+      if (right instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbRight = (ByteBufferExtendedCell) right;
+        return ByteBufferUtils.compareTo(left.getQualifierArray(),
+          left.getQualifierOffset() + qualCommonPrefix,
+          left.getQualifierLength() - qualCommonPrefix, bbRight.getQualifierByteBuffer(),
+          bbRight.getQualifierPosition() + qualCommonPrefix,
+          right.getQualifierLength() - qualCommonPrefix);
+      } else {
+        return Bytes.compareTo(left.getQualifierArray(),
+          left.getQualifierOffset() + qualCommonPrefix,
+          left.getQualifierLength() - qualCommonPrefix, right.getQualifierArray(),
+          right.getQualifierOffset() + qualCommonPrefix,
+          right.getQualifierLength() - qualCommonPrefix);
+      }
+    }
   }
 
   protected static class SeekerState {
@@ -954,25 +1033,55 @@ abstract class BufferedDataBlockEncoder extends AbstractDataBlockEncoder {
       return 0;
     }
 
+    // These findCommonPrefix* methods rely on the fact that keyOnlyKv is the "right" cell argument
+    // and always on-heap
+
     private static int findCommonPrefixInRowPart(Cell left, Cell right, int rowCommonPrefix) {
-      return Bytes.findCommonPrefix(left.getRowArray(), right.getRowArray(),
-        left.getRowLength() - rowCommonPrefix, right.getRowLength() - rowCommonPrefix,
-        left.getRowOffset() + rowCommonPrefix, right.getRowOffset() + rowCommonPrefix);
+      if (left instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;
+        return ByteBufferUtils.findCommonPrefix(bbLeft.getRowByteBuffer(),
+          bbLeft.getRowPosition() + rowCommonPrefix, left.getRowLength() - rowCommonPrefix,
+          right.getRowArray(), right.getRowOffset() + rowCommonPrefix,
+          right.getRowLength() - rowCommonPrefix);
+      } else {
+        return Bytes.findCommonPrefix(left.getRowArray(), right.getRowArray(),
+          left.getRowLength() - rowCommonPrefix, right.getRowLength() - rowCommonPrefix,
+          left.getRowOffset() + rowCommonPrefix, right.getRowOffset() + rowCommonPrefix);
+      }
     }
 
     private static int findCommonPrefixInFamilyPart(Cell left, Cell right, int familyCommonPrefix) {
-      return Bytes.findCommonPrefix(left.getFamilyArray(), right.getFamilyArray(),
-        left.getFamilyLength() - familyCommonPrefix, right.getFamilyLength() - familyCommonPrefix,
-        left.getFamilyOffset() + familyCommonPrefix, right.getFamilyOffset() + familyCommonPrefix);
+      if (left instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;
+        return ByteBufferUtils.findCommonPrefix(bbLeft.getFamilyByteBuffer(),
+          bbLeft.getFamilyPosition() + familyCommonPrefix,
+          left.getFamilyLength() - familyCommonPrefix, right.getFamilyArray(),
+          right.getFamilyOffset() + familyCommonPrefix,
+          right.getFamilyLength() - familyCommonPrefix);
+      } else {
+        return Bytes.findCommonPrefix(left.getFamilyArray(), right.getFamilyArray(),
+          left.getFamilyLength() - familyCommonPrefix, right.getFamilyLength() - familyCommonPrefix,
+          left.getFamilyOffset() + familyCommonPrefix,
+          right.getFamilyOffset() + familyCommonPrefix);
+      }
     }
 
     private static int findCommonPrefixInQualifierPart(Cell left, Cell right,
       int qualifierCommonPrefix) {
-      return Bytes.findCommonPrefix(left.getQualifierArray(), right.getQualifierArray(),
-        left.getQualifierLength() - qualifierCommonPrefix,
-        right.getQualifierLength() - qualifierCommonPrefix,
-        left.getQualifierOffset() + qualifierCommonPrefix,
-        right.getQualifierOffset() + qualifierCommonPrefix);
+      if (left instanceof ByteBufferExtendedCell) {
+        ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;
+        return ByteBufferUtils.findCommonPrefix(bbLeft.getQualifierByteBuffer(),
+          bbLeft.getQualifierPosition() + qualifierCommonPrefix,
+          left.getQualifierLength() - qualifierCommonPrefix, right.getQualifierArray(),
+          right.getQualifierOffset() + qualifierCommonPrefix,
+          right.getQualifierLength() - qualifierCommonPrefix);
+      } else {
+        return Bytes.findCommonPrefix(left.getQualifierArray(), right.getQualifierArray(),
+          left.getQualifierLength() - qualifierCommonPrefix,
+          right.getQualifierLength() - qualifierCommonPrefix,
+          left.getQualifierOffset() + qualifierCommonPrefix,
+          right.getQualifierOffset() + qualifierCommonPrefix);
+      }
     }
 
     private void moveToPrevious() {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/BufferedDataBlockEncoder.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/BufferedDataBlockEncoder.java
@@ -1036,7 +1036,8 @@ abstract class BufferedDataBlockEncoder extends AbstractDataBlockEncoder {
     // These findCommonPrefix* methods rely on the fact that keyOnlyKv is the "right" cell argument
     // and always on-heap
 
-    private static int findCommonPrefixInRowPart(Cell left, Cell right, int rowCommonPrefix) {
+    private static int findCommonPrefixInRowPart(Cell left, KeyValue.KeyOnlyKeyValue right,
+      int rowCommonPrefix) {
       if (left instanceof ByteBufferExtendedCell) {
         ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;
         return ByteBufferUtils.findCommonPrefix(bbLeft.getRowByteBuffer(),
@@ -1050,7 +1051,8 @@ abstract class BufferedDataBlockEncoder extends AbstractDataBlockEncoder {
       }
     }
 
-    private static int findCommonPrefixInFamilyPart(Cell left, Cell right, int familyCommonPrefix) {
+    private static int findCommonPrefixInFamilyPart(Cell left, KeyValue.KeyOnlyKeyValue right,
+      int familyCommonPrefix) {
       if (left instanceof ByteBufferExtendedCell) {
         ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;
         return ByteBufferUtils.findCommonPrefix(bbLeft.getFamilyByteBuffer(),
@@ -1066,7 +1068,7 @@ abstract class BufferedDataBlockEncoder extends AbstractDataBlockEncoder {
       }
     }
 
-    private static int findCommonPrefixInQualifierPart(Cell left, Cell right,
+    private static int findCommonPrefixInQualifierPart(Cell left, KeyValue.KeyOnlyKeyValue right,
       int qualifierCommonPrefix) {
       if (left instanceof ByteBufferExtendedCell) {
         ByteBufferExtendedCell bbLeft = (ByteBufferExtendedCell) left;

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/ByteBufferUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/ByteBufferUtils.java
@@ -779,6 +779,30 @@ public final class ByteBufferUtils {
   }
 
   /**
+   * Find length of common prefix in two arrays.
+   * @param left        ByteBuffer to be compared.
+   * @param leftOffset  Offset in left ByteBuffer.
+   * @param leftLength  Length of left ByteBuffer.
+   * @param right       Array to be compared
+   * @param rightOffset Offset in right Array.
+   * @param rightLength Length of right Array.
+   */
+  public static int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength, byte[] right,
+    int rightOffset, int rightLength) {
+    int length = Math.min(leftLength, rightLength);
+    int result = 0;
+
+    while (
+      result < length
+        && ByteBufferUtils.toByte(left, leftOffset + result) == right[rightOffset + result]
+    ) {
+      result++;
+    }
+
+    return result;
+  }
+
+  /**
    * Check whether two parts in the same buffer are equal.
    * @param buffer      In which buffer there are parts
    * @param offsetLeft  Beginning of first part.


### PR DESCRIPTION
### What
This PR updates BufferedEncodedSeeker#seekToKeyInBlock (used extensively in the reverse scan path) to avoid calling `CellUtil.cloneRow` for off-heap Cell seek targets.

### Implementation Notes
For `private` "findCommonPrefix*" methods, I used an invariant that the "right" cell is always a `keyOnlyKv` and therefore on-heap.

For the `public` "compareCommonPrefix*" methods, I added extra paths to them to account for either the left or right cell to be on or off-heap to keep the behavior optimized for any external callers. In practice, I believe these methods are internal to `BufferedEncodedSeeker` except for a few unit tests so I'd be open to reducing the branching to just optimize for the left cell being able to be on/off-heap. I'd love some feedback on this approach as it adds a fair amount of extra code that isn't strictly necessary for this PR.

I also added a test that is a clone of a current `seekToKeyInBlock` over a sample of data with the only variation being that the seek target cell is an off-heap cell instead of an on-heap one to give coverage over the new path here. Let me know if you'd like to see any more tests. 

### Testing
Some (naive and non-JMH) testing has been done of the new code path here. It looks to be in the range of about 20-30% faster than the old path for off-heap cell seek targets. Obviously, take these numbers with a grain of salt as they're not from JMH. 

[HBASE-28012](https://issues.apache.org/jira/browse/HBASE-28012)