### PR TITLE
HBASE-28025 Enhance ByteBufferUtils.findCommonPrefix to compare 8 bytes each time

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/ByteBufferUtils.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/ByteBufferUtils.java
@@ -80,6 +80,14 @@ public final class ByteBufferUtils {
     abstract int putLong(ByteBuffer buffer, int index, long val);
   }
 
+  static abstract class CommonPrefixer {
+    abstract int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength, byte[] right,
+      int rightOffset, int rightLength);
+
+    abstract int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength, ByteBuffer right,
+      int rightOffset, int rightLength);
+  }
+
   static class ComparerHolder {
     static final String UNSAFE_COMPARER_NAME = ComparerHolder.class.getName() + "$UnsafeComparer";
 
@@ -318,6 +326,111 @@ public final class ByteBufferUtils {
       @Override
       int putLong(ByteBuffer buffer, int index, long val) {
         return UnsafeAccess.putLong(buffer, index, val);
+      }
+    }
+  }
+
+  static class CommonPrefixerHolder {
+    static final String UNSAFE_COMMON_PREFIXER_NAME =
+      CommonPrefixerHolder.class.getName() + "$UnsafeCommonPrefixer";
+
+    static final CommonPrefixer BEST_COMMON_PREFIXER = getBestCommonPrefixer();
+
+    static CommonPrefixer getBestCommonPrefixer() {
+      try {
+        Class<? extends CommonPrefixer> theClass =
+          Class.forName(UNSAFE_COMMON_PREFIXER_NAME).asSubclass(CommonPrefixer.class);
+
+        return theClass.getConstructor().newInstance();
+      } catch (Throwable t) { // ensure we really catch *everything*
+        return PureJavaCommonPrefixer.INSTANCE;
+      }
+    }
+
+    static final class PureJavaCommonPrefixer extends CommonPrefixer {
+      static final PureJavaCommonPrefixer INSTANCE = new PureJavaCommonPrefixer();
+
+      private PureJavaCommonPrefixer() {
+      }
+
+      @Override
+      public int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength, byte[] right,
+        int rightOffset, int rightLength) {
+        int length = Math.min(leftLength, rightLength);
+        int result = 0;
+
+        while (
+          result < length
+            && ByteBufferUtils.toByte(left, leftOffset + result) == right[rightOffset + result]
+        ) {
+          result++;
+        }
+
+        return result;
+      }
+
+      @Override
+      int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength, ByteBuffer right,
+        int rightOffset, int rightLength) {
+        int length = Math.min(leftLength, rightLength);
+        int result = 0;
+
+        while (
+          result < length && ByteBufferUtils.toByte(left, leftOffset + result)
+              == ByteBufferUtils.toByte(right, rightOffset + result)
+        ) {
+          result++;
+        }
+
+        return result;
+      }
+    }
+
+    static final class UnsafeCommonPrefixer extends CommonPrefixer {
+
+      static {
+        if (!UNSAFE_UNALIGNED) {
+          throw new Error();
+        }
+      }
+
+      public UnsafeCommonPrefixer() {
+      }
+
+      @Override
+      public int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength, byte[] right,
+        int rightOffset, int rightLength) {
+        long offset1Adj;
+        Object refObj1 = null;
+        if (left.isDirect()) {
+          offset1Adj = leftOffset + UnsafeAccess.directBufferAddress(left);
+        } else {
+          offset1Adj = leftOffset + left.arrayOffset() + UnsafeAccess.BYTE_ARRAY_BASE_OFFSET;
+          refObj1 = left.array();
+        }
+        return findCommonPrefixUnsafe(refObj1, offset1Adj, leftLength, right,
+          rightOffset + UnsafeAccess.BYTE_ARRAY_BASE_OFFSET, rightLength);
+      }
+
+      @Override
+      public int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength, ByteBuffer right,
+        int rightOffset, int rightLength) {
+        long offset1Adj, offset2Adj;
+        Object refObj1 = null, refObj2 = null;
+        if (left.isDirect()) {
+          offset1Adj = leftOffset + UnsafeAccess.directBufferAddress(left);
+        } else {
+          offset1Adj = leftOffset + left.arrayOffset() + UnsafeAccess.BYTE_ARRAY_BASE_OFFSET;
+          refObj1 = left.array();
+        }
+        if (right.isDirect()) {
+          offset2Adj = rightOffset + UnsafeAccess.directBufferAddress(right);
+        } else {
+          offset2Adj = rightOffset + right.arrayOffset() + UnsafeAccess.BYTE_ARRAY_BASE_OFFSET;
+          refObj2 = right.array();
+        }
+        return findCommonPrefixUnsafe(refObj1, offset1Adj, leftLength, refObj2, offset2Adj,
+          rightLength);
       }
     }
   }
@@ -744,14 +857,7 @@ public final class ByteBufferUtils {
    */
   public static int findCommonPrefix(byte[] left, int leftOffset, int leftLength, byte[] right,
     int rightOffset, int rightLength) {
-    int length = Math.min(leftLength, rightLength);
-    int result = 0;
-
-    while (result < length && left[leftOffset + result] == right[rightOffset + result]) {
-      result++;
-    }
-
-    return result;
+    return Bytes.findCommonPrefix(left, right, leftLength, rightLength, leftOffset, rightOffset);
   }
 
   /**
@@ -765,17 +871,8 @@ public final class ByteBufferUtils {
    */
   public static int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength,
     ByteBuffer right, int rightOffset, int rightLength) {
-    int length = Math.min(leftLength, rightLength);
-    int result = 0;
-
-    while (
-      result < length && ByteBufferUtils.toByte(left, leftOffset + result)
-          == ByteBufferUtils.toByte(right, rightOffset + result)
-    ) {
-      result++;
-    }
-
-    return result;
+    return CommonPrefixerHolder.BEST_COMMON_PREFIXER.findCommonPrefix(left, leftOffset, leftLength,
+      right, rightOffset, rightLength);
   }
 
   /**
@@ -789,17 +886,8 @@ public final class ByteBufferUtils {
    */
   public static int findCommonPrefix(ByteBuffer left, int leftOffset, int leftLength, byte[] right,
     int rightOffset, int rightLength) {
-    int length = Math.min(leftLength, rightLength);
-    int result = 0;
-
-    while (
-      result < length
-        && ByteBufferUtils.toByte(left, leftOffset + result) == right[rightOffset + result]
-    ) {
-      result++;
-    }
-
-    return result;
+    return CommonPrefixerHolder.BEST_COMMON_PREFIXER.findCommonPrefix(left, leftOffset, leftLength,
+      right, rightOffset, rightLength);
   }
 
   /**
@@ -970,6 +1058,43 @@ public final class ByteBufferUtils {
       }
     }
     return l1 - l2;
+  }
+
+  static int findCommonPrefixUnsafe(Object left, long leftOffset, int leftLength, Object right,
+    long rightOffset, int rightLength) {
+    final int stride = 8;
+    final int minLength = Math.min(leftLength, rightLength);
+    int strideLimit = minLength & ~(stride - 1);
+    int result = 0;
+    int i;
+
+    for (i = 0; i < strideLimit; i += stride) {
+      long lw = HBasePlatformDependent.getLong(left, leftOffset + (long) i);
+      long rw = HBasePlatformDependent.getLong(right, rightOffset + (long) i);
+
+      if (lw != rw) {
+        if (!UnsafeAccess.LITTLE_ENDIAN) {
+          return result + (Long.numberOfLeadingZeros(lw ^ rw) / Bytes.SIZEOF_LONG);
+        } else {
+          return result + (Long.numberOfTrailingZeros(lw ^ rw) / Bytes.SIZEOF_LONG);
+        }
+      } else {
+        result += Bytes.SIZEOF_LONG;
+      }
+    }
+
+    // The epilogue to cover the last (minLength % stride) elements.
+    for (; i < minLength; i++) {
+      byte il = HBasePlatformDependent.getByte(left, leftOffset + i);
+      byte ir = HBasePlatformDependent.getByte(right, rightOffset + i);
+      if (il != ir) {
+        return result;
+      } else {
+        result++;
+      }
+    }
+
+    return result;
   }
 
   /**

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteBufferUtils.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestByteBufferUtils.java
@@ -606,6 +606,37 @@ public class TestByteBufferUtils {
     assertTrue(ByteBufferUtils.equals(bb, 0, a.length, a, 0, a.length));
   }
 
+  @Test
+  public void testFindCommonPrefix() {
+    ByteBuffer bb1 = ByteBuffer.allocate(135);
+    ByteBuffer bb2 = ByteBuffer.allocate(135);
+    ByteBuffer bb3 = ByteBuffer.allocateDirect(135);
+    byte[] b = new byte[71];
+
+    fillBB(bb1, (byte) 5);
+    fillBB(bb2, (byte) 5);
+    fillBB(bb3, (byte) 5);
+    fillArray(b, (byte) 5);
+
+    assertEquals(135,
+      ByteBufferUtils.findCommonPrefix(bb1, 0, bb1.remaining(), bb2, 0, bb2.remaining()));
+    assertEquals(71, ByteBufferUtils.findCommonPrefix(bb1, 0, bb1.remaining(), b, 0, b.length));
+    assertEquals(135,
+      ByteBufferUtils.findCommonPrefix(bb1, 0, bb1.remaining(), bb3, 0, bb3.remaining()));
+    assertEquals(71, ByteBufferUtils.findCommonPrefix(bb3, 0, bb3.remaining(), b, 0, b.length));
+
+    b[13] = 9;
+    assertEquals(13, ByteBufferUtils.findCommonPrefix(bb1, 0, bb1.remaining(), b, 0, b.length));
+
+    bb2.put(134, (byte) 6);
+    assertEquals(134,
+      ByteBufferUtils.findCommonPrefix(bb1, 0, bb1.remaining(), bb2, 0, bb2.remaining()));
+
+    bb2.put(6, (byte) 4);
+    assertEquals(6,
+      ByteBufferUtils.findCommonPrefix(bb1, 0, bb1.remaining(), bb2, 0, bb2.remaining()));
+  }
+
   private static void fillBB(ByteBuffer bb, byte b) {
     for (int i = bb.position(); i < bb.limit(); i++) {
       bb.put(i, b);


### PR DESCRIPTION
### What

This PR updates `ByteBufferUtils#findCommonPrefix` and `Bytes#findCommonPrefix` to compare 8 bytes from the input buffers/arrays if `Unsafe` access is available. On platforms where Unsafe is unavailable, we use the current implementations. This is a similar optimization as to what is already done with `ByteBufferUtils#compareToUnsafe`.

### Implementation Notes
There was a `Bytes#findCommonPrefix` method and a `ByteBufferUtils#findCommonPrefix` method that both accepted `byte[]` args. I've updated the `ByteBufferUtils#findCommonPrefix` method to delegate to `Bytes#findCommonPrefix` and applied the optimization for 8 byte at a time comparison to the `Bytes` class. 

Overall, the implementation draws a ton of inspiration from `ByteBufferUtils#compareToUnsafe`. The only large change that I made is for how we handle mismatches in the big endian case. I used the number of leading zeros intrinsic there instead of the number of trailing zeros intrinsic to find which byte was mismatched. 

### Testing
I've added some unit tests to cover testing the path with unsafe enabled and disabled.
### Benchmarking
~I haven't done any micro-benchmarking of the new "faster" implementations vs. the current implementations. I'll update the JIRA with a link to those when I get a chance to write them. For now, I'm assuming that this method of finding common prefixes is faster than the current one based off the previous micro-benchmarking results for `compareTo` (as this is very similar code).~ I've done some microbenchmarking with JMH. The results are [in this JIRA comment](https://issues.apache.org/jira/browse/HBASE-28025?focusedCommentId=17755667&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17755667)

[HBASE-28025](https://issues.apache.org/jira/browse/HBASE-28025)