### PR TITLE
HBASE-28485: Re-use ZstdDecompressCtx/ZstdCompressCtx for performance

### DIFF
--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdCompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdCompressor.java
@@ -170,6 +170,7 @@ public class ZstdCompressor implements CanReinit, Compressor {
     bytesWritten = 0;
     finish = false;
     finished = false;
+    ctx.reset();
     ctx.setLevel(level);
     if (dict != null) {
       ctx.loadDict(dict);

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdCompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdCompressor.java
@@ -53,8 +53,8 @@ public class ZstdCompressor implements CanReinit, Compressor {
     if (dictionary != null) {
       this.dictId = ZstdCodec.getDictionaryId(dictionary);
       this.dict = new ZstdDictCompress(dictionary, level);
+      this.ctx.loadDict(this.dict);
     }
-    this.ctx.loadDict(this.dict);
   }
 
   ZstdCompressor(final int level, final int bufferSize) {
@@ -171,8 +171,12 @@ public class ZstdCompressor implements CanReinit, Compressor {
     finish = false;
     finished = false;
     ctx.setLevel(level);
-    // loadDict() accepts null to clear the dictionary
-    ctx.loadDict(dict);
+    if (dict != null) {
+      ctx.loadDict(dict);
+    } else {
+      // loadDict((byte[]) accepts null to clear the dictionary
+      ctx.loadDict((byte[]) null);
+    }
   }
 
   @Override

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdDecompressor.java
@@ -50,8 +50,8 @@ public class ZstdDecompressor implements CanReinit, Decompressor {
     if (dictionary != null) {
       this.dictId = ZstdCodec.getDictionaryId(dictionary);
       this.dict = new ZstdDictDecompress(dictionary);
+      this.ctx.loadDict(this.dict);
     }
-    this.ctx.loadDict(this.dict);
   }
 
   ZstdDecompressor(final int bufferSize) {
@@ -108,8 +108,12 @@ public class ZstdDecompressor implements CanReinit, Decompressor {
     outBuf.position(outBuf.capacity());
     finished = false;
     ctx.reset();
-    // loadDict() accepts null to clear the dictionary
-    ctx.loadDict(dict);
+    if (dict != null) {
+      ctx.loadDict(dict);
+    } else {
+      // loadDict((byte[]) accepts null to clear the dictionary
+      ctx.loadDict((byte[]) null);
+    }
   }
 
   @Override


### PR DESCRIPTION
The zstd documentation recommends re-using context objects when possible, because their creation has some expense. They can be more cheaply reset than re-created. In this PR, create one `Zstd(De)compressCtx` for the lifetime of a `Compressor` or `Decompressor` object.