### PR TITLE
HBASE-28223 Include shaded netty-all in hbase-shaded-mapreduce

### DIFF
--- a/hbase-shaded/hbase-shaded-mapreduce/pom.xml
+++ b/hbase-shaded/hbase-shaded-mapreduce/pom.xml
@@ -129,6 +129,11 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>io.netty</groupId>
+      <artifactId>netty-all</artifactId>
+      <scope>compile</scope>
+    </dependency>
   </dependencies>
   <build>
     <plugins>


### PR DESCRIPTION
Move netty-all to compile scope in `hbase-shaded-mapreduce`, because it's a required runtime dependency for MR clients which use TLS connections for HBase and ZK.