### PR TITLE
HBASE-28327 Add `remove(String name, Metric metric)` method to MetricRegistry

### DIFF
--- a/hbase-metrics-api/src/main/java/org/apache/hadoop/hbase/metrics/MetricRegistry.java
+++ b/hbase-metrics-api/src/main/java/org/apache/hadoop/hbase/metrics/MetricRegistry.java
@@ -98,7 +98,7 @@ public interface MetricRegistry extends MetricSet {
 
   /**
    * Removes the metric with the given name only if it is registered to the provided metric.
-   * @param name the name of the metric
+   * @param name   the name of the metric
    * @param metric the metric expected to be registered to the given name
    * @return true if the metric is removed.
    */

--- a/hbase-metrics-api/src/main/java/org/apache/hadoop/hbase/metrics/MetricRegistry.java
+++ b/hbase-metrics-api/src/main/java/org/apache/hadoop/hbase/metrics/MetricRegistry.java
@@ -97,6 +97,14 @@ public interface MetricRegistry extends MetricSet {
   boolean remove(String name);
 
   /**
+   * Removes the metric with the given name only if it is registered to the provided metric.
+   * @param name the name of the metric
+   * @param metric the metric expected to be registered to the given name
+   * @return true if the metric is removed.
+   */
+  boolean remove(String name, Metric metric);
+
+  /**
    * Return the MetricRegistryInfo object for this registry.
    * @return MetricRegistryInfo describing the registry.
    */

--- a/hbase-metrics/src/main/java/org/apache/hadoop/hbase/metrics/impl/MetricRegistryImpl.java
+++ b/hbase-metrics/src/main/java/org/apache/hadoop/hbase/metrics/impl/MetricRegistryImpl.java
@@ -114,7 +114,8 @@ public class MetricRegistryImpl implements MetricRegistry {
     return metrics.remove(name) != null;
   }
 
-  @Override public boolean remove(String name, Metric metric) {
+  @Override
+  public boolean remove(String name, Metric metric) {
     return metrics.remove(name, metric);
   }
 

--- a/hbase-metrics/src/main/java/org/apache/hadoop/hbase/metrics/impl/MetricRegistryImpl.java
+++ b/hbase-metrics/src/main/java/org/apache/hadoop/hbase/metrics/impl/MetricRegistryImpl.java
@@ -114,6 +114,10 @@ public class MetricRegistryImpl implements MetricRegistry {
     return metrics.remove(name) != null;
   }
 
+  @Override public boolean remove(String name, Metric metric) {
+    return metrics.remove(name, metric);
+  }
+
   @Override
   public MetricRegistryInfo getMetricRegistryInfo() {
     return info;

--- a/hbase-metrics/src/test/java/org/apache/hadoop/hbase/metrics/impl/TestMetricRegistryImpl.java
+++ b/hbase-metrics/src/test/java/org/apache/hadoop/hbase/metrics/impl/TestMetricRegistryImpl.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.metrics.impl;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
@@ -140,5 +141,23 @@ public class TestMetricRegistryImpl {
     assertEquals(counter, metrics.get("mycounter"));
     assertEquals(gauge, metrics.get("mygauge"));
     assertEquals(timer, metrics.get("mytimer"));
+  }
+
+  @Test
+  public void testRemove() {
+    CounterImpl counter1 = new CounterImpl();
+    CounterImpl counter2 = new CounterImpl();
+    registry.register("mycounter", counter1);
+
+    boolean removed = registry.remove("mycounter", counter2);
+    Optional<Metric> metric = registry.get("mycounter");
+    assertFalse(removed);
+    assertTrue(metric.isPresent());
+    assertEquals(metric.get(), counter1);
+
+    removed = registry.remove("mycounter");
+    metric = registry.get("mycounter");
+    assertTrue(removed);
+    assertFalse(metric.isPresent());
   }
 }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-28327

This will help us clean up metrics safely. We will remove a `Metric` with the specified `name` from the metric registry if and only if the provided `metric` matches the object in the registry.

