### PR TITLE
Update ByteBuffAllocator.java

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
@@ -171,6 +171,9 @@ public class ByteBuffAllocator {
       // that by the time a handler originated response is actually done writing to socket and so
       // released the BBs it used, the handler might have processed one more read req. On an avg 2x
       // we consider and consider that also for the max buffers to pool
+      if (poolBufSize == 0) {
+        throw new IllegalArgumentException("poolBufSize cannot be zero");
+      }
       int bufsForTwoMB = (2 * 1024 * 1024) / poolBufSize;
       int maxBuffCount =
         conf.getInt(MAX_BUFFER_COUNT_KEY, conf.getInt(HConstants.REGION_SERVER_HANDLER_COUNT,


### PR DESCRIPTION
In `ByteBuffAllocator.java`, there is no value checking for `poolBufSize` and this variable is directly used to calculate the `bufsForTwoMB`. When `poolBufSize` is mistakenly set to 0, the code would cause division by 0 and throw ArithmeticException to crash the system.

```java
public static ByteBuffAllocator create(Configuration conf, boolean reservoirEnabled) {
    int poolBufSize = conf.getInt(BUFFER_SIZE_KEY, DEFAULT_BUFFER_SIZE);
    if (reservoirEnabled) {
    . . .
    int bufsForTwoMB = (2 * 1024 * 1024) / poolBufSize;
    . . .
```

I add a piece of code to check whether `poolBufSize` is equal to 0 during runtime, and if it's 0, it will raise an `IllegalArgumentException` exception with the given message.