### PR TITLE
HBASE-28332 Type conversion is no need in method CompactionChecker.chore()

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -1684,14 +1684,13 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
 
     @Override
     protected void chore() {
-      for (Region r : this.instance.onlineRegions.values()) {
+      for (HRegion hr : this.instance.onlineRegions.values()) {
         // If region is read only or compaction is disabled at table level, there's no need to
         // iterate through region's stores
-        if (r == null || r.isReadOnly() || !r.getTableDescriptor().isCompactionEnabled()) {
+        if (hr == null || hr.isReadOnly() || !hr.getTableDescriptor().isCompactionEnabled()) {
           continue;
         }
 
-        HRegion hr = (HRegion) r;
         for (HStore s : hr.stores.values()) {
           try {
             long multiplier = s.getCompactionCheckMultiplier();
@@ -1719,7 +1718,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
               }
             }
           } catch (IOException e) {
-            LOG.warn("Failed major compaction check on " + r, e);
+            LOG.warn("Failed major compaction check on " + hr, e);
           }
         }
       }


### PR DESCRIPTION
Details see: [HBASE-28332](https://issues.apache.org/jira/browse/HBASE-28332)