### PR TITLE
fix violations of Sonarqube rule java:S2111

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceBackupCopyJob.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceBackupCopyJob.java
@@ -198,7 +198,7 @@ public class MapReduceBackupCopyJob implements BackupCopyJob {
           if (newProgress > lastProgress) {
 
             BigDecimal progressData =
-              new BigDecimal(newProgress * 100).setScale(1, BigDecimal.ROUND_HALF_UP);
+              BigDecimal.valueOf(newProgress * 100).setScale(1, BigDecimal.ROUND_HALF_UP);
             String newProgressStr = progressData + "%";
             LOG.info("Progress: " + newProgressStr);
             updateProgress(backupInfo, backupManager, progressData.intValue(), bytesCopied);
@@ -212,7 +212,7 @@ public class MapReduceBackupCopyJob implements BackupCopyJob {
         float newProgress =
           progressDone + job.mapProgress() * subTaskPercntgInWholeTask * (1 - INIT_PROGRESS);
         BigDecimal progressData =
-          new BigDecimal(newProgress * 100).setScale(1, BigDecimal.ROUND_HALF_UP);
+          BigDecimal.valueOf(newProgress * 100).setScale(1, BigDecimal.ROUND_HALF_UP);
 
         String newProgressStr = progressData + "%";
         LOG.info("Progress: " + newProgressStr + " subTask: " + subTaskPercntgInWholeTask


### PR DESCRIPTION
Hello,

This PR fixes 2 violations of Sonarqube Rule java:S2111 : ['"BigDecimal(double)" should not be used'](https://rules.sonarsource.com/java/RSPEC-2111).
For more details, please see [CERT, NUM10-J.](https://wiki.sei.cmu.edu/confluence/x/kzdGBQ)

The patch was automatically generated using the ViolationFixer tool.