### PR TITLE
HBASE-28421 Add ofs (Ozone Filesystem) support for acquireDelegationToken

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1495,6 +1495,10 @@ public final class HConstants {
   /** Config key for hbase temporary directory in hdfs */
   public static final String TEMPORARY_FS_DIRECTORY_KEY = "hbase.fs.tmp.dir";
 
+  public static final String FILESYSTEM_DELEGATION_TOKEN_MAPPING =
+    "hbase.fs.dt.mapping";
+  public static final String DEFAULT_FILESYSTEM_DELEGATION_TOKEN_MAPPING = "ofs=OzoneToken";
+
   /**
    * Don't use it! This'll get you the wrong path in a secure cluster. Use
    * FileSystem.getHomeDirectory() or "/user/" +

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/FsDelegationToken.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/token/FsDelegationToken.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.security.token;
 
+import static org.apache.hadoop.hbase.HConstants.DEFAULT_FILESYSTEM_DELEGATION_TOKEN_MAPPING;
+import static org.apache.hadoop.hbase.HConstants.FILESYSTEM_DELEGATION_TOKEN_MAPPING;
 import static org.apache.hadoop.hdfs.protocol.HdfsConstants.HDFS_URI_SCHEME;
 import static org.apache.hadoop.hdfs.security.token.delegation.DelegationTokenIdentifier.HDFS_DELEGATION_KIND;
 import static org.apache.hadoop.hdfs.web.WebHdfsConstants.SWEBHDFS_SCHEME;
@@ -71,7 +73,8 @@ public class FsDelegationToken {
   public void acquireDelegationToken(final FileSystem fs) throws IOException {
     String tokenKind;
     String scheme = fs.getUri().getScheme();
-    this.customDelegationTokenIdentifierMapping = parseInput(fs.getConf().get("hbase.dt.mapping", ""));
+    this.customDelegationTokenIdentifierMapping = parseDelegationTokenMapping(fs.getConf().get(
+      FILESYSTEM_DELEGATION_TOKEN_MAPPING, DEFAULT_FILESYSTEM_DELEGATION_TOKEN_MAPPING));
     if (SWEBHDFS_SCHEME.equalsIgnoreCase(scheme)) {
       tokenKind = SWEBHDFS_TOKEN_KIND.toString();
     } else if (WEBHDFS_SCHEME.equalsIgnoreCase(scheme)) {
@@ -89,7 +92,7 @@ public class FsDelegationToken {
     acquireDelegationToken(tokenKind, fs);
   }
 
-  private static Map<String, String> parseInput(String input) {
+  private static Map<String, String> parseDelegationTokenMapping(String input) {
     Map<String, String> resultMap = new HashMap<>();
     String[] pairs = input.split(";");
     for (String pair : pairs) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestFsDelegationToken.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/token/TestFsDelegationToken.java
@@ -88,6 +88,12 @@ public class TestFsDelegationToken {
     when(webhdfsToken.getKind()).thenReturn(WEBHDFS_TOKEN_KIND);
     when(swebhdfsToken.getKind()).thenReturn(SWEBHDFS_TOKEN_KIND);
     when(ofsToken.getKind()).thenReturn(OZONE_TOKEN_KIND);
+
+    Configuration conf = new Configuration();
+    when(fileSystem.getConf()).thenReturn(conf);
+    when(webHdfsFileSystem.getConf()).thenReturn(conf);
+    when(swebHdfsFileSystem.getConf()).thenReturn(conf);
+    when(rootedOzoneFileSystem.getConf()).thenReturn(conf);
   }
 
   @Test
@@ -127,9 +133,6 @@ public class TestFsDelegationToken {
 
   @Test
   public void acquireDelegationTokenByTokenKind_OzoneFileSystem() throws IOException {
-    Configuration conf = new Configuration();
-    conf.set("hbase.dt.mapping", "ofs=OzoneToken");
-    when(rootedOzoneFileSystem.getConf()).thenReturn(conf);
     fsDelegationToken.acquireDelegationToken(rootedOzoneFileSystem);
     assertEquals(fsDelegationToken.getUserToken().getKind(), OZONE_TOKEN_KIND);
   }


### PR DESCRIPTION
Add a configuration key hbase.fs.dt.mapping to allow custom mapping of file system scheme to delegation token identifiers. User can specify the mapping using the format "scheme1=tokenid2;scheme2=tokenid2" to specify two pairs of file system scheme to delegation token identifier mapping. By default, it is "ofs=OzoneToken" which allows ofs file system to map to OzoneToken  identifier.