### PR TITLE
HBASE-28038 Add TLS settings to ZooKeeper client

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -24,13 +24,10 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
-import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
-
-import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 
 /**
  * HConstants holds a bunch of HBase-related constants
@@ -221,12 +218,6 @@ public final class HConstants {
   /** Client port of ZooKeeper for client to locate meta */
   public static final String CLIENT_ZOOKEEPER_CLIENT_PORT =
     "hbase.client.zookeeper.property.clientPort";
-
-  /** Supported ZooKeeper client TLS properties */
-  public static final Set<String> ZOOKEEPER_CLIENT_TLS_PROPERTIES =
-    ImmutableSet.of("client.secure", "clientCnxnSocket", "ssl.keyStore.location",
-      "ssl.keyStore.password", "ssl.keyStore.passwordPath", "ssl.trustStore.location",
-      "ssl.trustStore.password", "ssl.trustStore.passwordPath");
 
   /** Indicate whether the client ZK are observer nodes of the server ZK */
   public static final String CLIENT_ZOOKEEPER_OBSERVER_MODE =

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -219,6 +219,18 @@ public final class HConstants {
   public static final String CLIENT_ZOOKEEPER_CLIENT_PORT =
     "hbase.client.zookeeper.property.clientPort";
 
+  /** Supported ZooKeeper client TLS properties */
+  public static final List<String> ZOOKEEPER_CLIENT_TLS_PROPERTIES =
+    Arrays.asList(
+      "client.secure",
+      "clientCnxnSocket",
+      "ssl.keyStore.location",
+      "ssl.keyStore.password",
+      "ssl.keyStore.passwordPath",
+      "ssl.trustStore.location",
+      "ssl.trustStore.password",
+      "ssl.trustStore.passwordPath");
+
   /** Indicate whether the client ZK are observer nodes of the server ZK */
   public static final String CLIENT_ZOOKEEPER_OBSERVER_MODE =
     "hbase.client.zookeeper.observer.mode";

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -24,9 +24,11 @@ import java.nio.charset.Charset;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
+import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -220,8 +222,8 @@ public final class HConstants {
     "hbase.client.zookeeper.property.clientPort";
 
   /** Supported ZooKeeper client TLS properties */
-  public static final List<String> ZOOKEEPER_CLIENT_TLS_PROPERTIES =
-    Arrays.asList("client.secure", "clientCnxnSocket", "ssl.keyStore.location",
+  public static final Set<String> ZOOKEEPER_CLIENT_TLS_PROPERTIES =
+    ImmutableSet.of("client.secure", "clientCnxnSocket", "ssl.keyStore.location",
       "ssl.keyStore.password", "ssl.keyStore.passwordPath", "ssl.trustStore.location",
       "ssl.trustStore.password", "ssl.trustStore.passwordPath");
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -28,8 +28,9 @@ import java.util.Set;
 import java.util.UUID;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.hbase.util.Bytes;
-import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 
 /**
  * HConstants holds a bunch of HBase-related constants

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -221,15 +221,9 @@ public final class HConstants {
 
   /** Supported ZooKeeper client TLS properties */
   public static final List<String> ZOOKEEPER_CLIENT_TLS_PROPERTIES =
-    Arrays.asList(
-      "client.secure",
-      "clientCnxnSocket",
-      "ssl.keyStore.location",
-      "ssl.keyStore.password",
-      "ssl.keyStore.passwordPath",
-      "ssl.trustStore.location",
-      "ssl.trustStore.password",
-      "ssl.trustStore.passwordPath");
+    Arrays.asList("client.secure", "clientCnxnSocket", "ssl.keyStore.location",
+      "ssl.keyStore.password", "ssl.keyStore.passwordPath", "ssl.trustStore.location",
+      "ssl.trustStore.password", "ssl.trustStore.passwordPath");
 
   /** Indicate whether the client ZK are observer nodes of the server ZK */
   public static final String CLIENT_ZOOKEEPER_OBSERVER_MODE =

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKConfig.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKConfig.java
@@ -43,7 +43,7 @@ public final class ZKConfig {
   private static final String ZOOKEEPER_JAVA_PROPERTY_PREFIX = "zookeeper.";
 
   /** Supported ZooKeeper client TLS properties */
-  private static final Set<String> ZOOKEEPER_CLIENT_TLS_PROPERTIES =
+  static final Set<String> ZOOKEEPER_CLIENT_TLS_PROPERTIES =
     ImmutableSet.of("client.secure", "clientCnxnSocket", "ssl.keyStore.location",
       "ssl.keyStore.password", "ssl.keyStore.passwordPath", "ssl.trustStore.location",
       "ssl.trustStore.password", "ssl.trustStore.passwordPath");

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKConfig.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKConfig.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map.Entry;
 import java.util.Properties;
+import java.util.Set;
 import org.apache.commons.validator.routines.InetAddressValidator;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
@@ -28,6 +29,7 @@ import org.apache.hadoop.util.StringUtils;
 import org.apache.yetus.audience.InterfaceAudience;
 
 import org.apache.hbase.thirdparty.com.google.common.base.Splitter;
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableSet;
 
 /**
  * Utility methods for reading, and building the ZooKeeper configuration. The order and priority for
@@ -39,6 +41,12 @@ public final class ZKConfig {
 
   private static final String VARIABLE_START = "${";
   private static final String ZOOKEEPER_JAVA_PROPERTY_PREFIX = "zookeeper.";
+
+  /** Supported ZooKeeper client TLS properties */
+  private static final Set<String> ZOOKEEPER_CLIENT_TLS_PROPERTIES =
+    ImmutableSet.of("client.secure", "clientCnxnSocket", "ssl.keyStore.location",
+      "ssl.keyStore.password", "ssl.keyStore.passwordPath", "ssl.trustStore.location",
+      "ssl.trustStore.password", "ssl.trustStore.passwordPath");
 
   private ZKConfig() {
   }
@@ -342,7 +350,7 @@ public final class ZKConfig {
           continue;
         }
         String zkKey = key.substring(prefix.length());
-        if (!HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES.contains(zkKey)) {
+        if (!ZOOKEEPER_CLIENT_TLS_PROPERTIES.contains(zkKey)) {
           continue;
         }
         String value = entry.getValue();

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/zookeeper/TestZKConfig.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/zookeeper/TestZKConfig.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.zookeeper;
 
+import static org.apache.hadoop.hbase.zookeeper.ZKConfig.ZOOKEEPER_CLIENT_TLS_PROPERTIES;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertTrue;
 
@@ -94,7 +95,7 @@ public class TestZKConfig {
   public void testZooKeeperTlsPropertiesClient() {
     // Arrange
     Configuration conf = HBaseConfiguration.create();
-    for (String p : HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
+    for (String p : ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
       conf.set(HConstants.ZK_CFG_PROPERTY_PREFIX + p, p);
       String zkprop = "zookeeper." + p;
       System.clearProperty(zkprop);
@@ -104,7 +105,7 @@ public class TestZKConfig {
     ZKConfig.getClientZKQuorumServersString(conf);
 
     // Assert
-    for (String p : HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
+    for (String p : ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
       String zkprop = "zookeeper." + p;
       assertEquals("Invalid or unset system property: " + zkprop, p, System.getProperty(zkprop));
       System.clearProperty(zkprop);
@@ -115,7 +116,7 @@ public class TestZKConfig {
   public void testZooKeeperTlsPropertiesServer() {
     // Arrange
     Configuration conf = HBaseConfiguration.create();
-    for (String p : HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
+    for (String p : ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
       conf.set(HConstants.ZK_CFG_PROPERTY_PREFIX + p, p);
       String zkprop = "zookeeper." + p;
       System.clearProperty(zkprop);
@@ -125,7 +126,7 @@ public class TestZKConfig {
     ZKConfig.getZKQuorumServersString(conf);
 
     // Assert
-    for (String p : HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
+    for (String p : ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
       String zkprop = "zookeeper." + p;
       assertEquals("Invalid or unset system property: " + zkprop, p, System.getProperty(zkprop));
       System.clearProperty(zkprop);

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/zookeeper/TestZKConfig.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/zookeeper/TestZKConfig.java
@@ -90,6 +90,48 @@ public class TestZKConfig {
     testKey("server1:2182,server2:2183,server1", 2181, "/hbase", true);
   }
 
+  @Test
+  public void testZooKeeperTlsPropertiesClient() {
+    // Arrange
+    Configuration conf = HBaseConfiguration.create();
+    for (String p : HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
+      conf.set(HConstants.ZK_CFG_PROPERTY_PREFIX + p, p);
+      String zkprop = "zookeeper." + p;
+      System.clearProperty(zkprop);
+    }
+
+    // Act
+    ZKConfig.getClientZKQuorumServersString(conf);
+
+    // Assert
+    for (String p : HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
+      String zkprop = "zookeeper." + p;
+      assertEquals("Invalid or unset system property: " + zkprop, p, System.getProperty(zkprop));
+      System.clearProperty(zkprop);
+    }
+  }
+
+  @Test
+  public void testZooKeeperTlsPropertiesServer() {
+    // Arrange
+    Configuration conf = HBaseConfiguration.create();
+    for (String p : HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
+      conf.set(HConstants.ZK_CFG_PROPERTY_PREFIX + p, p);
+      String zkprop = "zookeeper." + p;
+      System.clearProperty(zkprop);
+    }
+
+    // Act
+    ZKConfig.getZKQuorumServersString(conf);
+
+    // Assert
+    for (String p : HConstants.ZOOKEEPER_CLIENT_TLS_PROPERTIES) {
+      String zkprop = "zookeeper." + p;
+      assertEquals("Invalid or unset system property: " + zkprop, p, System.getProperty(zkprop));
+      System.clearProperty(zkprop);
+    }
+  }
+
   private void testKey(String ensemble, int port, String znode) throws IOException {
     testKey(ensemble, port, znode, false); // not support multiple client ports
   }


### PR DESCRIPTION
Looks like HBase has 2 different prefixes for ZooKeeper properties:
`hbase.zookeeper.property.`
`hbase.client.zookeeper.property.`

and we also have these:
`hbase.zookeeper.quorum`
`hbase.client.zookeeper.quorum`

Unfortunately I couldn't decrypt the meaning of each of every one of them, but we'd like to set system properties here which will be effective for all ZooKeeper clients in the same java process. Hence I only added the following properties which will be set in both client and server modes.
```
hbase.zookeeper.property.client.secure
hbase.zookeeper.property.clientCnxnSocket
hbase.zookeeper.property.ssl.keyStore.location
hbase.zookeeper.property.ssl.keyStore.password
hbase.zookeeper.property.ssl.keyStore.passwordPath
hbase.zookeeper.property.ssl.trustStore.location
hbase.zookeeper.property.ssl.trustStore.password
hbase.zookeeper.property.ssl.trustStore.passwordPath
```

Please also note that *passwordPath properties are supported only from ZooKeeper 3.8 (stable version today), but HBase is still on 3.5 meaning these properties are currently ineffective with the default setup.

Doc question: shall I add documentation in this patch or separately?

Target versions: 2.4 and onwards.