### PR TITLE
HBASE-28238 rpcservice should perform some important admin operation to priority ADMIN_QOS

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseRpcServicesBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseRpcServicesBase.java
@@ -310,6 +310,7 @@ public abstract class HBaseRpcServicesBase<S extends HBaseServerBase<?>>
   }
 
   @Override
+  @QosPriority(priority = HConstants.ADMIN_QOS)
   public UpdateConfigurationResponse updateConfiguration(RpcController controller,
     UpdateConfigurationRequest request) throws ServiceException {
     try {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -1545,6 +1545,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
   }
 
   @Override
+  @QosPriority(priority = HConstants.ADMIN_QOS)
   public CompactionSwitchResponse compactionSwitch(RpcController controller,
     CompactionSwitchRequest request) throws ServiceException {
     rpcPreCheck("compactionSwitch");
@@ -2223,6 +2224,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
    * @param request    the request
    */
   @Override
+  @QosPriority(priority = HConstants.ADMIN_QOS)
   public RollWALWriterResponse rollWALWriter(final RpcController controller,
     final RollWALWriterRequest request) throws ServiceException {
     try {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRSQosFunction.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRSQosFunction.java
@@ -72,5 +72,8 @@ public class TestRSQosFunction extends QosTestBase {
     checkMethod(conf, "CloseRegion", HConstants.ADMIN_QOS, qosFunction);
     checkMethod(conf, "CompactRegion", HConstants.ADMIN_QOS, qosFunction);
     checkMethod(conf, "FlushRegion", HConstants.ADMIN_QOS, qosFunction);
+    checkMethod(conf, "UpdateConfiguration", HConstants.ADMIN_QOS, qosFunction);
+    checkMethod(conf, "CompactionSwitch", HConstants.ADMIN_QOS, qosFunction);
+    checkMethod(conf, "RollWALWriter", HConstants.ADMIN_QOS, qosFunction);
   }
 }


### PR DESCRIPTION
The updateConfiguration operation called by admin should be considered a higher priority operation and given to the priority queue, but is currently considered to have the same priority as read and write requests. If the handle is occupied, the configuration cannot be updated. In fact, in our scenario, some abnormal phoenix sql is killed by controlling the amount of data that scan can filter with dynamic parameters. Abnormal sql often results in a full handle. In this case, the configuration cannot be dynamically modified to implement emergency traffic limiting.