### PR TITLE
HBASE-28254 Flaky test: TestTableShell

### DIFF
--- a/hbase-shell/src/test/ruby/hbase/table_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/table_test.rb
@@ -681,11 +681,15 @@ module Hbase
       create_test_table(@test_name_raw)
       @test_table = table(@test_name_raw)
 
-      # Instert test data
+      # Insert test data
       @test_table.put(1, "x:a", 1)
+      sleep(1.0/10.0)
       @test_table.put(2, "x:raw1", 11)
+      sleep(1.0/10.0)
       @test_table.put(2, "x:raw1", 11)
+      sleep(1.0/10.0)
       @test_table.put(2, "x:raw1", 11)
+      sleep(1.0/10.0)
       @test_table.put(2, "x:raw1", 11)
 
       args = {}

--- a/hbase-shell/src/test/ruby/hbase/table_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/table_test.rb
@@ -683,13 +683,13 @@ module Hbase
 
       # Insert test data
       @test_table.put(1, "x:a", 1)
-      sleep(1.0/10.0)
+      sleep(1.0/1000.0)
       @test_table.put(2, "x:raw1", 11)
-      sleep(1.0/10.0)
+      sleep(1.0/1000.0)
       @test_table.put(2, "x:raw1", 11)
-      sleep(1.0/10.0)
+      sleep(1.0/1000.0)
       @test_table.put(2, "x:raw1", 11)
-      sleep(1.0/10.0)
+      sleep(1.0/1000.0)
       @test_table.put(2, "x:raw1", 11)
 
       args = {}


### PR DESCRIPTION
Add some delay (1/1000s) between HBase shell commands in Ruby to avoid two commands ending up with the same version.

Please backport until `branch-2.4`