### PR TITLE
HBASE-28342 Decommissioned hosts should be rejected by the HMaster

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1623,10 +1623,10 @@ public final class HConstants {
   public final static boolean HBASE_SERVER_USEIP_ENABLED_DEFAULT = false;
 
   /**
-   * Should the HMaster reject hosts of decommissioned RegionServers, bypassing matching their port
-   * and startcode parts of their ServerName or not? When True, the HMaster will reject a
-   * RegionServer's request to `reportForDuty` if it's hostname exists in the list of decommissioned
-   * RegionServers it maintains internally. Added in HBASE-28342.
+   * Should the HMaster reject hosts of decommissioned RegionServers, bypass matching their port and
+   * startcode parts of their ServerName or not? When True, the HMaster will reject a RegionServer's
+   * request to `reportForDuty` if it's hostname exists in the list of decommissioned RegionServers
+   * it maintains internally. Added in HBASE-28342.
    */
   public final static String REJECT_DECOMMISSIONED_HOSTS_KEY =
     "hbase.master.reject.decommissioned.hosts";

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1622,6 +1622,20 @@ public final class HConstants {
    */
   public final static boolean HBASE_SERVER_USEIP_ENABLED_DEFAULT = false;
 
+  /**
+   * Should the HMaster reject hosts of decommissioned RegionServers, bypassing matching their port
+   * and startcode parts of their ServerName or not? When True, the HMaster will reject a
+   * RegionServer's request to `reportForDuty` if it's hostname exists in the list of decommissioned
+   * RegionServers it maintains internally. Added in HBASE-28342.
+   */
+  public final static String REJECT_DECOMMISSIONED_HOSTS_KEY =
+    "hbase.master.reject.decommissioned.hosts";
+
+  /**
+   * Default value of {@link #REJECT_DECOMMISSIONED_HOSTS_KEY}
+   */
+  public final static boolean REJECT_DECOMMISSIONED_HOSTS_DEFAULT = false;
+
   private HConstants() {
     // Can't be instantiated with this ctor.
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/DecommissionedHostRejectedException.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/DecommissionedHostRejectedException.java
@@ -21,8 +21,8 @@ import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.yetus.audience.InterfaceAudience;
 
 @InterfaceAudience.Private
-public class HostIsConsideredDecommissionedException extends HBaseIOException {
-  public HostIsConsideredDecommissionedException(String message) {
+public class DecommissionedHostRejectedException extends HBaseIOException {
+  public DecommissionedHostRejectedException(String message) {
     super(message);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -546,7 +546,6 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         HConstants.DEFAULT_HBASE_MASTER_BALANCER_MAX_RIT_PERCENT);
 
       // Do we publish the status?
-
       boolean shouldPublish =
         conf.getBoolean(HConstants.STATUS_PUBLISHED, HConstants.STATUS_PUBLISHED_DEFAULT);
       Class<? extends ClusterStatusPublisher.Publisher> publisherClass =
@@ -997,7 +996,10 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     masterRegion = MasterRegionFactory.create(this);
     rsListStorage = new MasterRegionServerList(masterRegion, this);
 
+    // Initialize the ServerManager and register it as a configuration observer
     this.serverManager = createServerManager(this, rsListStorage);
+    this.configurationManager.registerObserver(this.serverManager);
+
     this.syncReplicationReplayWALManager = new SyncReplicationReplayWALManager(this);
     if (
       !conf.getBoolean(HBASE_SPLIT_WAL_COORDINATED_BY_ZK, DEFAULT_HBASE_SPLIT_COORDINATED_BY_ZK)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HostIsConsideredDecommissionedException.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HostIsConsideredDecommissionedException.java
@@ -1,0 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master;
+
+import org.apache.hadoop.hbase.HBaseIOException;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class HostIsConsideredDecommissionedException extends HBaseIOException {
+  public HostIsConsideredDecommissionedException(String message) {
+    super(message);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/ServerManager.java
@@ -720,13 +720,8 @@ public class ServerManager implements ConfigurationObserver {
    * Remove the server from the drain list.
    */
   public synchronized boolean removeServerFromDrainList(final ServerName sn) {
-    // Warn if the server (sn) is not online. ServerName is of the form:
-    // <hostname> , <port> , <startcode>
+    LOG.info("Removing server {} from the draining list.", sn);
 
-    if (!this.isServerOnline(sn)) {
-      LOG.warn("Server " + sn + " is not currently online. "
-        + "Removing from draining list anyway, as requested.");
-    }
     // Remove the server from the draining servers lists.
     return this.drainingServers.remove(sn);
   }
@@ -736,22 +731,23 @@ public class ServerManager implements ConfigurationObserver {
    * @return True if the server is added or the server is already on the drain list.
    */
   public synchronized boolean addServerToDrainList(final ServerName sn) {
-    // Warn if the server (sn) is not online. ServerName is of the form:
-    // <hostname> , <port> , <startcode>
-
-    if (!this.isServerOnline(sn)) {
-      LOG.warn("Server " + sn + " is not currently online. "
-        + "Ignoring request to add it to draining list.");
+    // If master is not rejecting decommissioned hosts, warn if the server (sn) is not online.
+    // However, we want to add servers even if they're not online if the master is configured
+    // to reject decommissioned hosts
+    if (!rejectDecommissionedHostsConfig && !this.isServerOnline(sn)) {
+      LOG.warn("Server {} is not currently online. Ignoring request to add it to draining list.",
+        sn);
       return false;
     }
-    // Add the server to the draining servers lists, if it's not already in
-    // it.
+
+    // Add the server to the draining servers lists, if it's not already in it.
     if (this.drainingServers.contains(sn)) {
-      LOG.warn("Server " + sn + " is already in the draining server list."
-        + "Ignoring request to add it again.");
+      LOG.warn(
+        "Server {} is already in the draining server list. Ignoring request to add it again.", sn);
       return true;
     }
-    LOG.info("Server " + sn + " added to draining server list.");
+
+    LOG.info("Server {} added to draining server list.", sn);
     return this.drainingServers.add(sn);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -120,6 +120,7 @@ import org.apache.hadoop.hbase.ipc.RpcServer;
 import org.apache.hadoop.hbase.ipc.ServerNotRunningYetException;
 import org.apache.hadoop.hbase.ipc.ServerRpcController;
 import org.apache.hadoop.hbase.log.HBaseMarkers;
+import org.apache.hadoop.hbase.master.HostIsConsideredDecommissionedException;
 import org.apache.hadoop.hbase.mob.MobFileCache;
 import org.apache.hadoop.hbase.mob.RSMobFileCleanerChore;
 import org.apache.hadoop.hbase.monitoring.TaskMonitor;
@@ -2662,6 +2663,11 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
       IOException ioe = ProtobufUtil.getRemoteException(se);
       if (ioe instanceof ClockOutOfSyncException) {
         LOG.error(HBaseMarkers.FATAL, "Master rejected startup because clock is out of sync", ioe);
+        // Re-throw IOE will cause RS to abort
+        throw ioe;
+      } else if (ioe instanceof HostIsConsideredDecommissionedException) {
+        LOG.error(HBaseMarkers.FATAL,
+          "Master rejected startup because the host is considered decommissioned", ioe);
         // Re-throw IOE will cause RS to abort
         throw ioe;
       } else if (ioe instanceof ServerNotRunningYetException) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -120,7 +120,7 @@ import org.apache.hadoop.hbase.ipc.RpcServer;
 import org.apache.hadoop.hbase.ipc.ServerNotRunningYetException;
 import org.apache.hadoop.hbase.ipc.ServerRpcController;
 import org.apache.hadoop.hbase.log.HBaseMarkers;
-import org.apache.hadoop.hbase.master.HostIsConsideredDecommissionedException;
+import org.apache.hadoop.hbase.master.DecommissionedHostRejectedException;
 import org.apache.hadoop.hbase.mob.MobFileCache;
 import org.apache.hadoop.hbase.mob.RSMobFileCleanerChore;
 import org.apache.hadoop.hbase.monitoring.TaskMonitor;
@@ -2665,7 +2665,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
         LOG.error(HBaseMarkers.FATAL, "Master rejected startup because clock is out of sync", ioe);
         // Re-throw IOE will cause RS to abort
         throw ioe;
-      } else if (ioe instanceof HostIsConsideredDecommissionedException) {
+      } else if (ioe instanceof DecommissionedHostRejectedException) {
         LOG.error(HBaseMarkers.FATAL,
           "Master rejected startup because the host is considered decommissioned", ioe);
         // Re-throw IOE will cause RS to abort

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRegionServerReportForDuty.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRegionServerReportForDuty.java
@@ -17,13 +17,12 @@
  */
 package org.apache.hadoop.hbase.regionserver;
 
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertTrue;
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.*;
 
 import java.io.IOException;
 import java.io.StringWriter;
-import java.util.ArrayList;
-import java.util.List;
+import java.util.Collections;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.commons.lang3.StringUtils;
@@ -32,6 +31,7 @@ import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.LocalHBaseCluster;
+import org.apache.hadoop.hbase.MatcherPredicate;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.SingleProcessHBaseCluster.MiniHBaseClusterRegionServer;
 import org.apache.hadoop.hbase.ipc.ServerNotRunningYetException;
@@ -271,106 +271,26 @@ public class TestRegionServerReportForDuty {
     assertEquals(0, master.getMaster().getServerManager().getDrainingServersList().size());
     assertEquals(1, master.getMaster().getServerManager().getOnlineServers().size());
 
-    // Decommission the region server and tries to re-add it
-    List<ServerName> serversToDecommission = new ArrayList<ServerName>();
-    serversToDecommission.add(rs.getRegionServer().getServerName());
-    master.getMaster().decommissionRegionServers(serversToDecommission, true);
-
-    // Assert that the server is now decommissioned
-    ServerName decommissionedServer = master.getMaster().listDecommissionedRegionServers().get(0);
-    assertEquals(1, master.getMaster().listDecommissionedRegionServers().size());
-    assertEquals(1, master.getMaster().getServerManager().getDrainingServersList().size());
-    assertEquals(1, master.getMaster().getServerManager().getOnlineServers().size());
-    assertEquals(rs.getRegionServer().getServerName().toString(),
-      decommissionedServer.getServerName());
+    // Decommission the 1st rs
+    master.getMaster().decommissionRegionServers(
+      Collections.singletonList(rs.getRegionServer().getServerName()), false);
 
     // Create a second region server
     cluster.getConfiguration().set(HConstants.REGION_SERVER_IMPL, MyRegionServer.class.getName());
     rs2 = cluster.addRegionServer();
     rs2.start();
-    waitForSecondRsStarted();
 
-    // Assert that the number of decommissioned and live hosts didn't change and that the hostname
-    // of rs2 matches that of the decommissioned server
+    // Assert that the number of decommissioned and live hosts didn't change and that rs2 is aborted
     String rs2HostName = rs2.getRegionServer().getServerName().getHostname();
+    String decommissionedHostName =
+      master.getMaster().listDecommissionedRegionServers().get(0).getHostname();
     assertEquals(1, master.getMaster().listDecommissionedRegionServers().size());
     assertEquals(1, master.getMaster().getServerManager().getDrainingServersList().size());
     assertEquals(1, master.getMaster().getServerManager().getOnlineServers().size());
-    assertEquals(rs2HostName, decommissionedServer.getHostname());
-  }
-
-  /**
-   * Tests that the RegionServer's reportForDuty gets accepted by the master when the master is not
-   * configured to reject decommissioned hosts, even when there is a match for the joining
-   * RegionServer in the list of decommissioned servers. Test case for HBASE-28342.
-   */
-  @Test
-  public void testReportForDutyGetsAcceptedByMasterWhenNotConfiguredToRejectDecommissionedHosts()
-    throws Exception {
-    // Start a master and wait for it to become the active/primary master.
-    // Use a random unique port
-    cluster.getConfiguration().setInt(HConstants.MASTER_PORT, HBaseTestingUtil.randomFreePort());
-    cluster.getConfiguration().setInt(ServerManager.WAIT_ON_REGIONSERVERS_MINTOSTART, 1);
-    cluster.getConfiguration().setInt(ServerManager.WAIT_ON_REGIONSERVERS_MAXTOSTART, 1);
-
-    // Set the cluster to not reject decommissioned hosts (default behavior)
-    cluster.getConfiguration().setBoolean(HConstants.REJECT_DECOMMISSIONED_HOSTS_KEY, false);
-
-    master = cluster.addMaster();
-    rs = cluster.addRegionServer();
-    LOG.debug("Starting master: " + master.getMaster().getServerName());
-    master.start();
-    rs.start();
-    waitForClusterOnline(master);
-
-    assertEquals(0, master.getMaster().listDecommissionedRegionServers().size());
-    assertEquals(0, master.getMaster().getServerManager().getDrainingServersList().size());
-    assertEquals(1, master.getMaster().getServerManager().getOnlineServers().size());
-
-    // Decommission the region server and tries to re-add it
-    List<ServerName> serversToDecommission = new ArrayList<>();
-    serversToDecommission.add(rs.getRegionServer().getServerName());
-    master.getMaster().decommissionRegionServers(serversToDecommission, true);
-
-    // Assert that the server is now decommissioned
-    ServerName decommissionedServer = master.getMaster().listDecommissionedRegionServers().get(0);
-    assertEquals(1, master.getMaster().listDecommissionedRegionServers().size());
-    assertEquals(1, master.getMaster().getServerManager().getDrainingServersList().size());
-    assertEquals(1, master.getMaster().getServerManager().getOnlineServers().size());
-    assertEquals(rs.getRegionServer().getServerName().toString(),
-      decommissionedServer.getServerName());
-
-    // Create a second region server and try adding both region servers to it, it should succeed
-    cluster.getConfiguration().set(HConstants.REGION_SERVER_IMPL, MyRegionServer.class.getName());
-    rs2 = cluster.addRegionServer();
-    rs2.start();
-    waitForSecondRsStarted();
-
-    master.getMaster().stop("Stopping master");
-
-    // Start a new master and use another random unique port
-    // Also let it wait for exactly 2 region severs to report in
-    cluster.getConfiguration().setInt(HConstants.MASTER_PORT, HBaseTestingUtil.randomFreePort());
-    cluster.getConfiguration().setInt(ServerManager.WAIT_ON_REGIONSERVERS_MINTOSTART, 2);
-    cluster.getConfiguration().setInt(ServerManager.WAIT_ON_REGIONSERVERS_MAXTOSTART, 2);
-    backupMaster = cluster.addMaster();
-    LOG.debug("Starting new master: " + backupMaster.getMaster().getServerName());
-    backupMaster.start();
-
-    waitForClusterOnline(backupMaster);
-
-    // Assert that the backup master has become active.
-    assertTrue(backupMaster.getMaster().isActiveMaster());
-    assertTrue(backupMaster.getMaster().isInitialized());
-
-    // Assert that the number of decommissioned hosts is the same and that the live and online hosts
-    // did in fact change and rs2 is now part of the cluster even though there is a match for its
-    // hostname in the list of decommissioned servers
-    String rs2HostName = rs2.getRegionServer().getServerName().getHostname();
-    assertEquals(1, backupMaster.getMaster().listDecommissionedRegionServers().size());
-    assertEquals(1, backupMaster.getMaster().getServerManager().getDrainingServersList().size());
-    assertEquals(2, backupMaster.getMaster().getServerManager().getOnlineServers().size());
-    assertEquals(rs2HostName, decommissionedServer.getHostname());
+    assertTrue(master.getMaster().getServerManager().getOnlineServers()
+      .containsKey(rs.getRegionServer().getServerName()));
+    assertEquals(rs2HostName, decommissionedHostName);
+    testUtil.waitFor(10000, new MatcherPredicate<>(rs2.getRegionServer()::isAborted, is(false)));
   }
 
   /**


### PR DESCRIPTION
Fixes: [HBASE-28342](https://issues.apache.org/jira/browse/HBASE-28342).

This PR adds support to specifying a new configuration value in `hbase-site.xml` which is: `"hbase.master.reject.decommissioned.hosts"`.

When the value is set to `true` the Master will reject RegionServers reporting for duty if and only if their hostnames match any of the servers currently present in the list of decommissioned servers (in the draining servers list). Default value for the configuration is `false`. This configuration is also implemented as live-loadable, the `ServerManager` class now implements the `ConfigurationObserver` interface and listens to changes to this value.

This small patch allows operators to prevent faulty hosts from rejoining the cluster by specifying that configuration property to `true`, decommissioning the servers and then work on fixing them. Once fixed, operators can then rollback the config value to `false` which ends up allowing the RegionServer to rejoin from now fixed host.