### PR TITLE
HBASE-28305 Add "Uncompressed StoreFileSize" column to the table.jsp

### DIFF
--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -315,6 +315,7 @@
             <th>Region Server</th>
             <th>ReadRequests</th>
             <th>WriteRequests</th>
+            <th>Uncompressed StoreFileSize</th>
             <th>StorefileSize</th>
             <th>Num.Storefiles</th>
             <th>MemSize</th>
@@ -338,6 +339,7 @@
               String hostAndPort = "";
               String readReq = "N/A";
               String writeReq = "N/A";
+              String fileSizeUncompressed = ZEROMB;
               String fileSize = ZEROMB;
               String fileCount = "N/A";
               String memSize = ZEROMB;
@@ -356,6 +358,10 @@
                     if (rSize > 0) {
                     fileSize = StringUtils.byteDesc((long) rSize);
                     }
+                    double rSizeUncompressed = load.getUncompressedStoreFileSize().get(Size.Unit.BYTE);
+                    if (rSizeUncompressed > 0) {
+                    fileSizeUncompressed = StringUtils.byteDesc((long) rSizeUncompressed);
+                    }
                     fileCount = String.format("%,1d", load.getStoreFileCount());
                     double mSize = load.getMemStoreSize().get(Size.Unit.BYTE);
                     if (mSize > 0) {
@@ -370,6 +376,7 @@
             <td><a href="http://<%= hostAndPort %>/rs-status"><%= StringEscapeUtils.escapeHtml4(hostAndPort) %></a></td>
             <td><%= readReq%></td>
             <td><%= writeReq%></td>
+            <td><%= fileSizeUncompressed%></td>
             <td><%= fileSize%></td>
             <td><%= fileCount%></td>
             <td><%= memSize%></td>
@@ -834,6 +841,7 @@
 <%
   long totalReadReq = 0;
   long totalWriteReq = 0;
+  long totalSizeUncompressed = 0;
   long totalSize = 0;
   long totalStoreFileCount = 0;
   long totalMemSize = 0;
@@ -844,6 +852,7 @@
   long totalBlocksLocalWithSsdWeight = 0;
   String totalCompactionProgress = "";
   String totalMemSizeStr = ZEROMB;
+  String totalSizeUncompressedStr = ZEROMB;
   String totalSizeStr = ZEROMB;
   String totalLocality = "";
   String totalLocalityForSsd = "";
@@ -865,6 +874,7 @@
         if (regionMetrics != null) {
           totalReadReq += regionMetrics.getReadRequestCount();
           totalWriteReq += regionMetrics.getWriteRequestCount();
+          totalSizeUncompressed += regionMetrics.getUncompressedStoreFileSize().get(Size.Unit.MEGABYTE);
           totalSize += regionMetrics.getStoreFileSize().get(Size.Unit.MEGABYTE);
           totalStoreFileCount += regionMetrics.getStoreFileCount();
           totalMemSize += regionMetrics.getMemStoreSize().get(Size.Unit.MEGABYTE);
@@ -889,6 +899,9 @@
   }
   if (totalSize > 0) {
     totalSizeStr = StringUtils.byteDesc(totalSize*1024l*1024);
+  }
+  if (totalSizeUncompressed > 0){
+    totalSizeUncompressedStr = StringUtils.byteDesc(totalSizeUncompressed*1024l*1024);
   }
   if (totalMemSize > 0) {
     totalMemSizeStr = StringUtils.byteDesc(totalMemSize*1024l*1024);
@@ -920,6 +933,7 @@
             <th>Region Server</th>
             <th>ReadRequests<br>(<%= String.format("%,1d", totalReadReq)%>)</th>
             <th>WriteRequests<br>(<%= String.format("%,1d", totalWriteReq)%>)</th>
+            <th>Uncompressed StoreFileSize<br>(<%= totalSizeUncompressedStr %>)</th>
             <th>StorefileSize<br>(<%= totalSizeStr %>)</th>
             <th>Num.Storefiles<br>(<%= String.format("%,1d", totalStoreFileCount)%>)</th>
             <th>MemSize<br>(<%= totalMemSizeStr %>)</th>
@@ -944,6 +958,7 @@
             RegionMetrics load = hriEntry.getValue();
             String readReq = "N/A";
             String writeReq = "N/A";
+            String regionSizeUncompressed = ZEROMB;
             String regionSize = ZEROMB;
             String fileCount = "N/A";
             String memSize = ZEROMB;
@@ -951,6 +966,10 @@
             if (load != null) {
               readReq = String.format("%,1d", load.getReadRequestCount());
               writeReq = String.format("%,1d", load.getWriteRequestCount());
+              double rSizeUncompressed = load.getUncompressedStoreFileSize().get(Size.Unit.BYTE);
+              if (rSizeUncompressed > 0) {
+                regionSizeUncompressed = StringUtils.byteDesc((long)rSizeUncompressed);
+              }
               double rSize = load.getStoreFileSize().get(Size.Unit.BYTE);
               if (rSize > 0) {
                 regionSize = StringUtils.byteDesc((long)rSize);
@@ -987,6 +1006,7 @@
           <%= buildRegionDeployedServerTag(regionInfo, master, regionsToServer) %>
           <td><%= readReq%></td>
           <td><%= writeReq%></td>
+          <td><%= regionSizeUncompressed%></td>
           <td><%= regionSize%></td>
           <td><%= fileCount%></td>
           <td><%= memSize%></td>


### PR DESCRIPTION
Currently, HBase Web UI can only see the uncompressed StoreFile size of each Region on the Region Server page, but sometimes we also hope to see this information on the table details page, which can help analyze the data distribution of each table.