### PR TITLE
HBASE-28408 Rephrase confusing log message

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/RestoreTablesClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/RestoreTablesClient.java
@@ -173,7 +173,8 @@ public class RestoreTablesClient {
     }
 
     if (dirList.isEmpty()) {
-      LOG.info("No incremental changes since full backup for '" + sTable + "', skipping incremental restore step.");
+      LOG.info("No incremental changes since full backup for '" + sTable
+        + "', skipping incremental restore step.");
       return;
     }
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/RestoreTablesClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/RestoreTablesClient.java
@@ -173,7 +173,7 @@ public class RestoreTablesClient {
     }
 
     if (dirList.isEmpty()) {
-      LOG.warn("Nothing has changed, so there is no need to restore '" + sTable + "'");
+      LOG.info("No incremental changes since full backup for '" + sTable + "', skipping incremental restore step.");
       return;
     }
 


### PR DESCRIPTION
Assume a user has a series of backups: Full1, Inc2, Inc3, where a table has not changed between Full1 and Inc3, but has changed after Inc3.
When restoring that table to Inc3, a log warning was outputted mentioning there was no need for a restore. This message in fact means there is no need for the incremental restore portion of the restore process.