### PR TITLE
HBASE-28317: Expose client TLS certificate on RpcCallContext

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
@@ -64,7 +64,7 @@ public interface RpcCallContext {
   /**
    * Returns the TLS certificate(s) that the client presented to this HBase server when making its
    * connection. TLS is orthogonal to Kerberos, so this is unrelated to
-   * {@link this#getRequestUser()}. Both, one, or neither may be present.
+   * {@link RpcCallContext#getRequestUser()}. Both, one, or neither may be present.
    */
   Optional<X509Certificate[]> getClientCertificateChain();
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.ipc;
 
 import java.net.InetAddress;
+import java.security.cert.X509Certificate;
 import java.util.Optional;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -59,6 +60,13 @@ public interface RpcCallContext {
   default Optional<String> getRequestUserName() {
     return getRequestUser().map(User::getShortName);
   }
+
+  /**
+   * Returns the TLS certificate that the client presented to this HBase server when making its
+   * connection. TLS is orthogonal to Kerberos, so this is unrelated to
+   * {@link this#getRequestUser()}. Both, one, or neither, may be present.
+   */
+  Optional<X509Certificate> getClientCertificate();
 
   /** Returns Address of remote client in this call */
   InetAddress getRemoteAddress();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcCallContext.java
@@ -62,11 +62,11 @@ public interface RpcCallContext {
   }
 
   /**
-   * Returns the TLS certificate that the client presented to this HBase server when making its
+   * Returns the TLS certificate(s) that the client presented to this HBase server when making its
    * connection. TLS is orthogonal to Kerberos, so this is unrelated to
-   * {@link this#getRequestUser()}. Both, one, or neither, may be present.
+   * {@link this#getRequestUser()}. Both, one, or neither may be present.
    */
-  Optional<X509Certificate> getClientCertificate();
+  Optional<X509Certificate[]> getClientCertificateChain();
 
   /** Returns Address of remote client in this call */
   InetAddress getRemoteAddress();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -96,7 +96,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
 
   protected final User user;
   protected final InetAddress remoteAddress;
-  protected final X509Certificate clientCertificate;
+  protected final X509Certificate[] clientCertificateChain;
   protected RpcCallback rpcCallback;
 
   private long responseCellSize = 0;
@@ -136,11 +136,11 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
     if (connection != null) {
       this.user = connection.user;
       this.retryImmediatelySupported = connection.retryImmediatelySupported;
-      this.clientCertificate = connection.clientCertificate;
+      this.clientCertificateChain = connection.clientCertificateChain;
     } else {
       this.user = null;
       this.retryImmediatelySupported = false;
-      this.clientCertificate = null;
+      this.clientCertificateChain = null;
     }
     this.remoteAddress = remoteAddress;
     this.timeout = timeout;
@@ -503,8 +503,8 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   }
 
   @Override
-  public Optional<X509Certificate> getClientCertificate() {
-    return Optional.ofNullable(clientCertificate);
+  public Optional<X509Certificate[]> getClientCertificateChain() {
+    return Optional.ofNullable(clientCertificateChain);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerCall.java
@@ -23,6 +23,7 @@ import io.opentelemetry.context.Scope;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.security.cert.X509Certificate;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
@@ -95,6 +96,7 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
 
   protected final User user;
   protected final InetAddress remoteAddress;
+  protected final X509Certificate clientCertificate;
   protected RpcCallback rpcCallback;
 
   private long responseCellSize = 0;
@@ -134,9 +136,11 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
     if (connection != null) {
       this.user = connection.user;
       this.retryImmediatelySupported = connection.retryImmediatelySupported;
+      this.clientCertificate = connection.clientCertificate;
     } else {
       this.user = null;
       this.retryImmediatelySupported = false;
+      this.clientCertificate = null;
     }
     this.remoteAddress = remoteAddress;
     this.timeout = timeout;
@@ -496,6 +500,11 @@ public abstract class ServerCall<T extends ServerRpcConnection> implements RpcCa
   @Override
   public Optional<User> getRequestUser() {
     return Optional.ofNullable(user);
+  }
+
+  @Override
+  public Optional<X509Certificate> getClientCertificate() {
+    return Optional.ofNullable(clientCertificate);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
@@ -134,8 +134,7 @@ abstract class ServerRpcConnection implements Closeable {
   protected User user = null;
   protected UserGroupInformation ugi = null;
   protected SaslServerAuthenticationProviders saslProviders = null;
-  // volatile because this gets set after this object is constructed, when TLS handshake finishes
-  protected volatile X509Certificate clientCertificate = null;
+  protected X509Certificate[] clientCertificateChain = null;
 
   public ServerRpcConnection(RpcServer rpcServer) {
     this.rpcServer = rpcServer;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/ServerRpcConnection.java
@@ -31,6 +31,7 @@ import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.nio.ByteBuffer;
 import java.security.GeneralSecurityException;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Objects;
@@ -133,6 +134,8 @@ abstract class ServerRpcConnection implements Closeable {
   protected User user = null;
   protected UserGroupInformation ugi = null;
   protected SaslServerAuthenticationProviders saslProviders = null;
+  // volatile because this gets set after this object is constructed, when TLS handshake finishes
+  protected volatile X509Certificate clientCertificate = null;
 
   public ServerRpcConnection(RpcServer rpcServer) {
     this.rpcServer = rpcServer;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Constructor;
 import java.net.InetAddress;
 import java.security.PrivilegedAction;
 import java.security.PrivilegedExceptionAction;
+import java.security.cert.X509Certificate;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
@@ -812,6 +813,11 @@ public class TestNamedQueueRecorder {
       @Override
       public Optional<User> getRequestUser() {
         return getUser(userName);
+      }
+
+      @Override
+      public Optional<X509Certificate> getClientCertificate() {
+        return Optional.empty();
       }
 
       @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestNamedQueueRecorder.java
@@ -816,7 +816,7 @@ public class TestNamedQueueRecorder {
       }
 
       @Override
-      public Optional<X509Certificate> getClientCertificate() {
+      public Optional<X509Certificate[]> getClientCertificateChain() {
         return Optional.empty();
       }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
@@ -215,7 +215,7 @@ public class TestRpcLogDetails {
       }
 
       @Override
-      public Optional<X509Certificate> getClientCertificate() {
+      public Optional<X509Certificate[]> getClientCertificateChain() {
         return Optional.empty();
       }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/namequeues/TestRpcLogDetails.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertFalse;
 import java.io.IOException;
 import java.net.InetAddress;
 import java.nio.ByteBuffer;
+import java.security.cert.X509Certificate;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
@@ -211,6 +212,11 @@ public class TestRpcLogDetails {
       @Override
       public Optional<User> getRequestUser() {
         return null;
+      }
+
+      @Override
+      public Optional<X509Certificate> getClientCertificate() {
+        return Optional.empty();
       }
 
       @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
@@ -277,7 +277,7 @@ public class TestRegionProcedureStore extends RegionProcedureStoreTestBase {
       }
 
       @Override
-      public Optional<X509Certificate> getClientCertificate() {
+      public Optional<X509Certificate[]> getClientCertificateChain() {
         return Optional.empty();
       }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestRegionProcedureStore.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import java.net.InetAddress;
+import java.security.cert.X509Certificate;
 import java.util.HashSet;
 import java.util.Map;
 import java.util.Optional;
@@ -272,6 +273,11 @@ public class TestRegionProcedureStore extends RegionProcedureStoreTestBase {
 
       @Override
       public Optional<User> getRequestUser() {
+        return Optional.empty();
+      }
+
+      @Override
+      public Optional<X509Certificate> getClientCertificate() {
         return Optional.empty();
       }
 


### PR DESCRIPTION
At my employer we plan on using a coprocessor to log information about some requests to HBase. For this to be useful to us, we need to know who each request is coming from. We use HBase's TLS support with mutual authentication to authenticate clients. I'd like a way to expose the client certificate used on a request to coprocessors. For setups using Kerberos authentication, RpcCall exposes the Kerberos principal shortname via `getRequestUser()`, so this would be the TLS equivalent to that. I've tested this patch applied to 2.5.x in my company's infrastructure.

I found that in order for this patch to be useful to me, I also need netty to fix a related bug which I reported as https://github.com/netty/netty/issues/13796. This doesn't need to block this PR.