### PR TITLE
HBASE-28109 NPE for the region state: Failed to become active master (HMaster)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1412,7 +1412,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     RetryCounter rc = null;
     while (!isStopped()) {
       RegionState rs = this.assignmentManager.getRegionStates().getRegionState(ri);
-      if (rs.isOpened()) {
+      if (rs != null && rs.isOpened()) {
         if (this.getServerManager().isServerOnline(rs.getServerName())) {
           return true;
         }


### PR DESCRIPTION
There's a chance for rs to be NULL when starting up the HMaster. Then we ran into NPE exception
```
2023-09-18 14:17:40,452 ERROR [master/hmaster:16000:becomeActiveMaster] master.HMaster: Failed to become active master
java.lang.NullPointerException
        at org.apache.hadoop.hbase.master.HMaster.isRegionOnline(HMaster.java:1229)
        at org.apache.hadoop.hbase.master.HMaster.waitForMetaOnline(HMaster.java:1218)
        at org.apache.hadoop.hbase.master.HMaster.finishActiveMasterInitialization(HMaster.java:968)
        at org.apache.hadoop.hbase.master.HMaster.startActiveMasterManager(HMaster.java:2193)
        at org.apache.hadoop.hbase.master.HMaster.lambda$run$0(HMaster.java:528)
        at java.lang.Thread.run(Thread.java:750)
```
This PR add a simple check and make HMaster keep waiting instead of directly shutting down.