### PR TITLE
HBASE-26268: Provide coprocessor hooks for updateConfiguration and clearRegionBlockCache

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -626,22 +626,30 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
   }
 
   private void preUpdateConfiguration() throws IOException {
-    if (rpcServices instanceof RSRpcServices) {
-      ((RSRpcServices) rpcServices).server.getRegionServerCoprocessorHost()
-        .preUpdateConfiguration(conf);
-    } else if (rpcServices instanceof MasterRpcServices) {
-      ((MasterRpcServices) rpcServices).server.getMasterCoprocessorHost()
-        .preUpdateConfiguration(conf);
+    if (rpcServices instanceof RSRpcServices && rpcServices.server != null) {
+      RSRpcServices rsRpcServices = (RSRpcServices) rpcServices;
+      if (rsRpcServices.server.getRegionServerCoprocessorHost() != null) {
+        rsRpcServices.server.getRegionServerCoprocessorHost().preUpdateConfiguration(conf);
+      }
+    } else if (rpcServices instanceof MasterRpcServices && rpcServices.server != null) {
+      MasterRpcServices masterRpcServices = (MasterRpcServices) rpcServices;
+      if (masterRpcServices.server.getMasterCoprocessorHost() != null) {
+        masterRpcServices.server.getMasterCoprocessorHost().preUpdateConfiguration(conf);
+      }
     }
   }
 
   private void postUpdateConfiguration() throws IOException {
-    if (rpcServices instanceof RSRpcServices) {
-      ((RSRpcServices) rpcServices).server.getRegionServerCoprocessorHost()
-        .postUpdateConfiguration(conf);
-    } else if (rpcServices instanceof MasterRpcServices) {
-      ((MasterRpcServices) rpcServices).server.getMasterCoprocessorHost()
-        .postUpdateConfiguration(conf);
+    if (rpcServices instanceof RSRpcServices && rpcServices.server != null) {
+      RSRpcServices rsRpcServices = (RSRpcServices) rpcServices;
+      if (rsRpcServices.server.getRegionServerCoprocessorHost() != null) {
+        rsRpcServices.server.getRegionServerCoprocessorHost().postUpdateConfiguration(conf);
+      }
+    } else if (rpcServices instanceof MasterRpcServices && rpcServices.server != null) {
+      MasterRpcServices masterRpcServices = (MasterRpcServices) rpcServices;
+      if (masterRpcServices.server.getMasterCoprocessorHost() != null) {
+        masterRpcServices.server.getMasterCoprocessorHost().postUpdateConfiguration(conf);
+      }
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -627,20 +627,20 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
 
   private void preUpdateConfiguration() throws IOException {
     if (rpcServices instanceof RSRpcServices) {
-      ((RSRpcServices)rpcServices).server.getRegionServerCoprocessorHost()
+      ((RSRpcServices) rpcServices).server.getRegionServerCoprocessorHost()
         .preUpdateConfiguration(conf);
     } else if (rpcServices instanceof MasterRpcServices) {
-      ((MasterRpcServices)rpcServices).server.getMasterCoprocessorHost()
+      ((MasterRpcServices) rpcServices).server.getMasterCoprocessorHost()
         .preUpdateConfiguration(conf);
     }
   }
 
   private void postUpdateConfiguration() throws IOException {
     if (rpcServices instanceof RSRpcServices) {
-      ((RSRpcServices)rpcServices).server.getRegionServerCoprocessorHost()
+      ((RSRpcServices) rpcServices).server.getRegionServerCoprocessorHost()
         .postUpdateConfiguration(conf);
     } else if (rpcServices instanceof MasterRpcServices) {
-      ((MasterRpcServices)rpcServices).server.getMasterCoprocessorHost()
+      ((MasterRpcServices) rpcServices).server.getMasterCoprocessorHost()
         .postUpdateConfiguration(conf);
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -190,7 +190,11 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
   private void setupSignalHandlers() {
     if (!SystemUtils.IS_OS_WINDOWS) {
       HBasePlatformDependent.handle("HUP", (number, name) -> {
-        updateConfiguration();
+        try {
+          updateConfiguration();
+        } catch (IOException e) {
+          LOG.error("Problem while reloading configuration", e);
+        }
       });
     }
   }
@@ -613,7 +617,7 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
   /**
    * Reload the configuration from disk.
    */
-  public void updateConfiguration() {
+  public void updateConfiguration() throws IOException {
     LOG.info("Reloading the configuration from disk.");
     // Reload the configuration from disk.
     preUpdateConfiguration();
@@ -622,29 +626,21 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
     postUpdateConfiguration();
   }
 
-  private void preUpdateConfiguration() {
-    try {
-      CoprocessorHost<?, ?> coprocessorHost = getCoprocessorHost();
-      if (coprocessorHost instanceof RegionServerCoprocessorHost) {
-        ((RegionServerCoprocessorHost) coprocessorHost).preUpdateConfiguration(conf);
-      } else if (coprocessorHost instanceof MasterCoprocessorHost) {
-        ((MasterCoprocessorHost) coprocessorHost).preUpdateConfiguration(conf);
-      }
-    } catch (IOException e) {
-      LOG.error("Error while calling coprocessor preUpdateConfiguration()", e);
+  private void preUpdateConfiguration() throws IOException {
+    CoprocessorHost<?, ?> coprocessorHost = getCoprocessorHost();
+    if (coprocessorHost instanceof RegionServerCoprocessorHost) {
+      ((RegionServerCoprocessorHost) coprocessorHost).preUpdateConfiguration(conf);
+    } else if (coprocessorHost instanceof MasterCoprocessorHost) {
+      ((MasterCoprocessorHost) coprocessorHost).preUpdateConfiguration(conf);
     }
   }
 
-  private void postUpdateConfiguration() {
-    try {
-      CoprocessorHost<?, ?> coprocessorHost = getCoprocessorHost();
-      if (coprocessorHost instanceof RegionServerCoprocessorHost) {
-        ((RegionServerCoprocessorHost) coprocessorHost).postUpdateConfiguration(conf);
-      } else if (coprocessorHost instanceof MasterCoprocessorHost) {
-        ((MasterCoprocessorHost) coprocessorHost).postUpdateConfiguration(conf);
-      }
-    } catch (IOException e) {
-      LOG.error("Error while calling coprocessor postUpdateConfiguration()", e);
+  private void postUpdateConfiguration() throws IOException {
+    CoprocessorHost<?, ?> coprocessorHost = getCoprocessorHost();
+    if (coprocessorHost instanceof RegionServerCoprocessorHost) {
+      ((RegionServerCoprocessorHost) coprocessorHost).postUpdateConfiguration(conf);
+    } else if (coprocessorHost instanceof MasterCoprocessorHost) {
+      ((MasterCoprocessorHost) coprocessorHost).postUpdateConfiguration(conf);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -187,9 +187,6 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
 
   protected final NettyEventLoopGroupConfig eventLoopGroupConfig;
 
-  /**
-   * If running on Windows, do windows-specific setup.
-   */
   private void setupSignalHandlers() {
     if (!SystemUtils.IS_OS_WINDOWS) {
       HBasePlatformDependent.handle("HUP", (number, name) -> {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MasterObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MasterObserver.java
@@ -1875,10 +1875,22 @@ public interface MasterObserver {
     String userName, List<Permission> permissions) throws IOException {
   }
 
+  /**
+   * Called before reloading the HMaster's {@link Configuration} from disk
+   * @param ctx           the coprocessor instance's environment
+   * @param preReloadConf the {@link Configuration} in use prior to reload
+   * @throws IOException if you need to signal an IO error
+   */
   default void preUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
     Configuration preReloadConf) throws IOException {
   }
 
+  /**
+   * Called after reloading the HMaster's {@link Configuration} from disk
+   * @param ctx            the coprocessor instance's environment
+   * @param postReloadConf the {@link Configuration} that was loaded
+   * @throws IOException if you need to signal an IO error
+   */
   default void postUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
     Configuration postReloadConf) throws IOException {
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MasterObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MasterObserver.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ClusterMetrics;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.MetaMutationAnnotation;
@@ -1873,4 +1874,10 @@ public interface MasterObserver {
   default void postHasUserPermissions(ObserverContext<MasterCoprocessorEnvironment> ctx,
     String userName, List<Permission> permissions) throws IOException {
   }
+
+  default void preUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    Configuration preReloadConf) throws IOException { }
+
+  default void postUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    Configuration postReloadConf) throws IOException { }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MasterObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MasterObserver.java
@@ -1876,8 +1876,10 @@ public interface MasterObserver {
   }
 
   default void preUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
-    Configuration preReloadConf) throws IOException { }
+    Configuration preReloadConf) throws IOException {
+  }
 
   default void postUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
-    Configuration postReloadConf) throws IOException { }
+    Configuration postReloadConf) throws IOException {
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
@@ -171,19 +171,42 @@ public interface RegionServerObserver {
 
   }
 
+  /**
+   * Called before clearing the block caches for one or more regions
+   * @param ctx the coprocessor instance's environment
+   * @throws IOException if you need to signal an IO error
+   */
   default void preClearRegionBlockCache(ObserverContext<RegionServerCoprocessorEnvironment> ctx)
     throws IOException {
   }
 
+  /**
+   * Called after clearing the block caches for one or more regions
+   * @param ctx   the coprocessor instance's environment
+   * @param stats statistics about the cache evictions that happened
+   * @throws IOException if you need to signal an IO error
+   */
   default void postClearRegionBlockCache(ObserverContext<RegionServerCoprocessorEnvironment> ctx,
     CacheEvictionStats stats) throws IOException {
   }
 
+  /**
+   * Called before reloading the RegionServer's {@link Configuration} from disk
+   * @param ctx           the coprocessor instance's environment
+   * @param preReloadConf the {@link Configuration} in use prior to reload
+   * @throws IOException if you need to signal an IO error
+   */
   default void preUpdateRegionServerConfiguration(
     ObserverContext<RegionServerCoprocessorEnvironment> ctx, Configuration preReloadConf)
     throws IOException {
   }
 
+  /**
+   * Called after reloading the RegionServer's {@link Configuration} from disk
+   * @param ctx            the coprocessor instance's environment
+   * @param postReloadConf the {@link Configuration} that was loaded
+   * @throws IOException if you need to signal an IO error
+   */
   default void postUpdateRegionServerConfiguration(
     ObserverContext<RegionServerCoprocessorEnvironment> ctx, Configuration postReloadConf)
     throws IOException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hbase.coprocessor;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.CacheEvictionStats;
-import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.replication.ReplicationEndpoint;
@@ -172,19 +171,22 @@ public interface RegionServerObserver {
 
   }
 
-  default void preClearRegionBlockCache(
-    ObserverContext<RegionServerCoprocessorEnvironment> ctx) throws IOException { }
+  default void preClearRegionBlockCache(ObserverContext<RegionServerCoprocessorEnvironment> ctx)
+    throws IOException {
+  }
 
-  default void postClearRegionBlockCache(
-    ObserverContext<RegionServerCoprocessorEnvironment> ctx, CacheEvictionStats stats)
-    throws IOException { }
+  default void postClearRegionBlockCache(ObserverContext<RegionServerCoprocessorEnvironment> ctx,
+    CacheEvictionStats stats) throws IOException {
+  }
 
   default void preUpdateRegionServerConfiguration(
     ObserverContext<RegionServerCoprocessorEnvironment> ctx, Configuration preReloadConf)
-    throws IOException { }
+    throws IOException {
+  }
 
   default void postUpdateRegionServerConfiguration(
     ObserverContext<RegionServerCoprocessorEnvironment> ctx, Configuration postReloadConf)
-    throws IOException { }
+    throws IOException {
+  }
 
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/RegionServerObserver.java
@@ -18,6 +18,9 @@
 package org.apache.hadoop.hbase.coprocessor;
 
 import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.CacheEvictionStats;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.replication.ReplicationEndpoint;
@@ -168,5 +171,20 @@ public interface RegionServerObserver {
     Mutation mutation) throws IOException {
 
   }
+
+  default void preClearRegionBlockCache(
+    ObserverContext<RegionServerCoprocessorEnvironment> ctx) throws IOException { }
+
+  default void postClearRegionBlockCache(
+    ObserverContext<RegionServerCoprocessorEnvironment> ctx, CacheEvictionStats stats)
+    throws IOException { }
+
+  default void preUpdateRegionServerConfiguration(
+    ObserverContext<RegionServerCoprocessorEnvironment> ctx, Configuration preReloadConf)
+    throws IOException { }
+
+  default void postUpdateRegionServerConfiguration(
+    ObserverContext<RegionServerCoprocessorEnvironment> ctx, Configuration postReloadConf)
+    throws IOException { }
 
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -724,6 +724,11 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     return rpcServices;
   }
 
+  @Override
+  protected MasterCoprocessorHost getCoprocessorHost() {
+    return getMasterCoprocessorHost();
+  }
+
   public boolean balanceSwitch(final boolean b) throws IOException {
     return getMasterRpcServices().switchBalancer(b, BalanceSwitchMode.ASYNC);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterCoprocessorHost.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterCoprocessorHost.java
@@ -2114,4 +2114,22 @@ public class MasterCoprocessorHost
       }
     });
   }
+
+  public void preUpdateConfiguration(Configuration preReloadConf) throws IOException {
+    execOperation(coprocEnvironments.isEmpty() ? null : new MasterObserverOperation() {
+      @Override
+      public void call(MasterObserver observer) throws IOException {
+        observer.preUpdateMasterConfiguration(this, preReloadConf);
+      }
+    });
+  }
+
+  public void postUpdateConfiguration(Configuration postReloadConf) throws IOException {
+    execOperation(coprocEnvironments.isEmpty() ? null : new MasterObserverOperation() {
+      @Override
+      public void call(MasterObserver observer) throws IOException {
+        observer.postUpdateMasterConfiguration(this, postReloadConf);
+      }
+    });
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -588,6 +588,11 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
   }
 
   @Override
+  protected RegionServerCoprocessorHost getCoprocessorHost() {
+    return getRegionServerCoprocessorHost();
+  }
+
+  @Override
   protected boolean canCreateBaseZNode() {
     return !clusterMode();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerCoprocessorHost.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerCoprocessorHost.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.regionserver;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.CacheEvictionStats;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.Mutation;
@@ -236,6 +237,42 @@ public class RegionServerCoprocessorHost
       @Override
       public void call(RegionServerObserver observer) throws IOException {
         observer.postExecuteProcedures(this);
+      }
+    });
+  }
+
+  public void preUpdateConfiguration(Configuration preReloadConf) throws IOException {
+    execOperation(coprocEnvironments.isEmpty() ? null : new RegionServerObserverOperation() {
+      @Override
+      public void call(RegionServerObserver observer) throws IOException {
+        observer.preUpdateRegionServerConfiguration(this, preReloadConf);
+      }
+    });
+  }
+
+  public void postUpdateConfiguration(Configuration postReloadConf) throws IOException {
+    execOperation(coprocEnvironments.isEmpty() ? null : new RegionServerObserverOperation() {
+      @Override
+      public void call(RegionServerObserver observer) throws IOException {
+        observer.postUpdateRegionServerConfiguration(this, postReloadConf);
+      }
+    });
+  }
+
+  public void preClearRegionBlockCache() throws IOException {
+    execOperation(coprocEnvironments.isEmpty() ? null : new RegionServerObserverOperation() {
+      @Override
+      public void call(RegionServerObserver observer) throws IOException {
+        observer.preClearRegionBlockCache(this);
+      }
+    });
+  }
+
+  public void postClearRegionBlockCache(CacheEvictionStats stats) throws IOException {
+    execOperation(coprocEnvironments.isEmpty() ? null : new RegionServerObserverOperation() {
+      @Override
+      public void call(RegionServerObserver observer) throws IOException {
+        observer.postClearRegionBlockCache(this, stats);
       }
     });
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AccessController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AccessController.java
@@ -34,6 +34,7 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ArrayBackedTag;
+import org.apache.hadoop.hbase.CacheEvictionStats;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.CellUtil;
@@ -2576,4 +2577,28 @@ public class AccessController implements MasterCoprocessor, RegionCoprocessor,
     accessChecker.requirePermission(getActiveUser(ctx), "updateRSGroupConfig", null,
       Permission.Action.ADMIN);
   }
+
+  @Override
+  public void preClearRegionBlockCache(ObserverContext<RegionServerCoprocessorEnvironment> ctx)
+    throws IOException {
+    accessChecker.requirePermission(getActiveUser(ctx), "clearRegionBlockCache", null,
+      Permission.Action.ADMIN);
+  }
+
+  @Override
+  public void preUpdateRegionServerConfiguration(
+    ObserverContext<RegionServerCoprocessorEnvironment> ctx, Configuration preReloadConf)
+    throws IOException {
+    accessChecker.requirePermission(getActiveUser(ctx), "updateConfiguration", null,
+      Permission.Action.ADMIN);
+  }
+
+  @Override
+  public void preUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    Configuration preReloadConf) throws IOException {
+    accessChecker.requirePermission(getActiveUser(ctx), "updateConfiguration", null,
+      Permission.Action.ADMIN);
+  }
+
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AccessController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AccessController.java
@@ -34,7 +34,6 @@ import java.util.TreeSet;
 import java.util.stream.Collectors;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ArrayBackedTag;
-import org.apache.hadoop.hbase.CacheEvictionStats;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.CellUtil;
@@ -2599,6 +2598,5 @@ public class AccessController implements MasterCoprocessor, RegionCoprocessor,
     accessChecker.requirePermission(getActiveUser(ctx), "updateConfiguration", null,
       Permission.Action.ADMIN);
   }
-
 
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/coprocessor/TestMasterObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/coprocessor/TestMasterObserver.java
@@ -191,6 +191,8 @@ public class TestMasterObserver {
     private boolean postLockHeartbeatCalled;
     private boolean preMasterStoreFlushCalled;
     private boolean postMasterStoreFlushCalled;
+    private boolean preUpdateMasterConfigurationCalled;
+    private boolean postUpdateMasterConfigurationCalled;
 
     public void resetStates() {
       preCreateTableRegionInfosCalled = false;
@@ -284,6 +286,8 @@ public class TestMasterObserver {
       postLockHeartbeatCalled = false;
       preMasterStoreFlushCalled = false;
       postMasterStoreFlushCalled = false;
+      preUpdateMasterConfigurationCalled = false;
+      postUpdateMasterConfigurationCalled = false;
     }
 
     @Override
@@ -1264,6 +1268,17 @@ public class TestMasterObserver {
       throws IOException {
     }
 
+    @Override
+    public void preUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
+      Configuration preReloadConf) throws IOException {
+      preUpdateMasterConfigurationCalled = true;
+    }
+
+    @Override
+    public void postUpdateMasterConfiguration(ObserverContext<MasterCoprocessorEnvironment> ctx,
+      Configuration postReloadConf) throws IOException {
+      postUpdateMasterConfigurationCalled = true;
+    }
   }
 
   private static HBaseTestingUtil UTIL = new HBaseTestingUtil();
@@ -1713,6 +1728,25 @@ public class TestMasterObserver {
 
       assertTrue("Master store flush called", cp.preMasterStoreFlushCalled);
       assertTrue("Master store flush called", cp.postMasterStoreFlushCalled);
+    }
+  }
+
+  @Test
+  public void testUpdateConfiguration() throws Exception {
+    SingleProcessHBaseCluster cluster = UTIL.getHBaseCluster();
+    HMaster master = cluster.getMaster();
+    MasterCoprocessorHost host = master.getMasterCoprocessorHost();
+    CPMasterObserver cp = host.findCoprocessor(CPMasterObserver.class);
+    cp.resetStates();
+    assertFalse("No update configuration call", cp.preUpdateMasterConfigurationCalled);
+    assertFalse("No update configuration call", cp.postUpdateMasterConfigurationCalled);
+
+    try (Connection connection = ConnectionFactory.createConnection(UTIL.getConfiguration());
+      Admin admin = connection.getAdmin()) {
+      admin.updateConfiguration();
+
+      assertTrue("Update configuration called", cp.preUpdateMasterConfigurationCalled);
+      assertTrue("Update configuration called", cp.postUpdateMasterConfigurationCalled);
     }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestAccessController.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestAccessController.java
@@ -3087,6 +3087,41 @@ public class TestAccessController extends SecureTestUtil {
   }
 
   @Test
+  public void testUpdateMasterConfiguration() throws Exception {
+    AccessTestAction action = () -> {
+      ACCESS_CONTROLLER.preUpdateMasterConfiguration(ObserverContextImpl.createAndPrepare(CP_ENV),
+        null);
+      return null;
+    };
+
+    verifyAllowed(action, SUPERUSER, USER_ADMIN);
+    verifyDenied(action, USER_CREATE, USER_RW, USER_RO, USER_NONE, USER_OWNER);
+  }
+
+  @Test
+  public void testUpdateRegionServerConfiguration() throws Exception {
+    AccessTestAction action = () -> {
+      ACCESS_CONTROLLER
+        .preUpdateRegionServerConfiguration(ObserverContextImpl.createAndPrepare(RSCP_ENV), null);
+      return null;
+    };
+
+    verifyAllowed(action, SUPERUSER, USER_ADMIN);
+    verifyDenied(action, USER_CREATE, USER_RW, USER_RO, USER_NONE, USER_OWNER);
+  }
+
+  @Test
+  public void testClearRegionBlockCache() throws Exception {
+    AccessTestAction action = () -> {
+      ACCESS_CONTROLLER.preClearRegionBlockCache(ObserverContextImpl.createAndPrepare(RSCP_ENV));
+      return null;
+    };
+
+    verifyAllowed(action, SUPERUSER, USER_ADMIN);
+    verifyDenied(action, USER_CREATE, USER_RW, USER_RO, USER_NONE, USER_OWNER);
+  }
+
+  @Test
   public void testTransitSyncReplicationPeerState() throws Exception {
     AccessTestAction action = new AccessTestAction() {
       @Override


### PR DESCRIPTION
Provide coprocessor hooks for updateConfiguration and clearRegionBlockCache. Also, use these new hooks in AccessController to gate access to these operations. This closes a minor security hole.