### PR TITLE
HBASE-28157. hbck should report previously reported regions with null region location

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/hbck/HbckChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/hbck/HbckChore.java
@@ -230,10 +230,7 @@ public class HbckChore extends ScheduledChore {
 
     for (Map.Entry<String, HbckRegionInfo> entry : report.getRegionInfoMap().entrySet()) {
       HbckRegionInfo hri = entry.getValue();
-      ServerName locationInMeta = hri.getMetaEntry().getRegionServer();
-      if (locationInMeta == null) {
-        continue;
-      }
+      ServerName locationInMeta = hri.getMetaEntry().getRegionServer(); // can be null
       if (hri.getDeployedOn().size() == 0) {
         // skip the offline region which belong to disabled table.
         if (report.getDisabledTableRegions().contains(hri.getRegionNameAsString())) {

--- a/hbase-server/src/main/resources/hbase-webapps/master/hbck.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/hbck.jsp
@@ -355,9 +355,13 @@
  * If a live server reference, make it a link.
  * If dead, make it italic.
  * If unknown, make it plain.
+ * If null, make it "null".
  */
 private static String formatServerName(HMaster master,
    ServerManager serverManager, ServerName serverName) {
+  if (serverName == null) {
+    return "null";
+  }
   String sn = serverName.toString();
   if (serverManager.isServerOnline(serverName)) {
     int infoPort = master.getRegionServerInfoPort(serverName);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestHbckChore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestHbckChore.java
@@ -150,6 +150,13 @@ public class TestHbckChore extends TestAssignmentManagerBase {
     hbckChore.choreForTesting();
     inconsistentRegions = hbckChore.getLastReport().getInconsistentRegions();
     assertFalse(inconsistentRegions.containsKey(regionName));
+
+    // Test for case4: No region location for a previously reported region. Probably due to
+    // TRSP bug or bypass.
+    am.offlineRegion(hri);
+    hbckChore.choreForTesting();
+    inconsistentRegions = hbckChore.getLastReport().getInconsistentRegions();
+    assertTrue(inconsistentRegions.containsKey(regionName));
   }
 
   @Test


### PR DESCRIPTION
Ensure that hbck will report as inconsistent regions where previously a location was reported but now the region location is null, if it is not expected to be offline.