### PR TITLE
HBASE-28470 Fix typo in Java method comment

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -792,7 +792,7 @@ public interface Admin extends Abortable, Closeable {
 
   /**
    * Unassign a Region.
-   * @param regionName Region name to assign.
+   * @param regionName Region name to unassign.
    * @throws IOException if a remote or network exception occurs
    */
   void unassign(byte[] regionName) throws IOException;


### PR DESCRIPTION
The java method comment contains a typo. 

The comment incorrectly states "Region name to assign" instead of "Region name to unassign".