### PR TITLE
HBASE-27982 Synchronous replication should check if the file system supports truncate API.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/SyncReplicationReplayWALManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/SyncReplicationReplayWALManager.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.master.replication;
 
+import static org.apache.hadoop.fs.CommonPathCapabilities.FS_TRUNCATE;
 import static org.apache.hadoop.hbase.replication.ReplicationUtils.getPeerRemoteWALDir;
 import static org.apache.hadoop.hbase.replication.ReplicationUtils.getPeerReplayWALDir;
 import static org.apache.hadoop.hbase.replication.ReplicationUtils.getPeerSnapshotWALDir;
@@ -157,6 +158,10 @@ public class SyncReplicationReplayWALManager {
         }
       }
     });
+    if (!this.fs.hasPathCapability(walRootDir, FS_TRUNCATE)) {
+      LOG.warn("File system " + fs.getScheme() + " path " + walRootDir +
+        " does not support truncate. Synchronous WAL may not function properly.");
+    }
   }
 
   public void registerPeer(String peerId) {


### PR DESCRIPTION
This PR checks for truncate capability of the WAL file system. Log a warning if not. I am not sure if it's better to simply let it throw exception and abort. Happy to change the PR according to the feedbacks.