### PR TITLE
Hbase 28030: Adding unit test for FileNotFoundException when split a wal in SplitLogWorker

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseFaultInjector.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseFaultInjector.java
@@ -1,0 +1,25 @@
+package org.apache.hadoop.hbase;
+
+import org.apache.yetus.audience.InterfaceAudience;
+import java.io.IOException;
+
+@InterfaceAudience.Private
+public class HBaseFaultInjector {
+  private static HBaseFaultInjector instance = new HBaseFaultInjector();
+
+  public static HBaseFaultInjector get() {
+    return instance;
+  }
+
+  public static void set(HBaseFaultInjector injector) {
+    instance = injector;
+  }
+
+  public void injectIOException() throws IOException {}
+
+  public void killTaskNode(ServerName name) {}
+
+  public void collectFNFException() {
+
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SplitLogWorker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SplitLogWorker.java
@@ -25,6 +25,7 @@ import java.net.SocketTimeoutException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseFaultInjector;
 import org.apache.hadoop.hbase.NotServingRegionException;
 import org.apache.hadoop.hbase.Server;
 import org.apache.hadoop.hbase.client.RetriesExhaustedException;
@@ -114,6 +115,7 @@ public class SplitLogWorker implements Runnable {
       if (e instanceof FileNotFoundException) {
         // A wal file may not exist anymore. Nothing can be recovered so move on
         LOG.warn("Done, WAL {} does not exist anymore", filename, e);
+        HBaseFaultInjector.get().collectFNFException();
         return Status.DONE;
       }
       Throwable cause = e.getCause();


### PR DESCRIPTION
Basically, we add a unit test for reproducing the FileNotFoundException encountered in SplitLogWorker.java in case [HBase-20583|https://issues.apache.org/jira/browse/HBASE-20583]. 

Here is the workflow of reproducing that. First of all, the WAL file directory will be renamed to a new directory with “-splitting” postfix by the SplitLogManager at the Master. Then the SpitLogWorker at the region server would grab the task to finish it and after finishing ZkWatcher at master would first delete the WAL file and then delete the corresponding zknode. 

When an IOException happening in between deleting WAL and deleting zknode, there would be condition check to decide whether to schedule that task again. If the regionerServer that executed that task dead when the resubmit check was being performed, (needs a very special crash time: after the task is finished but before the resubmitting is checked ), the task would be resubmitted but at the new round, because the WAL is deleted, we would encounter the FileNotFoundException as described in [HBase-20583|https://issues.apache.org/jira/browse/HBASE-20583].

To reproduce the unit test, we added a new HBaseFaultInjector class to inject the IOException and regionerserver shutdown after finishing the task but before the resubmitting check. 
