### PR TITLE
HBASE-28274 Flaky test: TestFanOutOneBlockAsyncDFSOutput (Part 2)

### DIFF
--- a/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/io/asyncfs/TestFanOutOneBlockAsyncDFSOutput.java
+++ b/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/io/asyncfs/TestFanOutOneBlockAsyncDFSOutput.java
@@ -52,10 +52,12 @@ import org.apache.hadoop.ipc.RemoteException;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.FixMethodOrder;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.junit.rules.TestName;
+import org.junit.runners.MethodSorters;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -65,6 +67,7 @@ import org.apache.hbase.thirdparty.io.netty.channel.EventLoopGroup;
 import org.apache.hbase.thirdparty.io.netty.channel.nio.NioEventLoopGroup;
 import org.apache.hbase.thirdparty.io.netty.channel.socket.nio.NioSocketChannel;
 
+@FixMethodOrder(MethodSorters.NAME_ASCENDING)
 @Category({ MiscTests.class, MediumTests.class })
 public class TestFanOutOneBlockAsyncDFSOutput extends AsyncFSTestBase {
 
@@ -143,7 +146,7 @@ public class TestFanOutOneBlockAsyncDFSOutput extends AsyncFSTestBase {
   }
 
   @Test
-  public void testRecover() throws IOException, InterruptedException, ExecutionException {
+  public void test0Recover() throws IOException, InterruptedException, ExecutionException {
     Path f = new Path("/" + name.getMethodName());
     EventLoop eventLoop = EVENT_LOOP_GROUP.next();
     FanOutOneBlockAsyncDFSOutput out = FanOutOneBlockAsyncDFSOutputHelper.createOutput(FS, f, true,

--- a/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/io/asyncfs/TestFanOutOneBlockAsyncDFSOutput.java
+++ b/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/io/asyncfs/TestFanOutOneBlockAsyncDFSOutput.java
@@ -146,8 +146,8 @@ public class TestFanOutOneBlockAsyncDFSOutput extends AsyncFSTestBase {
   }
 
   /**
-   * Test method has been renamed to be the first in NAME_ASCENDING.
-   * It's an ugly hack to avoid flakiness.
+   * Test method has been renamed to be the first in NAME_ASCENDING. It's an ugly hack to avoid
+   * flakiness.
    */
   @Test
   public void test0Recover() throws IOException, InterruptedException, ExecutionException {

--- a/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/io/asyncfs/TestFanOutOneBlockAsyncDFSOutput.java
+++ b/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/io/asyncfs/TestFanOutOneBlockAsyncDFSOutput.java
@@ -145,6 +145,10 @@ public class TestFanOutOneBlockAsyncDFSOutput extends AsyncFSTestBase {
     writeAndVerify(FS, f, out);
   }
 
+  /**
+   * Test method has been renamed to be the first in NAME_ASCENDING.
+   * It's an ugly hack to avoid flakiness.
+   */
   @Test
   public void test0Recover() throws IOException, InterruptedException, ExecutionException {
     Path f = new Path("/" + name.getMethodName());


### PR DESCRIPTION
This is not included in Flaky Test reports, but happens quite frequently for me locally. `testRecover()` passes the expected failure and throws error:

```
java.lang.AssertionError: flush should fail
	at org.junit.Assert.fail(Assert.java:89)
	at org.apache.hadoop.hbase.io.asyncfs.TestFanOutOneBlockAsyncDFSOutput.testRecover(TestFanOutOneBlockAsyncDFSOutput.java:154)
```

Looks like it happens only if the other test `testConnectToDatanodeFailed()` precedes it. They do similar thing: restart one of the DataNodes to generate failure in FS connection. I've tried the following things to fix it:

- changed the ID of DataNode to be restarted to be unique in the 2 tests,
- added `CLUSTER.waitDatanodeFullyStarted()` at the end of testConnectToDatanodeFailed.

None of them helped unfortunately, so I ended up with this ugly solution of strict test ordering. Open for any ideas from experts.

Please backport until `branch-2.4`.