### PR TITLE
HBASE-28146: Make ServerManager rsAdmins map thread safe

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
@@ -720,19 +720,14 @@ public class ServerManager {
   public AdminService.BlockingInterface getRsAdmin(final ServerName sn) throws IOException {
     AdminService.BlockingInterface admin = this.rsAdmins.get(sn);
     if (admin == null) {
-      return this.rsAdmins.computeIfAbsent(sn, server -> {
-        LOG.debug("New admin connection to " + server.toString());
-        if (server.equals(master.getServerName()) && master instanceof HRegionServer) {
-          // A master is also a region server now, see HBASE-10569 for details
-          return ((HRegionServer) master).getRSRpcServices();
-        } else {
-          try {
-            return this.connection.getAdmin(server);
-          } catch (IOException e) {
-            throw new RuntimeException(e);
-          }
-        }
-      });
+      LOG.debug("New admin connection to " + sn.toString());
+      if (sn.equals(master.getServerName()) && master instanceof HRegionServer) {
+        // A master is also a region server now, see HBASE-10569 for details
+        admin = ((HRegionServer) master).getRSRpcServices();
+      } else {
+        admin = this.connection.getAdmin(sn);
+      }
+      this.rsAdmins.put(sn, admin);
     }
     return admin;
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
@@ -23,12 +23,12 @@ import java.io.IOException;
 import java.net.InetAddress;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentNavigableMap;
 import java.util.concurrent.ConcurrentSkipListMap;
 import java.util.concurrent.CopyOnWriteArrayList;
@@ -128,7 +128,8 @@ public class ServerManager {
    * Map of admin interfaces per registered regionserver; these interfaces we use to control
    * regionservers out on the cluster
    */
-  private final Map<ServerName, AdminService.BlockingInterface> rsAdmins = new HashMap<>();
+  private final Map<ServerName, AdminService.BlockingInterface> rsAdmins =
+    new ConcurrentHashMap<>();
 
   /** List of region servers that should not get any more new regions. */
   private final ArrayList<ServerName> drainingServers = new ArrayList<>();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
@@ -707,7 +707,7 @@ public class ServerManager {
    * @throws RetriesExhaustedException wrapping a ConnectException if failed
    */
   public AdminService.BlockingInterface getRsAdmin(final ServerName sn) throws IOException {
-    LOG.debug("New admin connection to " + sn.toString());
+    LOG.debug("New admin connection to {}", sn);
     if (sn.equals(master.getServerName()) && master instanceof HRegionServer) {
       // A master is also a region server now, see HBASE-10569 for details
       return ((HRegionServer) master).getRSRpcServices();


### PR DESCRIPTION
On 2.x [the ServerManager registers admins in a HashMap](https://github.com/apache/hbase/blob/branch-2/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java). This can result in thread safety issues — we recently observed an exception which caused a region to be indefinitely stuck in transition until we could manually intervene. We saw the following exception in the HMaster logs:

```
2023-10-11 02:20:05.213 [RSProcedureDispatcher-pool-325] ERROR org.apache.hadoop.hbase.master.procedure.RSProcedureDispatcher: Unexpected error caught, this may cause the procedure to hang forever
    java.lang.ClassCastException: class java.util.HashMap$Node cannot be cast to class java.util.HashMap$TreeNode (java.util.HashMap$Node and java.util.HashMap$TreeNode are in module java.base of loader 'bootstrap')
        at java.util.HashMap$TreeNode.moveRootToFront(HashMap.java:1900) ~[?:?]
        at java.util.HashMap$TreeNode.treeify(HashMap.java:2016) ~[?:?]
        at java.util.HashMap.treeifyBin(HashMap.java:768) ~[?:?]
        at java.util.HashMap.putVal(HashMap.java:640) ~[?:?]
        at java.util.HashMap.put(HashMap.java:608) ~[?:?]
        at org.apache.hadoop.hbase.master.ServerManager.getRsAdmin(ServerManager.java:723)
```

This error is not a particularly clear indication of concurrency issues, but that's more an issue with HashMap error handling. Here's [a SO thread](https://stackoverflow.com/questions/29967401/strange-hashmap-exception-hashmapnode-cannot-be-cast-to-hashmaptreenode) which discusses the error and why it occurs. [This is a good explanation imo](https://stackoverflow.com/questions/29967401/strange-hashmap-exception-hashmapnode-cannot-be-cast-to-hashmaptreenode#comment48054536_29967401).

cc @bbeaudreault @hgromer @eab148 @bozzkar