### PR TITLE
HBASE-28120 Switch that allows avoiding reopening all regions when altering table

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -1530,24 +1530,6 @@ public interface Admin extends Abortable, Closeable {
    *             {@link #modifyTable(TableDescriptor)}
    */
   @Deprecated
-  default void modifyTable(TableName tableName, TableDescriptor td, boolean reopenRegions)
-    throws IOException {
-    if (!tableName.equals(td.getTableName())) {
-      throw new IllegalArgumentException("the specified table name '" + tableName
-        + "' doesn't match with the HTD one: " + td.getTableName());
-    }
-    modifyTable(td, reopenRegions);
-  }
-
-  /**
-   * Modify an existing table, more IRB friendly version.
-   * @param tableName name of table.
-   * @param td        modified description of the table
-   * @throws IOException if a remote or network exception occurs
-   * @deprecated since 2.0 version and will be removed in 3.0 version. use
-   *             {@link #modifyTable(TableDescriptor)}
-   */
-  @Deprecated
   default void modifyTable(TableName tableName, TableDescriptor td) throws IOException {
     if (!tableName.equals(td.getTableName())) {
       throw new IllegalArgumentException("the specified table name '" + tableName

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -1530,7 +1530,8 @@ public interface Admin extends Abortable, Closeable {
    *             {@link #modifyTable(TableDescriptor)}
    */
   @Deprecated
-  default void modifyTable(TableName tableName, TableDescriptor td, boolean reopenRegions) throws IOException {
+  default void modifyTable(TableName tableName, TableDescriptor td, boolean reopenRegions)
+    throws IOException {
     if (!tableName.equals(td.getTableName())) {
       throw new IllegalArgumentException("the specified table name '" + tableName
         + "' doesn't match with the HTD one: " + td.getTableName());
@@ -1572,6 +1573,7 @@ public interface Admin extends Abortable, Closeable {
   default void modifyTable(TableDescriptor td) throws IOException {
     get(modifyTableAsync(td, true), getSyncWaitTimeout(), TimeUnit.MILLISECONDS);
   }
+
   /**
    * Modify an existing table, more IRB friendly version. Asynchronous operation. This means that it
    * may be a while before your schema change is updated across all of the table. You can use

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -1530,12 +1530,38 @@ public interface Admin extends Abortable, Closeable {
    *             {@link #modifyTable(TableDescriptor)}
    */
   @Deprecated
+  default void modifyTable(TableName tableName, TableDescriptor td, boolean reopenRegions) throws IOException {
+    if (!tableName.equals(td.getTableName())) {
+      throw new IllegalArgumentException("the specified table name '" + tableName
+        + "' doesn't match with the HTD one: " + td.getTableName());
+    }
+    modifyTable(td, reopenRegions);
+  }
+
+  /**
+   * Modify an existing table, more IRB friendly version.
+   * @param tableName name of table.
+   * @param td        modified description of the table
+   * @throws IOException if a remote or network exception occurs
+   * @deprecated since 2.0 version and will be removed in 3.0 version. use
+   *             {@link #modifyTable(TableDescriptor)}
+   */
+  @Deprecated
   default void modifyTable(TableName tableName, TableDescriptor td) throws IOException {
     if (!tableName.equals(td.getTableName())) {
       throw new IllegalArgumentException("the specified table name '" + tableName
         + "' doesn't match with the HTD one: " + td.getTableName());
     }
-    modifyTable(td);
+    modifyTable(td, true);
+  }
+
+  /**
+   * Modify an existing table, more IRB friendly version.
+   * @param td modified description of the table
+   * @throws IOException if a remote or network exception occurs
+   */
+  default void modifyTable(TableDescriptor td, boolean reopenRegions) throws IOException {
+    get(modifyTableAsync(td, reopenRegions), getSyncWaitTimeout(), TimeUnit.MILLISECONDS);
   }
 
   /**
@@ -1544,9 +1570,8 @@ public interface Admin extends Abortable, Closeable {
    * @throws IOException if a remote or network exception occurs
    */
   default void modifyTable(TableDescriptor td) throws IOException {
-    get(modifyTableAsync(td), getSyncWaitTimeout(), TimeUnit.MILLISECONDS);
+    get(modifyTableAsync(td, true), getSyncWaitTimeout(), TimeUnit.MILLISECONDS);
   }
-
   /**
    * Modify an existing table, more IRB friendly version. Asynchronous operation. This means that it
    * may be a while before your schema change is updated across all of the table. You can use
@@ -1559,7 +1584,7 @@ public interface Admin extends Abortable, Closeable {
    * @return the result of the async modify. You can use Future.get(long, TimeUnit) to wait on the
    *         operation to complete
    * @deprecated since 2.0 version and will be removed in 3.0 version. use
-   *             {@link #modifyTableAsync(TableDescriptor)}
+   *             {@link #modifyTableAsync(TableDescriptor, boolean)}
    */
   @Deprecated
   default Future<Void> modifyTableAsync(TableName tableName, TableDescriptor td)
@@ -1568,7 +1593,7 @@ public interface Admin extends Abortable, Closeable {
       throw new IllegalArgumentException("the specified table name '" + tableName
         + "' doesn't match with the HTD one: " + td.getTableName());
     }
-    return modifyTableAsync(td);
+    return modifyTableAsync(td, true);
   }
 
   /**
@@ -1582,7 +1607,7 @@ public interface Admin extends Abortable, Closeable {
    * @return the result of the async modify. You can use Future.get(long, TimeUnit) to wait on the
    *         operation to complete
    */
-  Future<Void> modifyTableAsync(TableDescriptor td) throws IOException;
+  Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException;
 
   /**
    * Change the store file tracker of the given table.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -193,13 +193,12 @@ public interface AsyncAdmin {
    * Modify an existing table, more IRB friendly version.
    * @param desc modified description of the table
    */
-  default CompletableFuture<Void> modifyTable(TableDescriptor desc){
+  default CompletableFuture<Void> modifyTable(TableDescriptor desc) {
     return modifyTable(desc, true);
   }
 
   /**
    * Modify an existing table, more IRB friendly version.
-   *
    * @param desc          description of the table
    * @param reopenRegions By default, 'modifyTable' reopens all regions, potentially causing a RIT
    *                      (Region In Transition) storm in large tables. If set to 'false', regions

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -193,7 +193,21 @@ public interface AsyncAdmin {
    * Modify an existing table, more IRB friendly version.
    * @param desc modified description of the table
    */
-  CompletableFuture<Void> modifyTable(TableDescriptor desc);
+  default CompletableFuture<Void> modifyTable(TableDescriptor desc){
+    return modifyTable(desc, true);
+  }
+
+  /**
+   * Modify an existing table, more IRB friendly version.
+   *
+   * @param desc          description of the table
+   * @param reopenRegions By default, 'modifyTable' reopens all regions, potentially causing a RIT
+   *                      (Region In Transition) storm in large tables. If set to 'false', regions
+   *                      will remain unaware of the modification until they are individually
+   *                      reopened. Please note that this may temporarily result in configuration
+   *                      inconsistencies among regions.
+   */
+  CompletableFuture<Void> modifyTable(TableDescriptor desc, boolean reopenRegions);
 
   /**
    * Change the store file tracker of the given table.

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
@@ -148,7 +148,12 @@ class AsyncHBaseAdmin implements AsyncAdmin {
 
   @Override
   public CompletableFuture<Void> modifyTable(TableDescriptor desc) {
-    return wrap(rawAdmin.modifyTable(desc));
+    return modifyTable(desc, true);
+  }
+
+  @Override
+  public CompletableFuture<Void> modifyTable(TableDescriptor desc, boolean reopenRegions) {
+    return wrap(rawAdmin.modifyTable(desc, reopenRegions));
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
@@ -392,7 +392,7 @@ public class HBaseAdmin implements Admin {
   }
 
   @Override
-  public Future<Void> modifyTableAsync(TableDescriptor td) throws IOException {
+  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException {
     ModifyTableResponse response = executeCallable(
       new MasterCallable<ModifyTableResponse>(getConnection(), getRpcControllerFactory()) {
         long nonceGroup = ng.getNonceGroup();
@@ -402,7 +402,8 @@ public class HBaseAdmin implements Admin {
         protected ModifyTableResponse rpcCall() throws Exception {
           setPriority(td.getTableName());
           ModifyTableRequest request =
-            RequestConverter.buildModifyTableRequest(td.getTableName(), td, nonceGroup, nonce);
+            RequestConverter.buildModifyTableRequest(td.getTableName(), td, nonceGroup,
+              nonce, reopenRegions);
           return master.modifyTable(getRpcController(), request);
         }
       });

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
@@ -392,7 +392,8 @@ public class HBaseAdmin implements Admin {
   }
 
   @Override
-  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) throws IOException {
+  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions)
+    throws IOException {
     ModifyTableResponse response = executeCallable(
       new MasterCallable<ModifyTableResponse>(getConnection(), getRpcControllerFactory()) {
         long nonceGroup = ng.getNonceGroup();
@@ -401,9 +402,8 @@ public class HBaseAdmin implements Admin {
         @Override
         protected ModifyTableResponse rpcCall() throws Exception {
           setPriority(td.getTableName());
-          ModifyTableRequest request =
-            RequestConverter.buildModifyTableRequest(td.getTableName(), td, nonceGroup,
-              nonce, reopenRegions);
+          ModifyTableRequest request = RequestConverter.buildModifyTableRequest(td.getTableName(),
+            td, nonceGroup, nonce, reopenRegions);
           return master.modifyTable(getRpcController(), request);
         }
       });

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -659,9 +659,14 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
 
   @Override
   public CompletableFuture<Void> modifyTable(TableDescriptor desc) {
+    return modifyTable(desc, true);
+  }
+
+  public CompletableFuture<Void> modifyTable(TableDescriptor desc, boolean reopenRegions) {
+    // TODO fill the request with reopenRegions
     return this.<ModifyTableRequest, ModifyTableResponse> procedureCall(desc.getTableName(),
       RequestConverter.buildModifyTableRequest(desc.getTableName(), desc, ng.getNonceGroup(),
-        ng.newNonce()),
+        ng.newNonce(), reopenRegions),
       (s, c, req, done) -> s.modifyTable(c, req, done), (resp) -> resp.getProcId(),
       new ModifyTableProcedureBiConsumer(this, desc.getTableName()));
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
@@ -54,9 +54,24 @@ public interface TableDescriptor {
       if (result != 0) {
         return result;
       }
+      result = getColumnFamilyComparator(cfComparator).compare(lhs, rhs);
+      if (result != 0){
+        return result;
+      }
+      // punt on comparison for ordering, just calculate difference
+      return Integer.compare(lhs.getValues().hashCode(), rhs.getValues().hashCode());
+    };
+  }
+
+  /**
+   * Check if the ColumnFamilyDescriptors in two tableDescriptors are consistent.
+   */
+  static Comparator<TableDescriptor>
+    getColumnFamilyComparator(Comparator<ColumnFamilyDescriptor> cfComparator) {
+    return (TableDescriptor lhs, TableDescriptor rhs) -> {
       Collection<ColumnFamilyDescriptor> lhsFamilies = Arrays.asList(lhs.getColumnFamilies());
       Collection<ColumnFamilyDescriptor> rhsFamilies = Arrays.asList(rhs.getColumnFamilies());
-      result = Integer.compare(lhsFamilies.size(), rhsFamilies.size());
+      int result = Integer.compare(lhsFamilies.size(), rhsFamilies.size());
       if (result != 0) {
         return result;
       }
@@ -69,7 +84,7 @@ public interface TableDescriptor {
         }
       }
       // punt on comparison for ordering, just calculate difference
-      return Integer.compare(lhs.getValues().hashCode(), rhs.getValues().hashCode());
+      return 0;
     };
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptor.java
@@ -54,24 +54,9 @@ public interface TableDescriptor {
       if (result != 0) {
         return result;
       }
-      result = getColumnFamilyComparator(cfComparator).compare(lhs, rhs);
-      if (result != 0){
-        return result;
-      }
-      // punt on comparison for ordering, just calculate difference
-      return Integer.compare(lhs.getValues().hashCode(), rhs.getValues().hashCode());
-    };
-  }
-
-  /**
-   * Check if the ColumnFamilyDescriptors in two tableDescriptors are consistent.
-   */
-  static Comparator<TableDescriptor>
-    getColumnFamilyComparator(Comparator<ColumnFamilyDescriptor> cfComparator) {
-    return (TableDescriptor lhs, TableDescriptor rhs) -> {
       Collection<ColumnFamilyDescriptor> lhsFamilies = Arrays.asList(lhs.getColumnFamilies());
       Collection<ColumnFamilyDescriptor> rhsFamilies = Arrays.asList(rhs.getColumnFamilies());
-      int result = Integer.compare(lhsFamilies.size(), rhsFamilies.size());
+      result = Integer.compare(lhsFamilies.size(), rhsFamilies.size());
       if (result != 0) {
         return result;
       }
@@ -84,7 +69,7 @@ public interface TableDescriptor {
         }
       }
       // punt on comparison for ordering, just calculate difference
-      return 0;
+      return Integer.compare(lhs.getValues().hashCode(), rhs.getValues().hashCode());
     };
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
@@ -1295,7 +1295,8 @@ public final class RequestConverter {
    * @return a ModifyTableRequest
    */
   public static ModifyTableRequest buildModifyTableRequest(final TableName tableName,
-    final TableDescriptor tableDesc, final long nonceGroup, final long nonce, boolean reopenRegions) {
+    final TableDescriptor tableDesc, final long nonceGroup, final long nonce,
+    boolean reopenRegions) {
     ModifyTableRequest.Builder builder = ModifyTableRequest.newBuilder();
     builder.setTableName(ProtobufUtil.toProtoTableName(tableName));
     builder.setTableSchema(ProtobufUtil.toTableSchema(tableDesc));

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/RequestConverter.java
@@ -1295,12 +1295,13 @@ public final class RequestConverter {
    * @return a ModifyTableRequest
    */
   public static ModifyTableRequest buildModifyTableRequest(final TableName tableName,
-    final TableDescriptor tableDesc, final long nonceGroup, final long nonce) {
+    final TableDescriptor tableDesc, final long nonceGroup, final long nonce, boolean reopenRegions) {
     ModifyTableRequest.Builder builder = ModifyTableRequest.newBuilder();
     builder.setTableName(ProtobufUtil.toProtoTableName(tableName));
     builder.setTableSchema(ProtobufUtil.toTableSchema(tableDesc));
     builder.setNonceGroup(nonceGroup);
     builder.setNonce(nonce);
+    builder.setReopenRegions(reopenRegions);
     return builder.build();
   }
 

--- a/hbase-protocol-shaded/src/main/protobuf/Master.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/Master.proto
@@ -193,6 +193,7 @@ message ModifyTableRequest {
   required TableSchema table_schema = 2;
   optional uint64 nonce_group = 3 [default = 0];
   optional uint64 nonce = 4 [default = 0];
+  optional bool reopen_regions = 5 [default = true];
 }
 
 message ModifyTableResponse {

--- a/hbase-protocol-shaded/src/main/protobuf/MasterProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/MasterProcedure.proto
@@ -82,6 +82,7 @@ message ModifyTableStateData {
   required TableSchema modified_table_schema = 3;
   required bool delete_column_family_in_modify = 4;
   optional bool should_check_descriptor = 5;
+  optional bool reopen_regions = 6;
 }
 
 enum TruncateTableState {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -1470,7 +1470,8 @@ public class MasterRpcServices extends RSRpcServices
     throws ServiceException {
     try {
       long procId = master.modifyTable(ProtobufUtil.toTableName(req.getTableName()),
-        ProtobufUtil.toTableDescriptor(req.getTableSchema()), req.getNonceGroup(), req.getNonce());
+        ProtobufUtil.toTableDescriptor(req.getTableSchema()), req.getNonceGroup(), req.getNonce(),
+        req.getReopenRegions());
       return ModifyTableResponse.newBuilder().setProcId(procId).build();
     } catch (IOException ioe) {
       throw new ServiceException(ioe);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
@@ -152,8 +152,19 @@ public interface MasterServices extends Server {
    * @param tableName  The table name
    * @param descriptor The updated table descriptor
    */
+  default long modifyTable(final TableName tableName, final TableDescriptor descriptor,
+    final long nonceGroup, final long nonce) throws IOException {
+    return modifyTable(tableName, descriptor, nonceGroup, nonce, true);
+  }
+
+  /**
+   * Modify the descriptor of an existing table
+   * @param tableName     The table name
+   * @param descriptor    The updated table descriptor
+   * @param reopenRegions Whether to reopen regions after modifying the table descriptor
+   */
   long modifyTable(final TableName tableName, final TableDescriptor descriptor,
-    final long nonceGroup, final long nonce) throws IOException;
+    final long nonceGroup, final long nonce, final boolean reopenRegions) throws IOException;
 
   /**
    * Modify the store file tracker of an existing table

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -31,7 +31,6 @@ import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNotFoundException;
-import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.client.TableDescriptor;
@@ -95,8 +94,7 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
   public ModifyTableProcedure(final MasterProcedureEnv env,
     final TableDescriptor newTableDescriptor, final ProcedurePrepareLatch latch,
     final TableDescriptor oldTableDescriptor, final boolean shouldCheckDescriptor,
-    final boolean reopenRegions)
-    throws HBaseIOException {
+    final boolean reopenRegions) throws HBaseIOException {
     super(env, latch);
     this.reopenRegions = reopenRegions;
     initialize(oldTableDescriptor, shouldCheckDescriptor);
@@ -132,14 +130,14 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
       }
       if (
         this.unmodifiedTableDescriptor.getColumnFamilyCount()
-          != this.modifiedTableDescriptor.getColumnFamilyCount()
+            != this.modifiedTableDescriptor.getColumnFamilyCount()
       ) {
         throw new HBaseIOException(
           "Cannot add or remove column families when this modification " + "won't reopen regions.");
       }
       if (
         this.unmodifiedTableDescriptor.getCoprocessorDescriptors().hashCode()
-          != this.modifiedTableDescriptor.getCoprocessorDescriptors().hashCode()
+            != this.modifiedTableDescriptor.getCoprocessorDescriptors().hashCode()
       ) {
         throw new HBaseIOException(
           "Can not modify Coprocessor when table modification won't reopen regions");
@@ -157,8 +155,8 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
     }
   }
 
-  private boolean isTablePropertyModified(TableDescriptor oldDescriptor, TableDescriptor newDescriptor,
-    String key) {
+  private boolean isTablePropertyModified(TableDescriptor oldDescriptor,
+    TableDescriptor newDescriptor, String key) {
     String oldV = oldDescriptor.getValue(key);
     String newV = newDescriptor.getValue(key);
     if (oldV == null && newV == null) {
@@ -312,8 +310,7 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
         .setUserInfo(MasterProcedureUtil.toProtoUserInfo(getUser()))
         .setModifiedTableSchema(ProtobufUtil.toTableSchema(modifiedTableDescriptor))
         .setDeleteColumnFamilyInModify(deleteColumnFamilyInModify)
-        .setShouldCheckDescriptor(shouldCheckDescriptor)
-        .setReopenRegions(reopenRegions);
+        .setShouldCheckDescriptor(shouldCheckDescriptor).setReopenRegions(reopenRegions);
 
     if (unmodifiedTableDescriptor != null) {
       modifyTableMsg

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
@@ -258,7 +258,6 @@ public class MockNoopMasterServices implements MasterServices {
     return -1;
   }
 
-
   @Override
   public long enableTable(final TableName tableName, final long nonceGroup, final long nonce)
     throws IOException {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
@@ -253,6 +253,13 @@ public class MockNoopMasterServices implements MasterServices {
   }
 
   @Override
+  public long modifyTable(TableName tableName, TableDescriptor descriptor, long nonceGroup,
+    long nonce, boolean reopenRegions) throws IOException {
+    return -1;
+  }
+
+
+  @Override
   public long enableTable(final TableName tableName, final long nonceGroup, final long nonce)
     throws IOException {
     return -1;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedure.java
@@ -659,11 +659,10 @@ public class TestModifyTableProcedure extends TestTableDDLProcedureBase {
     // Test 5: Modifying TTL as part of CF property is allowed
     int newTTL = 60000;
     htd = UTIL.getAdmin().getDescriptor(tableName);
-    modifiedDescriptor =
-      TableDescriptorBuilder
-        .newBuilder(htd).modifyColumnFamily(ColumnFamilyDescriptorBuilder
-          .newBuilder("cf".getBytes()).setTimeToLive(newTTL).build())
-        .build();
+    modifiedDescriptor = TableDescriptorBuilder.newBuilder(htd)
+      .modifyColumnFamily(
+        ColumnFamilyDescriptorBuilder.newBuilder("cf".getBytes()).setTimeToLive(newTTL).build())
+      .build();
     ProcedureTestingUtility.submitAndWait(procExec, new ModifyTableProcedure(
       procExec.getEnvironment(), modifiedDescriptor, null, htd, false, reopenRegions));
     // The default TTL should be set before the change is applied.

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -855,6 +855,9 @@ module Hbase
             puts 'Updating all regions with the new schema...'
           end
           future.get
+          if reopen_regions == true
+            alter_status(table_name_str)
+          end
         end
       end
     end

--- a/hbase-shell/src/main/ruby/hbase_constants.rb
+++ b/hbase-shell/src/main/ruby/hbase_constants.rb
@@ -99,6 +99,7 @@ module HBaseConstants
   VALUE = 'VALUE'.freeze
   VERSIONS = org.apache.hadoop.hbase.HConstants::VERSIONS
   VISIBILITY = 'VISIBILITY'.freeze
+  REOPEN_REGIONS = 'REOPEN_REGIONS'.freeze
 
   # aliases
   ENDKEY = STOPROW

--- a/hbase-shell/src/main/ruby/shell/commands/alter.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/alter.rb
@@ -108,6 +108,18 @@ There could be more than one alteration in one command:
   hbase> alter 't1', { NAME => 'f1', VERSIONS => 3 },
    { MAX_FILESIZE => '134217728' }, { METHOD => 'delete', NAME => 'f2' },
    OWNER => 'johndoe', METADATA => { 'mykey' => 'myvalue' }
+
+You can also use the REOPEN_REGIONS=>'false' to avoid regions RIT, which let the
+modification take effect after regions was reopened (Be careful, the regions of
+the table may be configured inconsistently If regions are not reopened after the
+modification). This can be used for changing CONFIGURATIONS, changing other table
+level properties. Few of the actions like changing region replicas, modifying
+coprocessors, adding or removing Column Families are not allowed for safety.
+
+  hbase> alter 't1', REOPEN_REGIONS => 'false', CONFIGURATION => {'hbase.hregion.scan
+  .loadColumnFamiliesOnDemand' => 'true'}
+  hbase> alter 't1', NAME => 'f1', REOPEN_REGIONS => 'false', TTL => '12000'
+
 EOF
       end
 

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
@@ -904,7 +904,7 @@ public class ThriftAdmin implements Admin {
   }
 
   @Override
-  public Future<Void> modifyTableAsync(TableDescriptor td) {
+  public Future<Void> modifyTableAsync(TableDescriptor td, boolean reopenRegions) {
     throw new NotImplementedException("modifyTableAsync not supported in ThriftAdmin");
   }
 


### PR DESCRIPTION
* This is to prevent RIT storms. 
* The changes have been made in both alter and alter sync commands. 
