### PR TITLE
HBASE-28448 CompressionTest hangs when run over a Ozone ofs path (#5771)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CompressionTest.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CompressionTest.java
@@ -146,17 +146,18 @@ public class CompressionTest {
 
     Configuration conf = new Configuration();
     Path path = new Path(args[0]);
-    FileSystem fs = path.getFileSystem(conf);
-    if (fs.exists(path)) {
-      System.err.println("The specified path exists, aborting!");
-      System.exit(1);
-    }
+    try (FileSystem fs = path.getFileSystem(conf)) {
+      if (fs.exists(path)) {
+        System.err.println("The specified path exists, aborting!");
+        System.exit(1);
+      }
 
-    try {
-      doSmokeTest(fs, path, args[1]);
-    } finally {
-      fs.delete(path, false);
+      try {
+        doSmokeTest(fs, path, args[1]);
+      } finally {
+        fs.delete(path, false);
+      }
+      System.out.println("SUCCESS");
     }
-    System.out.println("SUCCESS");
   }
 }


### PR DESCRIPTION
This bug was found via HDDS-10564.

(cherry picked from commit adc79a0a9c2b579915a902f611a66edfddf3149c)
(cherry picked from commit 0aaf372c5afbc006c9dcf192e053ce6501f000b7)
(cherry picked from commit 7e1a69d09b5ad522d66b2e2db2f247b6db1f1234)