### PR TITLE
HBASE-28017: set request and response sizes in NettyRpcDuplexHandler

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcDuplexHandler.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcDuplexHandler.java
@@ -110,6 +110,7 @@ class NettyRpcDuplexHandler extends ChannelDuplexHandler {
       } else {
         ctx.write(buf, promise);
       }
+      call.callStats.setRequestSizeBytes(totalSize);
     }
   }
 
@@ -162,6 +163,7 @@ class NettyRpcDuplexHandler extends ChannelDuplexHandler {
       }
       return;
     }
+    call.callStats.setResponseSizeBytes(totalSize);
     if (remoteExc != null) {
       call.setException(remoteExc);
       return;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-28017

These new calls have equivalents in BlockingRpcConnection's read/write methods. This will ensure that request/response size metrics are available to those using the netty client.

cc @bbeaudreault @hgromer @eab148 @bozzkar