### PR TITLE
HBASE-26974 Introduce a LogRollProcedure

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
@@ -702,6 +702,26 @@ public final class BackupSystemTable implements Closeable {
   }
 
   /**
+   * read Region Server last roll log result (timestamp) from the backup system table
+   * @param server     Region Server name
+   * @param backupRoot root directory path to backup
+   * @throws IOException exception
+   */
+  public Long getRegionServerLastLogRollResult(String server, String backupRoot)
+    throws IOException {
+    try (Table table = connection.getTable(tableName)) {
+      Get get = createGetForRegionServerLastLogRollResult(server, backupRoot);
+      byte[] value =
+        table.get(get).getValue(BackupSystemTable.META_FAMILY, Bytes.toBytes("rs-log-ts"));
+      if (value == null) {
+        return Long.MIN_VALUE;
+      } else {
+        return Bytes.toLong(value);
+      }
+    }
+  }
+
+  /**
    * Writes Region Server last roll log result (timestamp) to backup system table table
    * @param server     Region Server name
    * @param ts         last log timestamp
@@ -1457,6 +1477,17 @@ public final class BackupSystemTable implements Closeable {
     String s = Bytes.toString(cloneRow);
     int index = s.lastIndexOf(NULL);
     return s.substring(index + 1);
+  }
+
+  /**
+   * Creates Get for store RS last log result
+   * @param server server name
+   * @return put operation
+   */
+  private Get createGetForRegionServerLastLogRollResult(String server, String backupRoot) {
+    Get get = new Get(rowkey(RS_LOG_TS_PREFIX, backupRoot, NULL, server));
+    get.addColumn(BackupSystemTable.META_FAMILY, Bytes.toBytes("rs-log-ts"));
+    return get;
   }
 
   /**

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/FullTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/FullTableBackupClient.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hbase.backup.BackupInfo.BackupState;
 import org.apache.hadoop.hbase.backup.BackupRequest;
 import org.apache.hadoop.hbase.backup.BackupRestoreFactory;
 import org.apache.hadoop.hbase.backup.BackupType;
-import org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager;
 import org.apache.hadoop.hbase.backup.util.BackupUtils;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
@@ -151,8 +150,7 @@ public class FullTableBackupClient extends TableBackupClient {
 
       Map<String, String> props = new HashMap<>();
       props.put("backupRoot", backupInfo.getBackupRootDir());
-      admin.execProcedure(LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_SIGNATURE,
-        LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_NAME, props);
+      BackupUtils.rollWALWriters(admin, props);
 
       newTimestamps = backupManager.readRegionServerLastLogRollResult();
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalBackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalBackupManager.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
-import org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager;
 import org.apache.hadoop.hbase.backup.util.BackupUtils;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
@@ -88,8 +87,7 @@ public class IncrementalBackupManager extends BackupManager {
     props.put("backupRoot", backupInfo.getBackupRootDir());
 
     try (Admin admin = conn.getAdmin()) {
-      admin.execProcedure(LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_SIGNATURE,
-        LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_NAME, props);
+      BackupUtils.rollWALWriters(admin, props);
     }
     newTimestamps = readRegionServerLastLogRollResult();
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/LogRollProcedure.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/LogRollProcedure.java
@@ -1,0 +1,188 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup.master;
+
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.BACKUP_ENABLE_DEFAULT;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.BACKUP_ENABLE_KEY;
+import static org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager.LOGROLL_PROCEDURE_ENABLED;
+import static org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager.LOGROLL_PROCEDURE_ENABLED_DEFAULT;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotEnabledException;
+import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
+import org.apache.hadoop.hbase.client.TableState;
+import org.apache.hadoop.hbase.master.TableStateManager;
+import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.master.procedure.TableProcedureInterface;
+import org.apache.hadoop.hbase.procedure2.ProcedureStateSerializer;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
+import org.apache.hadoop.hbase.procedure2.ProcedureYieldException;
+import org.apache.hadoop.hbase.procedure2.StateMachineProcedure;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos.LogRollData;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos.LogRollState;
+
+@InterfaceAudience.Private
+public class LogRollProcedure extends StateMachineProcedure<MasterProcedureEnv, LogRollState>
+  implements TableProcedureInterface {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RSLogRollProcedure.class);
+
+  private Configuration conf;
+
+  private String backupRoot;
+
+  public LogRollProcedure() {
+  }
+
+  public LogRollProcedure(final String backupRoot, final Configuration conf) {
+    this.backupRoot = backupRoot;
+    this.conf = conf;
+  }
+
+  @Override
+  protected LockState acquireLock(final MasterProcedureEnv env) {
+    if (env.getProcedureScheduler().waitTableSharedLock(this, getTableName())) {
+      return LockState.LOCK_EVENT_WAIT;
+    }
+    return LockState.LOCK_ACQUIRED;
+  }
+
+  @Override
+  protected void releaseLock(final MasterProcedureEnv env) {
+    env.getProcedureScheduler().wakeTableSharedLock(this, getTableName());
+  }
+
+  @Override
+  protected Flow executeFromState(MasterProcedureEnv env, LogRollState state)
+    throws ProcedureSuspendedException, ProcedureYieldException, InterruptedException {
+    LOG.info("{} execute state={}", this, state);
+
+    try {
+      switch (state) {
+        case LOG_ROLL_PRE_CHECK:
+          TableStateManager tsm = env.getMasterServices().getTableStateManager();
+          TableState tableState = tsm.getTableState(getTableName());
+          if (!tableState.isEnabled()) {
+            throw new TableNotEnabledException(getTableName() + " is in state " + tableState);
+          }
+          setNextState(LogRollState.LOG_ROLL_ROLL_LOG_ON_EACH_RS);
+          return Flow.HAS_MORE_STATE;
+        case LOG_ROLL_ROLL_LOG_ON_EACH_RS:
+          final List<ServerName> onlineServers =
+            env.getMasterServices().getServerManager().getOnlineServersList();
+          final List<RSLogRollProcedure> subProcedures = new ArrayList<>(onlineServers.size());
+          final BackupSystemTable table =
+            new BackupSystemTable(env.getMasterServices().getConnection());
+          final HashMap<String, Long> lastLogRollResults =
+            table.readRegionServerLastLogRollResult(backupRoot);
+          final long now = EnvironmentEdgeManager.currentTime();
+          for (ServerName server : onlineServers) {
+            long lastLogRollResult =
+              lastLogRollResults.getOrDefault(server.getAddress().toString(), Long.MIN_VALUE);
+            if (lastLogRollResult > now) {
+              LOG.warn("Bad lastLogRollResult={}. reset lastLogRollResult.", lastLogRollResult);
+              lastLogRollResult = Long.MIN_VALUE;
+            }
+            subProcedures.add(new RSLogRollProcedure(server, backupRoot, lastLogRollResult));
+          }
+          addChildProcedure(subProcedures.toArray(new RSLogRollProcedure[0]));
+          return Flow.NO_MORE_STATE;
+      }
+    } catch (Exception e) {
+      setFailure("log-roll", e);
+    }
+    return Flow.NO_MORE_STATE;
+  }
+
+  @Override
+  protected void rollbackState(MasterProcedureEnv env, LogRollState state) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected LogRollState getState(int stateId) {
+    return LogRollState.forNumber(stateId);
+  }
+
+  @Override
+  protected int getStateId(LogRollState state) {
+    return state.getNumber();
+  }
+
+  @Override
+  protected LogRollState getInitialState() {
+    return LogRollState.LOG_ROLL_ROLL_LOG_ON_EACH_RS;
+  }
+
+  @Override
+  protected boolean abort(MasterProcedureEnv env) {
+    return false;
+  }
+
+  @Override
+  protected void serializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    serializer.serialize(LogRollData.newBuilder().setBackupRoot(backupRoot).build());
+  }
+
+  @Override
+  protected void deserializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    this.backupRoot = serializer.deserialize(LogRollData.class).getBackupRoot();
+  }
+
+  @Override
+  public TableName getTableName() {
+    return BackupSystemTable.getTableName(conf);
+  }
+
+  @Override
+  protected void afterReplay(MasterProcedureEnv env) {
+    Configuration conf = env.getMasterConfiguration();
+    if (!conf.getBoolean(BACKUP_ENABLE_KEY, BACKUP_ENABLE_DEFAULT)) {
+      setFailure("log-roll", new IOException("backup is DISABLED"));
+      LOG.info("backup is DISABLED. Mark unfinished procedure {} as FAILED", this);
+      return;
+    }
+    if (!conf.getBoolean(LOGROLL_PROCEDURE_ENABLED, LOGROLL_PROCEDURE_ENABLED_DEFAULT)) {
+      setFailure("log-roll", new IOException("LogRollProcedure is DISABLED"));
+      LOG.info("LogRollProcedure is DISABLED. Mark unfinished procedure {} as FAILED", this);
+      return;
+    }
+    this.conf = conf;
+  }
+
+  @Override
+  public TableOperationType getTableOperationType() {
+    return TableOperationType.READ;
+  }
+
+  @Override
+  protected void toStringClassDetails(StringBuilder sb) {
+    sb.append(getClass().getSimpleName()).append(", backupRoot=").append(backupRoot);
+  }
+}

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/RSLogRollProcedure.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/RSLogRollProcedure.java
@@ -1,0 +1,172 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup.master;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
+import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.master.procedure.ServerProcedureInterface;
+import org.apache.hadoop.hbase.procedure2.ProcedureStateSerializer;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
+import org.apache.hadoop.hbase.procedure2.ProcedureUtil;
+import org.apache.hadoop.hbase.procedure2.ProcedureYieldException;
+import org.apache.hadoop.hbase.procedure2.StateMachineProcedure;
+import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos.RSLogRollData;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos.RSLogRollState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ProcedureProtos.ProcedureState;
+
+@InterfaceAudience.Private
+public class RSLogRollProcedure extends StateMachineProcedure<MasterProcedureEnv, RSLogRollState>
+  implements ServerProcedureInterface {
+
+  private static final Logger LOG = LoggerFactory.getLogger(RSLogRollProcedure.class);
+
+  private ServerName targetServer;
+
+  private String backupRoot;
+
+  private long lastLogRollResult;
+
+  private RetryCounter retryCounter;
+
+  public RSLogRollProcedure() {
+  }
+
+  public RSLogRollProcedure(ServerName targetServer, String backupRoot, long lastLogRollResult) {
+    this.targetServer = targetServer;
+    this.backupRoot = backupRoot;
+    this.lastLogRollResult = lastLogRollResult;
+  }
+
+  @Override
+  protected Flow executeFromState(MasterProcedureEnv env, RSLogRollState state)
+    throws ProcedureSuspendedException, ProcedureYieldException, InterruptedException {
+    LOG.info("{} execute state={}", this, state);
+
+    switch (state) {
+      case RS_LOG_ROLL_ROLL_LOG_REMOTE:
+        addChildProcedure(new RSLogRollRemoteProcedure(targetServer, backupRoot));
+        setNextState(RSLogRollState.RS_LOG_ROLL_CONFIRM_RESULT);
+        return Flow.HAS_MORE_STATE;
+      case RS_LOG_ROLL_CONFIRM_RESULT:
+        // if server is crashed. skip the rest steps.
+        if (!env.getMasterServices().getServerManager().isServerOnline(targetServer)) {
+          return Flow.NO_MORE_STATE;
+        }
+        try {
+          BackupSystemTable table = new BackupSystemTable(env.getMasterServices().getConnection());
+          long newestLogRollResult = table
+            .getRegionServerLastLogRollResult(targetServer.getAddress().toString(), backupRoot);
+          LOG.debug("newestLogRollResult={}, lastLogRollResult={}", newestLogRollResult,
+            lastLogRollResult);
+          if (newestLogRollResult > lastLogRollResult) {
+            return Flow.NO_MORE_STATE;
+          } else {
+            setNextState(RSLogRollState.RS_LOG_ROLL_ROLL_LOG_REMOTE);
+            return Flow.HAS_MORE_STATE;
+          }
+        } catch (IOException e) {
+          if (retryCounter == null) {
+            retryCounter = ProcedureUtil.createRetryCounter(env.getMasterConfiguration());
+          }
+          long backoff = retryCounter.getBackoffTimeAndIncrementAttempts();
+          LOG.warn("Failed get newest log roll result, retry later", e);
+          setTimeout(Math.toIntExact(backoff));
+          setState(ProcedureState.WAITING_TIMEOUT);
+          skipPersistence();
+          throw new ProcedureSuspendedException();
+        }
+      default:
+        throw new UnsupportedOperationException("unhandled state=" + state);
+    }
+  }
+
+  @Override
+  protected void rollbackState(MasterProcedureEnv env, RSLogRollState state) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected RSLogRollState getState(int stateId) {
+    return RSLogRollState.forNumber(stateId);
+  }
+
+  @Override
+  protected int getStateId(RSLogRollState state) {
+    return state.getNumber();
+  }
+
+  @Override
+  protected RSLogRollState getInitialState() {
+    return RSLogRollState.RS_LOG_ROLL_ROLL_LOG_REMOTE;
+  }
+
+  @Override
+  public ServerName getServerName() {
+    return targetServer;
+  }
+
+  @Override
+  public boolean hasMetaTableRegion() {
+    return false;
+  }
+
+  @Override
+  public ServerOperationType getServerOperationType() {
+    return ServerOperationType.LOG_ROLL;
+  }
+
+  @Override
+  protected void serializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    super.serializeStateData(serializer);
+    RSLogRollData.Builder builder = RSLogRollData.newBuilder();
+    builder.setTargetServer(ProtobufUtil.toServerName(targetServer)).setBackupRoot(backupRoot)
+      .setLastLogRollResult(lastLogRollResult);
+    serializer.serialize(builder.build());
+  }
+
+  @Override
+  protected void deserializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    super.deserializeStateData(serializer);
+    RSLogRollData data = serializer.deserialize(RSLogRollData.class);
+    this.targetServer = ProtobufUtil.toServerName(data.getTargetServer());
+    this.backupRoot = data.getBackupRoot();
+    this.lastLogRollResult = data.getLastLogRollResult();
+  }
+
+  @Override
+  protected synchronized boolean setTimeoutFailure(MasterProcedureEnv env) {
+    setState(ProcedureState.RUNNABLE);
+    env.getProcedureScheduler().addFront(this);
+    return false;
+  }
+
+  @Override
+  protected void toStringClassDetails(StringBuilder sb) {
+    sb.append(getClass().getSimpleName()).append(" targetServer=").append(targetServer)
+      .append(", backupRoot=").append(backupRoot).append(", lastLogRollResult=")
+      .append(lastLogRollResult);
+  }
+}

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/RSLogRollRemoteProcedure.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/RSLogRollRemoteProcedure.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup.master;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.backup.regionserver.LogRollCallable;
+import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.master.procedure.RSProcedureDispatcher.ServerOperation;
+import org.apache.hadoop.hbase.master.procedure.ServerProcedureInterface;
+import org.apache.hadoop.hbase.master.procedure.ServerRemoteProcedure;
+import org.apache.hadoop.hbase.procedure2.ProcedureStateSerializer;
+import org.apache.hadoop.hbase.procedure2.RemoteProcedureDispatcher.RemoteOperation;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos.RSLogRollParameter;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos.RSLogRollRemoteData;
+
+@InterfaceAudience.Private
+public class RSLogRollRemoteProcedure extends ServerRemoteProcedure
+  implements ServerProcedureInterface {
+
+  private String backupRoot;
+
+  public RSLogRollRemoteProcedure() {
+  }
+
+  public RSLogRollRemoteProcedure(ServerName targetServer, String backupRoot) {
+    this.targetServer = targetServer;
+    this.backupRoot = backupRoot;
+  }
+
+  @Override
+  protected void rollback(MasterProcedureEnv env) {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
+  protected boolean abort(MasterProcedureEnv env) {
+    return false;
+  }
+
+  @Override
+  protected void serializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    serializer.serialize(RSLogRollRemoteData.newBuilder().setBackupRoot(backupRoot)
+      .setTargetServer(ProtobufUtil.toServerName(targetServer)).build());
+  }
+
+  @Override
+  protected void deserializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    RSLogRollRemoteData data = serializer.deserialize(RSLogRollRemoteData.class);
+    this.backupRoot = data.getBackupRoot();
+    this.targetServer = ProtobufUtil.toServerName(data.getTargetServer());
+  }
+
+  @Override
+  public Optional<RemoteOperation> remoteCallBuild(MasterProcedureEnv env, ServerName serverName) {
+    return Optional.of(new ServerOperation(this, getProcId(), LogRollCallable.class,
+      RSLogRollParameter.newBuilder().setBackupRoot(backupRoot).build().toByteArray()));
+  }
+
+  @Override
+  public ServerName getServerName() {
+    return targetServer;
+  }
+
+  @Override
+  public boolean hasMetaTableRegion() {
+    return false;
+  }
+
+  @Override
+  public ServerOperationType getServerOperationType() {
+    return ServerOperationType.LOG_ROLL;
+  }
+
+  @Override
+  protected void complete(MasterProcedureEnv env, Throwable error) {
+    // do not retry. just returns.
+    if (error != null) {
+      LOG.warn("Failed to roll wal for {}", targetServer, error);
+    }
+    succ = true;
+  }
+
+  @Override
+  protected void toStringClassDetails(StringBuilder sb) {
+    sb.append(getClass().getSimpleName()).append(" targetServer=").append(targetServer)
+      .append(", backupRoot=").append(backupRoot);
+  }
+}

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/regionserver/LogRollCallable.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/regionserver/LogRollCallable.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup.regionserver;
+
+import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
+import org.apache.hadoop.hbase.executor.EventType;
+import org.apache.hadoop.hbase.procedure2.BaseRSProcedureCallable;
+import org.apache.hadoop.hbase.regionserver.wal.AbstractFSWAL;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos.RSLogRollParameter;
+
+@InterfaceAudience.Private
+public class LogRollCallable extends BaseRSProcedureCallable {
+
+  private static final Logger LOG = LoggerFactory.getLogger(LogRollCallable.class);
+
+  private String backupRoot;
+
+  @Override
+  protected void doCall() throws Exception {
+    long highest = rs.getWALs().stream().mapToLong(wal -> ((AbstractFSWAL<?>) wal).getFilenum())
+      .max().orElse(-1L);
+    AbstractFSWAL<?> fsWAL = (AbstractFSWAL<?>) rs.getWAL(null);
+
+    long filenum = fsWAL.getFilenum();
+    LOG.info("Trying to roll log. Current log number={}, highest={}", filenum, highest);
+    rs.getWalRoller().requestRollAll();
+    rs.getWalRoller().waitUntilWalRollFinished();
+    LOG.info("After roll log, Current log number={}", fsWAL.getFilenum());
+
+    final String server = rs.getServerName().getAddress().toString();
+    final BackupSystemTable table = new BackupSystemTable(rs.getConnection());
+    long sts = table.getRegionServerLastLogRollResult(server, backupRoot);
+    if (sts > highest) {
+      LOG.warn("Won't update server's last roll log result: current={}, new={}", sts, highest);
+    } else {
+      table.writeRegionServerLastLogRollResult(server, highest, backupRoot);
+    }
+  }
+
+  @Override
+  protected void initParameter(byte[] parameter) throws Exception {
+    this.backupRoot = RSLogRollParameter.parseFrom(parameter).getBackupRoot();
+  }
+
+  @Override
+  public EventType getEventType() {
+    return EventType.RS_LOG_ROLL;
+  }
+}

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/util/BackupUtils.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/util/BackupUtils.java
@@ -17,6 +17,12 @@
  */
 package org.apache.hadoop.hbase.backup.util;
 
+import static org.apache.hadoop.hbase.HConstants.DEFAULT_HBASE_RPC_TIMEOUT;
+import static org.apache.hadoop.hbase.HConstants.HBASE_RPC_TIMEOUT_KEY;
+import static org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_ID;
+import static org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_NAME;
+import static org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_SIGNATURE;
+
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.net.URLDecoder;
@@ -51,14 +57,17 @@ import org.apache.hadoop.hbase.backup.impl.BackupManifest;
 import org.apache.hadoop.hbase.backup.impl.BackupManifest.BackupImage;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionUtils;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.master.region.MasterRegionFactory;
 import org.apache.hadoop.hbase.tool.BulkLoadHFiles;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSTableDescriptors;
 import org.apache.hadoop.hbase.util.FSUtils;
+import org.apache.hadoop.hbase.util.Threads;
 import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
@@ -762,4 +771,29 @@ public final class BackupUtils {
     return BackupRestoreConstants.BACKUPID_PREFIX + recentTimestamp;
   }
 
+  public static void rollWALWriters(Admin admin, Map<String, String> props) throws IOException {
+    byte[] ret =
+      admin.execProcedureWithReturn(ROLLLOG_PROCEDURE_SIGNATURE, ROLLLOG_PROCEDURE_NAME, props);
+    // if ret is empty, it means that the master is configured to use zk as coordinator to roll
+    // WAL for all region servers, otherwise proc-v2 would be used, and the ret is the proc id
+    if (ret != null && ret.length > 0) {
+      // add proc id to the props map
+      props.put(ROLLLOG_PROCEDURE_ID, Long.toString(Bytes.toLong(ret)));
+    }
+
+    // keep asking if procedure is finished until it times out
+    long start = EnvironmentEdgeManager.currentTime();
+    long rpcTimeoutMs =
+      admin.getConfiguration().getLong(HBASE_RPC_TIMEOUT_KEY, DEFAULT_HBASE_RPC_TIMEOUT);
+
+    int tries = 0;
+    boolean done = false;
+    while ((EnvironmentEdgeManager.currentTime() - start) < rpcTimeoutMs && !done) {
+      Threads.sleep(ConnectionUtils.getPauseTime(rpcTimeoutMs, tries++));
+      done = admin.isProcedureFinished(ROLLLOG_PROCEDURE_SIGNATURE, ROLLLOG_PROCEDURE_NAME, props);
+    }
+    if (!done) {
+      throw new IOException("Unable to roll WALs in " + rpcTimeoutMs + " ms, last try = " + tries);
+    }
+  }
 }

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupBase.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupBase.java
@@ -44,7 +44,6 @@ import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
 import org.apache.hadoop.hbase.backup.impl.FullTableBackupClient;
 import org.apache.hadoop.hbase.backup.impl.IncrementalBackupManager;
 import org.apache.hadoop.hbase.backup.impl.IncrementalTableBackupClient;
-import org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager;
 import org.apache.hadoop.hbase.backup.util.BackupUtils;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
@@ -206,8 +205,7 @@ public class TestBackupBase {
 
         Map<String, String> props = new HashMap<>();
         props.put("backupRoot", backupInfo.getBackupRootDir());
-        admin.execProcedure(LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_SIGNATURE,
-          LogRollMasterProcedureManager.ROLLLOG_PROCEDURE_NAME, props);
+        BackupUtils.rollWALWriters(admin, props);
         failStageIf(Stage.stage_2);
         newTimestamps = backupManager.readRegionServerLastLogRollResult();
 

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/master/TestLogRollProcedure.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/master/TestLogRollProcedure.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup.master;
+
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.BACKUP_ENABLE_KEY;
+import static org.apache.hadoop.hbase.backup.master.LogRollMasterProcedureManager.LOGROLL_PROCEDURE_ENABLED;
+import static org.apache.hadoop.hbase.procedure2.RemoteProcedureDispatcher.DISPATCH_DELAY_CONF_KEY;
+import static org.apache.hadoop.hbase.procedure2.RemoteProcedureDispatcher.DISPATCH_MAX_QUEUE_SIZE_CONF_KEY;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.SingleProcessHBaseCluster;
+import org.apache.hadoop.hbase.backup.util.BackupUtils;
+import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.procedure.ProcedureManagerHost;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.regionserver.wal.AbstractFSWAL;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+
+@Category(MediumTests.class)
+public class TestLogRollProcedure {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestLogRollProcedure.class);
+
+  @Rule
+  public TestName name = new TestName();
+
+  private final static HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+
+  private Configuration conf;
+
+  @Before
+  public void setUp() throws Exception {
+    conf = TEST_UTIL.getConfiguration();
+    conf.setBoolean(BACKUP_ENABLE_KEY, true);
+    conf.setBoolean(LOGROLL_PROCEDURE_ENABLED, true);
+    conf.set(DISPATCH_DELAY_CONF_KEY, "2000");
+    conf.set(DISPATCH_MAX_QUEUE_SIZE_CONF_KEY, "128");
+    conf.set(ProcedureManagerHost.MASTER_PROCEDURE_CONF_KEY,
+      LogRollMasterProcedureManager.class.getName());
+    TEST_UTIL.startMiniCluster(2);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testSimpleLogRoll() throws IOException {
+    HRegionServer rs = TEST_UTIL.getHBaseCluster().getRegionServer(0);
+    long fileNumBefore = ((AbstractFSWAL<?>) rs.getWAL(null)).getFilenum();
+
+    Map<String, String> props = new HashMap<>();
+    props.put("backupRoot", "/hbase/backup");
+    BackupUtils.rollWALWriters(TEST_UTIL.getAdmin(), props);
+
+    long fileNumAfter = ((AbstractFSWAL<?>) rs.getWAL(null)).getFilenum();
+    assertTrue(fileNumAfter > fileNumBefore);
+  }
+
+  @Test
+  public void testMasterRestarts() throws IOException {
+    SingleProcessHBaseCluster cluster = TEST_UTIL.getHBaseCluster();
+    HRegionServer rs = cluster.getRegionServer(0);
+    long fileNumBefore = ((AbstractFSWAL<?>) rs.getWAL(null)).getFilenum();
+
+    String backupRoot = "/hbase/backup";
+    LogRollProcedure procedure = new LogRollProcedure(backupRoot, conf);
+    long procId = cluster.getMaster().getMasterProcedureExecutor().submitProcedure(procedure);
+
+    TEST_UTIL.waitFor(60000, () -> cluster.getMaster().getMasterProcedureExecutor().getProcedures()
+      .stream().anyMatch(p -> p instanceof RSLogRollRemoteProcedure));
+    ServerName serverName = cluster.getMaster().getServerName();
+    cluster.killMaster(serverName);
+    cluster.waitForMasterToStop(serverName, 30000);
+    cluster.startMaster();
+    cluster.waitForActiveAndReadyMaster();
+
+    ProcedureExecutor<MasterProcedureEnv> exec = cluster.getMaster().getMasterProcedureExecutor();
+    TEST_UTIL.waitFor(30000, () -> exec.isRunning() && exec.isFinished(procId));
+
+    long fileNumAfter = ((AbstractFSWAL<?>) rs.getWAL(null)).getFilenum();
+
+    assertTrue(fileNumAfter > fileNumBefore);
+  }
+}

--- a/hbase-protocol-shaded/src/main/protobuf/Backup.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/Backup.proto
@@ -119,3 +119,31 @@ message BackupInfo {
     STORE_MANIFEST = 5;
   }
 }
+
+enum LogRollState {
+  LOG_ROLL_PRE_CHECK = 1;
+  LOG_ROLL_ROLL_LOG_ON_EACH_RS = 2;
+}
+enum RSLogRollState {
+  RS_LOG_ROLL_ROLL_LOG_REMOTE = 1;
+  RS_LOG_ROLL_CONFIRM_RESULT = 2;
+}
+
+message LogRollData {
+  required string backup_root = 1;
+}
+
+message RSLogRollData {
+  required string backup_root = 1;
+  required ServerName target_server = 2;
+  required int64 last_log_roll_result = 3;
+}
+
+message RSLogRollRemoteData {
+  required string backup_root = 1;
+  required ServerName target_server = 2;
+}
+
+message RSLogRollParameter {
+  required string backup_root = 1;
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventType.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventType.java
@@ -297,7 +297,13 @@ public enum EventType {
    * RS flush regions.<br>
    * RS_FLUSH_OPERATIONS
    */
-  RS_FLUSH_REGIONS(89, ExecutorType.RS_FLUSH_OPERATIONS);
+  RS_FLUSH_REGIONS(89, ExecutorType.RS_FLUSH_OPERATIONS),
+
+  /**
+   * RS log roll.<br>
+   * RS_LOG_ROLL
+   */
+  RS_LOG_ROLL(90, ExecutorType.RS_LOG_ROLL);
 
   private final int code;
   private final ExecutorType executor;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/ExecutorType.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/ExecutorType.java
@@ -55,8 +55,8 @@ public enum ExecutorType {
   RS_IN_MEMORY_COMPACTION(34),
   RS_CLAIM_REPLICATION_QUEUE(35),
   RS_SNAPSHOT_OPERATIONS(36),
-
-  RS_FLUSH_OPERATIONS(37);
+  RS_FLUSH_OPERATIONS(37),
+  RS_LOG_ROLL(38);
 
   ExecutorType(int value) {
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ServerProcedureInterface.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ServerProcedureInterface.java
@@ -55,7 +55,12 @@ public interface ServerProcedureInterface {
     /**
      * send verify snapshot request to region server and handle the response
      */
-    VERIFY_SNAPSHOT
+    VERIFY_SNAPSHOT,
+
+    /**
+     * send roll log request to region server and handle the response
+     */
+    LOG_ROLL
   }
 
   /** Returns Name of this server instance. */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ServerQueue.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ServerQueue.java
@@ -41,6 +41,7 @@ class ServerQueue extends Queue<ServerName> {
       case CLAIM_REPLICATION_QUEUES:
       case CLAIM_REPLICATION_QUEUE_REMOTE:
       case VERIFY_SNAPSHOT:
+      case LOG_ROLL:
         return false;
       default:
         break;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -1910,6 +1910,10 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
       conf.getInt("hbase.regionserver.executor.flush.operations.threads", 3);
     executorService.startExecutorService(executorService.new ExecutorConfig()
       .setExecutorType(ExecutorType.RS_FLUSH_OPERATIONS).setCorePoolSize(rsFlushOperationThreads));
+    final int logRollThreads =
+      conf.getInt("hbase.regionserver.executor.backup.log.roll.threads", 1);
+    executorService.startExecutorService(executorService.new ExecutorConfig()
+      .setExecutorType(ExecutorType.RS_LOG_ROLL).setCorePoolSize(logRollThreads));
 
     Threads.setDaemonThreadRunning(this.walRoller, getName() + ".logRoller",
       uncaughtExceptionHandler);


### PR DESCRIPTION
**This PR tries to reimplement the log-roll procedure with proc-v2.** 

**Modifies the following things**

**client side:**

instead of calling `admin.execProcedure()`, now we call `admin.execProcedureWithReturn`, and the returned value depends on the configuration in the server side. If master is configured to used proc-v2, the value would be the procedure id, otherwise nothing. Then we will keep asking master if the procedure has finished by calling `admin.isProcedureFinished` until it finished or failed. This was implemented in `BackupUtils#rollWALWriters`.

**server side**

1. enhanced `LogRollMasterProcedureManager` to support both proc-v1 and proc-v2

2. introduce 3 new procedures.

**LogRollProcedure**
The `LogRollProcedure` is used to roll WAL for all the regionservers in the cluster. It acquires the shared lock of the backup system table. It has 2 states: 
`LOG_ROLL_PRE_CHECK` : make sure the backup system table exists and is enabled
`LOG_ROLL_ROLL_LOG_ON_EACH_RS` : roll all rs WAL writers

**RSLogRollProcedure**
The RSLogRollProcedure is used to schedule a RSLogRollRemoteProcedure for each regionserver. When the subprocedure returns, the RSLogRollProcedure will check the logrolling result in the backup system table. If failed, The RSLogRollProcedure will schedule a new RSLogRollRemoteProcedure to retry.

**RSLogRollRemoteProcedure**
The RSLogRollRemoteProcedure is used to send the log roll request to the remote server.

any suggestions and feedbacks are appreciated.