### PR TITLE
HBASE-28059 Use correct units in RegionLoad#getStoreUncompressedSizeMB()

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/RegionLoad.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/RegionLoad.java
@@ -329,7 +329,7 @@ public class RegionLoad implements RegionMetrics {
    */
   @Deprecated
   public int getStoreUncompressedSizeMB() {
-    return (int) metrics.getUncompressedStoreFileSize().get(Size.Unit.KILOBYTE);
+    return (int) metrics.getUncompressedStoreFileSize().get(Size.Unit.MEGABYTE);
   }
 
   /** Returns the data locality of region in the regionserver. */


### PR DESCRIPTION
Correctly extract megabytes from a Size object. This bug only affects 2.x versions, so targeting branch-2.5.