### PR TITLE
HBASE-28122: Support TLSv1.3 cipher suites

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
@@ -116,10 +116,7 @@ public final class X509Util {
   public static final int DEFAULT_HANDSHAKE_DETECTION_TIMEOUT_MILLIS = 5000;
 
   private static String[] getTls13Ciphers() {
-    return new String[] {
-      "TLS_AES_128_GCM_SHA256",
-      "TLS_AES_256_GCM_SHA384"
-    };
+    return new String[] { "TLS_AES_128_GCM_SHA256", "TLS_AES_256_GCM_SHA384" };
   }
 
   private static String[] getGCMCiphers() {
@@ -151,9 +148,9 @@ public final class X509Util {
 
   /**
    * Not all of our default ciphers are available in OpenSSL. Takes our default cipher lists and
-   * filters them to only those available in OpenSsl. Prefers TLS 1.3, then GCM, then CBC because GCM tends to
-   * be better and faster, and we don't need to worry about the java8 vs 9 performance issue if
-   * OpenSSL is handling it.
+   * filters them to only those available in OpenSsl. Prefers TLS 1.3, then GCM, then CBC because
+   * GCM tends to be better and faster, and we don't need to worry about the java8 vs 9 performance
+   * issue if OpenSSL is handling it.
    */
   private static String[] getOpenSslFilteredDefaultCiphers() {
     if (!OpenSsl.isAvailable()) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
@@ -224,6 +224,9 @@ public final class X509Util {
       // Must be Java 9 or later
       int javaVersionInt = Integer.parseInt(javaVersion);
       if (javaVersionInt >= 11) {
+        LOG.debug(
+          "Using Java11+ optimized cipher suites for Java version {}, including TLSv1.3 support",
+          javaVersion);
         return DEFAULT_CIPHERS_JAVA11;
       } else {
         LOG.debug("Using Java9+ optimized cipher suites for Java version {}", javaVersion);

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
@@ -220,16 +220,22 @@ public final class X509Util {
   static String[] getDefaultCipherSuitesForJavaVersion(String javaVersion) {
     Objects.requireNonNull(javaVersion);
 
-    try {
+    if (javaVersion.matches("\\d+")) {
+      // Must be Java 9 or later
       int javaVersionInt = Integer.parseInt(javaVersion);
       if (javaVersionInt >= 11) {
         return DEFAULT_CIPHERS_JAVA11;
-      } else if (javaVersionInt >= 9) {
-        return DEFAULT_CIPHERS_JAVA9;
       } else {
-        return DEFAULT_CIPHERS_JAVA8;
+        LOG.debug("Using Java9+ optimized cipher suites for Java version {}", javaVersion);
+        return DEFAULT_CIPHERS_JAVA9;
       }
-    } catch (NumberFormatException ignore) {
+    } else if (javaVersion.startsWith("1.")) {
+      // Must be Java 1.8 or earlier
+      LOG.debug("Using Java8 optimized cipher suites for Java version {}", javaVersion);
+      return DEFAULT_CIPHERS_JAVA8;
+    } else {
+      LOG.debug("Could not parse java version {}, using Java8 optimized cipher suites",
+        javaVersion);
       return DEFAULT_CIPHERS_JAVA8;
     }
   }

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/crypto/tls/TestX509Util.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/crypto/tls/TestX509Util.java
@@ -379,21 +379,21 @@ public class TestX509Util extends AbstractTestX509Parameterized {
   public void testGetDefaultCipherSuitesJava9() {
     String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("9");
     // Java 9+ default should have the GCM suites first
-    assertThat(cipherSuites[0], containsString("GCM"));
+    assertEquals(cipherSuites[0], "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
   }
 
   @Test
   public void testGetDefaultCipherSuitesJava10() {
     String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("10");
     // Java 9+ default should have the GCM suites first
-    assertThat(cipherSuites[0], containsString("GCM"));
+    assertEquals(cipherSuites[0], "TLS_ECDHE_ECDSA_WITH_AES_128_GCM_SHA256");
   }
 
   @Test
   public void testGetDefaultCipherSuitesJava11() {
     String[] cipherSuites = X509Util.getDefaultCipherSuitesForJavaVersion("11");
-    // Java 9+ default should have the GCM suites first
-    assertThat(cipherSuites[0], containsString("GCM"));
+    // Java 11+ default should have the TLSv1.3 suites first
+    assertThat(cipherSuites[0], containsString("TLS_AES_128_GCM"));
   }
 
   @Test


### PR DESCRIPTION
When using OpenSSL/BoringSSL, put these cipher suites at the top of our preference list always. When using the JDK cipher support, only put these on the list if on JDK 11+.