### PR TITLE
HBASE-28113  Modify the way of acquiring the RegionStateNode lock in checkOnlineRegionsReport to tryLock

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -1398,8 +1398,10 @@ public class AssignmentManager {
         continue;
       }
       final long lag = 1000;
-      // It is likely that another thread is currently holding the lock. To avoid deadlock, use
-      // tryLock waiting for a specified period of time
+      // This is just a fallback check designed to identify unexpected data inconsistencies, so we
+      // use tryLock to attempt to acquire the lock, and if the lock cannot be acquired, we skip the
+      // check. This will not cause any additional problems and also prevents the regionServerReport
+      // call from being stuck for too long which may cause deadlock on region assignment.
       if (regionNode.tryLock()) {
         try {
           long diff = EnvironmentEdgeManager.currentTime() - regionNode.getLastUpdate();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -1398,41 +1398,37 @@ public class AssignmentManager {
         continue;
       }
       final long lag = 1000;
-      try {
-        // It is likely that another thread is currently holding the lock. To avoid deadlock, use
-        // tryLock waiting for a specified period of time
-        if (regionNode.tryLock(10, TimeUnit.SECONDS)) {
-          try {
-            long diff = EnvironmentEdgeManager.currentTime() - regionNode.getLastUpdate();
-            if (regionNode.isInState(State.OPENING, State.OPEN)) {
-              // This is possible as a region server has just closed a region but the region server
-              // report is generated before the closing, but arrive after the closing. Make sure
-              // there
-              // is some elapsed time so less false alarms.
-              if (!regionNode.getRegionLocation().equals(serverName) && diff > lag) {
-                LOG.warn("Reporting {} server does not match {} (time since last "
-                  + "update={}ms); closing...", serverName, regionNode, diff);
-                closeRegionSilently(serverNode.getServerName(), regionName);
-              }
-            } else if (!regionNode.isInState(State.CLOSING, State.SPLITTING)) {
-              // So, we can get report that a region is CLOSED or SPLIT because a heartbeat
-              // came in at about same time as a region transition. Make sure there is some
-              // elapsed time so less false alarms.
-              if (diff > lag) {
-                LOG.warn("Reporting {} state does not match {} (time since last update={}ms)",
-                  serverName, regionNode, diff);
-              }
+      // It is likely that another thread is currently holding the lock. To avoid deadlock, use
+      // tryLock waiting for a specified period of time
+      if (regionNode.tryLock()) {
+        try {
+          long diff = EnvironmentEdgeManager.currentTime() - regionNode.getLastUpdate();
+          if (regionNode.isInState(State.OPENING, State.OPEN)) {
+            // This is possible as a region server has just closed a region but the region server
+            // report is generated before the closing, but arrive after the closing. Make sure
+            // there
+            // is some elapsed time so less false alarms.
+            if (!regionNode.getRegionLocation().equals(serverName) && diff > lag) {
+              LOG.warn("Reporting {} server does not match {} (time since last "
+                + "update={}ms); closing...", serverName, regionNode, diff);
+              closeRegionSilently(serverNode.getServerName(), regionName);
             }
-          } finally {
-            regionNode.unlock();
+          } else if (!regionNode.isInState(State.CLOSING, State.SPLITTING)) {
+            // So, we can get report that a region is CLOSED or SPLIT because a heartbeat
+            // came in at about same time as a region transition. Make sure there is some
+            // elapsed time so less false alarms.
+            if (diff > lag) {
+              LOG.warn("Reporting {} state does not match {} (time since last update={}ms)",
+                serverName, regionNode, diff);
+            }
           }
-        } else {
-          LOG.warn(
-            "Unable to acquire lock for regionNode {}. It is likely that another thread is currently holding the lock. To avoid deadlock, skip execution for now.",
-            regionNode);
+        } finally {
+          regionNode.unlock();
         }
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
+      } else {
+        LOG.warn(
+          "Unable to acquire lock for regionNode {}. It is likely that another thread is currently holding the lock. To avoid deadlock, skip execution for now.",
+          regionNode);
       }
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -1402,35 +1402,37 @@ public class AssignmentManager {
         // It is likely that another thread is currently holding the lock. To avoid deadlock, use
         // tryLock waiting for a specified period of time
         if (regionNode.tryLock(10, TimeUnit.SECONDS)) {
-          long diff = EnvironmentEdgeManager.currentTime() - regionNode.getLastUpdate();
-          if (regionNode.isInState(State.OPENING, State.OPEN)) {
-            // This is possible as a region server has just closed a region but the region server
-            // report is generated before the closing, but arrive after the closing. Make sure there
-            // is some elapsed time so less false alarms.
-            if (!regionNode.getRegionLocation().equals(serverName) && diff > lag) {
-              LOG.warn("Reporting {} server does not match {} (time since last "
-                + "update={}ms); closing...", serverName, regionNode, diff);
-              closeRegionSilently(serverNode.getServerName(), regionName);
+          try {
+            long diff = EnvironmentEdgeManager.currentTime() - regionNode.getLastUpdate();
+            if (regionNode.isInState(State.OPENING, State.OPEN)) {
+              // This is possible as a region server has just closed a region but the region server
+              // report is generated before the closing, but arrive after the closing. Make sure
+              // there
+              // is some elapsed time so less false alarms.
+              if (!regionNode.getRegionLocation().equals(serverName) && diff > lag) {
+                LOG.warn("Reporting {} server does not match {} (time since last "
+                  + "update={}ms); closing...", serverName, regionNode, diff);
+                closeRegionSilently(serverNode.getServerName(), regionName);
+              }
+            } else if (!regionNode.isInState(State.CLOSING, State.SPLITTING)) {
+              // So, we can get report that a region is CLOSED or SPLIT because a heartbeat
+              // came in at about same time as a region transition. Make sure there is some
+              // elapsed time so less false alarms.
+              if (diff > lag) {
+                LOG.warn("Reporting {} state does not match {} (time since last update={}ms)",
+                  serverName, regionNode, diff);
+              }
             }
-          } else if (!regionNode.isInState(State.CLOSING, State.SPLITTING)) {
-            // So, we can get report that a region is CLOSED or SPLIT because a heartbeat
-            // came in at about same time as a region transition. Make sure there is some
-            // elapsed time so less false alarms.
-            if (diff > lag) {
-              LOG.warn("Reporting {} state does not match {} (time since last update={}ms)",
-                serverName, regionNode, diff);
-            }
+          } finally {
+            regionNode.unlock();
           }
         } else {
           LOG.warn(
             "Unable to acquire lock for regionNode {}. It is likely that another thread is currently holding the lock. To avoid deadlock, skip execution for now.",
             regionNode);
-          continue;
         }
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
-      } finally {
-        regionNode.unlock();
       }
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateNode.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateNode.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.master.assignment;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.hbase.HConstants;
@@ -321,6 +322,10 @@ public class RegionStateNode implements Comparable<RegionStateNode> {
 
   public void lock() {
     lock.lock();
+  }
+
+  public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
+    return lock.tryLock(time, unit);
   }
 
   public void unlock() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateNode.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateNode.java
@@ -19,7 +19,6 @@ package org.apache.hadoop.hbase.master.assignment;
 
 import java.util.Arrays;
 import java.util.concurrent.ConcurrentMap;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.locks.Lock;
 import java.util.concurrent.locks.ReentrantLock;
 import org.apache.hadoop.hbase.HConstants;
@@ -324,8 +323,8 @@ public class RegionStateNode implements Comparable<RegionStateNode> {
     lock.lock();
   }
 
-  public boolean tryLock(long time, TimeUnit unit) throws InterruptedException {
-    return lock.tryLock(time, unit);
+  public boolean tryLock() {
+    return lock.tryLock();
   }
 
   public void unlock() {


### PR DESCRIPTION
To prevent threads from being blocked by the lock of RegionStateNode, modify the way of acquiring the RegionStateNode lock in checkOnlineRegionsReport to tryLock.