### PR TITLE
HBASE-28307 Add hbase-openssl module and include in release binaries

### DIFF
--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -62,8 +62,8 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
-      <groupId>org.apache.hbase.thirdparty</groupId>
-      <artifactId>hbase-shaded-netty-tcnative</artifactId>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-openssl</artifactId>
     </dependency>
     <dependency>
       <groupId>org.apache.hbase</groupId>

--- a/hbase-assembly/pom.xml
+++ b/hbase-assembly/pom.xml
@@ -62,6 +62,10 @@
       <scope>compile</scope>
     </dependency>
     <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-shaded-netty-tcnative</artifactId>
+    </dependency>
+    <dependency>
       <groupId>org.apache.hbase</groupId>
       <artifactId>hbase-server</artifactId>
     </dependency>

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
@@ -299,8 +299,8 @@ public final class X509Util {
    * Adds SslProvider.OPENSSL if OpenSsl is available and enabled. In order to make it available,
    * one must ensure that a properly shaded netty-tcnative is on the classpath. Properly shaded
    * means relocated to be prefixed with "org.apache.hbase.thirdparty" like the rest of the netty
-   * classes. We make available org.apache.hbase:hbase-openssl as a convenience module which
-   * one can use to pull in a shaded netty-tcnative statically linked against boringssl.
+   * classes. We make available org.apache.hbase:hbase-openssl as a convenience module which one can
+   * use to pull in a shaded netty-tcnative statically linked against boringssl.
    */
   private static boolean configureOpenSslIfAvailable(SslContextBuilder sslContextBuilder,
     Configuration conf) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
@@ -299,7 +299,8 @@ public final class X509Util {
    * Adds SslProvider.OPENSSL if OpenSsl is available and enabled. In order to make it available,
    * one must ensure that a properly shaded netty-tcnative is on the classpath. Properly shaded
    * means relocated to be prefixed with "org.apache.hbase.thirdparty" like the rest of the netty
-   * classes.
+   * classes. We make available org.apache.hbase:hbase-openssl as a convenience module which
+   * one can use to pull in a shaded netty-tcnative statically linked against boringssl.
    */
   private static boolean configureOpenSslIfAvailable(SslContextBuilder sslContextBuilder,
     Configuration conf) {

--- a/hbase-extensions/hbase-openssl/pom.xml
+++ b/hbase-extensions/hbase-openssl/pom.xml
@@ -1,0 +1,43 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements.  See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership.  The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+  -->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-extensions</artifactId>
+    <version>${revision}</version>
+    <relativePath>../pom.xml</relativePath>
+  </parent>
+
+  <artifactId>hbase-openssl</artifactId>
+  <packaging>jar</packaging>
+  <name>Apache HBase - OpenSSL support for TLS RPC</name>
+  <description>Includes tcnative bindings so that netty TLS can use OpenSSL</description>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hbase.thirdparty</groupId>
+      <artifactId>hbase-shaded-netty-tcnative</artifactId>
+      <scope>runtime</scope>
+    </dependency>
+  </dependencies>
+
+</project>

--- a/hbase-extensions/pom.xml
+++ b/hbase-extensions/pom.xml
@@ -1,0 +1,107 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <!--
+    /*
+     * Licensed to the Apache Software Foundation (ASF) under one
+     * or more contributor license agreements.  See the NOTICE file
+     * distributed with this work for additional information
+     * regarding copyright ownership.  The ASF licenses this file
+     * to you under the Apache License, Version 2.0 (the
+     * "License"); you may not use this file except in compliance
+     * with the License.  You may obtain a copy of the License at
+     *
+     *     http://www.apache.org/licenses/LICENSE-2.0
+     *
+     * Unless required by applicable law or agreed to in writing, software
+     * distributed under the License is distributed on an "AS IS" BASIS,
+     * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+     * See the License for the specific language governing permissions and
+     * limitations under the License.
+     */
+  -->
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>org.apache.hbase</groupId>
+    <artifactId>hbase-build-configuration</artifactId>
+    <version>${revision}</version>
+    <relativePath>../hbase-build-configuration</relativePath>
+  </parent>
+
+  <artifactId>hbase-extensions</artifactId>
+  <packaging>pom</packaging>
+  <name>Apache HBase - Extensions</name>
+  <description>Parent for optional extension modules</description>
+
+  <modules>
+    <module>hbase-openssl</module>
+  </modules>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.apache.hbase</groupId>
+      <artifactId>hbase-resource-bundle</artifactId>
+      <optional>true</optional>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <pluginManagement>
+      <plugins>
+        <!-- This entry overrides the excludeFileFilter element in the findbugs
+             configuration of the hbase/pom.xml file. This override specifies that
+             the excluded-filter-file is found TWO levels up from a grandchild project. -->
+        <plugin>
+          <groupId>com.github.spotbugs</groupId>
+          <artifactId>spotbugs-maven-plugin</artifactId>
+          <configuration>
+            <excludeFilterFile>${project.basedir}/../../dev-support/spotbugs-exclude.xml</excludeFilterFile>
+            <spotbugsXmlOutput>true</spotbugsXmlOutput>
+            <xmlOutput>true</xmlOutput>
+            <effort>Max</effort>
+          </configuration>
+        </plugin>
+        <plugin>
+          <!--Make it so assembly:single does nothing in here-->
+          <artifactId>maven-assembly-plugin</artifactId>
+          <configuration>
+            <skipAssembly>true</skipAssembly>
+          </configuration>
+        </plugin>
+      </plugins>
+    </pluginManagement>
+    <plugins>
+      <!-- Special configuration for findbugs just in the parent, emulating the setup in
+           hbase/pom.xml. Note that exclude-file-filter is found ONE level up from this project. -->
+      <plugin>
+        <groupId>com.github.spotbugs</groupId>
+        <artifactId>spotbugs-maven-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>spotbugs</goal>
+            </goals>
+            <inherited>false</inherited>
+            <configuration>
+              <excludeFilterFile>${project.basedir}/../dev-support/spotbugs-exclude.xml</excludeFilterFile>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-checkstyle-plugin</artifactId>
+        <configuration>
+          <failOnViolation>true</failOnViolation>
+        </configuration>
+      </plugin>
+      <plugin>
+        <!--Make it so assembly:single does nothing in here-->
+        <artifactId>maven-assembly-plugin</artifactId>
+        <configuration>
+          <skipAssembly>true</skipAssembly>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+
+</project>

--- a/hbase-extensions/pom.xml
+++ b/hbase-extensions/pom.xml
@@ -36,14 +36,6 @@
     <module>hbase-openssl</module>
   </modules>
 
-  <dependencies>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-resource-bundle</artifactId>
-      <optional>true</optional>
-    </dependency>
-  </dependencies>
-
   <build>
     <pluginManagement>
       <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -1751,6 +1751,11 @@
       </dependency>
       <dependency>
         <groupId>org.apache.hbase.thirdparty</groupId>
+        <artifactId>hbase-shaded-netty-tcnative</artifactId>
+        <version>${hbase-thirdparty.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase.thirdparty</groupId>
         <artifactId>hbase-shaded-protobuf</artifactId>
         <version>${hbase-thirdparty.version}</version>
       </dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -758,6 +758,7 @@
     <module>hbase-asyncfs</module>
     <module>hbase-logging</module>
     <module>hbase-compression</module>
+    <module>hbase-extensions</module>
   </modules>
   <scm>
     <connection>scm:git:git://gitbox.apache.org/repos/asf/hbase.git</connection>
@@ -1329,6 +1330,11 @@
       <dependency>
         <groupId>org.apache.hbase</groupId>
         <artifactId>hbase-compression-zstd</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>org.apache.hbase</groupId>
+        <artifactId>hbase-openssl</artifactId>
         <version>${project.version}</version>
       </dependency>
       <!-- General dependencies -->


### PR DESCRIPTION
EDIT: I've updated the title and description to account for the new direction. The new direction makes it easier for people to include tcnative in their own projects as well as in our release binaries.

Introduces the following module hierarchy:

```
hbase
 -\ hbase-assembly
 -\ hbase-client
 -\ etc...
 -\ hbase-extensions
   -\ hbase-openssl
```

`hbase-openssl` includes runtime dependency on hbase-shaded-netty-tcnative.  `hbase-assembly` has been updated to depend on `hbase-openssl` instead. I've verified that the binaries still include the right jar:

```
❯ tar -ztvf hbase-assembly/target/hbase-4.0.0-alpha-1-SNAPSHOT-client-bin.tar.gz | grep tcnative
-rw-r--r--  0 root   root  5437808 Jan 22  2020 hbase-4.0.0-alpha-1-SNAPSHOT-client/lib/hbase-shaded-netty-tcnative-4.1.5.jar
❯ tar -ztvf hbase-assembly/target/hbase-4.0.0-alpha-1-SNAPSHOT-bin.tar.gz | grep tcnative
-rw-r--r--  0 root   root  5437808 Jan 22  2020 hbase-4.0.0-alpha-1-SNAPSHOT/lib/hbase-shaded-netty-tcnative-4.1.5.jar
```

I've also tested this in a downstream project to verify that the tcnative classes/libs get added to my fat jar if i include hbase-openssl dependency in my downstream project.