### PR TITLE
HBASE-28158 Decouple RIT list management from TRSP invocation

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
@@ -125,7 +125,7 @@ public class RegionStates {
   RegionStateNode createRegionStateNode(RegionInfo regionInfo) {
     synchronized (regionsMapLock) {
       RegionStateNode node = regionsMap.computeIfAbsent(regionInfo.getRegionName(),
-        key -> new RegionStateNode(regionInfo, regionInTransition));
+        key -> new RegionStateNode(this, regionInfo));
 
       if (encodedRegionsMap.get(regionInfo.getEncodedName()) != node) {
         encodedRegionsMap.put(regionInfo.getEncodedName(), node);
@@ -627,7 +627,21 @@ public class RegionStates {
 
   public boolean isRegionInTransition(final RegionInfo regionInfo) {
     final RegionStateNode node = regionInTransition.get(regionInfo);
-    return node != null ? node.isInTransition() : false;
+    return node != null;
+  }
+
+  public void addRegionInTransition(final RegionInfo regionInfo) {
+    if (
+      regionInTransition.putIfAbsent(regionInfo, getOrCreateRegionStateNode(regionInfo)) == null
+    ) {
+      LOG.info("Added RIT " + regionInfo);
+    }
+  }
+
+  public void removeRegionInTransition(final RegionInfo regionInfo) {
+    if (regionInTransition.remove(regionInfo) != null) {
+      LOG.info("Removed RIT " + regionInfo);
+    }
   }
 
   public RegionState getRegionTransitionState(RegionInfo hri) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestAssignmentManagerUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestAssignmentManagerUtil.java
@@ -83,6 +83,7 @@ public class TestAssignmentManagerUtil {
       assertFalse(((ReentrantLock) regionNode.lock).isLocked());
       TransitRegionStateProcedure proc = regionNode.getProcedure();
       if (proc != null) {
+        regionNode.removeInTransition();
         regionNode.unsetProcedure(proc);
       }
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestReopenTableRegionsProcedureBackoff.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestReopenTableRegionsProcedureBackoff.java
@@ -120,6 +120,7 @@ public class TestReopenTableRegionsProcedureBackoff {
       // reset to the correct state
       regionNode.setState(State.OPEN);
       regionNode.setOpenSeqNum(openSeqNum);
+      regionNode.removeInTransition();
       regionNode.unsetProcedure(trsp);
     } finally {
       regionNode.unlock();


### PR DESCRIPTION
Only remove a region from the RIT map when assignment reaches a suitable terminal state.

Before this change we would map a RIT list entry to a running TRSP. This is problematic because the in-transition state does not always correspond to the lifetime of a TRSP. In cases of an operator bypass or bug or timeout the region will still be in transition from the user or operator perspective but not included in the RIT list.