### PR TITLE
HBASE-28448 CompressionTest hangs when run over a Ozone ofs path

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CompressionTest.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CompressionTest.java
@@ -152,17 +152,18 @@ public class CompressionTest {
 
     Configuration conf = new Configuration();
     Path path = new Path(args[0]);
-    FileSystem fs = path.getFileSystem(conf);
-    if (fs.exists(path)) {
-      System.err.println("The specified path exists, aborting!");
-      System.exit(1);
-    }
+    try (FileSystem fs = path.getFileSystem(conf)) {
+      if (fs.exists(path)) {
+        System.err.println("The specified path exists, aborting!");
+        System.exit(1);
+      }
 
-    try {
-      doSmokeTest(fs, path, args[1]);
-    } finally {
-      fs.delete(path, false);
+      try {
+        doSmokeTest(fs, path, args[1]);
+      } finally {
+        fs.delete(path, false);
+      }
+      System.out.println("SUCCESS");
     }
-    System.out.println("SUCCESS");
   }
 }


### PR DESCRIPTION
CompressionTest should close the FileSystem object otherwise some resources may not be released, which caused an Ozone output stream user thread to hang.

Deployed on a cluster, ran the same command `hbase org.apache.hadoop.hbase.util.CompressionTest ofs://ozone/vol1/bucket1/test_file.txt snappy` to verify it no longer hangs on an Ozone path.