### PR TITLE
HBASE-28292 Make Delay prefetch property to be dynamically configured

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -24,6 +24,7 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
@@ -456,6 +457,8 @@ public final class HFile {
     HFileBlock.FSReader getUncachedBlockReader();
 
     boolean prefetchComplete();
+
+    boolean prefetchStarted();
 
     /**
      * To close the stream's socket. Note: This can be concurrently called from multiple threads and

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -24,7 +24,6 @@ import java.net.InetSocketAddress;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.LongAdder;
 import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -46,7 +46,7 @@ public class HFilePreadReader extends HFileReaderImpl {
 
     // Prefetch file blocks upon open if requested
     if (cacheConf.shouldPrefetchOnOpen() && cacheIfCompactionsOff() && shouldCache.booleanValue()) {
-      PrefetchExecutor.request(path, false, new Runnable() {
+      PrefetchExecutor.request(path, new Runnable() {
         @Override
         public void run() {
           long offset = 0;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -46,7 +46,7 @@ public class HFilePreadReader extends HFileReaderImpl {
 
     // Prefetch file blocks upon open if requested
     if (cacheConf.shouldPrefetchOnOpen() && cacheIfCompactionsOff() && shouldCache.booleanValue()) {
-      PrefetchExecutor.request(path, new Runnable() {
+      PrefetchExecutor.request(path, false, new Runnable() {
         @Override
         public void run() {
           long offset = 0;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -27,7 +27,6 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Optional;
-import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntConsumer;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -27,6 +27,7 @@ import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
 import java.util.Optional;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.function.IntConsumer;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
@@ -1656,6 +1657,10 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
   @Override
   public boolean prefetchComplete() {
     return PrefetchExecutor.isCompleted(path);
+  }
+
+  public boolean prefetchStarted() {
+    return PrefetchExecutor.isPrefetchStarted();
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -1659,6 +1659,11 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     return PrefetchExecutor.isCompleted(path);
   }
 
+  /**
+   * Returns true if block prefetching was started after waiting for specified delay, false
+   * otherwise
+   */
+  @Override
   public boolean prefetchStarted() {
     return PrefetchExecutor.isPrefetchStarted();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PrefetchExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PrefetchExecutor.java
@@ -50,11 +50,11 @@ public final class PrefetchExecutor {
   public static final float PREFETCH_DELAY_VARIATION_DEFAULT_VALUE = 0.2f;
 
   /** Futures for tracking block prefetch activity */
-  public static final Map<Path, Future<?>> prefetchFutures = new ConcurrentSkipListMap<>();
+  private static final Map<Path, Future<?>> prefetchFutures = new ConcurrentSkipListMap<>();
   /** Runnables for resetting the prefetch activity */
-  public static final Map<Path, Runnable> prefetchRunnable = new ConcurrentSkipListMap<>();
+  private static final Map<Path, Runnable> prefetchRunnable = new ConcurrentSkipListMap<>();
   /** Executor pool shared among all HFiles for block prefetch */
-  public static final ScheduledExecutorService prefetchExecutorPool;
+  private static final ScheduledExecutorService prefetchExecutorPool;
   /** Delay before beginning prefetch */
   private static int prefetchDelayMillis;
   /** Variation in prefetch delay times, to mitigate stampedes */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PrefetchExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PrefetchExecutor.java
@@ -184,8 +184,6 @@ public final class PrefetchExecutor{
     return prefetchRunnable;
   }
 
-  @RestrictedApi(explanation = "Should only be called in tests", link = "",
-    allowedOnPath = ".*/src/test/.*")
   static boolean isPrefetchStarted() {
     AtomicBoolean prefetchStarted = new AtomicBoolean(false);
     for (Map.Entry<Path, Future<?>> entry : prefetchFutures.entrySet()) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PrefetchExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PrefetchExecutor.java
@@ -20,7 +20,6 @@ package org.apache.hadoop.hbase.io.hfile;
 import com.google.errorprone.annotations.RestrictedApi;
 import java.util.Map;
 import java.util.concurrent.ConcurrentSkipListMap;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.RejectedExecutionException;
 import java.util.concurrent.ScheduledExecutorService;
@@ -29,7 +28,6 @@ import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeUnit;
-import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.regex.Pattern;
 import org.apache.hadoop.conf.Configuration;
@@ -43,7 +41,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 @InterfaceAudience.Private
-public final class PrefetchExecutor{
+public final class PrefetchExecutor {
 
   private static final Logger LOG = LoggerFactory.getLogger(PrefetchExecutor.class);
   /** Wait time in miliseconds before executing prefetch */
@@ -104,8 +102,8 @@ public final class PrefetchExecutor{
           TraceUtil.tracedRunnable(runnable, "PrefetchExecutor.request");
         final Future<?> future =
           prefetchExecutorPool.schedule(tracedRunnable, delay, TimeUnit.MILLISECONDS);
-          prefetchFutures.put(path, future);
-          prefetchRunnable.put(path, runnable);
+        prefetchFutures.put(path, future);
+        prefetchRunnable.put(path, runnable);
       } catch (RejectedExecutionException e) {
         prefetchFutures.remove(path);
         prefetchRunnable.remove(path);
@@ -156,19 +154,19 @@ public final class PrefetchExecutor{
 
   /* Visible for testing only */
   @RestrictedApi(explanation = "Should only be called in tests", link = "",
-    allowedOnPath = ".*/src/test/.*")
+      allowedOnPath = ".*/src/test/.*")
   static ScheduledExecutorService getExecutorPool() {
     return prefetchExecutorPool;
   }
 
   @RestrictedApi(explanation = "Should only be called in tests", link = "",
-    allowedOnPath = ".*/src/test/.*")
+      allowedOnPath = ".*/src/test/.*")
   static Map<Path, Future<?>> getPrefetchFutures() {
     return prefetchFutures;
   }
 
   @RestrictedApi(explanation = "Should only be called in tests", link = "",
-    allowedOnPath = ".*/src/test/.*")
+      allowedOnPath = ".*/src/test/.*")
   static Map<Path, Runnable> getPrefetchRunnable() {
     return prefetchRunnable;
   }
@@ -180,9 +178,8 @@ public final class PrefetchExecutor{
       Future<?> v = entry.getValue();
       ScheduledFuture sf = (ScheduledFuture) prefetchFutures.get(k);
       long waitTime = sf.getDelay(TimeUnit.MILLISECONDS);
-      LOG.info("Remaining wait time is : {}", waitTime);
       if (waitTime < 0) {
-        //At this point prefetch is started
+        // At this point prefetch is started
         prefetchStarted.set(true);
         break;
       }
@@ -199,7 +196,7 @@ public final class PrefetchExecutor{
     prefetchFutures.forEach((k, v) -> {
       ScheduledFuture sf = (ScheduledFuture) prefetchFutures.get(k);
       if (!(sf.getDelay(TimeUnit.MILLISECONDS) > 0)) {
-        //the thread is still pending delay expiration and has not started to run yet, so can be
+        // the thread is still pending delay expiration and has not started to run yet, so can be
         // re-scheduled at no cost.
         interrupt(k);
         request(k, prefetchRunnable.get(k));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PrefetchExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/PrefetchExecutor.java
@@ -66,8 +66,8 @@ public final class PrefetchExecutor {
     // 1s here for tests, consider 30s in hbase-default.xml
     // Set to 0 for no delay
     prefetchDelayMillis = conf.getInt(PREFETCH_DELAY, 1000);
-    prefetchDelayVariation = conf.getFloat(PREFETCH_DELAY_VARIATION,
-      PREFETCH_DELAY_VARIATION_DEFAULT_VALUE);
+    prefetchDelayVariation =
+      conf.getFloat(PREFETCH_DELAY_VARIATION, PREFETCH_DELAY_VARIATION_DEFAULT_VALUE);
     int prefetchThreads = conf.getInt("hbase.hfile.thread.prefetch", 4);
     prefetchExecutorPool = new ScheduledThreadPoolExecutor(prefetchThreads, new ThreadFactory() {
       @Override
@@ -195,8 +195,8 @@ public final class PrefetchExecutor {
 
   public static void loadConfiguration(Configuration conf) {
     prefetchDelayMillis = conf.getInt(PREFETCH_DELAY, 1000);
-    prefetchDelayVariation = conf.getFloat(PREFETCH_DELAY_VARIATION,
-      PREFETCH_DELAY_VARIATION_DEFAULT_VALUE);
+    prefetchDelayVariation =
+      conf.getFloat(PREFETCH_DELAY_VARIATION, PREFETCH_DELAY_VARIATION_DEFAULT_VALUE);
     prefetchFutures.forEach((k, v) -> {
       ScheduledFuture sf = (ScheduledFuture) prefetchFutures.get(k);
       if (!(sf.getDelay(TimeUnit.MILLISECONDS) > 0)) {
@@ -205,8 +205,8 @@ public final class PrefetchExecutor {
         interrupt(k);
         request(k, prefetchRunnable.get(k));
       }
-      LOG.debug("Reset called on Prefetch of file {} with delay {}, delay variation {}",
-        k, prefetchDelayMillis, prefetchDelayVariation);
+      LOG.debug("Reset called on Prefetch of file {} with delay {}, delay variation {}", k,
+        prefetchDelayMillis, prefetchDelayVariation);
     });
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -2043,7 +2043,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     this.compactSplitThread = new CompactSplit(this);
 
     //Prefetch Notifier
-    this.prefetchExecutorNotifier = new PrefetchExecutorNotifier(conf, this);
+    this.prefetchExecutorNotifier = new PrefetchExecutorNotifier(conf);
 
     // Background thread to check for compactions; needed if region has not gotten updates
     // in a while. It will take care of not checking too frequently on store-by-store basis.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -2042,7 +2042,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     // Compaction thread
     this.compactSplitThread = new CompactSplit(this);
 
-    //Prefetch Notifier
+    // Prefetch Notifier
     this.prefetchExecutorNotifier = new PrefetchExecutorNotifier(conf);
 
     // Background thread to check for compactions; needed if region has not gotten updates

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -495,6 +495,9 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
    */
   private ReplicationMarkerChore replicationMarkerChore;
 
+  // A timer submit requests to the PrefetchExecutor
+  private PrefetchExecutorNotifier prefetchExecutorNotifier;
+
   /**
    * Starts a HRegionServer at the default location.
    * <p/>
@@ -2039,6 +2042,9 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     // Compaction thread
     this.compactSplitThread = new CompactSplit(this);
 
+    //Prefetch Notifier
+    this.prefetchExecutorNotifier = new PrefetchExecutorNotifier(conf, this);
+
     // Background thread to check for compactions; needed if region has not gotten updates
     // in a while. It will take care of not checking too frequently on store-by-store basis.
     this.compactionChecker = new CompactionChecker(this, this.compactionCheckFrequency, this);
@@ -2128,6 +2134,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     configurationManager.registerObserver(this.compactSplitThread);
     configurationManager.registerObserver(this.cacheFlusher);
     configurationManager.registerObserver(this.rpcServices);
+    configurationManager.registerObserver(this.prefetchExecutorNotifier);
     configurationManager.registerObserver(this);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/PrefetchExecutorNotifier.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/PrefetchExecutorNotifier.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.conf.ConfigurationManager;
+import org.apache.hadoop.hbase.conf.PropagatingConfigurationObserver;
+import org.apache.hadoop.hbase.io.hfile.PrefetchExecutor;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+
+/**
+ * Class to submit requests for PrefetchExecutor depending on configuration change
+ */
+@InterfaceAudience.Private
+public final class PrefetchExecutorNotifier implements PropagatingConfigurationObserver {
+  private static final Logger LOG = LoggerFactory.getLogger(CompactSplit.class);
+
+  /** Wait time in miliseconds before executing prefetch */
+  public static final String PREFETCH_DELAY = "hbase.hfile.prefetch.delay";
+
+
+  private final HRegionServer server;
+  private final Configuration conf;
+
+  PrefetchExecutorNotifier(Configuration conf, HRegionServer server) {
+    this.server = server;
+    this.conf = server.getConfiguration();
+  }
+
+  // only for test
+  public PrefetchExecutorNotifier(Configuration conf) {
+    this.server = null;
+    this.conf = conf;
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void onConfigurationChange(Configuration newConf) {
+    // Update prefetch delay in the prefetch executor class
+    // interrupt and restart threads which have not started executing
+
+    PrefetchExecutor.loadConfiguration(conf);
+    LOG.info("Config hbase.hfile.prefetch.delay is changed to {}",
+      conf.getInt(PREFETCH_DELAY, 1000));
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void registerChildren(ConfigurationManager manager) {
+    // No children to register.
+  }
+
+  /**
+   * {@inheritDoc}
+   */
+  @Override
+  public void deregisterChildren(ConfigurationManager manager) {
+    // No children to register
+  }
+
+  public int getPrefetchDelay() {
+    return PrefetchExecutor.getPrefetchDelay();
+  }
+  public long getComputedPrefetchDelay() { return PrefetchExecutor.getComputedPrefetchDelay();}
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/PrefetchExecutorNotifier.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/PrefetchExecutorNotifier.java
@@ -30,7 +30,7 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.Private
 public final class PrefetchExecutorNotifier implements PropagatingConfigurationObserver {
-  private static final Logger LOG = LoggerFactory.getLogger(CompactSplit.class);
+  private static final Logger LOG = LoggerFactory.getLogger(PrefetchExecutorNotifier.class);
 
   /** Wait time in miliseconds before executing prefetch */
   public static final String PREFETCH_DELAY = "hbase.hfile.prefetch.delay";

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/PrefetchExecutorNotifier.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/PrefetchExecutorNotifier.java
@@ -25,7 +25,6 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-
 /**
  * Class to submit requests for PrefetchExecutor depending on configuration change
  */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/PrefetchExecutorNotifier.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/PrefetchExecutorNotifier.java
@@ -35,19 +35,10 @@ public final class PrefetchExecutorNotifier implements PropagatingConfigurationO
 
   /** Wait time in miliseconds before executing prefetch */
   public static final String PREFETCH_DELAY = "hbase.hfile.prefetch.delay";
-
-
-  private final HRegionServer server;
   private final Configuration conf;
-
-  PrefetchExecutorNotifier(Configuration conf, HRegionServer server) {
-    this.server = server;
-    this.conf = server.getConfiguration();
-  }
 
   // only for test
   public PrefetchExecutorNotifier(Configuration conf) {
-    this.server = null;
     this.conf = conf;
   }
 
@@ -58,7 +49,6 @@ public final class PrefetchExecutorNotifier implements PropagatingConfigurationO
   public void onConfigurationChange(Configuration newConf) {
     // Update prefetch delay in the prefetch executor class
     // interrupt and restart threads which have not started executing
-
     PrefetchExecutor.loadConfiguration(conf);
     LOG.info("Config hbase.hfile.prefetch.delay is changed to {}",
       conf.getInt(PREFETCH_DELAY, 1000));
@@ -83,5 +73,4 @@ public final class PrefetchExecutorNotifier implements PropagatingConfigurationO
   public int getPrefetchDelay() {
     return PrefetchExecutor.getPrefetchDelay();
   }
-  public long getComputedPrefetchDelay() { return PrefetchExecutor.getComputedPrefetchDelay();}
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.io.hfile;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasName;
 import static org.apache.hadoop.hbase.client.trace.hamcrest.SpanDataMatchers.hasParentSpanId;
 import static org.apache.hadoop.hbase.io.hfile.CacheConfig.CACHE_DATA_BLOCKS_COMPRESSED_KEY;
+import static org.apache.hadoop.hbase.io.hfile.PrefetchExecutor.*;
 import static org.apache.hadoop.hbase.regionserver.CompactSplit.HBASE_REGION_SERVER_ENABLE_COMPACTION;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.allOf;
@@ -334,6 +335,44 @@ public class TestPrefetch {
       boolean isCached = c != null;
       assertTrue(isCached);
     });
+  }
+
+  @Test
+  public void testOnConfigurationChange() {
+    // change PREFETCH_DELAY_ENABLE_KEY from false to true
+    conf.setInt(PREFETCH_DELAY, 40000);
+    PrefetchExecutor.loadConfiguration(conf);
+    assertTrue(getPrefetchDelay() == 40000);
+
+    // restore
+    conf.setInt(PREFETCH_DELAY, 30000);
+    PrefetchExecutor.loadConfiguration(conf);
+    assertTrue(getPrefetchDelay() == 30000);
+
+  }
+
+  @Test
+  public void testPrefetchWithDelay() throws Exception {
+    conf.setInt(PREFETCH_DELAY, 40000);
+    PrefetchExecutor.loadConfiguration(conf);
+
+    HFileContext context = new HFileContextBuilder().withCompression(Compression.Algorithm.GZ)
+      .withBlockSize(DATA_BLOCK_SIZE).build();
+    Path storeFile = writeStoreFile("TestPrefetchWithDelay", context);
+    readStoreFile(storeFile);
+    assertTrue(getPrefetchDelay() == 40000);
+  }
+
+  @Test
+  public void testPrefetchWithDefaultDelay() throws Exception {
+    conf.setInt(PREFETCH_DELAY, 1000);
+    PrefetchExecutor.loadConfiguration(conf);
+
+    HFileContext context = new HFileContextBuilder().withCompression(Compression.Algorithm.GZ)
+      .withBlockSize(DATA_BLOCK_SIZE).build();
+    Path storeFile = writeStoreFile("TestPrefetchWithDelay", context);
+    readStoreFile(storeFile);
+    assertTrue(getPrefetchDelay() == 1000);
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
@@ -360,12 +360,10 @@ public class TestPrefetch {
     conf.setInt(PREFETCH_DELAY, 25000);
     prefetchExecutorNotifier.onConfigurationChange(conf);
 
-    // Write file
     HFileContext context = new HFileContextBuilder().withCompression(Compression.Algorithm.GZ)
       .withBlockSize(DATA_BLOCK_SIZE).build();
     Path storeFile = writeStoreFile("TestPrefetchWithDelay", context);
-
-    // Open the file
+    
     HFile.Reader reader = HFile.createReader(fs, storeFile, cacheConf, true, conf);
     long startTime = System.currentTimeMillis();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
@@ -371,14 +371,13 @@ public class TestPrefetch {
 
     // Wait for 20 seconds, no thread should start prefetch
     Thread.sleep(20000);
-    assertFalse("Prefetch threads should not be running at this point",
-      reader.prefetchStarted());
+    assertFalse("Prefetch threads should not be running at this point", reader.prefetchStarted());
     while (!reader.prefetchStarted()) {
       assertTrue("Prefetch delay has not been expired yet",
         getElapsedTime(startTime) < PrefetchExecutor.getPrefetchDelay());
     }
     if (reader.prefetchStarted()) {
-      //Added some delay as we have started the timer a bit late.
+      // Added some delay as we have started the timer a bit late.
       Thread.sleep(500);
       assertTrue("Prefetch should start post configured delay",
         getElapsedTime(startTime) > PrefetchExecutor.getPrefetchDelay());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
@@ -363,7 +363,7 @@ public class TestPrefetch {
     HFileContext context = new HFileContextBuilder().withCompression(Compression.Algorithm.GZ)
       .withBlockSize(DATA_BLOCK_SIZE).build();
     Path storeFile = writeStoreFile("TestPrefetchWithDelay", context);
-    
+
     HFile.Reader reader = HFile.createReader(fs, storeFile, cacheConf, true, conf);
     long startTime = System.currentTimeMillis();
 


### PR DESCRIPTION
Make the prefetch delay configurable. The prefetch delay is associated to hbase.hfile.prefetch.delay configuration. There are some cases where configuring hbase.hfile.prefetch.delay would help in achieving better throughput. 

