### PR TITLE
HBASE-27989. ByteBuffAllocator causes ArithmeticException due to improper poolBufSize value checking

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
@@ -180,8 +180,8 @@ public class ByteBuffAllocator {
         conf.getInt(MAX_BUFFER_COUNT_KEY, conf.getInt(HConstants.REGION_SERVER_HANDLER_COUNT,
           HConstants.DEFAULT_REGION_SERVER_HANDLER_COUNT) * bufsForTwoMB * 2);
       int minSizeForReservoirUse = conf.getInt(MIN_ALLOCATE_SIZE_KEY, poolBufSize / 6);
-      if (minSizeForReservoirUse == 0) {
-        LOG.warn("The minimal size for reservoir use is set to zero so that all allocations "
+      if (minSizeForReservoirUse <= 0) {
+        LOG.warn("The minimal size for reservoir use is less or equal to zero, all allocations "
           + "will be from the pool. Set a higher " + MIN_ALLOCATE_SIZE_KEY + " to avoid this.");
       }
       Class<?> clazz = conf.getClass(BYTEBUFF_ALLOCATOR_CLASS, ByteBuffAllocator.class);

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
@@ -180,6 +180,10 @@ public class ByteBuffAllocator {
         conf.getInt(MAX_BUFFER_COUNT_KEY, conf.getInt(HConstants.REGION_SERVER_HANDLER_COUNT,
           HConstants.DEFAULT_REGION_SERVER_HANDLER_COUNT) * bufsForTwoMB * 2);
       int minSizeForReservoirUse = conf.getInt(MIN_ALLOCATE_SIZE_KEY, poolBufSize / 6);
+      if (minSizeForReservoirUse == 0) {
+        LOG.warn("The minimal size for reservoir use is set to zero so that all allocations " +
+            "will be from the pool. Set a higher " + MIN_ALLOCATE_SIZE_KEY + " to avoid this.");
+      }
       Class<?> clazz = conf.getClass(BYTEBUFF_ALLOCATOR_CLASS, ByteBuffAllocator.class);
       return (ByteBuffAllocator) ReflectionUtils.newInstance(clazz, true, maxBuffCount, poolBufSize,
         minSizeForReservoirUse);

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
@@ -172,8 +172,8 @@ public class ByteBuffAllocator {
       // released the BBs it used, the handler might have processed one more read req. On an avg 2x
       // we consider and consider that also for the max buffers to pool
       if (poolBufSize <= 0) {
-        throw new IllegalArgumentException(BUFFER_SIZE_KEY + " must be positive. Please disable " +
-          "the reservoir rather than setting the size of the buffer to zero or negative.");
+        throw new IllegalArgumentException(BUFFER_SIZE_KEY + " must be positive. Please disable "
+          + "the reservoir rather than setting the size of the buffer to zero or negative.");
       }
       int bufsForTwoMB = (2 * 1024 * 1024) / poolBufSize;
       int maxBuffCount =
@@ -181,8 +181,8 @@ public class ByteBuffAllocator {
           HConstants.DEFAULT_REGION_SERVER_HANDLER_COUNT) * bufsForTwoMB * 2);
       int minSizeForReservoirUse = conf.getInt(MIN_ALLOCATE_SIZE_KEY, poolBufSize / 6);
       if (minSizeForReservoirUse == 0) {
-        LOG.warn("The minimal size for reservoir use is set to zero so that all allocations " +
-            "will be from the pool. Set a higher " + MIN_ALLOCATE_SIZE_KEY + " to avoid this.");
+        LOG.warn("The minimal size for reservoir use is set to zero so that all allocations "
+          + "will be from the pool. Set a higher " + MIN_ALLOCATE_SIZE_KEY + " to avoid this.");
       }
       Class<?> clazz = conf.getClass(BYTEBUFF_ALLOCATOR_CLASS, ByteBuffAllocator.class);
       return (ByteBuffAllocator) ReflectionUtils.newInstance(clazz, true, maxBuffCount, poolBufSize,

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/ByteBuffAllocator.java
@@ -171,6 +171,10 @@ public class ByteBuffAllocator {
       // that by the time a handler originated response is actually done writing to socket and so
       // released the BBs it used, the handler might have processed one more read req. On an avg 2x
       // we consider and consider that also for the max buffers to pool
+      if (poolBufSize <= 0) {
+        throw new IllegalArgumentException(BUFFER_SIZE_KEY + " must be positive. Please disable " +
+          "the reservoir rather than setting the size of the buffer to zero or negative.");
+      }
       int bufsForTwoMB = (2 * 1024 * 1024) / poolBufSize;
       int maxBuffCount =
         conf.getInt(MAX_BUFFER_COUNT_KEY, conf.getInt(HConstants.REGION_SERVER_HANDLER_COUNT,


### PR DESCRIPTION
### Description of PR
https://issues.apache.org/jira/browse/HBASE-27989
This PR prohibits setting `hbase.server.allocator.buffer.size` to 0 or negative. A warning is also added if the minimum size for reservoir use is set to zero.

### How was this patch tested?
1. set `hbase.server.allocator.buffer.size=0`
2. run `org.apache.hadoop.hbase.io.hfile.bucket.TestBucketCacheRefCnt#testInBucketCache`
The test now throws an `IllegalArgumentException` with detailed message.