### PR TITLE
HBASE-28105 NPE in QuotaCache if Table is dropped from cluster

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
@@ -371,19 +371,21 @@ public class QuotaCache implements Stoppable {
 
       // Update table machine quota factors
       for (TableName tableName : tableQuotaCache.keySet()) {
-        double factor = 1;
-        try {
-          long regionSize = tableRegionStatesCount.get(tableName).getOpenRegions();
-          if (regionSize == 0) {
-            factor = 0;
-          } else {
-            int localRegionSize = rsServices.getRegions(tableName).size();
-            factor = 1.0 * localRegionSize / regionSize;
+        if (tableRegionStatesCount.containsKey(tableName)) {
+          double factor = 1;
+          try {
+            long regionSize = tableRegionStatesCount.get(tableName).getOpenRegions();
+            if (regionSize == 0) {
+              factor = 0;
+            } else {
+              int localRegionSize = rsServices.getRegions(tableName).size();
+              factor = 1.0 * localRegionSize / regionSize;
+            }
+          } catch (IOException e) {
+            LOG.warn("Get table regions failed: {}", tableName, e);
           }
-        } catch (IOException e) {
-          LOG.warn("Get table regions failed: {}", tableName, e);
+          tableMachineQuotaFactors.put(tableName, factor);
         }
-        tableMachineQuotaFactors.put(tableName, factor);
       }
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
@@ -387,7 +387,7 @@ public class QuotaCache implements Stoppable {
           tableMachineQuotaFactors.put(tableName, factor);
         } else {
           // TableName might have already been dropped (outdated)
-            tableMachineQuotaFactors.remove(tableName);
+          tableMachineQuotaFactors.remove(tableName);
         }
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
@@ -385,6 +385,9 @@ public class QuotaCache implements Stoppable {
             LOG.warn("Get table regions failed: {}", tableName, e);
           }
           tableMachineQuotaFactors.put(tableName, factor);
+        } else {
+          // TableName might have already been dropped (outdated)
+            tableMachineQuotaFactors.remove(tableName);
         }
       }
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-28105

Avoid NPE by making sure the table exists in the latest metadata.