### PR TITLE
HBASE-24179 Backport fix for "Netty SASL implementation does not wait for challenge response" to branch-2.x

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/AbstractHBaseSaslRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/AbstractHBaseSaslRpcClient.java
@@ -83,12 +83,22 @@ public abstract class AbstractHBaseSaslRpcClient {
     }
   }
 
+  /**
+   * Computes the initial response a client sends to a server to begin the SASL challenge/response
+   * handshake. If the client's SASL mechanism does not require that an initial response is sent to
+   * begin the handshake, this method will return a null byte array, indicating no initial response
+   * needs to be sent by this client. It is unclear as to whether all SASL implementations will
+   * return a non-empty initial response, so this implementation is written such that this is
+   * allowed. All known SASL mechanism implementations in the JDK provide non-empty initial
+   * responses.
+   * @return The client's initial response to send the server (which may be empty), or null if this
+   *         implementation does not require an initial response to be sent.
+   */
   public byte[] getInitialResponse() throws SaslException {
     if (saslClient.hasInitialResponse()) {
       return saslClient.evaluateChallenge(EMPTY_TOKEN);
-    } else {
-      return EMPTY_TOKEN;
     }
+    return null;
   }
 
   public boolean isComplete() {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/AbstractHBaseSaslRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/AbstractHBaseSaslRpcClient.java
@@ -85,20 +85,16 @@ public abstract class AbstractHBaseSaslRpcClient {
 
   /**
    * Computes the initial response a client sends to a server to begin the SASL challenge/response
-   * handshake. If the client's SASL mechanism does not require that an initial response is sent to
-   * begin the handshake, this method will return a null byte array, indicating no initial response
-   * needs to be sent by this client. It is unclear as to whether all SASL implementations will
-   * return a non-empty initial response, so this implementation is written such that this is
-   * allowed. All known SASL mechanism implementations in the JDK provide non-empty initial
-   * responses.
-   * @return The client's initial response to send the server (which may be empty), or null if this
-   *         implementation does not require an initial response to be sent.
+   * handshake. If the client's SASL mechanism does not have an initial response, an empty token
+   * will be returned without querying the evaluateChallenge method, as an authentication processing
+   * must be started by client.
+   * @return The client's initial response to send the server (which may be empty).
    */
   public byte[] getInitialResponse() throws SaslException {
     if (saslClient.hasInitialResponse()) {
       return saslClient.evaluateChallenge(EMPTY_TOKEN);
     }
-    return null;
+    return EMPTY_TOKEN;
   }
 
   public boolean isComplete() {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/NettyHBaseSaslRpcClientHandler.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/NettyHBaseSaslRpcClientHandler.java
@@ -132,26 +132,19 @@ public class NettyHBaseSaslRpcClientHandler extends SimpleChannelInboundHandler<
           return saslRpcClient.getInitialResponse();
         }
       });
-      if (initialResponse != null) {
-        writeResponse(ctx, initialResponse);
-      } else {
-        LOG.trace("SASL initialResponse was null, not sending response to server.");
-      }
+      assert initialResponse != null;
+      writeResponse(ctx, initialResponse);
       // HBASE-23881 We do not want to check if the SaslClient thinks the handshake is
       // complete as, at this point, we've not heard a back from the server with it's reply
       // to our first challenge response. We should wait for at least one reply
       // from the server before calling negotiation complete.
       //
-      // Each SASL mechanism has its own handshake. Some mechanisms calculate a single client
-      // buffer
-      // to be sent to the server while others have multiple exchanges to negotiate
-      // authentication. GSSAPI(Kerberos)
-      // and DIGEST-MD5 both are examples of mechanisms which have multiple steps. Mechanisms
-      // which have multiple steps
-      // will not return true on `SaslClient#isComplete()` until the handshake has fully
-      // completed. Mechanisms which
-      // only send a single buffer may return true on `isComplete()` after that initial response
-      // is calculated.
+      // Each SASL mechanism has its own handshake. Some mechanisms calculate a single client buffer
+      // to be sent to the server while others have multiple exchanges to negotiate authentication.
+      // GSSAPI(Kerberos) and DIGEST-MD5 both are examples of mechanisms which have multiple steps.
+      // Mechanisms which have multiple steps will not return true on `SaslClient#isComplete()`
+      // until the handshake has fully completed. Mechanisms which only send a single buffer may
+      // return true on `isComplete()` after that initial response is calculated.
     } catch (Exception e) {
       // the exception thrown by handlerAdded will not be passed to the exceptionCaught below
       // because netty will remove a handler if handlerAdded throws an exception.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/NettyHBaseSaslRpcClientHandler.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/NettyHBaseSaslRpcClientHandler.java
@@ -57,6 +57,8 @@ public class NettyHBaseSaslRpcClientHandler extends SimpleChannelInboundHandler<
 
   private final Configuration conf;
 
+  private final SaslClientAuthenticationProvider provider;
+
   // flag to mark if Crypto AES encryption is enable
   private boolean needProcessConnectionHeader = false;
 
@@ -71,6 +73,7 @@ public class NettyHBaseSaslRpcClientHandler extends SimpleChannelInboundHandler<
     this.saslPromise = saslPromise;
     this.ugi = ugi;
     this.conf = conf;
+    this.provider = provider;
     this.saslRpcClient = new NettyHBaseSaslRpcClient(conf, provider, token, serverAddr,
       securityInfo, fallbackAllowed, conf.get("hbase.rpc.protection",
         SaslUtil.QualityOfProtection.AUTHENTICATION.name().toLowerCase()));
@@ -87,6 +90,10 @@ public class NettyHBaseSaslRpcClientHandler extends SimpleChannelInboundHandler<
       return;
     }
 
+    // HBASE-23881 Clearly log when the client thinks that the SASL negotiation is complete.
+    if (LOG.isTraceEnabled()) {
+      LOG.trace("SASL negotiation for {} is complete", provider.getSaslAuthMethod().getName());
+    }
     saslRpcClient.setupSaslHandler(ctx.pipeline(), HANDLER_NAME);
     removeHandlers(ctx);
 
@@ -127,8 +134,24 @@ public class NettyHBaseSaslRpcClientHandler extends SimpleChannelInboundHandler<
       });
       if (initialResponse != null) {
         writeResponse(ctx, initialResponse);
+      } else {
+        LOG.trace("SASL initialResponse was null, not sending response to server.");
       }
-      tryComplete(ctx);
+      // HBASE-23881 We do not want to check if the SaslClient thinks the handshake is
+      // complete as, at this point, we've not heard a back from the server with it's reply
+      // to our first challenge response. We should wait for at least one reply
+      // from the server before calling negotiation complete.
+      //
+      // Each SASL mechanism has its own handshake. Some mechanisms calculate a single client
+      // buffer
+      // to be sent to the server while others have multiple exchanges to negotiate
+      // authentication. GSSAPI(Kerberos)
+      // and DIGEST-MD5 both are examples of mechanisms which have multiple steps. Mechanisms
+      // which have multiple steps
+      // will not return true on `SaslClient#isComplete()` until the handshake has fully
+      // completed. Mechanisms which
+      // only send a single buffer may return true on `isComplete()` after that initial response
+      // is calculated.
     } catch (Exception e) {
       // the exception thrown by handlerAdded will not be passed to the exceptionCaught below
       // because netty will remove a handler if handlerAdded throws an exception.
@@ -163,6 +186,8 @@ public class NettyHBaseSaslRpcClientHandler extends SimpleChannelInboundHandler<
     });
     if (response != null) {
       writeResponse(ctx, response);
+    } else {
+      LOG.trace("SASL challenge response was empty, not sending response to server.");
     }
     tryComplete(ctx);
   }

--- a/hbase-examples/src/main/java/org/apache/hadoop/hbase/security/provider/example/ShadeSaslClientAuthenticationProvider.java
+++ b/hbase-examples/src/main/java/org/apache/hadoop/hbase/security/provider/example/ShadeSaslClientAuthenticationProvider.java
@@ -60,6 +60,12 @@ public class ShadeSaslClientAuthenticationProvider extends ShadeSaslAuthenticati
     return userInfoPB.build();
   }
 
+  @Override
+  public boolean canRetry() {
+    // A static username/password either works or it doesn't. No kind of relogin/retry necessary.
+    return false;
+  }
+
   static class ShadeSaslClientCallbackHandler implements CallbackHandler {
     private final String username;
     private final char[] password;

--- a/hbase-examples/src/main/java/org/apache/hadoop/hbase/security/provider/example/ShadeSaslServerAuthenticationProvider.java
+++ b/hbase-examples/src/main/java/org/apache/hadoop/hbase/security/provider/example/ShadeSaslServerAuthenticationProvider.java
@@ -139,7 +139,6 @@ public class ShadeSaslServerAuthenticationProvider extends ShadeSaslAuthenticati
 
     @Override
     public void handle(Callback[] callbacks) throws InvalidToken, UnsupportedCallbackException {
-      LOG.info("SaslServerCallbackHandler called", new Exception());
       NameCallback nc = null;
       PasswordCallback pc = null;
       AuthorizeCallback ac = null;

--- a/hbase-examples/src/test/java/org/apache/hadoop/hbase/security/provider/example/TestShadeSaslAuthenticationProvider.java
+++ b/hbase-examples/src/test/java/org/apache/hadoop/hbase/security/provider/example/TestShadeSaslAuthenticationProvider.java
@@ -305,7 +305,7 @@ public class TestShadeSaslAuthenticationProvider {
       rootCause.printStackTrace(new PrintWriter(writer));
       String text = writer.toString();
       assertTrue("Message did not contain expected text",
-        text.contains("Connection reset by peer"));
+        text.contains(InvalidToken.class.getName()));
     }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyHBaseSaslRpcServerHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyHBaseSaslRpcServerHandler.java
@@ -89,7 +89,7 @@ class NettyHBaseSaslRpcServerHandler extends SimpleChannelInboundHandler<ByteBuf
     rpcServer.metrics.authenticationFailure();
     String clientIP = this.toString();
     // attempting user could be null
-    RpcServer.AUDITLOG.warn("{}{}: {}", RpcServer.AUTH_FAILED_FOR, clientIP,
+    RpcServer.AUDITLOG.warn("{} {}: {}", RpcServer.AUTH_FAILED_FOR, clientIP,
       conn.saslServer != null ? conn.saslServer.getAttemptingUser() : "Unknown");
     NettyFutureUtils.safeClose(ctx);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleServerRpcConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/SimpleServerRpcConnection.java
@@ -229,7 +229,7 @@ class SimpleServerRpcConnection extends ServerRpcConnection {
         this.rpcServer.metrics.authenticationFailure();
         String clientIP = this.toString();
         // attempting user could be null
-        RpcServer.AUDITLOG.warn("{}{}: {}", RpcServer.AUTH_FAILED_FOR, clientIP,
+        RpcServer.AUDITLOG.warn("{} {}: {}", RpcServer.AUTH_FAILED_FOR, clientIP,
           saslServer.getAttemptingUser());
         throw e;
       } finally {


### PR DESCRIPTION
- Backport HBASE-23881 "Netty SASL implementation does not wait for challenge response"
- Backport HBASE-24263 "TestDelegationToken is broken"
- Fix assertion to check for InvalidToken.class.getName() to ensure bug is fixed