### PR TITLE
HBASE-28126 Update MaxNumberOfRegionsCount in TestSimpleRegionNormalizer

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
@@ -533,7 +533,7 @@ public class TestSimpleRegionNormalizer {
     final List<RegionInfo> regionInfos = createRegionInfos(tableName, 3);
     final Map<byte[], Integer> regionSizes = createRegionSizesMap(regionInfos, 0, 0, 0);
     setupMocksForNormalizer(regionSizes, regionInfos);
-    assertEquals(50, normalizer.getMergeRequestMaxNumberOfRegionsCount());
+    assertEquals(100, normalizer.getMergeRequestMaxNumberOfRegionsCount());
     List<NormalizationPlan> plans = normalizer.computePlansForTable(tableDescriptor);
     assertThat(plans, contains(new MergeNormalizationPlan.Builder().addTarget(regionInfos.get(0), 0)
       .addTarget(regionInfos.get(1), 0).addTarget(regionInfos.get(2), 0).build()));


### PR DESCRIPTION
The default config was updated to 100 but update of the test was missed.