### PR TITLE
HBASE-28311 Few ITs (using MiniMRYarnCluster on hadoop-2) are failing…

### DIFF
--- a/hbase-it/pom.xml
+++ b/hbase-it/pom.xml
@@ -408,6 +408,10 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-minikdc</artifactId>
         </dependency>
+        <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-testing-util</artifactId>
+        </dependency>
       </dependencies>
       <build>
         <plugins>

--- a/hbase-it/pom.xml
+++ b/hbase-it/pom.xml
@@ -114,19 +114,6 @@
       <artifactId>${compat.module}</artifactId>
       <version>${project.version}</version>
     </dependency>
-    <dependency>
-      <groupId>org.apache.hbase</groupId>
-      <artifactId>hbase-testing-util</artifactId>
-      <exclusions>
-        <!--This dependency pulls in hadoop-minicluster
-             which pulls in the below. It messes up
-             this build at assembly time. See HBASE-22029-->
-        <exclusion>
-          <groupId>com.sun.jersey</groupId>
-          <artifactId>jersey-core</artifactId>
-        </exclusion>
-      </exclusions>
-    </dependency>
     <!-- Required by tests using MiniMRCluster -->
     <dependency>
       <groupId>org.bouncycastle</groupId>
@@ -408,6 +395,9 @@
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-minikdc</artifactId>
         </dependency>
+        <!-- ITs using MiniMRYarnCluster fail with NCDFE, so adding this here. We are not having
+        same exclusions as in hadoop-3 profile, as for hadoop-3 it runs fine even with exclusions.
+        See HBASE-28311 for details. -->
         <dependency>
           <groupId>org.apache.hbase</groupId>
           <artifactId>hbase-testing-util</artifactId>
@@ -475,6 +465,19 @@
         <dependency>
           <groupId>org.apache.hadoop</groupId>
           <artifactId>hadoop-minikdc</artifactId>
+        </dependency>
+        <dependency>
+          <groupId>org.apache.hbase</groupId>
+          <artifactId>hbase-testing-util</artifactId>
+          <exclusions>
+            <!--This dependency pulls in hadoop-minicluster
+                 which pulls in the below. It messes up
+                 this build at assembly time. See HBASE-22029-->
+            <exclusion>
+              <groupId>com.sun.jersey</groupId>
+              <artifactId>jersey-core</artifactId>
+            </exclusion>
+          </exclusions>
         </dependency>
       </dependencies>
       <build>


### PR DESCRIPTION
… due to NCDFE: com/sun/jersey/core/util/FeaturesAndProperties
- Add hbase-testing-util in hadoop-2 profile with no exclusion of com.sun.jersey:jersey-core dependency
- Move hbase-testing-util, which has exclusion of  com.sun.jersey:jersey-core dependency, to hadoop-3 profile from default dependency list
