### PR TITLE
HBASE-28220 Split the queueCallTime, processCallTime and totalCallTime according to queue type when using RWQueueRpcExecutor

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServerSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServerSource.java
@@ -46,6 +46,27 @@ public interface MetricsHBaseServerSource extends ExceptionTrackingSource {
   String PROCESS_CALL_TIME_DESC = "Processing call time.";
   String TOTAL_CALL_TIME_NAME = "totalCallTime";
   String TOTAL_CALL_TIME_DESC = "Total call time, including both queued and processing time.";
+  String QUEUE_READ_CALL_TIME_NAME = "queueReadCallTime";
+  String QUEUE_READ_CALL_TIME_DESC = "Queue read call time.";
+  String PROCESS_READ_CALL_TIME_NAME = "processReadCallTime";
+  String PROCESS_READ_CALL_TIME_DESC = "Process read call time.";
+  String TOTAL_READ_CALL_TIME_NAME = "totalReadCallTime";
+  String TOTAL_READ_CALL_TIME_DESC =
+    "Total read call time, including both queued and processing time.";
+  String QUEUE_WRITE_CALL_TIME_NAME = "queueWriteCallTime";
+  String QUEUE_WRITE_CALL_TIME_DESC = "Queue write call time.";
+  String PROCESS_WRITE_CALL_TIME_NAME = "processWriteCallTime";
+  String PROCESS_WRITE_CALL_TIME_DESC = "Process write call time.";
+  String TOTAL_WRITE_CALL_TIME_NAME = "totalWriteCallTime";
+  String TOTAL_WRITE_CALL_TIME_DESC =
+    "Total write call time, including both queued and processing time.";
+  String QUEUE_SCAN_CALL_TIME_NAME = "queueScanCallTime";
+  String QUEUE_SCAN_CALL_TIME_DESC = "Queue scan call time.";
+  String PROCESS_SCAN_CALL_TIME_NAME = "processScanCallTime";
+  String PROCESS_SCAN_CALL_TIME_DESC = "Process scan call time.";
+  String TOTAL_SCAN_CALL_TIME_NAME = "totalScanCallTime";
+  String TOTAL_SCAN_CALL_TIME_DESC =
+    "Total scan call time, including both queued and processing time.";
 
   String UNWRITABLE_TIME_NAME = "unwritableTime";
   String UNWRITABLE_TIME_DESC =
@@ -137,4 +158,22 @@ public interface MetricsHBaseServerSource extends ExceptionTrackingSource {
   void unwritableTime(long unwritableTime);
 
   void maxOutboundBytesExceeded();
+
+  void dequeuedReadCall(int qTime);
+
+  void processReadCall(int processingTime);
+
+  void queuedAndProcessedReadCall(int totalTime);
+
+  void dequeuedWriteCall(int qTime);
+
+  void processWriteCall(int processingTime);
+
+  void queuedAndProcessedWriteCall(int totalTime);
+
+  void dequeuedScanCall(int qTime);
+
+  void processScanCall(int processingTime);
+
+  void queuedAndProcessedScanCall(int totalTime);
 }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServerSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServerSourceImpl.java
@@ -42,6 +42,15 @@ public class MetricsHBaseServerSourceImpl extends ExceptionTrackingSourceImpl
   private MetricHistogram queueCallTime;
   private MetricHistogram processCallTime;
   private MetricHistogram totalCallTime;
+  private MetricHistogram queueReadCallTime;
+  private MetricHistogram processReadCallTime;
+  private MetricHistogram totalReadCallTime;
+  private MetricHistogram queueWriteCallTime;
+  private MetricHistogram processWriteCallTime;
+  private MetricHistogram totalWriteCallTime;
+  private MetricHistogram queueScanCallTime;
+  private MetricHistogram processScanCallTime;
+  private MetricHistogram totalScanCallTime;
   private MetricHistogram unwritableTime;
   private MetricHistogram requestSize;
   private MetricHistogram responseSize;
@@ -70,6 +79,24 @@ public class MetricsHBaseServerSourceImpl extends ExceptionTrackingSourceImpl
       this.getMetricsRegistry().newTimeHistogram(PROCESS_CALL_TIME_NAME, PROCESS_CALL_TIME_DESC);
     this.totalCallTime =
       this.getMetricsRegistry().newTimeHistogram(TOTAL_CALL_TIME_NAME, TOTAL_CALL_TIME_DESC);
+    this.queueReadCallTime = this.getMetricsRegistry().newTimeHistogram(QUEUE_READ_CALL_TIME_NAME,
+      QUEUE_READ_CALL_TIME_DESC);
+    this.processReadCallTime = this.getMetricsRegistry()
+      .newTimeHistogram(PROCESS_READ_CALL_TIME_NAME, PROCESS_READ_CALL_TIME_DESC);
+    this.totalReadCallTime = this.getMetricsRegistry().newTimeHistogram(TOTAL_READ_CALL_TIME_NAME,
+      TOTAL_READ_CALL_TIME_DESC);
+    this.queueWriteCallTime = this.getMetricsRegistry().newTimeHistogram(QUEUE_WRITE_CALL_TIME_NAME,
+      QUEUE_WRITE_CALL_TIME_DESC);
+    this.processWriteCallTime = this.getMetricsRegistry()
+      .newTimeHistogram(PROCESS_WRITE_CALL_TIME_NAME, PROCESS_WRITE_CALL_TIME_DESC);
+    this.totalWriteCallTime = this.getMetricsRegistry().newTimeHistogram(TOTAL_WRITE_CALL_TIME_NAME,
+      TOTAL_WRITE_CALL_TIME_DESC);
+    this.queueScanCallTime = this.getMetricsRegistry().newTimeHistogram(QUEUE_SCAN_CALL_TIME_NAME,
+      QUEUE_SCAN_CALL_TIME_DESC);
+    this.processScanCallTime = this.getMetricsRegistry()
+      .newTimeHistogram(PROCESS_SCAN_CALL_TIME_NAME, PROCESS_SCAN_CALL_TIME_DESC);
+    this.totalScanCallTime = this.getMetricsRegistry().newTimeHistogram(TOTAL_SCAN_CALL_TIME_NAME,
+      TOTAL_SCAN_CALL_TIME_DESC);
     this.unwritableTime =
       this.getMetricsRegistry().newTimeHistogram(UNWRITABLE_TIME_NAME, UNWRITABLE_TIME_DESC);
     this.maxOutboundBytesExceeded = this.getMetricsRegistry()
@@ -138,6 +165,51 @@ public class MetricsHBaseServerSourceImpl extends ExceptionTrackingSourceImpl
   @Override
   public void queuedAndProcessedCall(int totalTime) {
     totalCallTime.add(totalTime);
+  }
+
+  @Override
+  public void dequeuedReadCall(int qTime) {
+    queueReadCallTime.add(qTime);
+  }
+
+  @Override
+  public void processReadCall(int processingTime) {
+    processReadCallTime.add(processingTime);
+  }
+
+  @Override
+  public void queuedAndProcessedReadCall(int totalTime) {
+    totalReadCallTime.add(totalTime);
+  }
+
+  @Override
+  public void dequeuedWriteCall(int qTime) {
+    queueWriteCallTime.add(qTime);
+  }
+
+  @Override
+  public void processWriteCall(int processingTime) {
+    processWriteCallTime.add(processingTime);
+  }
+
+  @Override
+  public void queuedAndProcessedWriteCall(int totalTime) {
+    totalWriteCallTime.add(totalTime);
+  }
+
+  @Override
+  public void dequeuedScanCall(int qTime) {
+    queueScanCallTime.add(qTime);
+  }
+
+  @Override
+  public void processScanCall(int processingTime) {
+    processScanCallTime.add(processingTime);
+  }
+
+  @Override
+  public void queuedAndProcessedScanCall(int totalTime) {
+    totalScanCallTime.add(totalTime);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/MetricsHBaseServer.java
@@ -97,6 +97,42 @@ public class MetricsHBaseServer {
     source.queuedAndProcessedCall(totalTime);
   }
 
+  void dequeuedReadCall(int qTime) {
+    source.dequeuedReadCall(qTime);
+  }
+
+  void processReadCall(int processingTime) {
+    source.processReadCall(processingTime);
+  }
+
+  void totalReadCall(int totalTime) {
+    source.queuedAndProcessedReadCall(totalTime);
+  }
+
+  void dequeuedWriteCall(int qTime) {
+    source.dequeuedWriteCall(qTime);
+  }
+
+  void processWriteCall(int processingTime) {
+    source.processWriteCall(processingTime);
+  }
+
+  void totalWriteCall(int totalTime) {
+    source.queuedAndProcessedWriteCall(totalTime);
+  }
+
+  void dequeuedScanCall(int qTime) {
+    source.dequeuedScanCall(qTime);
+  }
+
+  void processScanCall(int processingTime) {
+    source.processScanCall(processingTime);
+  }
+
+  void totalScanCall(int totalTime) {
+    source.queuedAndProcessedScanCall(totalTime);
+  }
+
   void unwritableTime(long unwritableTime) {
     source.unwritableTime(unwritableTime);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RWQueueRpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RWQueueRpcExecutor.java
@@ -142,13 +142,17 @@ public class RWQueueRpcExecutor extends RpcExecutor {
 
   protected boolean dispatchTo(boolean toWriteQueue, boolean toScanQueue,
     final CallRunner callTask) {
+    RpcCall call = callTask.getRpcCall();
     int queueIndex;
     if (toWriteQueue) {
       queueIndex = writeBalancer.getNextQueue(callTask);
+      call.setQueueType(RpcCall.CallQueueType.WRITE);
     } else if (toScanQueue) {
       queueIndex = numWriteQueues + numReadQueues + scanBalancer.getNextQueue(callTask);
+      call.setQueueType(RpcCall.CallQueueType.SCAN);
     } else {
       queueIndex = numWriteQueues + readBalancer.getNextQueue(callTask);
+      call.setQueueType(RpcCall.CallQueueType.READ);
     }
     Queue<CallRunner> queue = queues.get(queueIndex);
     if (queue.size() >= currentQueueLimit) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCall.java
@@ -132,4 +132,24 @@ public interface RpcCall extends RpcCallContext {
 
   /** Returns A short string format of this call without possibly lengthy params */
   String toShortString();
+
+  /**
+   * The queue type where the call is located. If {@link RWQueueRpcExecutor} is used, the queue type
+   * can be divided into read, write and scan.
+   */
+  static enum CallQueueType {
+    DEFAULT,
+    WRITE,
+    READ,
+    SCAN
+  }
+
+  /** Returns The queue type of this call. */
+  CallQueueType getQueueType();
+
+  /**
+   * Set the queue type of this call.
+   * @param type The queue type where the call is located.
+   */
+  void setQueueType(CallQueueType type);
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcServer.java
@@ -459,6 +459,25 @@ public abstract class RpcServer implements RpcServerInterface, ConfigurationObse
       metrics.dequeuedCall(qTime);
       metrics.processedCall(processingTime);
       metrics.totalCall(totalTime);
+      switch (call.getQueueType()) {
+        case READ:
+          metrics.dequeuedReadCall(qTime);
+          metrics.processReadCall(processingTime);
+          metrics.totalReadCall(totalTime);
+          break;
+        case WRITE:
+          metrics.dequeuedWriteCall(qTime);
+          metrics.processWriteCall(processingTime);
+          metrics.totalWriteCall(totalTime);
+          break;
+        case SCAN:
+          metrics.dequeuedScanCall(qTime);
+          metrics.processScanCall(processingTime);
+          metrics.totalScanCall(totalTime);
+          break;
+        case DEFAULT:
+          break;
+      }
       metrics.receivedRequest(requestSize);
       metrics.sentResponse(responseSize);
       // log any RPC responses that are slower than the configured warn

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -79,6 +79,8 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   protected long startTime;
   protected final long deadline;// the deadline to handle this call, if exceed we can drop it.
 
+  protected CallQueueType callQueueType;
+
   protected final ByteBuffAllocator bbAllocator;
 
   protected final CellBlockBuilder cellBlockBuilder;
@@ -145,6 +147,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
     this.cellBlockBuilder = cellBlockBuilder;
     this.reqCleanup = reqCleanup;
     this.span = Span.current();
+    this.callQueueType = CallQueueType.DEFAULT;
   }
 
   /**
@@ -566,5 +569,15 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   @Override
   public synchronized BufferChain getResponse() {
     return response;
+  }
+
+  @Override
+  public CallQueueType getQueueType() {
+    return callQueueType;
+  }
+
+  @Override
+  public void setQueueType(CallQueueType type) {
+    this.callQueueType = type;
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestRpcMetrics.java
@@ -134,6 +134,27 @@ public class TestRpcMetrics {
     HELPER.assertCounter("processCallTime_NumOps", 1, serverSource);
     HELPER.assertCounter("totalCallTime_NumOps", 1, serverSource);
 
+    mrpc.dequeuedReadCall(100);
+    mrpc.processReadCall(101);
+    mrpc.totalReadCall(102);
+    HELPER.assertCounter("queueReadCallTime_NumOps", 1, serverSource);
+    HELPER.assertCounter("processReadCallTime_NumOps", 1, serverSource);
+    HELPER.assertCounter("totalReadCallTime_NumOps", 1, serverSource);
+
+    mrpc.dequeuedWriteCall(100);
+    mrpc.processWriteCall(101);
+    mrpc.totalWriteCall(102);
+    HELPER.assertCounter("queueWriteCallTime_NumOps", 1, serverSource);
+    HELPER.assertCounter("processWriteCallTime_NumOps", 1, serverSource);
+    HELPER.assertCounter("totalWriteCallTime_NumOps", 1, serverSource);
+
+    mrpc.dequeuedScanCall(100);
+    mrpc.processScanCall(101);
+    mrpc.totalScanCall(102);
+    HELPER.assertCounter("queueScanCallTime_NumOps", 1, serverSource);
+    HELPER.assertCounter("processScanCallTime_NumOps", 1, serverSource);
+    HELPER.assertCounter("totalScanCallTime_NumOps", 1, serverSource);
+
     mrpc.sentBytes(103);
     mrpc.sentBytes(103);
     mrpc.sentBytes(103);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
@@ -859,6 +859,15 @@ public class TestNamedQueueRecorder {
       @Override
       public void incrementResponseExceptionSize(long exceptionSize) {
       }
+
+      @Override
+      public CallQueueType getQueueType() {
+        return CallQueueType.DEFAULT;
+      }
+
+      @Override
+      public void setQueueType(CallQueueType type) {
+      }
     };
     return rpcCall;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
@@ -258,6 +258,15 @@ public class TestRpcLogDetails {
       @Override
       public void incrementResponseExceptionSize(long exceptionSize) {
       }
+
+      @Override
+      public CallQueueType getQueueType() {
+        return CallQueueType.DEFAULT;
+      }
+
+      @Override
+      public void setQueueType(CallQueueType type) {
+      }
     };
     return rpcCall;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
@@ -320,6 +320,15 @@ public class TestRegionProcedureStore extends RegionProcedureStoreTestBase {
       @Override
       public void incrementResponseExceptionSize(long exceptionSize) {
       }
+
+      @Override
+      public CallQueueType getQueueType() {
+        return CallQueueType.DEFAULT;
+      }
+
+      @Override
+      public void setQueueType(CallQueueType type) {
+      }
     };
   }
 }


### PR DESCRIPTION
When using RWQueueRpcExecutor, in order to monitor the running status of the read and write queues separately, it is necessary to monitor the queueTime and processingTime of the request according to the queue type. In this way, the queue's queueCallTime, processCallTime and totalCallTime metrics are split according to the read and write queue types. So Add the following metrics：
1. queueReadCallTime
2. processReadCallTime
3. totalReadCallTime
4. queueWriteCallTime
5. processWriteCallTime
6. totalWriteCallTime
7. queueScanCallTime
8. processScanCallTime
9. totalScanCallTime

These metrics are important references for subsequent modification of parameters hbase.ipc.server.callqueue.read.ratio and hbase.ipc.server.callqueue.scan.ratio.