### PR TITLE
HBASE-28269 Fix broken ruby scripts and clean up logging

### DIFF
--- a/bin/draining_servers.rb
+++ b/bin/draining_servers.rb
@@ -25,7 +25,6 @@ include Java
 
 java_import org.apache.hadoop.hbase.HBaseConfiguration
 java_import org.apache.hadoop.hbase.client.ConnectionFactory
-java_import org.apache.hadoop.hbase.client.HBaseAdmin
 java_import org.apache.hadoop.hbase.zookeeper.ZKUtil
 java_import org.apache.hadoop.hbase.zookeeper.ZNodePaths
 java_import org.slf4j.LoggerFactory

--- a/bin/draining_servers.rb
+++ b/bin/draining_servers.rb
@@ -135,8 +135,12 @@ end
 
 hostOrServers = ARGV[1..ARGV.size]
 
-# Create a logger and save it to ruby global
-$LOG = LoggerFactory.getLogger(NAME)
+# disable debug/info logging on this script for clarity
+log_level = "ERROR"
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)
+
 case ARGV[0]
 when 'add'
   if ARGV.length < 2

--- a/bin/draining_servers.rb
+++ b/bin/draining_servers.rb
@@ -136,7 +136,7 @@ end
 hostOrServers = ARGV[1..ARGV.size]
 
 # disable debug/info logging on this script for clarity
-log_level = "ERROR"
+log_level = 'ERROR'
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)

--- a/bin/get-active-master.rb
+++ b/bin/get-active-master.rb
@@ -24,9 +24,10 @@ java_import org.apache.hadoop.hbase.zookeeper.ZKWatcher
 java_import org.apache.hadoop.hbase.zookeeper.MasterAddressTracker
 
 # disable debug/info logging on this script for clarity
-log_level = org.apache.logging.log4j.Level::ERROR
-org.apache.logging.log4j.core.config.Configurator.setAllLevels('org.apache.hadoop.hbase', log_level)
-org.apache.logging.log4j.core.config.Configurator.setAllLevels('org.apache.zookeeper', log_level)
+log_level = "ERROR"
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)
 
 config = HBaseConfiguration.create
 

--- a/bin/get-active-master.rb
+++ b/bin/get-active-master.rb
@@ -24,7 +24,7 @@ java_import org.apache.hadoop.hbase.zookeeper.ZKWatcher
 java_import org.apache.hadoop.hbase.zookeeper.MasterAddressTracker
 
 # disable debug/info logging on this script for clarity
-log_level = "ERROR"
+log_level = 'ERROR'
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)

--- a/bin/get-active-master.rb
+++ b/bin/get-active-master.rb
@@ -24,9 +24,9 @@ java_import org.apache.hadoop.hbase.zookeeper.ZKWatcher
 java_import org.apache.hadoop.hbase.zookeeper.MasterAddressTracker
 
 # disable debug/info logging on this script for clarity
-log_level = org.apache.log4j.Level::ERROR
-org.apache.log4j.Logger.getLogger('org.apache.hadoop.hbase').setLevel(log_level)
-org.apache.log4j.Logger.getLogger('org.apache.zookeeper').setLevel(log_level)
+log_level = org.apache.logging.log4j.Level::ERROR
+org.apache.logging.log4j.core.config.Configurator.setAllLevels('org.apache.hadoop.hbase', log_level)
+org.apache.logging.log4j.core.config.Configurator.setAllLevels('org.apache.zookeeper', log_level)
 
 config = HBaseConfiguration.create
 

--- a/bin/replication/copy_tables_desc.rb
+++ b/bin/replication/copy_tables_desc.rb
@@ -60,7 +60,7 @@ def copy(src, dst, table)
 end
 
 # disable debug/info logging on this script for clarity
-log_level = "ERROR"
+log_level = 'ERROR'
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)

--- a/bin/replication/copy_tables_desc.rb
+++ b/bin/replication/copy_tables_desc.rb
@@ -27,10 +27,8 @@ include Java
 java_import org.apache.hadoop.conf.Configuration
 java_import org.apache.hadoop.hbase.HBaseConfiguration
 java_import org.apache.hadoop.hbase.HConstants
-java_import org.apache.hadoop.hbase.HTableDescriptor
 java_import org.apache.hadoop.hbase.TableName
 java_import org.apache.hadoop.hbase.client.ConnectionFactory
-java_import org.apache.hadoop.hbase.client.HBaseAdmin
 java_import org.slf4j.LoggerFactory
 
 # Name of this script
@@ -45,7 +43,7 @@ end
 def copy(src, dst, table)
   # verify if table exists in source cluster
   begin
-    t = src.getTableDescriptor(TableName.valueOf(table))
+    t = src.getDescriptor(TableName.valueOf(table))
   rescue org.apache.hadoop.hbase.TableNotFoundException
     puts format("Source table \"%s\" doesn't exist, skipping.", table)
     return

--- a/bin/replication/copy_tables_desc.rb
+++ b/bin/replication/copy_tables_desc.rb
@@ -29,7 +29,6 @@ java_import org.apache.hadoop.hbase.HBaseConfiguration
 java_import org.apache.hadoop.hbase.HConstants
 java_import org.apache.hadoop.hbase.TableName
 java_import org.apache.hadoop.hbase.client.ConnectionFactory
-java_import org.slf4j.LoggerFactory
 
 # Name of this script
 NAME = 'copy_tables_desc'.freeze
@@ -60,9 +59,13 @@ def copy(src, dst, table)
   puts format('Schema for table "%s" was succesfully copied to remote cluster.', table)
 end
 
-usage if ARGV.size < 2 || ARGV.size > 3
+# disable debug/info logging on this script for clarity
+log_level = "ERROR"
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)
 
-LOG = LoggerFactory.getLogger(NAME)
+usage if ARGV.size < 2 || ARGV.size > 3
 
 parts1 = ARGV[0].split(':')
 

--- a/bin/shutdown_regionserver.rb
+++ b/bin/shutdown_regionserver.rb
@@ -35,7 +35,7 @@ def usage(msg = nil)
 end
 
 # disable debug/info logging on this script for clarity
-log_level = "ERROR"
+log_level = 'ERROR'
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
 org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)

--- a/bin/shutdown_regionserver.rb
+++ b/bin/shutdown_regionserver.rb
@@ -34,6 +34,12 @@ def usage(msg = nil)
   abort
 end
 
+# disable debug/info logging on this script for clarity
+log_level = "ERROR"
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)
+
 usage if ARGV.empty?
 
 ARGV.each do |x|

--- a/bin/shutdown_regionserver.rb
+++ b/bin/shutdown_regionserver.rb
@@ -24,7 +24,6 @@
 
 include Java
 java_import org.apache.hadoop.hbase.HBaseConfiguration
-java_import org.apache.hadoop.hbase.client.HBaseAdmin
 java_import org.apache.hadoop.hbase.client.ConnectionFactory
 
 def usage(msg = nil)

--- a/hbase-logging/src/main/java/org/apache/hadoop/hbase/logging/InternalLog4jUtils.java
+++ b/hbase-logging/src/main/java/org/apache/hadoop/hbase/logging/InternalLog4jUtils.java
@@ -47,7 +47,6 @@ final class InternalLog4jUtils {
   }
 
   static void setAllLevels(String loggerName, String levelName) {
-    org.apache.logging.log4j.Level level = getLevel(levelName);
     org.apache.logging.log4j.core.config.Configurator.setAllLevels(loggerName, getLevel(levelName));
   }
 

--- a/hbase-logging/src/main/java/org/apache/hadoop/hbase/logging/InternalLog4jUtils.java
+++ b/hbase-logging/src/main/java/org/apache/hadoop/hbase/logging/InternalLog4jUtils.java
@@ -36,13 +36,28 @@ final class InternalLog4jUtils {
   private InternalLog4jUtils() {
   }
 
-  static void setLogLevel(String loggerName, String levelName) {
+  private static org.apache.logging.log4j.Level getLevel(String levelName)
+    throws IllegalArgumentException {
     org.apache.logging.log4j.Level level =
       org.apache.logging.log4j.Level.toLevel(levelName.toUpperCase());
     if (!level.toString().equalsIgnoreCase(levelName)) {
       throw new IllegalArgumentException("Unsupported log level " + levelName);
     }
-    org.apache.logging.log4j.core.config.Configurator.setLevel(loggerName, level);
+    return level;
+  }
+
+  static void setAllLevels(String loggerName, String levelName) {
+    org.apache.logging.log4j.Level level = getLevel(levelName);
+    org.apache.logging.log4j.core.config.Configurator.setAllLevels(loggerName, getLevel(levelName));
+  }
+
+  static void setLogLevel(String loggerName, String levelName) {
+    org.apache.logging.log4j.core.config.Configurator.setLevel(loggerName, getLevel(levelName));
+  }
+
+  static void setRootLevel(String levelName) {
+    String loggerName = org.apache.logging.log4j.LogManager.getRootLogger().getName();
+    setLogLevel(loggerName, levelName);
   }
 
   static String getEffectiveLevel(String loggerName) {

--- a/hbase-logging/src/main/java/org/apache/hadoop/hbase/logging/Log4jUtils.java
+++ b/hbase-logging/src/main/java/org/apache/hadoop/hbase/logging/Log4jUtils.java
@@ -58,16 +58,30 @@ public final class Log4jUtils {
     }
   }
 
-  public static void setLogLevel(String loggerName, String levelName) {
-    Method method = getMethod("setLogLevel", String.class, String.class);
+  private static void invoke(Method method, Object... args) throws AssertionError {
     try {
-      method.invoke(null, loggerName, levelName);
+      method.invoke(null, args);
     } catch (IllegalAccessException e) {
       throw new AssertionError("should not happen", e);
     } catch (InvocationTargetException e) {
       throwUnchecked(e.getCause());
       throw new AssertionError("should not happen", e.getCause());
     }
+  }
+
+  public static void setAllLevels(String loggerName, String levelName) {
+    Method method = getMethod("setAllLevels", String.class, String.class);
+    invoke(method, loggerName, levelName);
+  }
+
+  public static void setLogLevel(String loggerName, String levelName) {
+    Method method = getMethod("setLogLevel", String.class, String.class);
+    invoke(method, loggerName, levelName);
+  }
+
+  public static void setRootLevel(String levelName) {
+    Method method = getMethod("setRootLevel", String.class);
+    invoke(method, levelName);
   }
 
   public static String getEffectiveLevel(String loggerName) {

--- a/hbase-shell/src/main/ruby/jar-bootstrap.rb
+++ b/hbase-shell/src/main/ruby/jar-bootstrap.rb
@@ -104,7 +104,7 @@ opts = GetoptLong.new(
 opts.ordering = GetoptLong::REQUIRE_ORDER
 
 script2run = nil
-log_level = org.apache.logging.log4j.Level::ERROR
+log_level = "ERROR"
 @shell_debug = false
 interactive = true
 full_backtrace = false
@@ -118,7 +118,7 @@ opts.each do |opt, arg|
   when D_ARG
     conf_from_cli = add_to_configuration(conf_from_cli, arg)
   when '--debug'
-    log_level = org.apache.logging.log4j.Level::DEBUG
+    log_level = "DEBUG"
     full_backtrace = true
     @shell_debug = true
     puts 'Setting DEBUG log level...'
@@ -138,8 +138,8 @@ script2run = ARGV.shift unless ARGV.empty?
 ARGV.unshift('-d') if @shell_debug
 
 # Set logging level to avoid verboseness
-org.apache.logging.log4j.core.config.Configurator.setAllLevels('org.apache.zookeeper', log_level)
-org.apache.logging.log4j.core.config.Configurator.setAllLevels('org.apache.hadoop', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
+org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)
 
 # Require HBase now after setting log levels
 require 'hbase_constants'
@@ -165,14 +165,14 @@ def debug
   if @shell_debug
     @shell_debug = false
     conf.back_trace_limit = 0
-    log_level = org.apache.logging.log4j.Level::ERROR
+    log_level = "ERROR"
   else
     @shell_debug = true
     conf.back_trace_limit = 100
-    log_level = org.apache.logging.log4j.Level::DEBUG
+    log_level = "DEBUG"
   end
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels('org.apache.zookeeper', log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels('org.apache.hadoop', log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)
   debug?
 end
 

--- a/hbase-shell/src/main/ruby/jar-bootstrap.rb
+++ b/hbase-shell/src/main/ruby/jar-bootstrap.rb
@@ -104,7 +104,7 @@ opts = GetoptLong.new(
 opts.ordering = GetoptLong::REQUIRE_ORDER
 
 script2run = nil
-log_level = "ERROR"
+log_level = 'ERROR'
 @shell_debug = false
 interactive = true
 full_backtrace = false
@@ -118,7 +118,7 @@ opts.each do |opt, arg|
   when D_ARG
     conf_from_cli = add_to_configuration(conf_from_cli, arg)
   when '--debug'
-    log_level = "DEBUG"
+    log_level = 'DEBUG'
     full_backtrace = true
     @shell_debug = true
     puts 'Setting DEBUG log level...'
@@ -165,11 +165,11 @@ def debug
   if @shell_debug
     @shell_debug = false
     conf.back_trace_limit = 0
-    log_level = "ERROR"
+    log_level = 'ERROR'
   else
     @shell_debug = true
     conf.back_trace_limit = 100
-    log_level = "DEBUG"
+    log_level = 'DEBUG'
   end
   org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
   org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop', log_level)

--- a/hbase-shell/src/test/ruby/no_cluster_tests_runner.rb
+++ b/hbase-shell/src/test/ruby/no_cluster_tests_runner.rb
@@ -28,11 +28,12 @@ unless defined?($TEST_CLUSTER)
   include Java
 
   # Set logging level to avoid verboseness
-  org.apache.log4j.Logger.getRootLogger.setLevel(org.apache.log4j.Level::OFF)
-  org.apache.log4j.Logger.getLogger("org.apache.zookeeper").setLevel(org.apache.log4j.Level::OFF)
-  org.apache.log4j.Logger.getLogger("org.apache.hadoop.hdfs").setLevel(org.apache.log4j.Level::OFF)
-  org.apache.log4j.Logger.getLogger("org.apache.hadoop.hbase").setLevel(org.apache.log4j.Level::OFF)
-  org.apache.log4j.Logger.getLogger("org.apache.hadoop.ipc.HBaseServer").setLevel(org.apache.log4j.Level::OFF)
+  log_level = org.apache.logging.log4j.Level::OFF
+  org.apache.logging.log4j.core.config.Configurator.setRootLevel(log_level)
+  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.zookeeper", log_level)
+  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.hdfs", log_level)
+  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.hbase", log_level)
+  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.ipc.HBaseServer", log_level)
 
   java_import org.apache.hadoop.hbase.HBaseTestingUtility
 

--- a/hbase-shell/src/test/ruby/no_cluster_tests_runner.rb
+++ b/hbase-shell/src/test/ruby/no_cluster_tests_runner.rb
@@ -28,12 +28,13 @@ unless defined?($TEST_CLUSTER)
   include Java
 
   # Set logging level to avoid verboseness
-  log_level = "OFF"
+  log_level = 'OFF'
   org.apache.hadoop.hbase.logging.Log4jUtils.setRootLevel(log_level)
-  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.zookeeper", log_level)
-  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.hdfs", log_level)
-  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.hbase", log_level)
-  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.ipc.HBaseServer", log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hdfs', log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils
+    .setAllLevels('org.apache.hadoop.ipc.HBaseServer', log_level)
 
   java_import org.apache.hadoop.hbase.HBaseTestingUtility
 

--- a/hbase-shell/src/test/ruby/no_cluster_tests_runner.rb
+++ b/hbase-shell/src/test/ruby/no_cluster_tests_runner.rb
@@ -28,12 +28,12 @@ unless defined?($TEST_CLUSTER)
   include Java
 
   # Set logging level to avoid verboseness
-  log_level = org.apache.logging.log4j.Level::OFF
-  org.apache.logging.log4j.core.config.Configurator.setRootLevel(log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.zookeeper", log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.hdfs", log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.hbase", log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.ipc.HBaseServer", log_level)
+  log_level = "OFF"
+  org.apache.hadoop.hbase.logging.Log4jUtils.setRootLevel(log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.zookeeper", log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.hdfs", log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.hbase", log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.ipc.HBaseServer", log_level)
 
   java_import org.apache.hadoop.hbase.HBaseTestingUtility
 

--- a/hbase-shell/src/test/ruby/tests_runner.rb
+++ b/hbase-shell/src/test/ruby/tests_runner.rb
@@ -27,12 +27,12 @@ unless defined?($TEST_CLUSTER)
   include Java
 
   # Set logging level to avoid verboseness
-  log_level = org.apache.logging.log4j.Level::OFF
-  org.apache.logging.log4j.core.config.Configurator.setRootLevel(log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.zookeeper", log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.hdfs", log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.hbase", log_level)
-  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.ipc.HBaseServer", log_level)
+  log_level = "OFF"
+  org.apache.hadoop.hbase.logging.Log4jUtils.setRootLevel(log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.zookeeper", log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.hdfs", log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.hbase", log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.ipc.HBaseServer", log_level)
 
   java_import org.apache.hadoop.hbase.HBaseTestingUtility
 

--- a/hbase-shell/src/test/ruby/tests_runner.rb
+++ b/hbase-shell/src/test/ruby/tests_runner.rb
@@ -27,11 +27,12 @@ unless defined?($TEST_CLUSTER)
   include Java
 
   # Set logging level to avoid verboseness
-  org.apache.log4j.Logger.getRootLogger.setLevel(org.apache.log4j.Level::OFF)
-  org.apache.log4j.Logger.getLogger("org.apache.zookeeper").setLevel(org.apache.log4j.Level::OFF)
-  org.apache.log4j.Logger.getLogger("org.apache.hadoop.hdfs").setLevel(org.apache.log4j.Level::OFF)
-  org.apache.log4j.Logger.getLogger("org.apache.hadoop.hbase").setLevel(org.apache.log4j.Level::OFF)
-  org.apache.log4j.Logger.getLogger("org.apache.hadoop.ipc.HBaseServer").setLevel(org.apache.log4j.Level::OFF)
+  log_level = org.apache.logging.log4j.Level::OFF
+  org.apache.logging.log4j.core.config.Configurator.setRootLevel(log_level)
+  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.zookeeper", log_level)
+  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.hdfs", log_level)
+  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.hbase", log_level)
+  org.apache.logging.log4j.core.config.Configurator.setAllLevels("org.apache.hadoop.ipc.HBaseServer", log_level)
 
   java_import org.apache.hadoop.hbase.HBaseTestingUtility
 

--- a/hbase-shell/src/test/ruby/tests_runner.rb
+++ b/hbase-shell/src/test/ruby/tests_runner.rb
@@ -27,12 +27,13 @@ unless defined?($TEST_CLUSTER)
   include Java
 
   # Set logging level to avoid verboseness
-  log_level = "OFF"
+  log_level = 'OFF'
   org.apache.hadoop.hbase.logging.Log4jUtils.setRootLevel(log_level)
-  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.zookeeper", log_level)
-  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.hdfs", log_level)
-  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.hbase", log_level)
-  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels("org.apache.hadoop.ipc.HBaseServer", log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.zookeeper', log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hdfs', log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils.setAllLevels('org.apache.hadoop.hbase', log_level)
+  org.apache.hadoop.hbase.logging.Log4jUtils
+    .setAllLevels('org.apache.hadoop.ipc.HBaseServer', log_level)
 
   java_import org.apache.hadoop.hbase.HBaseTestingUtility
 


### PR DESCRIPTION
* Removed redundant imports and replaced unsupported methods with alternates
* Removed usage of `org.apache.logging.log4j` and `org.apache.log4j.Logger` from ruby scripts
* Added new methods in `Log4jUtils.java` and `InternalLog4jUtils.java` to be used as alternative in scripts
* Disabled info/debug logging of existing ruby scripts to clean up noisy output