### PR TITLE
HBASE-25336 [branch-2.4] Use Address instead of InetSocketAddress in RpcClient implementation

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/AbstractRpcClient.java
@@ -21,9 +21,7 @@ import static org.apache.hadoop.hbase.ipc.IPCUtil.toIOE;
 import static org.apache.hadoop.hbase.ipc.IPCUtil.wrapException;
 
 import java.io.IOException;
-import java.net.InetSocketAddress;
 import java.net.SocketAddress;
-import java.net.UnknownHostException;
 import java.util.Collection;
 import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
@@ -321,7 +319,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
    * @return A pair with the Message response and the Cell data (if any).
    */
   private Message callBlockingMethod(Descriptors.MethodDescriptor md, HBaseRpcController hrc,
-    Message param, Message returnType, final User ticket, final InetSocketAddress isa)
+    Message param, Message returnType, final User ticket, final Address isa)
     throws ServiceException {
     BlockingRpcCallback<Message> done = new BlockingRpcCallback<>();
     callMethod(md, hrc, param, returnType, ticket, isa, done);
@@ -393,7 +391,7 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
   }
 
   Call callMethod(final Descriptors.MethodDescriptor md, final HBaseRpcController hrc,
-    final Message param, Message returnType, final User ticket, final InetSocketAddress inetAddr,
+    final Message param, Message returnType, final User ticket, final Address addr,
     final RpcCallback<Message> callback) {
     final MetricsConnection.CallStats cs = MetricsConnection.newCallStats();
     cs.setStartTime(EnvironmentEdgeManager.currentTime());
@@ -408,7 +406,6 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
       cs.setNumActionsPerServer(numActions);
     }
 
-    final Address addr = Address.fromSocketAddress(inetAddr);
     final AtomicInteger counter = concurrentCounterCache.getUnchecked(addr);
     Call call = new Call(nextCallId(), md, param, hrc.cellScanner(), returnType,
       hrc.getCallTimeout(), hrc.getPriority(), new RpcCallback<Call>() {
@@ -525,13 +522,6 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
 
     protected final Address addr;
 
-    // We cache the resolved InetSocketAddress for the channel so we do not do a DNS lookup
-    // per method call on the channel. If the remote target is removed or reprovisioned and
-    // its identity changes a new channel with a newly resolved InetSocketAddress will be
-    // created as part of retry, so caching here is fine.
-    // Normally, caching an InetSocketAddress is an anti-pattern.
-    protected InetSocketAddress isa;
-
     protected final AbstractRpcClient<?> rpcClient;
 
     protected final User ticket;
@@ -582,22 +572,8 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
     @Override
     public Message callBlockingMethod(Descriptors.MethodDescriptor md, RpcController controller,
       Message param, Message returnType) throws ServiceException {
-      // Look up remote address upon first call
-      if (isa == null) {
-        if (this.rpcClient.metrics != null) {
-          this.rpcClient.metrics.incrNsLookups();
-        }
-        isa = Address.toSocketAddress(addr);
-        if (isa.isUnresolved()) {
-          if (this.rpcClient.metrics != null) {
-            this.rpcClient.metrics.incrNsLookupsFailed();
-          }
-          isa = null;
-          throw new ServiceException(new UnknownHostException(addr + " could not be resolved"));
-        }
-      }
       return rpcClient.callBlockingMethod(md, configureRpcController(controller), param, returnType,
-        ticket, isa);
+        ticket, addr);
     }
   }
 
@@ -616,24 +592,9 @@ public abstract class AbstractRpcClient<T extends RpcConnection> implements RpcC
       Message returnType, RpcCallback<Message> done) {
       HBaseRpcController configuredController = configureRpcController(
         Preconditions.checkNotNull(controller, "RpcController can not be null for async rpc call"));
-      // Look up remote address upon first call
-      if (isa == null || isa.isUnresolved()) {
-        if (this.rpcClient.metrics != null) {
-          this.rpcClient.metrics.incrNsLookups();
-        }
-        isa = Address.toSocketAddress(addr);
-        if (isa.isUnresolved()) {
-          if (this.rpcClient.metrics != null) {
-            this.rpcClient.metrics.incrNsLookupsFailed();
-          }
-          isa = null;
-          controller.setFailed(addr + " could not be resolved");
-          return;
-        }
-      }
       // This method does not throw any exceptions, so the caller must provide a
       // HBaseRpcController which is used to pass the exceptions.
-      this.rpcClient.callMethod(md, configuredController, param, returnType, ticket, isa, done);
+      this.rpcClient.callMethod(md, configuredController, param, returnType, ticket, addr, done);
     }
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcConnection.java
@@ -32,7 +32,6 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.ipc.BufferCallBeforeInitHandler.BufferCallEvent;
 import org.apache.hadoop.hbase.ipc.HBaseRpcController.CancellationCallback;
-import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.security.NettyHBaseRpcConnectionHeaderHandler;
 import org.apache.hadoop.hbase.security.NettyHBaseSaslRpcClientHandler;
 import org.apache.hadoop.hbase.security.SaslChallengeDecoder;
@@ -210,18 +209,9 @@ class NettyRpcConnection extends RpcConnection {
     Promise<Boolean> saslPromise = ch.eventLoop().newPromise();
     final NettyHBaseSaslRpcClientHandler saslHandler;
     try {
-      if (this.metrics != null) {
-        this.metrics.incrNsLookups();
-      }
-      InetSocketAddress serverAddr = Address.toSocketAddress(remoteId.getAddress());
-      if (serverAddr.isUnresolved()) {
-        if (this.metrics != null) {
-          this.metrics.incrNsLookupsFailed();
-        }
-        throw new UnknownHostException(remoteId.getAddress() + " could not be resolved");
-      }
       saslHandler = new NettyHBaseSaslRpcClientHandler(saslPromise, ticket, provider, token,
-        serverAddr.getAddress(), securityInfo, rpcClient.fallbackAllowed, this.rpcClient.conf);
+        ((InetSocketAddress) ch.remoteAddress()).getAddress(), securityInfo,
+        rpcClient.fallbackAllowed, this.rpcClient.conf);
     } catch (IOException e) {
       failInit(ch, e);
       return;
@@ -285,16 +275,7 @@ class NettyRpcConnection extends RpcConnection {
   private void connect() throws UnknownHostException {
     assert eventLoop.inEventLoop();
     LOG.trace("Connecting to {}", remoteId.getAddress());
-    if (this.rpcClient.metrics != null) {
-      this.rpcClient.metrics.incrNsLookups();
-    }
-    InetSocketAddress remoteAddr = Address.toSocketAddress(remoteId.getAddress());
-    if (remoteAddr.isUnresolved()) {
-      if (this.rpcClient.metrics != null) {
-        this.rpcClient.metrics.incrNsLookupsFailed();
-      }
-      throw new UnknownHostException(remoteId.getAddress() + " could not be resolved");
-    }
+    InetSocketAddress remoteAddr = getRemoteInetAddress(rpcClient.metrics);
     this.channel = new Bootstrap().group(eventLoop).channel(rpcClient.channelClass)
       .option(ChannelOption.TCP_NODELAY, rpcClient.isTcpNoDelay())
       .option(ChannelOption.SO_KEEPALIVE, rpcClient.tcpKeepAlive)

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ipc/RpcConnection.java
@@ -18,11 +18,14 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.net.UnknownHostException;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.MetricsConnection;
 import org.apache.hadoop.hbase.codec.Codec;
+import org.apache.hadoop.hbase.net.Address;
 import org.apache.hadoop.hbase.security.SecurityInfo;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.provider.SaslClientAuthenticationProvider;
@@ -122,7 +125,7 @@ abstract class RpcConnection {
     this.remoteId = remoteId;
   }
 
-  protected void scheduleTimeoutTask(final Call call) {
+  protected final void scheduleTimeoutTask(final Call call) {
     if (call.timeout > 0) {
       call.timeoutTask = timeoutTimer.newTimeout(new TimerTask() {
 
@@ -137,7 +140,7 @@ abstract class RpcConnection {
     }
   }
 
-  protected byte[] getConnectionHeaderPreamble() {
+  protected final byte[] getConnectionHeaderPreamble() {
     // Assemble the preamble up in a buffer first and then send it. Writing individual elements,
     // they are getting sent across piecemeal according to wireshark and then server is messing
     // up the reading on occasion (the passed in stream is not buffered yet).
@@ -153,7 +156,7 @@ abstract class RpcConnection {
     return preamble;
   }
 
-  protected ConnectionHeader getConnectionHeader() {
+  protected final ConnectionHeader getConnectionHeader() {
     final ConnectionHeader.Builder builder = ConnectionHeader.newBuilder();
     builder.setServiceName(remoteId.getServiceName());
     final UserInformation userInfoPB = provider.getUserInfo(remoteId.ticket);
@@ -174,6 +177,21 @@ abstract class RpcConnection {
         conf.get("hbase.rpc.crypto.encryption.aes.cipher.transform", "AES/CTR/NoPadding"));
     }
     return builder.build();
+  }
+
+  protected final InetSocketAddress getRemoteInetAddress(MetricsConnection metrics)
+    throws UnknownHostException {
+    if (metrics != null) {
+      metrics.incrNsLookups();
+    }
+    InetSocketAddress remoteAddr = Address.toSocketAddress(remoteId.getAddress());
+    if (remoteAddr.isUnresolved()) {
+      if (metrics != null) {
+        metrics.incrNsLookupsFailed();
+      }
+      throw new UnknownHostException(remoteId.getAddress() + " could not be resolved");
+    }
+    return remoteAddr;
   }
 
   protected abstract void callTimeout(Call call);


### PR DESCRIPTION
Back-port of https://github.com/apache/hbase/pull/2716 to the 2.4 release line.
Follow-up of https://github.com/apache/hbase/pull/5515.

(cherry picked from commit f813479)
Co-authored-by: Duo Zhang <zhangduo@apache.org>
