### PR TITLE
HBASE-28052 Removing the useless parameters from ProcedureExecutor.loadProcedures

### DIFF
--- a/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/ProcedureExecutor.java
+++ b/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/ProcedureExecutor.java
@@ -332,7 +332,7 @@ public class ProcedureExecutor<TEnvironment> {
 
       @Override
       public void load(ProcedureIterator procIter) throws IOException {
-        loadProcedures(procIter, abortOnCorruption);
+        loadProcedures(procIter);
       }
 
       @Override
@@ -394,8 +394,7 @@ public class ProcedureExecutor<TEnvironment> {
     });
   }
 
-  private void loadProcedures(ProcedureIterator procIter, boolean abortOnCorruption)
-    throws IOException {
+  private void loadProcedures(ProcedureIterator procIter) throws IOException {
     // 1. Build the rollback stack
     int runnableCount = 0;
     int failedCount = 0;


### PR DESCRIPTION
Details see : [HBASE-28052](https://issues.apache.org/jira/browse/HBASE-28052)