### PR TITLE
HBASE-28349 Count atomic operations against read quotas

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/OperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/OperationQuota.java
@@ -32,7 +32,8 @@ public interface OperationQuota {
   public enum OperationType {
     MUTATE,
     GET,
-    SCAN
+    SCAN,
+    CHECK_AND_MUTATE
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
@@ -157,20 +157,21 @@ public class RegionServerRpcQuotaManager {
   /**
    * Check the quota for the current (rpc-context) user. Returns the OperationQuota used to get the
    * available quota and to report the data/usage of the operation.
-   * @param region the region where the operation will be performed
-   * @param type   the operation type
+   * @param region   the region where the operation will be performed
+   * @param type     the operation type
+   * @param isAtomic whether the given operation is atomic
    * @return the OperationQuota
    * @throws RpcThrottlingException if the operation cannot be executed due to quota exceeded.
    */
-  public OperationQuota checkQuota(final Region region, final OperationQuota.OperationType type)
-    throws IOException, RpcThrottlingException {
+  public OperationQuota checkQuota(final Region region, final OperationQuota.OperationType type,
+    boolean isAtomic) throws IOException, RpcThrottlingException {
     switch (type) {
       case SCAN:
         return checkQuota(region, 0, 0, 1);
       case GET:
         return checkQuota(region, 0, 1, 0);
       case MUTATE:
-        return checkQuota(region, 1, 0, 0);
+        return checkQuota(region, 1, isAtomic ? 1 : 0, 0);
     }
     throw new RuntimeException("Invalid operation type: " + type);
   }
@@ -178,18 +179,22 @@ public class RegionServerRpcQuotaManager {
   /**
    * Check the quota for the current (rpc-context) user. Returns the OperationQuota used to get the
    * available quota and to report the data/usage of the operation.
-   * @param region  the region where the operation will be performed
-   * @param actions the "multi" actions to perform
+   * @param region   the region where the operation will be performed
+   * @param actions  the "multi" actions to perform
+   * @param isAtomic whether the given operation is atomic
    * @return the OperationQuota
    * @throws RpcThrottlingException if the operation cannot be executed due to quota exceeded.
    */
-  public OperationQuota checkQuota(final Region region, final List<ClientProtos.Action> actions)
-    throws IOException, RpcThrottlingException {
+  public OperationQuota checkQuota(final Region region, final List<ClientProtos.Action> actions,
+    boolean isAtomic) throws IOException, RpcThrottlingException {
     int numWrites = 0;
     int numReads = 0;
     for (final ClientProtos.Action action : actions) {
       if (action.hasMutation()) {
         numWrites++;
+        if (isAtomic) {
+          numReads++;
+        }
       } else if (action.hasGet()) {
         numReads++;
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
@@ -181,7 +181,7 @@ public class RegionServerRpcQuotaManager {
    * available quota and to report the data/usage of the operation.
    * @param region   the region where the operation will be performed
    * @param actions  the "multi" actions to perform
-   * @param isAtomic whether the given operation is atomic
+   * @param isAtomic whether the RegionAction is atomic
    * @return the OperationQuota
    * @throws RpcThrottlingException if the operation cannot be executed due to quota exceeded.
    */
@@ -192,7 +192,11 @@ public class RegionServerRpcQuotaManager {
     for (final ClientProtos.Action action : actions) {
       if (action.hasMutation()) {
         numWrites++;
-        if (isAtomic) {
+        ClientProtos.MutationProto.MutationType mutationType = action.getMutation().getMutateType();
+        if (
+          isAtomic || mutationType == ClientProtos.MutationProto.MutationType.APPEND
+            || mutationType == ClientProtos.MutationProto.MutationType.INCREMENT
+        ) {
           numReads++;
         }
       } else if (action.hasGet()) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestAtomicReadQuota.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestAtomicReadQuota.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.quotas;
+
+import java.io.IOException;
+import java.util.UUID;
+import java.util.concurrent.TimeUnit;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.After;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ RegionServerTests.class, MediumTests.class })
+public class TestAtomicReadQuota {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestAtomicReadQuota.class);
+  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private static final TableName TABLE_NAME = TableName.valueOf(UUID.randomUUID().toString());
+  private static final byte[] FAMILY = Bytes.toBytes("cf");
+  private static final byte[] QUALIFIER = Bytes.toBytes("q");
+
+  @After
+  public void tearDown() throws Exception {
+    ThrottleQuotaTestUtil.clearQuotaCache(TEST_UTIL);
+    EnvironmentEdgeManager.reset();
+    TEST_UTIL.deleteTable(TABLE_NAME);
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    TEST_UTIL.getConfiguration().setBoolean(QuotaUtil.QUOTA_CONF_KEY, true);
+    TEST_UTIL.getConfiguration().setInt(QuotaCache.REFRESH_CONF_KEY, 1000);
+    TEST_UTIL.startMiniCluster(1);
+    TEST_UTIL.waitTableAvailable(QuotaTableUtil.QUOTA_TABLE_NAME);
+    TEST_UTIL.createTable(TABLE_NAME, FAMILY);
+    TEST_UTIL.waitTableAvailable(TABLE_NAME);
+    QuotaCache.TEST_FORCE_REFRESH = true;
+  }
+
+  @Test
+  public void testAtomicOpCountedAgainstReadCapacity() throws Exception {
+    ThrottleQuotaTestUtil.triggerUserCacheRefresh(TEST_UTIL, true, TABLE_NAME);
+    try (Admin admin = TEST_UTIL.getAdmin()) {
+      admin.setQuota(QuotaSettingsFactory.throttleUser(User.getCurrent().getShortName(),
+        ThrottleType.READ_NUMBER, 1, TimeUnit.MINUTES));
+    }
+    ThrottleQuotaTestUtil.triggerUserCacheRefresh(TEST_UTIL, false, TABLE_NAME);
+
+    Increment inc = new Increment(Bytes.toBytes("doot"));
+    inc.addColumn(FAMILY, QUALIFIER, 1);
+    try (Table table = getTable()) {
+      // we have a read quota configured, so this should fail
+      TEST_UTIL.waitFor(60_000, () -> {
+        try {
+          table.increment(inc);
+          return false;
+        } catch (Exception e) {
+          return e.getCause() instanceof RpcThrottlingException;
+        }
+      });
+    }
+  }
+
+  private Table getTable() throws IOException {
+    TEST_UTIL.getConfiguration().setInt("hbase.client.pause", 100);
+    TEST_UTIL.getConfiguration().setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 1);
+    return TEST_UTIL.getConnection().getTableBuilder(TABLE_NAME, null).setOperationTimeout(250)
+      .build();
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestAtomicReadQuota.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestAtomicReadQuota.java
@@ -18,6 +18,8 @@
 package org.apache.hadoop.hbase.quotas;
 
 import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
@@ -25,31 +27,37 @@ import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.CheckAndMutate;
 import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RowMutations;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
-import org.junit.After;
+import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Category({ RegionServerTests.class, MediumTests.class })
 public class TestAtomicReadQuota {
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestAtomicReadQuota.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestAtomicReadQuota.class);
   private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
   private static final TableName TABLE_NAME = TableName.valueOf(UUID.randomUUID().toString());
   private static final byte[] FAMILY = Bytes.toBytes("cf");
   private static final byte[] QUALIFIER = Bytes.toBytes("q");
 
-  @After
-  public void tearDown() throws Exception {
+  @AfterClass
+  public static void tearDown() throws Exception {
     ThrottleQuotaTestUtil.clearQuotaCache(TEST_UTIL);
     EnvironmentEdgeManager.reset();
     TEST_UTIL.deleteTable(TABLE_NAME);
@@ -68,26 +76,129 @@ public class TestAtomicReadQuota {
   }
 
   @Test
-  public void testAtomicOpCountedAgainstReadCapacity() throws Exception {
-    ThrottleQuotaTestUtil.triggerUserCacheRefresh(TEST_UTIL, true, TABLE_NAME);
+  public void testIncrementCountedAgainstReadCapacity() throws Exception {
+    setupQuota();
+
+    Increment inc = new Increment(Bytes.toBytes(UUID.randomUUID().toString()));
+    inc.addColumn(FAMILY, QUALIFIER, 1);
+    testThrottle(table -> table.increment(inc));
+  }
+
+  @Test
+  public void testRowMutationsCountedAgainstReadCapacity() throws Exception {
+    setupQuota();
+
+    byte[] row = Bytes.toBytes(UUID.randomUUID().toString());
+    Put put = new Put(row);
+    put.addColumn(FAMILY, Bytes.toBytes("doot"), Bytes.toBytes("v"));
+
+    RowMutations rowMutations = new RowMutations(row);
+    rowMutations.add(put);
+    testThrottle(table -> table.mutateRow(rowMutations));
+  }
+
+  @Test
+  public void testNonAtomicPutOmittedFromReadCapacity() throws Exception {
+    setupQuota();
+
+    byte[] row = Bytes.toBytes(UUID.randomUUID().toString());
+    Put put = new Put(row);
+    put.addColumn(FAMILY, Bytes.toBytes("doot"), Bytes.toBytes("v"));
+    try (Table table = getTable()) {
+      for (int i = 0; i < 100; i++) {
+        table.put(put);
+      }
+    }
+  }
+
+  @Test
+  public void testNonAtomicMultiPutOmittedFromReadCapacity() throws Exception {
+    setupQuota();
+
+    Put put1 = new Put(Bytes.toBytes(UUID.randomUUID().toString()));
+    put1.addColumn(FAMILY, Bytes.toBytes("doot"), Bytes.toBytes("v"));
+    Put put2 = new Put(Bytes.toBytes(UUID.randomUUID().toString()));
+    put2.addColumn(FAMILY, Bytes.toBytes("doot"), Bytes.toBytes("v"));
+
+    Increment inc = new Increment(Bytes.toBytes(UUID.randomUUID().toString()));
+    inc.addColumn(FAMILY, Bytes.toBytes("doot"), 1);
+
+    List<Put> puts = new ArrayList<>(2);
+    puts.add(put1);
+    puts.add(put2);
+
+    try (Table table = getTable()) {
+      for (int i = 0; i < 100; i++) {
+        table.put(puts);
+      }
+    }
+  }
+
+  @Test
+  public void testCheckAndMutateCountedAgainstReadCapacity() throws Exception {
+    setupQuota();
+
+    byte[] row = Bytes.toBytes(UUID.randomUUID().toString());
+    byte[] value = Bytes.toBytes("v");
+    Put put = new Put(row);
+    put.addColumn(FAMILY, Bytes.toBytes("doot"), value);
+    CheckAndMutate checkAndMutate =
+      CheckAndMutate.newBuilder(row).ifEquals(FAMILY, QUALIFIER, value).build(put);
+
+    testThrottle(table -> table.checkAndMutate(checkAndMutate));
+  }
+
+  @Test
+  public void testAtomicBatchCountedAgainstReadCapacity() throws Exception {
+    setupQuota();
+
+    byte[] row = Bytes.toBytes(UUID.randomUUID().toString());
+    Increment inc = new Increment(row);
+    inc.addColumn(FAMILY, Bytes.toBytes("doot"), 1);
+
+    List<Increment> incs = new ArrayList<>(2);
+    incs.add(inc);
+    incs.add(inc);
+
+    testThrottle(table -> {
+      Object[] results = new Object[] {};
+      table.batch(incs, results);
+      return results;
+    });
+  }
+
+  private void setupQuota() throws Exception {
     try (Admin admin = TEST_UTIL.getAdmin()) {
       admin.setQuota(QuotaSettingsFactory.throttleUser(User.getCurrent().getShortName(),
         ThrottleType.READ_NUMBER, 1, TimeUnit.MINUTES));
     }
     ThrottleQuotaTestUtil.triggerUserCacheRefresh(TEST_UTIL, false, TABLE_NAME);
+  }
 
-    Increment inc = new Increment(Bytes.toBytes("doot"));
-    inc.addColumn(FAMILY, QUALIFIER, 1);
+  private void cleanupQuota() throws Exception {
+    try (Admin admin = TEST_UTIL.getAdmin()) {
+      admin.setQuota(QuotaSettingsFactory.unthrottleUser(User.getCurrent().getShortName()));
+    }
+    ThrottleQuotaTestUtil.triggerUserCacheRefresh(TEST_UTIL, true, TABLE_NAME);
+  }
+
+  private void testThrottle(ThrowingFunction<Table, ?> request) throws Exception {
     try (Table table = getTable()) {
       // we have a read quota configured, so this should fail
       TEST_UTIL.waitFor(60_000, () -> {
         try {
-          table.increment(inc);
+          request.run(table);
           return false;
         } catch (Exception e) {
-          return e.getCause() instanceof RpcThrottlingException;
+          boolean success = e.getCause() instanceof RpcThrottlingException;
+          if (!success) {
+            LOG.error("Unexpected exception", e);
+          }
+          return success;
         }
       });
+    } finally {
+      cleanupQuota();
     }
   }
 
@@ -96,6 +207,11 @@ public class TestAtomicReadQuota {
     TEST_UTIL.getConfiguration().setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 1);
     return TEST_UTIL.getConnection().getTableBuilder(TABLE_NAME, null).setOperationTimeout(250)
       .build();
+  }
+
+  @FunctionalInterface
+  private interface ThrowingFunction<I, O> {
+    O run(I input) throws Exception;
   }
 
 }


### PR DESCRIPTION
Right now atomic operations are just treated as a single write from the quota perspective. Since an atomic operation also encompasses a read, it would make sense to increment readNum and readSize counts appropriately.

cc @bbeaudreault @hgromer @eab148 @bozzkar