### PR TITLE
Backport "HBASE-28379 Upgrade thirdparty dep to 4.1.6 (#5693)" to branch-2.6

### DIFF
--- a/hbase-protocol-shaded/pom.xml
+++ b/hbase-protocol-shaded/pom.xml
@@ -34,7 +34,7 @@
     <!--Version of protobuf that hbase uses internally (we shade our pb)
          Must match what is out in hbase-thirdparty include.
     -->
-    <internal.protobuf.version>3.24.3</internal.protobuf.version>
+    <internal.protobuf.version>3.25.2</internal.protobuf.version>
   </properties>
   <dependencies>
     <!--BE CAREFUL! Any dependency added here needs to be

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -83,7 +83,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.1</version>
           <executions>
             <execution>
               <id>aggregate-into-a-jar-with-relocated-third-parties</id>

--- a/pom.xml
+++ b/pom.xml
@@ -586,8 +586,12 @@
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.13</httpcore.version>
     <metrics-core.version>3.2.6</metrics-core.version>
-    <jackson.version>2.15.2</jackson.version>
-    <jackson.databind.version>2.15.2</jackson.databind.version>
+    <!--
+      Note that the version of jackson-[annotations,core,databind] must be kept in sync with the
+      version of jackson-jaxrs-json-provider shipped in hbase-thirdparty.
+    -->
+    <jackson.version>2.16.1</jackson.version>
+    <jackson.databind.version>2.16.1</jackson.databind.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
@@ -657,7 +661,13 @@
     <snappy.version>1.1.10.4</snappy.version>
     <xz.version>1.9</xz.version>
     <zstd-jni.version>1.5.5-2</zstd-jni.version>
-    <hbase-thirdparty.version>4.1.5</hbase-thirdparty.version>
+    <!--
+        Note that the version of protobuf shipped in hbase-thirdparty must match the version used
+        in hbase-protocol-shaded and hbase-examples. The version of jackson-[annotations,core,
+        databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
+        hbase-thirdparty.
+    -->
+    <hbase-thirdparty.version>4.1.6</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>


### PR DESCRIPTION
Trying out #5693 vs. branch-2.6. In particular, I'm hoping that the unit test suite will be more reliable here. Looks like hbase-examples handled shaded-protobuf slightly differently on this branch.