### PR TITLE
HBASE-28170 Put the cached time at the beginning of the block; run cache validation in the background when retrieving the persistent cache

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -22,8 +22,8 @@ import java.util.Optional;
 import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
 import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
+import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
 import org.apache.hadoop.hbase.io.hfile.bucket.BucketEntry;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
@@ -111,7 +111,6 @@ public class HFilePreadReader extends HFileReaderImpl {
                 block.release();
               }
             }
-            final long fileSize = offset;
             bucketCacheOptional.ifPresent(bc -> bc.fileCacheCompleted(path.getName()));
           } catch (IOException e) {
             // IOExceptions are probably due to region closes (relocation, etc.)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -78,7 +78,7 @@ public class HFilePreadReader extends HFileReaderImpl {
               // to the next block without actually going read all the way to the cache.
               if (bucketCacheOptional.isPresent()) {
                 BucketCache cache = bucketCacheOptional.get();
-                if(cache.getBackingMapValidated().get()) {
+                if (cache.getBackingMapValidated().get()) {
                   BlockCacheKey cacheKey = new BlockCacheKey(name, offset);
                   BucketEntry entry = cache.getBackingMap().get(cacheKey);
                   if (entry != null) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -78,21 +78,24 @@ public class HFilePreadReader extends HFileReaderImpl {
               // to the next block without actually going read all the way to the cache.
               if (bucketCacheOptional.isPresent()) {
                 BucketCache cache = bucketCacheOptional.get();
-                BlockCacheKey cacheKey = new BlockCacheKey(name, offset);
-                BucketEntry entry = cache.getBackingMap().get(cacheKey);
-                if (entry != null) {
-                  cacheKey = new BlockCacheKey(name, offset);
-                  entry = cache.getBackingMap().get(cacheKey);
-                  if (entry == null) {
-                    LOG.debug("No cache key {}, we'll read and cache it", cacheKey);
+                if(cache.getBackingMapValidated().get()) {
+                  BlockCacheKey cacheKey = new BlockCacheKey(name, offset);
+                  BucketEntry entry = cache.getBackingMap().get(cacheKey);
+                  if (entry != null) {
+                    cacheKey = new BlockCacheKey(name, offset);
+                    entry = cache.getBackingMap().get(cacheKey);
+                    if (entry == null) {
+                      LOG.debug("No cache key {}, we'll read and cache it", cacheKey);
+                    } else {
+                      offset += entry.getOnDiskSizeWithHeader();
+                      LOG.debug(
+                        "Found cache key {}. Skipping prefetch, the block is already cached.",
+                        cacheKey);
+                      continue;
+                    }
                   } else {
-                    offset += entry.getOnDiskSizeWithHeader();
-                    LOG.debug("Found cache key {}. Skipping prefetch, the block is already cached.",
-                      cacheKey);
-                    continue;
+                    LOG.debug("No entry in the backing map for cache key {}", cacheKey);
                   }
-                } else {
-                  LOG.debug("No entry in the backing map for cache key {}", cacheKey);
                 }
               }
               // Perhaps we got our block from cache? Unlikely as this may be, if it happens, then

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -40,7 +40,9 @@ public class HFilePreadReader extends HFileReaderImpl {
     Configuration conf) throws IOException {
     super(context, fileInfo, cacheConf, conf);
     final MutableBoolean fileAlreadyCached = new MutableBoolean(false);
-    BucketCache.getBucketCacheFromCacheConfig(cacheConf).ifPresent(bc -> fileAlreadyCached
+    Optional<BucketCache> bucketCacheOptional =
+      BucketCache.getBucketCacheFromCacheConfig(cacheConf);
+    bucketCacheOptional.ifPresent(bc -> fileAlreadyCached
       .setValue(bc.getFullyCachedFiles().get(path.getName()) == null ? false : true));
     // Prefetch file blocks upon open if requested
     if (
@@ -65,8 +67,6 @@ public class HFilePreadReader extends HFileReaderImpl {
             if (LOG.isTraceEnabled()) {
               LOG.trace("Prefetch start " + getPathOffsetEndStr(path, offset, end));
             }
-            Optional<BucketCache> bucketCacheOptional =
-              BucketCache.getBucketCacheFromCacheConfig(cacheConf);
             // Don't use BlockIterator here, because it's designed to read load-on-open section.
             long onDiskSizeOfNextBlock = -1;
             while (offset < end) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -1500,7 +1500,7 @@ public class BucketCache implements BlockCache, HeapSize {
         join();
         if (cachePersister != null) {
           LOG.info("Shutting down cache persister thread.");
-          cachePersister.interrupt();
+          cachePersister.shutdown();
           while (cachePersister.isAlive()) {
             Thread.sleep(10);
           }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -25,7 +25,6 @@ import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.HashSet;
 import java.util.Iterator;
@@ -51,9 +50,7 @@ import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.function.Consumer;
 import java.util.function.Function;
-import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.TableName;
@@ -391,8 +388,7 @@ public class BucketCache implements BlockCache, HeapSize {
 
   void startBucketCachePersisterThread() {
     LOG.info("Starting BucketCachePersisterThread");
-    cachePersister =
-      new BucketCachePersister(this, bucketcachePersistInterval);
+    cachePersister = new BucketCachePersister(this, bucketcachePersistInterval);
     cachePersister.setDaemon(true);
     cachePersister.start();
   }
@@ -1276,8 +1272,9 @@ public class BucketCache implements BlockCache, HeapSize {
   @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "OBL_UNSATISFIED_OBLIGATION",
       justification = "false positive, try-with-resources ensures close is called.")
   void persistToFile() throws IOException {
-    LOG.debug("Thread {} started persisting bucket cache to file", Thread.currentThread().getName());
-    if(!isCachePersistent()) {
+    LOG.debug("Thread {} started persisting bucket cache to file",
+      Thread.currentThread().getName());
+    if (!isCachePersistent()) {
       throw new IOException("Attempt to persist non-persistent cache mappings!");
     }
     File tempPersistencePath = new File(persistencePath + EnvironmentEdgeManager.currentTime());
@@ -1307,13 +1304,8 @@ public class BucketCache implements BlockCache, HeapSize {
     LOG.info("Started retrieving bucket cache from file");
     File persistenceFile = new File(persistencePath);
     if (!persistenceFile.exists()) {
-      File persistenceDir = new File(persistencePath.substring(0, persistencePath.lastIndexOf("/")));
-      StringBuilder b = new StringBuilder();
-      for(String file : persistenceDir.list()){
-        b.append(file).append("\n");
-      }
       LOG.warn("Persistence file missing! "
-        + "It's ok if it's first run after enabling persistent cache. List of files: {}", b);
+        + "It's ok if it's first run after enabling persistent cache.");
       bucketAllocator = new BucketAllocator(cacheCapacity, bucketSizes, backingMap, realCacheSize);
       blockNumber.add(backingMap.size());
       return;
@@ -1415,7 +1407,7 @@ public class BucketCache implements BlockCache, HeapSize {
           + "We need to validate each cache key in the backing map. "
           + "This may take some time, so we'll do it in a background thread,");
         Runnable cacheValidator = () -> {
-          while(bucketAllocator==null){
+          while (bucketAllocator == null) {
             try {
               Thread.sleep(50);
             } catch (InterruptedException ex) {
@@ -1434,7 +1426,8 @@ public class BucketCache implements BlockCache, HeapSize {
             }
           }
           LOG.info("Finished validating {} keys in the backing map. Recovered: {}. This took {}ms.",
-            totalKeysOriginally, backingMap.size(), (EnvironmentEdgeManager.currentTime() - startTime));
+            totalKeysOriginally, backingMap.size(),
+            (EnvironmentEdgeManager.currentTime() - startTime));
         };
         Thread t = new Thread(cacheValidator);
         t.setDaemon(true);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCachePersister.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCachePersister.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.io.hfile.bucket;
 
 import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -27,6 +28,8 @@ public class BucketCachePersister extends Thread {
   private final BucketCache cache;
   private final long intervalMillis;
   private static final Logger LOG = LoggerFactory.getLogger(BucketCachePersister.class);
+
+  private AtomicBoolean shutdown = new AtomicBoolean(false);
 
   public BucketCachePersister(BucketCache cache, long intervalMillis) {
     super("bucket-cache-persister");
@@ -45,12 +48,25 @@ public class BucketCachePersister extends Thread {
             cache.persistToFile();
             cache.setCacheInconsistent(false);
           }
+          // Thread.interrupt may cause an InterruptException inside util method used for checksum
+          // calculation in persistToFile. This util currently swallows the exception, causing this
+          // thread to net get interrupt, so we added this flag to indicate the persister thread
+          // should stop.
+          if (shutdown.get()) {
+            break;
+          }
         } catch (IOException e) {
           LOG.warn("Exception in BucketCachePersister.", e);
         }
       }
+      LOG.info("Finishing cache persister thread.");
     } catch (InterruptedException e) {
       LOG.warn("Interrupting BucketCachePersister thread.", e);
     }
+  }
+
+  public void shutdown() {
+    this.shutdown.set(true);
+    this.interrupt();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCachePersister.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCachePersister.java
@@ -36,20 +36,21 @@ public class BucketCachePersister extends Thread {
   }
 
   public void run() {
-    while (true) {
-      try {
-        Thread.sleep(intervalMillis);
-        if (cache.isCacheInconsistent()) {
-          LOG.debug("Cache is inconsistent, persisting to disk");
-          cache.persistToFile();
-          cache.setCacheInconsistent(false);
+    try {
+      while (true) {
+        try {
+          Thread.sleep(intervalMillis);
+          if (cache.isCacheInconsistent()) {
+            LOG.debug("Cache is inconsistent, persisting to disk");
+            cache.persistToFile();
+            cache.setCacheInconsistent(false);
+          }
+        } catch (IOException e) {
+          LOG.warn("Exception in BucketCachePersister.", e);
         }
-      } catch (IOException e) {
-        LOG.warn("IOException in BucketCachePersister {} ", e.getMessage());
-      } catch (InterruptedException iex) {
-        LOG.warn("InterruptedException in BucketCachePersister {} ", iex.getMessage());
-        break;
       }
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupting BucketCachePersister thread.", e);
     }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/FileIOEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/FileIOEngine.java
@@ -149,15 +149,14 @@ public class FileIOEngine extends PersistentIOEngine {
       }
     }
     if (maintainPersistence) {
-      dstBuff.position(length - Long.BYTES);
+      dstBuff.rewind();
       long cachedNanoTime = dstBuff.getLong();
       if (be.getCachedTime() != cachedNanoTime) {
         dstBuff.release();
-        throw new HBaseIOException("The cached time recorded within the cached block differs "
-          + "from its bucket entry, so it might not be the same.");
+        throw new HBaseIOException("The cached time recorded within the cached block: "
+          + cachedNanoTime + " differs from its bucket entry: " + be.getCachedTime());
       }
-      dstBuff.rewind();
-      dstBuff.limit(length - Long.BYTES);
+      dstBuff.limit(length);
       dstBuff = dstBuff.slice();
     } else {
       dstBuff.rewind();
@@ -167,10 +166,9 @@ public class FileIOEngine extends PersistentIOEngine {
 
   void checkCacheTime(BucketEntry be) throws IOException {
     long offset = be.offset();
-    int length = be.getLength();
     ByteBuff dstBuff = be.allocator.allocate(Long.BYTES);
     try {
-      accessFile(readAccessor, dstBuff, (offset + length - Long.BYTES));
+      accessFile(readAccessor, dstBuff, offset);
     } catch (IOException ioe) {
       dstBuff.release();
       throw ioe;
@@ -179,8 +177,8 @@ public class FileIOEngine extends PersistentIOEngine {
     long cachedNanoTime = dstBuff.getLong();
     if (be.getCachedTime() != cachedNanoTime) {
       dstBuff.release();
-      throw new HBaseIOException("The cached time recorded within the cached block differs "
-        + "from its bucket entry, so it might not be the same.");
+      throw new HBaseIOException("The cached time recorded within the cached block: "
+        + cachedNanoTime + " differs from its bucket entry: " + be.getCachedTime());
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetchWithBucketCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetchWithBucketCache.java
@@ -106,7 +106,7 @@ public class TestPrefetchWithBucketCache {
     // Prefetches the file blocks
     LOG.debug("First read should prefetch the blocks.");
     readStoreFile(storeFile);
-    BucketCache bc = BucketCache.getBuckedCacheFromCacheConfig(cacheConf).get();
+    BucketCache bc = BucketCache.getBucketCacheFromCacheConfig(cacheConf).get();
     // Our file should have 6 DATA blocks. We should wait for all of them to be cached
     Waiter.waitFor(conf, 300, () -> bc.getBackingMap().size() == 6);
     Map<BlockCacheKey, BucketEntry> snapshot = ImmutableMap.copyOf(bc.getBackingMap());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestRecoveryPersistentBucketCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestRecoveryPersistentBucketCache.java
@@ -64,7 +64,7 @@ public class TestRecoveryPersistentBucketCache {
     CacheTestUtils.HFileBlockPair[] blocks = CacheTestUtils.generateHFileBlocks(8192, 4);
 
     CacheTestUtils.HFileBlockPair[] smallerBlocks = CacheTestUtils.generateHFileBlocks(4096, 1);
-    // Add three blocks
+    // Add four blocks
     cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[0].getBlockName(), blocks[0].getBlock());
     cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[1].getBlockName(), blocks[1].getBlock());
     cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[2].getBlockName(), blocks[2].getBlock());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestRecoveryPersistentBucketCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestRecoveryPersistentBucketCache.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.bucket;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.CacheTestUtils;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import static org.apache.hadoop.hbase.io.hfile.CacheConfig.BUCKETCACHE_PERSIST_INTERVAL_KEY;
+import static org.apache.hadoop.hbase.io.hfile.bucket.BucketCache.DEFAULT_ERROR_TOLERATION_DURATION;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Basic test for check file's integrity before start BucketCache in fileIOEngine
+ */
+@Category(SmallTests.class)
+public class TestRecoveryPersistentBucketCache {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestRecoveryPersistentBucketCache.class);
+
+  final long capacitySize = 32 * 1024 * 1024;
+  final int writeThreads = BucketCache.DEFAULT_WRITER_THREADS;
+  final int writerQLen = BucketCache.DEFAULT_WRITER_QUEUE_ITEMS;
+
+  @Test
+  public void testBucketCacheRecovery() throws Exception {
+    HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+    Path testDir = TEST_UTIL.getDataTestDir();
+    TEST_UTIL.getTestFileSystem().mkdirs(testDir);
+    Configuration conf = HBaseConfiguration.create();
+    //Disables the persister thread by setting its interval to MAX_VALUE
+    conf.setLong(BUCKETCACHE_PERSIST_INTERVAL_KEY, Long.MAX_VALUE);
+    int[] bucketSizes = new int[] {8 * 1024 + 1024};
+    BucketCache bucketCache =
+      new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, 8192,
+        bucketSizes, writeThreads, writerQLen,
+        testDir + "/bucket.persistence", DEFAULT_ERROR_TOLERATION_DURATION, conf);
+
+    CacheTestUtils.HFileBlockPair[] blocks =
+      CacheTestUtils.generateHFileBlocks(8192, 4);
+
+    CacheTestUtils.HFileBlockPair[] smallerBlocks =
+      CacheTestUtils.generateHFileBlocks(4096, 1);
+    // Add three blocks
+    cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[0].getBlockName(), blocks[0].getBlock());
+    cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[1].getBlockName(), blocks[1].getBlock());
+    cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[2].getBlockName(), blocks[2].getBlock());
+    cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[3].getBlockName(), blocks[3].getBlock());
+    //saves the current state of the cache
+    bucketCache.persistToFile();
+    //evicts the 4th block
+    bucketCache.evictBlock(blocks[3].getBlockName());
+    //now adds a 5th block to bucket cache. This block is half the size of the previous
+    // blocks, and it will be added in the same offset of the previous evicted block.
+    // This overwrites part of the 4th block. Because we persisted only up to the
+    // 4th block addition, recovery would try to read the whole 4th block, but the cached time
+    // validation will fail, and we'll recover only the first three blocks
+    cacheAndWaitUntilFlushedToBucket(bucketCache, smallerBlocks[0].getBlockName(),
+      smallerBlocks[0].getBlock());
+
+    //Creates new bucket cache instance without persisting to file after evicting 4th block
+    // and caching 5th block. Here the cache file has the first three blocks, followed by the
+    // 5th block and the second half of 4th block (we evicted 4th block, freeing up its
+    // offset in the cache, then added 5th block which is half the size of other blocks, so it's
+    // going to override the first half of the 4th block in the cache). That's fine because
+    // the in-memory backing map has the right blocks and related offsets. However, the
+    // persistent map file only has information about the first four blocks. We validate the
+    // cache time recorded in the back map against the block data in the cache. This is recorded
+    // in the cache as the first 8 bytes of a block, so the 4th block had its first 8 blocks
+    // now overridden by the 5th block, causing this check to fail and removal of
+    // the 4th block from the backing map.
+    BucketCache newBucketCache =
+      new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, 8192,
+        bucketSizes, writeThreads, writerQLen,
+        testDir + "/bucket.persistence", DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    Thread.sleep(100);
+    assertEquals(3, newBucketCache.backingMap.size());
+    assertNull(newBucketCache.getBlock(blocks[3].getBlockName(), false, false, false));
+    assertNull(newBucketCache.getBlock(smallerBlocks[0].getBlockName(), false, false, false));
+    assertEquals(blocks[0].getBlock(), newBucketCache.getBlock(blocks[0].getBlockName(), false, false, false));
+    assertEquals(blocks[1].getBlock(), newBucketCache.getBlock(blocks[1].getBlockName(), false, false, false));
+    assertEquals(blocks[2].getBlock(), newBucketCache.getBlock(blocks[2].getBlockName(), false, false, false));
+    TEST_UTIL.cleanupTestDir();
+  }
+
+  private void waitUntilFlushedToBucket(BucketCache cache, BlockCacheKey cacheKey)
+    throws InterruptedException {
+    while (!cache.backingMap.containsKey(cacheKey) || cache.ramCache.containsKey(cacheKey)) {
+      Thread.sleep(100);
+    }
+  }
+
+  // BucketCache.cacheBlock is async, it first adds block to ramCache and writeQueue, then writer
+  // threads will flush it to the bucket and put reference entry in backingMap.
+  private void cacheAndWaitUntilFlushedToBucket(BucketCache cache, BlockCacheKey cacheKey,
+    Cacheable block) throws InterruptedException {
+    cache.cacheBlock(cacheKey, block);
+    waitUntilFlushedToBucket(cache, cacheKey);
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hbase.util.Pair;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.junit.experimental.theories.Theories;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -127,6 +128,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
+    Thread.sleep(100);
     assertEquals(0, bucketCache.getAllocator().getUsedSize());
     assertEquals(0, bucketCache.backingMap.size());
     // Add blocks
@@ -146,6 +148,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
+    Thread.sleep(100);
     assertEquals(0, bucketCache.getAllocator().getUsedSize());
     assertEquals(0, bucketCache.backingMap.size());
 
@@ -201,9 +204,13 @@ public class TestVerifyBucketCacheFile {
     Path testDir = TEST_UTIL.getDataTestDir();
     TEST_UTIL.getTestFileSystem().mkdirs(testDir);
 
+    Configuration conf = HBaseConfiguration.create();
+    //Disables the persister thread by setting its interval to MAX_VALUE
+    conf.setLong(BUCKETCACHE_PERSIST_INTERVAL_KEY, Long.MAX_VALUE);
     BucketCache bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
-        constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
+        constructedBlockSizes, writeThreads, writerQLen,
+        testDir + "/bucket.persistence", DEFAULT_ERROR_TOLERATION_DURATION, conf);
     long usedSize = bucketCache.getAllocator().getUsedSize();
     assertEquals(0, usedSize);
 
@@ -228,6 +235,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
+    Thread.sleep(100);
     assertEquals(0, bucketCache.getAllocator().getUsedSize());
     assertEquals(0, bucketCache.backingMap.size());
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
@@ -48,7 +48,6 @@ import org.apache.hadoop.hbase.util.Pair;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.junit.experimental.theories.Theories;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 
@@ -205,12 +204,11 @@ public class TestVerifyBucketCacheFile {
     TEST_UTIL.getTestFileSystem().mkdirs(testDir);
 
     Configuration conf = HBaseConfiguration.create();
-    //Disables the persister thread by setting its interval to MAX_VALUE
+    // Disables the persister thread by setting its interval to MAX_VALUE
     conf.setLong(BUCKETCACHE_PERSIST_INTERVAL_KEY, Long.MAX_VALUE);
-    BucketCache bucketCache =
-      new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
-        constructedBlockSizes, writeThreads, writerQLen,
-        testDir + "/bucket.persistence", DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    BucketCache bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
+      constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen,
+      testDir + "/bucket.persistence", DEFAULT_ERROR_TOLERATION_DURATION, conf);
     long usedSize = bucketCache.getAllocator().getUsedSize();
     assertEquals(0, usedSize);
 


### PR DESCRIPTION
On restarts, once we read the backing map from the persisted file, we compare the last modification time of the cache recorded there against the last modification time of the cache. If those differ, it means the cache has been updated after the backing map has been persisted, so the backing map might not be accurate. We then iterate though the backing map entires and compare the entries cached time against the related block in the cache, and if those differ, we remove the entry from the map.

Currently this validation is made at RS initialisation time, but with caches as large as 1.6TB/30M+ blocks, it can last to an hour, meaning the RS is useless over that time. This PR changes this validation to be performed in the background, whilst direct accesses to a block in the cache would also perform the "cached time" comparison.

This PR also moves the "cached time" to the beginning of the block in the cache, instead of the end. We noticed that with the "cached time" at the end we can fail to ensure consistency at some conditions. See UT added in TestRecoveryPersistentBucketCache for further reference.