### PR TITLE
HBASE-28043 Reduce seeks from beginning of block in StoreFileScanner.seekToPreviousRow

### DIFF
--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -185,6 +185,8 @@ public class PerformanceEvaluation extends Configured implements Tool {
     addCommandDescriptor(MetaWriteTest.class, "metaWrite",
       "Populate meta table;used with 1 thread; to be cleaned up by cleanMeta");
     addCommandDescriptor(ScanTest.class, "scan", "Run scan test (read every row)");
+    addCommandDescriptor(ReverseScanTest.class, "reverseScan",
+      "Run reverse scan test (read every row)");
     addCommandDescriptor(FilteredScanTest.class, "filterScan",
       "Run scan test using a filter to find a specific row based on it's value "
         + "(make sure to use --rows=20)");
@@ -2082,6 +2084,49 @@ public class PerformanceEvaluation extends Configured implements Tool {
         Scan scan = new Scan().withStartRow(format(opts.startRow)).setCaching(opts.caching)
           .setCacheBlocks(opts.cacheBlocks).setAsyncPrefetch(opts.asyncPrefetch)
           .setReadType(opts.scanReadType).setScanMetricsEnabled(true);
+        for (int family = 0; family < opts.families; family++) {
+          byte[] familyName = Bytes.toBytes(FAMILY_NAME_BASE + family);
+          if (opts.addColumns) {
+            for (int column = 0; column < opts.columns; column++) {
+              byte[] qualifier = column == 0 ? COLUMN_ZERO : Bytes.toBytes("" + column);
+              scan.addColumn(familyName, qualifier);
+            }
+          } else {
+            scan.addFamily(familyName);
+          }
+        }
+        if (opts.filterAll) {
+          scan.setFilter(new FilterAllFilter());
+        }
+        this.testScanner = table.getScanner(scan);
+      }
+      Result r = testScanner.next();
+      updateValueSize(r);
+      return true;
+    }
+  }
+
+  static class ReverseScanTest extends TableTest {
+    private ResultScanner testScanner;
+
+    ReverseScanTest(Connection con, TestOptions options, Status status) {
+      super(con, options, status);
+    }
+
+    @Override
+    void testTakedown() throws IOException {
+      if (this.testScanner != null) {
+        this.testScanner.close();
+      }
+      super.testTakedown();
+    }
+
+    @Override
+    boolean testRow(final int i, final long startTime) throws IOException {
+      if (this.testScanner == null) {
+        Scan scan = new Scan().setCaching(opts.caching).setCacheBlocks(opts.cacheBlocks)
+          .setAsyncPrefetch(opts.asyncPrefetch).setReadType(opts.scanReadType)
+          .setScanMetricsEnabled(true).setReversed(true);
         for (int family = 0; family < opts.families; family++) {
           byte[] familyName = Bytes.toBytes(FAMILY_NAME_BASE + family);
           if (opts.addColumns) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileReader.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.PrivateCellUtil;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.TimeRange;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.BloomFilterMetrics;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
@@ -146,7 +147,8 @@ public class StoreFileReader {
   public StoreFileScanner getStoreFileScanner(boolean cacheBlocks, boolean pread,
     boolean isCompaction, long readPt, long scannerOrder, boolean canOptimizeForNonNullColumn) {
     return new StoreFileScanner(this, getScanner(cacheBlocks, pread, isCompaction), !isCompaction,
-      reader.hasMVCCInfo(), readPt, scannerOrder, canOptimizeForNonNullColumn);
+      reader.hasMVCCInfo(), readPt, scannerOrder, canOptimizeForNonNullColumn,
+      reader.getDataBlockEncoding() == DataBlockEncoding.ROW_INDEX_V1);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -651,11 +651,10 @@ public class StoreFileScanner implements KeyValueScanner {
 
   private boolean isStillAtSeekTargetAfterSkippingNewerKvs(Cell seekKey) throws IOException {
     setCurrentCell(hfs.getCell());
-    return skipNewerKvsNewerThanReadpointReversed()
-      && getComparator().compareRows(cur, seekKey) <= 0;
+    return skipKvsNewerThanReadpointReversed() && getComparator().compareRows(cur, seekKey) <= 0;
   }
 
-  private boolean skipNewerKvsNewerThanReadpointReversed() throws IOException {
+  private boolean skipKvsNewerThanReadpointReversed() throws IOException {
     this.stopSkippingKVsIfNextRow = true;
     boolean resultOfSkipKVs;
     try {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -553,30 +553,29 @@ public class StoreFileScanner implements KeyValueScanner {
    * state for by setting {@link StoreFileScanner#previousRow}
    */
   private boolean seekToPreviousRowWithoutHint(Cell originalKey) throws IOException {
-    Cell key = originalKey;
-    do {
-      // Rewind to the cell before the beginning of this row
-      Cell keyAtBeginningOfRow = PrivateCellUtil.createFirstOnRow(key);
-      if (!seekBefore(keyAtBeginningOfRow)) {
-        return false;
-      }
+    // Rewind to the cell before the beginning of this row
+    Cell keyAtBeginningOfRow = PrivateCellUtil.createFirstOnRow(originalKey);
+    if (!seekBefore(keyAtBeginningOfRow)) {
+      return false;
+    }
 
-      // Rewind before this row and save what we find as a seek hint
-      Cell firstKeyOfPreviousRow = PrivateCellUtil.createFirstOnRow(hfs.getCell());
-      if (!seekBeforeAndSaveKeyToPreviousRow(firstKeyOfPreviousRow)) {
-        return false;
-      }
+    // Rewind before this row and save what we find as a seek hint
+    Cell firstKeyOfPreviousRow = PrivateCellUtil.createFirstOnRow(hfs.getCell());
+    if (!seekBeforeAndSaveKeyToPreviousRow(firstKeyOfPreviousRow)) {
+      return false;
+    }
 
-      // Seek back to the start of the previous row
-      if (!reseekAtOrAfter(firstKeyOfPreviousRow)) {
-        return false;
-      }
+    // Seek back to the start of the previous row
+    if (!reseekAtOrAfter(firstKeyOfPreviousRow)) {
+      return false;
+    }
 
-      if (isStillAtSeekTargetAfterSkippingNewerKvs(firstKeyOfPreviousRow)) {
-        return true;
-      }
-      key = firstKeyOfPreviousRow;
-    } while (true);
+    if (isStillAtSeekTargetAfterSkippingNewerKvs(firstKeyOfPreviousRow)) {
+      return true;
+    }
+
+    // If we need to continue to seek, let's attempt to use the hint
+    return seekToPreviousRowWithHint(firstKeyOfPreviousRow);
   }
 
   /**
@@ -605,7 +604,9 @@ public class StoreFileScanner implements KeyValueScanner {
   }
 
   private boolean seekBefore(Cell seekKey) throws IOException {
-    if (seekCount != null) seekCount.increment();
+    if (seekCount != null) {
+      seekCount.increment();
+    }
     if (!hfs.seekBefore(seekKey)) {
       this.cur = null;
       return false;
@@ -615,7 +616,9 @@ public class StoreFileScanner implements KeyValueScanner {
   }
 
   private boolean seekBeforeAndSaveKeyToPreviousRow(Cell seekKey) throws IOException {
-    if (seekCount != null) seekCount.increment();
+    if (seekCount != null) {
+      seekCount.increment();
+    }
     if (!hfs.seekBefore(seekKey)) {
       // Since the above seek failed, we need to position ourselves back at the start of the
       // block or else our reseek might fail. seekTo() cannot return false here as at least
@@ -630,7 +633,9 @@ public class StoreFileScanner implements KeyValueScanner {
   }
 
   private boolean seekAtOrAfter(Cell seekKey) throws IOException {
-    if (seekCount != null) seekCount.increment();
+    if (seekCount != null) {
+      seekCount.increment();
+    }
     if (!seekAtOrAfter(hfs, seekKey)) {
       this.cur = null;
       return false;
@@ -640,7 +645,9 @@ public class StoreFileScanner implements KeyValueScanner {
   }
 
   private boolean reseekAtOrAfter(Cell seekKey) throws IOException {
-    if (seekCount != null) seekCount.increment();
+    if (seekCount != null) {
+      seekCount.increment();
+    }
     if (!reseekAtOrAfter(hfs, seekKey)) {
       this.cur = null;
       return false;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -228,6 +228,7 @@ public class StoreFileScanner implements KeyValueScanner {
         }
       } finally {
         realSeekDone = true;
+        previousRow = null;
       }
     } catch (FileNotFoundException e) {
       throw e;
@@ -255,6 +256,7 @@ public class StoreFileScanner implements KeyValueScanner {
         }
       } finally {
         realSeekDone = true;
+        previousRow = null;
       }
     } catch (FileNotFoundException e) {
       throw e;
@@ -502,8 +504,7 @@ public class StoreFileScanner implements KeyValueScanner {
             if (seekCount != null) seekCount.increment();
             if (!hfs.seekBefore(firstKeyOfPreviousRow)) {
               // Since the above seek failed, we need to position ourselves back at the start of the
-              // block
-              // or else our re-seek might fail
+              // block or else our re-seek might fail
               if (!hfs.seekTo()) {
                 this.cur = null;
                 return false;
@@ -557,15 +558,13 @@ public class StoreFileScanner implements KeyValueScanner {
 
         Cell curCell = hfs.getCell();
         // We want to see to here eventually, but along the way lets get a seek hint for the prior
-        // row since
-        // previousRow is null
+        // row since previousRow is null
         Cell firstKeyOfPreviousRow = PrivateCellUtil.createFirstOnRow(curCell);
 
         if (seekCount != null) seekCount.increment();
         if (!hfs.seekBefore(firstKeyOfPreviousRow)) {
           // Since the above seek failed, we need to position ourselves back at the start of the
-          // block
-          // or else our re-seek might fail
+          // block or else our reseek might fail
           if (!hfs.seekTo()) {
             this.cur = null;
             return false;
@@ -618,10 +617,6 @@ public class StoreFileScanner implements KeyValueScanner {
 
   @Override
   public boolean backwardSeek(Cell key) throws IOException {
-    if (cur != null && getComparator().compareRows(cur, key) != 0) {
-      previousRow = null;
-    }
-
     seek(key);
     if (cur == null || getComparator().compareRows(cur, key) > 0) {
       return seekToPreviousRow(key);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -501,6 +501,9 @@ public class StoreFileScanner implements KeyValueScanner {
 
             if (seekCount != null) seekCount.increment();
             if (!hfs.seekBefore(firstKeyOfPreviousRow)) {
+              // Since the above seek failed, we need to position ourselves back at the start of the
+              // block
+              // or else our re-seek might fail
               if (!hfs.seekTo()) {
                 this.cur = null;
                 return false;
@@ -560,6 +563,13 @@ public class StoreFileScanner implements KeyValueScanner {
 
         if (seekCount != null) seekCount.increment();
         if (!hfs.seekBefore(firstKeyOfPreviousRow)) {
+          // Since the above seek failed, we need to position ourselves back at the start of the
+          // block
+          // or else our re-seek might fail
+          if (!hfs.seekTo()) {
+            this.cur = null;
+            return false;
+          }
           this.previousRow = null;
         } else {
           this.previousRow = hfs.getCell();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -280,7 +280,7 @@ public class TestHStoreFile {
     StoreFileReader r = file.getReader();
     assertNotNull(r);
     StoreFileScanner scanner =
-      new StoreFileScanner(r, mock(HFileScanner.class), false, false, 0, 0, false);
+      new StoreFileScanner(r, mock(HFileScanner.class), false, false, 0, 0, false, false);
 
     // Verify after instantiating scanner refCount is increased
     assertTrue("Verify file is being referenced", file.isReferencedInReads());
@@ -297,7 +297,7 @@ public class TestHStoreFile {
     ColumnFamilyDescriptor cfd = ColumnFamilyDescriptorBuilder.of(cf);
     when(store.getColumnFamilyDescriptor()).thenReturn(cfd);
     try (StoreFileScanner scanner =
-      new StoreFileScanner(reader, mock(HFileScanner.class), false, false, 0, 0, true)) {
+      new StoreFileScanner(reader, mock(HFileScanner.class), false, false, 0, 0, true, false)) {
       Scan scan = new Scan();
       scan.setColumnFamilyTimeRange(cf, 0, 1);
       assertFalse(scanner.shouldUseScanner(scan, store, 0));


### PR DESCRIPTION
### What

This PR attempts to optimize the StoreFileScanner.seekToPreviousRow (& related reverse scan methods) to reduce the number of seeks from the beginning of the block by introducing a variable "previousRow"

### Implementation Notes
~I still have some work to do to ensure that `StoreFileScanner` obeys it's interface/contract in lieu of the new changes as the introduction of state in previousRow greatly alters reverse seek behavior~ Finished with this, the only method that doesn't necessarily obey the contract is `next()` as it doesn't clear the `previousRow` state if the caller were to keep calling `next` past a row boundary. That is, if the caller were to perform `seekToPreviousRow` calls, call `next()` past a row boundary, and then call `seekToPreviousRow`, the result is that you'd seek back to before the row that you last called `seekToPreviousRow` on instead of the row that you're on.

### Testing
I've opened this PR to run the entire suite of hbase-server tests against this changeset. 

### Benchmarking
I need to benchmark the meta scanning as 1-row reverse scans are very common there. Bryan gave a fantastic suggestion in the JIRA to possibly only start using the new path if we're on the second seek rather than the first. 

[HBASE-28043](https://issues.apache.org/jira/browse/HBASE-28043)