### PR TITLE
HBASE-28385 make Scan estimates more realistic

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java
@@ -33,6 +33,11 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
 @InterfaceStability.Evolving
 public class DefaultOperationQuota implements OperationQuota {
 
+  // a single scan estimate can consume no more than this proportion of the limiter's limit
+  // this prevents a long-running scan from being estimated at, say, 100MB of IO against
+  // a <100MB/IO throttle (because this would never succeed)
+  private static final double MAX_SCAN_ESTIMATE_PROPORTIONAL_LIMIT_CONSUMPTION = 0.9;
+
   protected final List<QuotaLimiter> limiters;
   private final long writeCapacityUnit;
   private final long readCapacityUnit;
@@ -55,6 +60,7 @@ public class DefaultOperationQuota implements OperationQuota {
   protected long readCapacityUnitDiff = 0;
   private boolean useResultSizeBytes;
   private long blockSizeBytes;
+  private long maxScanEstimate;
 
   public DefaultOperationQuota(final Configuration conf, final int blockSizeBytes,
     final QuotaLimiter... limiters) {
@@ -62,6 +68,11 @@ public class DefaultOperationQuota implements OperationQuota {
     this.useResultSizeBytes =
       conf.getBoolean(OperationQuota.USE_RESULT_SIZE_BYTES, USE_RESULT_SIZE_BYTES_DEFAULT);
     this.blockSizeBytes = blockSizeBytes;
+    long readSizeLimit = Arrays.stream(limiters)
+        .mapToLong(QuotaLimiter::getReadLimit)
+        .min()
+        .orElse(Long.MAX_VALUE);
+    maxScanEstimate = Math.round(MAX_SCAN_ESTIMATE_PROPORTIONAL_LIMIT_CONSUMPTION * readSizeLimit);
   }
 
   /**
@@ -228,7 +239,7 @@ public class DefaultOperationQuota implements OperationQuota {
         estimate =
           Math.min(maxScannerResultSize, scanRequest.getNextCallSeq() * maxBlockBytesScanned);
       }
-      readConsumed = estimate;
+      readConsumed = Math.min(maxScanEstimate, estimate);
     }
 
     readCapacityUnitConsumed = calculateReadCapacityUnit(readConsumed);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java
@@ -68,10 +68,8 @@ public class DefaultOperationQuota implements OperationQuota {
     this.useResultSizeBytes =
       conf.getBoolean(OperationQuota.USE_RESULT_SIZE_BYTES, USE_RESULT_SIZE_BYTES_DEFAULT);
     this.blockSizeBytes = blockSizeBytes;
-    long readSizeLimit = Arrays.stream(limiters)
-        .mapToLong(QuotaLimiter::getReadLimit)
-        .min()
-        .orElse(Long.MAX_VALUE);
+    long readSizeLimit =
+      Arrays.stream(limiters).mapToLong(QuotaLimiter::getReadLimit).min().orElse(Long.MAX_VALUE);
     maxScanEstimate = Math.round(MAX_SCAN_ESTIMATE_PROPORTIONAL_LIMIT_CONSUMPTION * readSizeLimit);
   }
 
@@ -98,7 +96,9 @@ public class DefaultOperationQuota implements OperationQuota {
 
     readAvailable = Long.MAX_VALUE;
     for (final QuotaLimiter limiter : limiters) {
-      if (limiter.isBypass()) continue;
+      if (limiter.isBypass()) {
+        continue;
+      }
 
       limiter.checkQuota(numWrites, writeConsumed, numReads, readConsumed,
         writeCapacityUnitConsumed, readCapacityUnitConsumed);
@@ -118,7 +118,9 @@ public class DefaultOperationQuota implements OperationQuota {
 
     readAvailable = Long.MAX_VALUE;
     for (final QuotaLimiter limiter : limiters) {
-      if (limiter.isBypass()) continue;
+      if (limiter.isBypass()) {
+        continue;
+      }
 
       limiter.checkQuota(0, writeConsumed, 1, readConsumed, writeCapacityUnitConsumed,
         readCapacityUnitConsumed);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/ExceedOperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/ExceedOperationQuota.java
@@ -57,11 +57,11 @@ public class ExceedOperationQuota extends DefaultOperationQuota {
 
   @Override
   public void checkScanQuota(ClientProtos.ScanRequest scanRequest, long maxScannerResultSize,
-    long maxBlockBytesScanned) throws RpcThrottlingException {
-    Runnable estimateQuota =
-      () -> updateEstimateConsumeScanQuota(scanRequest, maxScannerResultSize, maxBlockBytesScanned);
-    CheckQuotaRunnable checkQuota =
-      () -> super.checkScanQuota(scanRequest, maxScannerResultSize, maxBlockBytesScanned);
+    long maxBlockBytesScanned, long prevBlockBytesScannedDifference) throws RpcThrottlingException {
+    Runnable estimateQuota = () -> updateEstimateConsumeScanQuota(scanRequest, maxScannerResultSize,
+      maxBlockBytesScanned, prevBlockBytesScannedDifference);
+    CheckQuotaRunnable checkQuota = () -> super.checkScanQuota(scanRequest, maxScannerResultSize,
+      maxBlockBytesScanned, prevBlockBytesScannedDifference);
     checkQuota(estimateQuota, checkQuota, 0, 1);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopOperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopOperationQuota.java
@@ -48,7 +48,7 @@ class NoopOperationQuota implements OperationQuota {
 
   @Override
   public void checkScanQuota(ClientProtos.ScanRequest scanRequest, long maxScannerResultSize,
-    long maxBlockBytesScanned) throws RpcThrottlingException {
+    long maxBlockBytesScanned, long prevBlockBytesScannedDifference) throws RpcThrottlingException {
     // no-op
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopOperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopOperationQuota.java
@@ -42,7 +42,7 @@ class NoopOperationQuota implements OperationQuota {
   }
 
   @Override
-  public void checkQuota(int numWrites, int numReads) throws RpcThrottlingException {
+  public void checkBatchQuota(int numWrites, int numReads) throws RpcThrottlingException {
     // no-op
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopOperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopOperationQuota.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
+
 /**
  * Noop operation quota returned when no quota is associated to the user/table
  */
@@ -40,7 +42,13 @@ class NoopOperationQuota implements OperationQuota {
   }
 
   @Override
-  public void checkQuota(int numWrites, int numReads, int numScans) throws RpcThrottlingException {
+  public void checkQuota(int numWrites, int numReads) throws RpcThrottlingException {
+    // no-op
+  }
+
+  @Override
+  public void checkScanQuota(ClientProtos.ScanRequest scanRequest, long maxScannerResultSize,
+    long maxBlockBytesScanned) throws RpcThrottlingException {
     // no-op
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopQuotaLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopQuotaLimiter.java
@@ -71,6 +71,11 @@ class NoopQuotaLimiter implements QuotaLimiter {
   }
 
   @Override
+  public long getReadLimit() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
   public String toString() {
     return "NoopQuotaLimiter";
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/OperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/OperationQuota.java
@@ -61,14 +61,17 @@ public interface OperationQuota {
   /**
    * Checks if it is possible to execute the scan. The quota will be estimated based on the
    * composition of the scan.
-   * @param scanRequest          the given scan operation
-   * @param maxScannerResultSize the maximum bytes to be returned by the scanner
-   * @param maxBlockBytesScanned the maximum bytes scanned in a single RPC call by the scanner
+   * @param scanRequest                     the given scan operation
+   * @param maxScannerResultSize            the maximum bytes to be returned by the scanner
+   * @param maxBlockBytesScanned            the maximum bytes scanned in a single RPC call by the
+   *                                        scanner
+   * @param prevBlockBytesScannedDifference the difference between BBS of the previous two next
+   *                                        calls
    * @throws RpcThrottlingException if the operation cannot be performed because RPC quota is
    *                                exceeded.
    */
   void checkScanQuota(ClientProtos.ScanRequest scanRequest, long maxScannerResultSize,
-    long maxBlockBytesScanned) throws RpcThrottlingException;
+    long maxBlockBytesScanned, long prevBlockBytesScannedDifference) throws RpcThrottlingException;
 
   /** Cleanup method on operation completion */
   void close();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/OperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/OperationQuota.java
@@ -23,6 +23,8 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
+
 /**
  * Interface that allows to check the quota available for an operation.
  */
@@ -51,11 +53,22 @@ public interface OperationQuota {
    * on the number of operations to perform and the average size accumulated during time.
    * @param numWrites number of write operation that will be performed
    * @param numReads  number of small-read operation that will be performed
-   * @param numScans  number of long-read operation that will be performed
    * @throws RpcThrottlingException if the operation cannot be performed because RPC quota is
    *                                exceeded.
    */
-  void checkQuota(int numWrites, int numReads, int numScans) throws RpcThrottlingException;
+  void checkQuota(int numWrites, int numReads) throws RpcThrottlingException;
+
+  /**
+   * Checks if it is possible to execute the scan. The quota will be estimated based on the
+   * composition of the scan.
+   * @param scanRequest          the given scan operation
+   * @param maxScannerResultSize the maximum bytes to be returned by the scanner
+   * @param maxBlockBytesScanned the maximum bytes scanned in a single RPC call by the scanner
+   * @throws RpcThrottlingException if the operation cannot be performed because RPC quota is
+   *                                exceeded.
+   */
+  void checkScanQuota(ClientProtos.ScanRequest scanRequest, long maxScannerResultSize,
+    long maxBlockBytesScanned) throws RpcThrottlingException;
 
   /** Cleanup method on operation completion */
   void close();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/OperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/OperationQuota.java
@@ -56,7 +56,7 @@ public interface OperationQuota {
    * @throws RpcThrottlingException if the operation cannot be performed because RPC quota is
    *                                exceeded.
    */
-  void checkQuota(int numWrites, int numReads) throws RpcThrottlingException;
+  void checkBatchQuota(int numWrites, int numReads) throws RpcThrottlingException;
 
   /**
    * Checks if it is possible to execute the scan. The quota will be estimated based on the

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaLimiter.java
@@ -76,6 +76,9 @@ public interface QuotaLimiter {
   /** Returns the number of bytes available to read to avoid exceeding the quota */
   long getReadAvailable();
 
+  /** Returns the maximum number of bytes ever available to read */
+  long getReadLimit();
+
   /** Returns the number of bytes available to write to avoid exceeding the quota */
   long getWriteAvailable();
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RateLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RateLimiter.java
@@ -35,7 +35,6 @@ import org.apache.yetus.audience.InterfaceStability;
       + "are mostly synchronized...but to me it looks like they are totally synchronized")
 public abstract class RateLimiter {
   public static final String QUOTA_RATE_LIMITER_CONF_KEY = "hbase.quota.rate.limiter";
-  private static final long QUOTA_RATE_LIMITER_MINIMUM_WAIT_INTERVAL_MS = 100L;
   private long tunit = 1000; // Timeunit factor for translating to ms.
   private long limit = Long.MAX_VALUE; // The max value available resource units can be refilled to.
   private long avail = Long.MAX_VALUE; // Currently available resource units
@@ -218,11 +217,7 @@ public abstract class RateLimiter {
    */
   public synchronized long waitInterval(final long amount) {
     // TODO Handle over quota?
-    long waitInterval = (amount <= avail) ? 0 : getWaitInterval(getLimit(), avail, amount);
-    if (waitInterval > 0) {
-      return Math.max(waitInterval, QUOTA_RATE_LIMITER_MINIMUM_WAIT_INTERVAL_MS);
-    }
-    return waitInterval;
+    return (amount <= avail) ? 0 : getWaitInterval(getLimit(), avail, amount);
   }
 
   // These two method are for strictly testing purpose only

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
@@ -159,16 +159,20 @@ public class RegionServerRpcQuotaManager {
    * available quota and to report the data/usage of the operation. This method is specific to scans
    * because estimating a scan's workload is more complicated than estimating the workload of a
    * get/put.
-   * @param region               the region where the operation will be performed
-   * @param scanRequest          the scan to be estimated against the quota
-   * @param maxScannerResultSize the maximum bytes to be returned by the scanner
-   * @param maxBlockBytesScanned the maximum bytes scanned in a single RPC call by the scanner
+   * @param region                          the region where the operation will be performed
+   * @param scanRequest                     the scan to be estimated against the quota
+   * @param maxScannerResultSize            the maximum bytes to be returned by the scanner
+   * @param maxBlockBytesScanned            the maximum bytes scanned in a single RPC call by the
+   *                                        scanner
+   * @param prevBlockBytesScannedDifference the difference between BBS of the previous two next
+   *                                        calls
    * @return the OperationQuota
    * @throws RpcThrottlingException if the operation cannot be executed due to quota exceeded.
    */
   public OperationQuota checkScanQuota(final Region region,
     final ClientProtos.ScanRequest scanRequest, long maxScannerResultSize,
-    long maxBlockBytesScanned) throws IOException, RpcThrottlingException {
+    long maxBlockBytesScanned, long prevBlockBytesScannedDifference)
+    throws IOException, RpcThrottlingException {
     Optional<User> user = RpcServer.getRequestUser();
     UserGroupInformation ugi;
     if (user.isPresent()) {
@@ -181,7 +185,8 @@ public class RegionServerRpcQuotaManager {
 
     OperationQuota quota = getQuota(ugi, table, region.getMinBlockSizeBytes());
     try {
-      quota.checkScanQuota(scanRequest, maxScannerResultSize, maxBlockBytesScanned);
+      quota.checkScanQuota(scanRequest, maxScannerResultSize, maxBlockBytesScanned,
+        prevBlockBytesScannedDifference);
     } catch (RpcThrottlingException e) {
       LOG.debug("Throttling exception for user=" + ugi.getUserName() + " table=" + table + " scan="
         + scanRequest.getScannerId() + ": " + e.getMessage());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
@@ -267,7 +267,7 @@ public class RegionServerRpcQuotaManager {
 
     OperationQuota quota = getQuota(ugi, table, region.getMinBlockSizeBytes());
     try {
-      quota.checkQuota(numWrites, numReads);
+      quota.checkBatchQuota(numWrites, numReads);
     } catch (RpcThrottlingException e) {
       LOG.debug("Throttling exception for user=" + ugi.getUserName() + " table=" + table
         + " numWrites=" + numWrites + " numReads=" + numReads + ": " + e.getMessage());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
@@ -244,6 +244,11 @@ public class TimeBasedLimiter implements QuotaLimiter {
   }
 
   @Override
+  public long getReadLimit() {
+    return Math.min(readSizeLimiter.getLimit(), reqSizeLimiter.getLimit());
+  }
+
+  @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
     builder.append("TimeBasedLimiter(");

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -429,7 +429,9 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
     private boolean fullRegionScan;
     private final String clientIPAndPort;
     private final String userName;
-    private final AtomicLong maxBlockBytesScanned = new AtomicLong(0);
+    private volatile long maxBlockBytesScanned = 0;
+    private volatile long prevBlockBytesScanned = 0;
+    private volatile long prevBlockBytesScannedDifference = 0;
 
     RegionScannerHolder(RegionScanner s, HRegion r, RpcCallback closeCallBack,
       RpcCallback shippedCallback, boolean needCursor, boolean fullRegionScan,
@@ -453,12 +455,20 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
       return nextCallSeq.compareAndSet(currentSeq, currentSeq + 1);
     }
 
-    synchronized long getMaxBlockBytesScanned() {
-      return maxBlockBytesScanned.get();
+    long getMaxBlockBytesScanned() {
+      return maxBlockBytesScanned;
     }
 
-    synchronized void setMaxBlockBytesScanned(long blockBytesScanned) {
-      maxBlockBytesScanned.set(Math.max(getMaxBlockBytesScanned(), blockBytesScanned));
+    long getPrevBlockBytesScannedDifference() {
+      return prevBlockBytesScannedDifference;
+    }
+
+    void updateBlockBytesScanned(long blockBytesScanned) {
+      prevBlockBytesScannedDifference = blockBytesScanned - prevBlockBytesScanned;
+      prevBlockBytesScanned = blockBytesScanned;
+      if (blockBytesScanned > maxBlockBytesScanned) {
+        maxBlockBytesScanned = blockBytesScanned;
+      }
     }
 
     // Should be called only when we need to print lease expired messages otherwise
@@ -3494,7 +3504,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
       if (rpcCall != null) {
         responseCellSize = rpcCall.getResponseCellSize();
         blockBytesScanned = rpcCall.getBlockBytesScanned();
-        rsh.setMaxBlockBytesScanned(blockBytesScanned);
+        rsh.updateBlockBytesScanned(blockBytesScanned);
       }
       region.getMetrics().updateScan();
       final MetricsRegionServer metricsRegionServer = server.getMetrics();
@@ -3599,7 +3609,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
     OperationQuota quota;
     try {
       quota = getRpcQuotaManager().checkScanQuota(region, request, maxScannerResultSize,
-        rsh.getMaxBlockBytesScanned());
+        rsh.getMaxBlockBytesScanned(), rsh.getPrevBlockBytesScannedDifference());
     } catch (IOException e) {
       addScannerLeaseBack(lease);
       throw new ServiceException(e);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -453,7 +453,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
       return nextCallSeq.compareAndSet(currentSeq, currentSeq + 1);
     }
 
-    long getMaxBlockBytesScanned() {
+    synchronized long getMaxBlockBytesScanned() {
       return maxBlockBytesScanned.get();
     }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestBlockBytesScannedQuota.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestBlockBytesScannedQuota.java
@@ -70,7 +70,8 @@ public class TestBlockBytesScannedQuota {
     TEST_UTIL.getConfiguration().setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 1);
     TEST_UTIL.getConfiguration().setLong(HConstants.HBASE_SERVER_SCANNER_MAX_RESULT_SIZE_KEY,
       MAX_SCANNER_RESULT_SIZE);
-    TEST_UTIL.getConfiguration().setClass(RateLimiter.QUOTA_RATE_LIMITER_CONF_KEY, AverageIntervalRateLimiter.class, RateLimiter.class);
+    TEST_UTIL.getConfiguration().setClass(RateLimiter.QUOTA_RATE_LIMITER_CONF_KEY,
+      AverageIntervalRateLimiter.class, RateLimiter.class);
 
     // quotas enabled, using block bytes scanned
     TEST_UTIL.getConfiguration().setBoolean(QuotaUtil.QUOTA_CONF_KEY, true);
@@ -161,7 +162,7 @@ public class TestBlockBytesScannedQuota {
 
     // Add 50 block/sec limit. This should support >1 scans
     admin.setQuota(QuotaSettingsFactory.throttleUser(userName, ThrottleType.REQUEST_SIZE,
-      Math.round(50 * blockSize), TimeUnit.SECONDS));
+      Math.round(50.1 * blockSize), TimeUnit.SECONDS));
     triggerUserCacheRefresh(TEST_UTIL, false, TABLE_NAME);
     waitMinuteQuota();
 
@@ -197,7 +198,8 @@ public class TestBlockBytesScannedQuota {
     // maxScannerResultSize (both larger than the 90MB limit). This test ensures that all
     // requests succeed, so the estimate never becomes large enough to cause read downtime
     long limit = 99 * 1024 * 1024;
-    assertTrue(limit <= MAX_SCANNER_RESULT_SIZE); // always true, but protecting against code changes
+    assertTrue(limit <= MAX_SCANNER_RESULT_SIZE); // always true, but protecting against code
+                                                  // changes
     admin.setQuota(QuotaSettingsFactory.throttleUser(userName, ThrottleType.REQUEST_SIZE, limit,
       TimeUnit.SECONDS));
     triggerUserCacheRefresh(TEST_UTIL, false, TABLE_NAME);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestBlockBytesScannedQuota.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestBlockBytesScannedQuota.java
@@ -23,6 +23,7 @@ import static org.apache.hadoop.hbase.quotas.ThrottleQuotaTestUtil.doPuts;
 import static org.apache.hadoop.hbase.quotas.ThrottleQuotaTestUtil.doScans;
 import static org.apache.hadoop.hbase.quotas.ThrottleQuotaTestUtil.triggerUserCacheRefresh;
 import static org.apache.hadoop.hbase.quotas.ThrottleQuotaTestUtil.waitMinuteQuota;
+import static org.junit.Assert.assertTrue;
 
 import java.util.concurrent.Callable;
 import java.util.concurrent.TimeUnit;
@@ -60,12 +61,16 @@ public class TestBlockBytesScannedQuota {
   private static final byte[] QUALIFIER = Bytes.toBytes("q");
 
   private static final TableName TABLE_NAME = TableName.valueOf("BlockBytesScannedQuotaTest");
+  private static final long MAX_SCANNER_RESULT_SIZE = 100 * 1024 * 1024;
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
     // client should fail fast
     TEST_UTIL.getConfiguration().setInt("hbase.client.pause", 10);
     TEST_UTIL.getConfiguration().setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 1);
+    TEST_UTIL.getConfiguration().setLong(HConstants.HBASE_SERVER_SCANNER_MAX_RESULT_SIZE_KEY,
+      MAX_SCANNER_RESULT_SIZE);
+    TEST_UTIL.getConfiguration().setClass(RateLimiter.QUOTA_RATE_LIMITER_CONF_KEY, AverageIntervalRateLimiter.class, RateLimiter.class);
 
     // quotas enabled, using block bytes scanned
     TEST_UTIL.getConfiguration().setBoolean(QuotaUtil.QUOTA_CONF_KEY, true);
@@ -167,6 +172,39 @@ public class TestBlockBytesScannedQuota {
 
     // With large caching, a big scan should succeed
     testTraffic(() -> doScans(10_000, table, 10_000), 10_000, 0);
+    triggerUserCacheRefresh(TEST_UTIL, false, TABLE_NAME);
+    waitMinuteQuota();
+
+    // Remove all the limits
+    admin.setQuota(QuotaSettingsFactory.unthrottleUser(userName));
+    triggerUserCacheRefresh(TEST_UTIL, true, TABLE_NAME);
+    testTraffic(() -> doScans(100, table, 1), 100, 0);
+    testTraffic(() -> doScans(100, table, 1), 100, 0);
+  }
+
+  @Test
+  public void testSmallScanNeverBlockedByLargeEstimate() throws Exception {
+    final Admin admin = TEST_UTIL.getAdmin();
+    final String userName = User.getCurrent().getShortName();
+    Table table = admin.getConnection().getTable(TABLE_NAME);
+
+    doPuts(10_000, FAMILY, QUALIFIER, table);
+    TEST_UTIL.flush(TABLE_NAME);
+
+    // Add 99MB/sec limit.
+    // This should never be blocked, but with a sequence number approaching 10k, without
+    // other intervention, we would estimate a scan workload approaching 625MB or the
+    // maxScannerResultSize (both larger than the 90MB limit). This test ensures that all
+    // requests succeed, so the estimate never becomes large enough to cause read downtime
+    long limit = 99 * 1024 * 1024;
+    assertTrue(limit <= MAX_SCANNER_RESULT_SIZE); // always true, but protecting against code changes
+    admin.setQuota(QuotaSettingsFactory.throttleUser(userName, ThrottleType.REQUEST_SIZE, limit,
+      TimeUnit.SECONDS));
+    triggerUserCacheRefresh(TEST_UTIL, false, TABLE_NAME);
+    waitMinuteQuota();
+
+    // should execute all requests
+    testTraffic(() -> doScans(10_000, table, 1), 10_000, 0);
     triggerUserCacheRefresh(TEST_UTIL, false, TABLE_NAME);
     waitMinuteQuota();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestDefaultOperationQuota.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestDefaultOperationQuota.java
@@ -1,0 +1,128 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.quotas;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ RegionServerTests.class, SmallTests.class })
+public class TestDefaultOperationQuota {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestDefaultOperationQuota.class);
+
+  @Test
+  public void testScanEstimateNewScanner() {
+    long blockSize = 64 * 1024;
+    long nextCallSeq = 0;
+    long maxScannerResultSize = 100 * 1024 * 1024;
+    long maxBlockBytesScanned = 0;
+    long prevBBSDifference = 0;
+    long estimate = DefaultOperationQuota.getScanReadConsumeEstimate(blockSize, nextCallSeq,
+      maxScannerResultSize, maxBlockBytesScanned, prevBBSDifference);
+
+    // new scanner should estimate scan read as 1 block
+    assertEquals(blockSize, estimate);
+  }
+
+  @Test
+  public void testScanEstimateSecondNextCall() {
+    long blockSize = 64 * 1024;
+    long nextCallSeq = 1;
+    long maxScannerResultSize = 100 * 1024 * 1024;
+    long maxBlockBytesScanned = 10 * blockSize;
+    long prevBBSDifference = 10 * blockSize;
+    long estimate = DefaultOperationQuota.getScanReadConsumeEstimate(blockSize, nextCallSeq,
+      maxScannerResultSize, maxBlockBytesScanned, prevBBSDifference);
+
+    // 2nd next call should be estimated at maxBBS
+    assertEquals(maxBlockBytesScanned, estimate);
+  }
+
+  @Test
+  public void testScanEstimateFlatWorkload() {
+    long blockSize = 64 * 1024;
+    long nextCallSeq = 100;
+    long maxScannerResultSize = 100 * 1024 * 1024;
+    long maxBlockBytesScanned = 10 * blockSize;
+    long prevBBSDifference = 0;
+    long estimate = DefaultOperationQuota.getScanReadConsumeEstimate(blockSize, nextCallSeq,
+      maxScannerResultSize, maxBlockBytesScanned, prevBBSDifference);
+
+    // flat workload should not overestimate
+    assertEquals(maxBlockBytesScanned, estimate);
+  }
+
+  @Test
+  public void testScanEstimateVariableFlatWorkload() {
+    long blockSize = 64 * 1024;
+    long nextCallSeq = 1;
+    long maxScannerResultSize = 100 * 1024 * 1024;
+    long maxBlockBytesScanned = 10 * blockSize;
+    long prevBBSDifference = 0;
+    for (int i = 0; i < 100; i++) {
+      long variation = Math.round(Math.random() * blockSize);
+      if (variation % 2 == 0) {
+        variation *= -1;
+      }
+      // despite +/- <1 block variation, we consider this workload flat
+      prevBBSDifference = variation;
+
+      long estimate = DefaultOperationQuota.getScanReadConsumeEstimate(blockSize, nextCallSeq + i,
+        maxScannerResultSize, maxBlockBytesScanned, prevBBSDifference);
+
+      // flat workload should not overestimate
+      assertEquals(maxBlockBytesScanned, estimate);
+    }
+  }
+
+  @Test
+  public void testScanEstimateGrowingWorkload() {
+    long blockSize = 64 * 1024;
+    long nextCallSeq = 100;
+    long maxScannerResultSize = 100 * 1024 * 1024;
+    long maxBlockBytesScanned = 20 * blockSize;
+    long prevBBSDifference = 10 * blockSize;
+    long estimate = DefaultOperationQuota.getScanReadConsumeEstimate(blockSize, nextCallSeq,
+      maxScannerResultSize, maxBlockBytesScanned, prevBBSDifference);
+
+    // growing workload should overestimate
+    assertTrue(nextCallSeq * maxBlockBytesScanned == estimate || maxScannerResultSize == estimate);
+  }
+
+  @Test
+  public void testScanEstimateShrinkingWorkload() {
+    long blockSize = 64 * 1024;
+    long nextCallSeq = 100;
+    long maxScannerResultSize = 100 * 1024 * 1024;
+    long maxBlockBytesScanned = 20 * blockSize;
+    long prevBBSDifference = -10 * blockSize;
+    long estimate = DefaultOperationQuota.getScanReadConsumeEstimate(blockSize, nextCallSeq,
+      maxScannerResultSize, maxBlockBytesScanned, prevBBSDifference);
+
+    // shrinking workload should only shrink estimate to maxBBS
+    assertEquals(maxBlockBytesScanned, estimate);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/ThrottleQuotaTestUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/ThrottleQuotaTestUtil.java
@@ -152,22 +152,21 @@ public final class ThrottleQuotaTestUtil {
     return opCount;
   }
 
-  static long doScans(int maxOps, Table table) {
+  static long doScans(int desiredRows, Table table, int caching) {
     int count = 0;
-    int caching = 100;
     try {
       Scan scan = new Scan();
       scan.setCaching(caching);
       scan.setCacheBlocks(false);
       ResultScanner scanner = table.getScanner(scan);
-      while (count < (maxOps * caching)) {
+      while (count < desiredRows) {
         scanner.next();
         count += 1;
       }
     } catch (IOException e) {
       LOG.error("scan failed after nRetries=" + count, e);
     }
-    return count / caching;
+    return count;
   }
 
   static void triggerUserCacheRefresh(HBaseTestingUtil testUtil, boolean bypass,


### PR DESCRIPTION
## Background

https://issues.apache.org/jira/browse/HBASE-28385

Let's say you're running a table scan with a throttle of 100MB/sec per RegionServer. Ideally your scans are going to pull down large results, often containing hundreds or thousands of blocks.

You will estimate each scan as costing a single block of read capacity, and if your quota is already exhausted then the server will evaluate the backoff required for your estimated consumption (1 block) to be available. This will often be ~1ms, causing your retries to basically be immediate.

Obviously it will routinely take much longer than 1ms for 100MB of IO to become available in the given configuration, so your retries will be destined to fail. At worst this can cause a saturation of your server's RPC layer, and at best this causes erroneous exhaustion of the client's retries.

## Proposal

This makes two major changes:
1. It introduces a more complex estimation of scan workloads. Specifically:
    * We begin tracking the `maxBlockBytesScanned`, `prevBlockBytesScanned`, and `prevBlockBytesScannedDiff` for each scanner in the `RegionScannerHolder`.
    * Keep in mind that there is already a server configured maxResultSize for scanners, and a call sequence number which increments with each `Scanner#next` call, beginning with 0
    * With all of these inputs, we can differentiate between a new, growing, shrinking, or flat scan workload. We can also tell how much work it has done per RPC recently. With all of this information we're in a position to make an educated estimate about how much work the scan will do in its next call
2. It introduces a maximum scan estimate based on the quota's limit. This ensures that we never indefinitely block a scan based on its estimate against an otherwise idle quota.

## Testing

I've deployed this to a test cluster and confirmed that large scan estimates quickly produced useful estimates and, consequently, meaningful waitInterval backoffs. I can also try to write a unit test which confirms this behavior.

cc @hgromer @eab148 @bozzkar