### PR TITLE
HBASE-28025 Enhance ByteBufferUtils.findCommonPrefix to compare 8 bytes each time [addendum]

### DIFF
--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestBytes.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/TestBytes.java
@@ -551,12 +551,10 @@ public class TestBytes extends TestCase {
     }
   }
 
-  @Test
   public void testFindCommonPrefix() throws Exception {
     testFindCommonPrefix(false);
   }
 
-  @Test
   public void testFindCommonPrefixUnsafe() throws Exception {
     testFindCommonPrefix(true);
   }


### PR DESCRIPTION
Remove the "@Test" annotation from the "TestBytes" class due to its reliance on "TestCase" from JUnit 3.