### PR TITLE
HBASE-28448 CompressionTest hangs when run over a Ozone ofs path (#5771)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CompressionTest.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CompressionTest.java
@@ -152,17 +152,18 @@ public class CompressionTest {
 
     Configuration conf = new Configuration();
     Path path = new Path(args[0]);
-    FileSystem fs = path.getFileSystem(conf);
-    if (fs.exists(path)) {
-      System.err.println("The specified path exists, aborting!");
-      System.exit(1);
-    }
+    try (FileSystem fs = path.getFileSystem(conf)) {
+      if (fs.exists(path)) {
+        System.err.println("The specified path exists, aborting!");
+        System.exit(1);
+      }
 
-    try {
-      doSmokeTest(fs, path, args[1]);
-    } finally {
-      fs.delete(path, false);
+      try {
+        doSmokeTest(fs, path, args[1]);
+      } finally {
+        fs.delete(path, false);
+      }
+      System.out.println("SUCCESS");
     }
-    System.out.println("SUCCESS");
   }
 }


### PR DESCRIPTION
This bug was found via HDDS-10564.

(cherry picked from commit adc79a0a9c2b579915a902f611a66edfddf3149c)