### PR TITLE
HBASE-28357 MoveWithAck#isSuccessfulScan for Region movement should use Region End Key for limiting scan to one region only

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/MoveWithAck.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/MoveWithAck.java
@@ -110,8 +110,9 @@ class MoveWithAck implements Callable<Boolean> {
    * Tries to scan a row from passed region
    */
   private void isSuccessfulScan(RegionInfo region) throws IOException {
-    Scan scan = new Scan().withStartRow(region.getStartKey()).setRaw(true).setOneRowLimit()
-      .setMaxResultSize(1L).setCaching(1).setFilter(new FirstKeyOnlyFilter()).setCacheBlocks(false);
+    Scan scan = new Scan().withStartRow(region.getStartKey()).withStopRow(region.getEndKey(), false)
+      .setRaw(true).setOneRowLimit().setMaxResultSize(1L).setCaching(1)
+      .setFilter(new FirstKeyOnlyFilter()).setCacheBlocks(false);
     try (Table table = conn.getTable(region.getTable());
       ResultScanner scanner = table.getScanner(scan)) {
       scanner.next();


### PR DESCRIPTION
Jira: HBASE-28357