### PR TITLE
HBASE-28453 FixedIntervalRateLimiter support for a shorter refill interval

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RateLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RateLimiter.java
@@ -35,7 +35,9 @@ import org.apache.yetus.audience.InterfaceStability;
       + "are mostly synchronized...but to me it looks like they are totally synchronized")
 public abstract class RateLimiter {
   public static final String QUOTA_RATE_LIMITER_CONF_KEY = "hbase.quota.rate.limiter";
-  private long tunit = 1000; // Timeunit factor for translating to ms.
+  public static final long DEFAULT_TIME_UNIT = 1000;
+
+  private long tunit = DEFAULT_TIME_UNIT; // Timeunit factor for translating to ms.
   private long limit = Long.MAX_VALUE; // The max value available resource units can be refilled to.
   private long avail = Long.MAX_VALUE; // Currently available resource units
 
@@ -157,7 +159,7 @@ public abstract class RateLimiter {
    * @param amount the number of required resources, a non-negative number
    * @return true if there are enough available resources, otherwise false
    */
-  private boolean isAvailable(final long amount) {
+  protected boolean isAvailable(final long amount) {
     if (isBypass()) {
       return true;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
@@ -49,15 +49,17 @@ public class TimeBasedLimiter implements QuotaLimiter {
         conf.getClass(RateLimiter.QUOTA_RATE_LIMITER_CONF_KEY, AverageIntervalRateLimiter.class)
           .getName())
     ) {
-      reqsLimiter = new FixedIntervalRateLimiter();
-      reqSizeLimiter = new FixedIntervalRateLimiter();
-      writeReqsLimiter = new FixedIntervalRateLimiter();
-      writeSizeLimiter = new FixedIntervalRateLimiter();
-      readReqsLimiter = new FixedIntervalRateLimiter();
-      readSizeLimiter = new FixedIntervalRateLimiter();
-      reqCapacityUnitLimiter = new FixedIntervalRateLimiter();
-      writeCapacityUnitLimiter = new FixedIntervalRateLimiter();
-      readCapacityUnitLimiter = new FixedIntervalRateLimiter();
+      long refillInterval = conf.getLong(FixedIntervalRateLimiter.RATE_LIMITER_REFILL_INTERVAL_MS,
+        RateLimiter.DEFAULT_TIME_UNIT);
+      reqsLimiter = new FixedIntervalRateLimiter(refillInterval);
+      reqSizeLimiter = new FixedIntervalRateLimiter(refillInterval);
+      writeReqsLimiter = new FixedIntervalRateLimiter(refillInterval);
+      writeSizeLimiter = new FixedIntervalRateLimiter(refillInterval);
+      readReqsLimiter = new FixedIntervalRateLimiter(refillInterval);
+      readSizeLimiter = new FixedIntervalRateLimiter(refillInterval);
+      reqCapacityUnitLimiter = new FixedIntervalRateLimiter(refillInterval);
+      writeCapacityUnitLimiter = new FixedIntervalRateLimiter(refillInterval);
+      readCapacityUnitLimiter = new FixedIntervalRateLimiter(refillInterval);
     } else {
       reqsLimiter = new AverageIntervalRateLimiter();
       reqSizeLimiter = new AverageIntervalRateLimiter();


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HBASE-28453

The AverageIntervalRateLimiter causes tiny wait intervals which can result in DDOS at worst, or poor UX at best. See below where we implemented a 10k request/second/machine quota at 10:43 and saw requests fall into immediate retry loops and inundate the cluster:
![](https://issues.apache.org/jira/secure/attachment/13067588/Screenshot%202024-03-21%20at%202.30.01%E2%80%AFPM.png)


The FixedIntervalRateLimiter causes large wait intervals which make it difficult to fully utilize a quota. See below where we were stuck only utilizing ~20% of our quota consistently. After restarting the cluster to use a FIRL with a 100ms refill interval we were able to achieve much better utilization:

![Screenshot 2024-03-22 at 9 42 52 AM](https://github.com/apache/hbase/assets/21689053/0c813e41-27ae-4227-8521-6e4a25b0c225)

As suggested above, this PR introduces support for a refill interval that is <= the TimeUnit of a FixedIntervalRateLimiter. This means that you can define a quota in a straightforward way, like 100MB/sec, while also acknowledging, for example, that you're willing to refill it every 100ms — suggesting that your retries for small/normal requests will often be ~100ms.

Simply set `hbase.quota.rate.limiter.refill.interval.ms` to your desired refill interval, and restart your RegionServers, to make use of this feature. By default the refill interval will just equal the TimeUnit, so this is a no-op without explicit configuration.

Here's an initial look at how a 100ms refill interval changed our wait interval percentiles in our QA environment:
![Screenshot 2024-03-22 at 1 36 21 PM](https://github.com/apache/hbase/assets/21689053/c76cb3ff-4cdc-4369-8d4f-db2a1bf56421)


@hgromer @eab148 @bozzkar @bbeaudreault 