### PR TITLE
HBASE-28447 New site configuration option "hfile.block.size"

### DIFF
--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -1078,6 +1078,21 @@ possible configurations would overwhelm and obscure the important.
       </description>
   </property>
   <property>
+      <name>hfile.block.size</name>
+      <value>65536</value>
+      <description>The default HFile block size to use for new files. If set, this will define
+      the default block size to use when writing HFiles, as long as a column family schema does
+      not define its own non-default block size. This is a bit complicated but required for
+      compatability. The rules are:
+        - If the column family schema specifies a non default block size, use it.
+        - Otherwise, if hfile.block.size in configuration specifies a non default block size,
+          use it.
+        - Otherwise, use the default block size.
+      The default is 65536.
+      Specifying the default in hfile.block.size is a no-op.
+      </description>
+  </property>
+  <property>
       <name>hfile.block.bloom.cacheonwrite</name>
       <value>false</value>
       <description>Enables cache-on-write for inline blocks of a compound Bloom filter.</description>

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -120,6 +120,14 @@ public final class HFile {
   // LOG is being used in HFileBlock and CheckSumUtil
   static final Logger LOG = LoggerFactory.getLogger(HFile.class);
 
+  /** The configuration key for HFile version to use for new files */
+  @InterfaceAudience.Public
+  public static final String FORMAT_VERSION_KEY = "hfile.format.version";
+
+  /** The configuration key for the default block size for an HFile */
+  @InterfaceAudience.Public
+  public static final String BLOCK_SIZE_KEY = "hfile.block.size";
+
   /**
    * Maximum length of key in HFile.
    */
@@ -311,9 +319,6 @@ public final class HFile {
       return new HFileWriterImpl(conf, cacheConf, path, ostream, fileContext);
     }
   }
-
-  /** The configuration key for HFile version to use for new files */
-  public static final String FORMAT_VERSION_KEY = "hfile.format.version";
 
   public static int getFormatVersion(Configuration conf) {
     int version = conf.getInt(FORMAT_VERSION_KEY, MAX_FORMAT_VERSION);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/DefaultMobStoreCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/DefaultMobStoreCompactor.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hbase.regionserver.ShipperListener;
 import org.apache.hadoop.hbase.regionserver.StoreFileScanner;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
 import org.apache.hadoop.hbase.regionserver.StoreScanner;
+import org.apache.hadoop.hbase.regionserver.StoreUtils;
 import org.apache.hadoop.hbase.regionserver.compactions.CloseChecker;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionProgress;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequestImpl;
@@ -351,8 +352,9 @@ public class DefaultMobStoreCompactor extends DefaultCompactor {
       .build();
     throughputController.start(compactionName);
     KeyValueScanner kvs = (scanner instanceof KeyValueScanner) ? (KeyValueScanner) scanner : null;
-    long shippedCallSizeLimit =
-      (long) request.getFiles().size() * this.store.getColumnFamilyDescriptor().getBlocksize();
+    int blockSize = StoreUtils.getBlockSize(store.getReadOnlyConfiguration(),
+      store.getColumnFamilyDescriptor().getBlocksize());
+    long shippedCallSizeLimit = (long) request.getFiles().size() * blockSize;
 
     Cell mobCell = null;
     List<String> committedMobWriterFileNames = new ArrayList<>();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobUtils.java
@@ -562,7 +562,8 @@ public final class MobUtils {
     boolean isCompaction) throws IOException {
     return createWriter(conf, fs, family, new Path(basePath, mobFileName.getFileName()),
       maxKeyCount, compression, cacheConfig, cryptoContext, StoreUtils.getChecksumType(conf),
-      StoreUtils.getBytesPerChecksum(conf), family.getBlocksize(), BloomType.NONE, isCompaction);
+      StoreUtils.getBytesPerChecksum(conf), StoreUtils.getBlockSize(conf, family.getBlocksize()),
+      BloomType.NONE, isCompaction);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -919,8 +919,10 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
       }
     }
 
-    minBlockSizeBytes = Arrays.stream(this.htableDescriptor.getColumnFamilies())
-      .mapToInt(ColumnFamilyDescriptor::getBlocksize).min().orElse(HConstants.DEFAULT_BLOCKSIZE);
+    minBlockSizeBytes = Math.min(
+      Arrays.stream(this.htableDescriptor.getColumnFamilies())
+        .mapToInt(ColumnFamilyDescriptor::getBlocksize).min().orElse(HConstants.DEFAULT_BLOCKSIZE),
+      conf.getInt(HFile.BLOCK_SIZE_KEY, HConstants.DEFAULT_BLOCKSIZE));
   }
 
   private void setHTableSpecificConf() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -329,7 +329,8 @@ public class HStore
   }
 
   private StoreContext initializeStoreContext(ColumnFamilyDescriptor family) throws IOException {
-    return new StoreContext.Builder().withBlockSize(family.getBlocksize())
+    return new StoreContext.Builder()
+      .withBlockSize(StoreUtils.getBlockSize(conf, family.getBlocksize()))
       .withEncryptionContext(EncryptionUtil.createEncryptionContext(conf, family))
       .withBloomType(family.getBloomFilterType()).withCacheConfig(createCacheConf(family))
       .withCellComparator(region.getTableDescriptor().isMetaTable() || conf

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/ScanInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/ScanInfo.java
@@ -62,8 +62,8 @@ public class ScanInfo {
   public ScanInfo(Configuration conf, ColumnFamilyDescriptor family, long ttl,
     long timeToPurgeDeletes, CellComparator comparator) {
     this(conf, family.getName(), family.getMinVersions(), family.getMaxVersions(), ttl,
-      family.getKeepDeletedCells(), family.getBlocksize(), timeToPurgeDeletes, comparator,
-      family.isNewVersionBehavior());
+      family.getKeepDeletedCells(), StoreUtils.getBlockSize(conf, family.getBlocksize()),
+      timeToPurgeDeletes, comparator, family.isNewVersionBehavior());
   }
 
   private static long getCellsPerTimeoutCheck(Configuration conf) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreUtils.java
@@ -204,4 +204,28 @@ public final class StoreUtils {
     }
     return f.applyAsLong(reader);
   }
+
+  /**
+   * Helper for figuring out what block size to use when writing. If the user set a block size in
+   * schema, we use that. We determine the user has set a size if the size is not the default size.
+   * Otherwise, we check if the user has set a block size in the configuration that is not the
+   * default size. This is annoyingly complicated but required for compatibility.
+   * <ul>
+   * <li>If the schema specifies a non default block size, use it.</li>
+   * <li>Otherwise, if the configuration specifies a non default block size, use it.</li>
+   * <li>Otherwise, use the default block size.</li>
+   * </ul>
+   * The default is defined by HConstants.DEFAULT_BLOCKSIZE.
+   * @param conf            The configuration, can be null. Use the store configuration wherever
+   *                        possible so we properly support site configuration overrides.
+   * @param schemaBlockSize The block size as specified in the column family schema.
+   * @return The block size to use.
+   */
+  public static int getBlockSize(Configuration conf, int schemaBlockSize) {
+    if (schemaBlockSize == HConstants.DEFAULT_BLOCKSIZE && conf != null) {
+      return conf.getInt(HFile.BLOCK_SIZE_KEY, HConstants.DEFAULT_BLOCKSIZE);
+    }
+    return schemaBlockSize;
+  }
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hbase.regionserver.StoreFileReader;
 import org.apache.hadoop.hbase.regionserver.StoreFileScanner;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
 import org.apache.hadoop.hbase.regionserver.StoreScanner;
+import org.apache.hadoop.hbase.regionserver.StoreUtils;
 import org.apache.hadoop.hbase.regionserver.TimeRangeTracker;
 import org.apache.hadoop.hbase.regionserver.throttle.ThroughputControlUtil;
 import org.apache.hadoop.hbase.regionserver.throttle.ThroughputController;
@@ -439,8 +440,9 @@ public abstract class Compactor<T extends CellSink> {
 
     throughputController.start(compactionName);
     Shipper shipper = (scanner instanceof Shipper) ? (Shipper) scanner : null;
-    long shippedCallSizeLimit =
-      (long) request.getFiles().size() * this.store.getColumnFamilyDescriptor().getBlocksize();
+    int blockSize = StoreUtils.getBlockSize(store.getReadOnlyConfiguration(),
+      store.getColumnFamilyDescriptor().getBlocksize());
+    long shippedCallSizeLimit = (long) request.getFiles().size() * blockSize;
     try {
       do {
         hasMore = scanner.next(cells, scannerContext);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerBase.java
@@ -113,7 +113,7 @@ abstract class StoreFileTrackerBase implements StoreFileTracker {
       .withIncludesTags(includesTag).withCompression(compression)
       .withCompressTags(family.isCompressTags()).withChecksumType(StoreUtils.getChecksumType(conf))
       .withBytesPerCheckSum(StoreUtils.getBytesPerChecksum(conf))
-      .withBlockSize(family.getBlocksize()).withHBaseCheckSum(true)
+      .withBlockSize(StoreUtils.getBlockSize(conf, family.getBlocksize())).withHBaseCheckSum(true)
       .withDataBlockEncoding(family.getDataBlockEncoding()).withEncryptionContext(encryptionContext)
       .withCreateTime(EnvironmentEdgeManager.currentTime()).withColumnFamily(family.getName())
       .withTableName(ctx.getTableName().getName()).withCellComparator(ctx.getComparator())

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -776,7 +776,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
       storeFileInfo.getHFileInfo().initMetaAndIndex(halfReader.getHFileReader());
       Map<byte[], byte[]> fileInfo = halfReader.loadFileInfo();
 
-      int blocksize = familyDescriptor.getBlocksize();
+      int blocksize = StoreUtils.getBlockSize(conf, familyDescriptor.getBlocksize());
       Algorithm compression = familyDescriptor.getCompressionType();
       BloomType bloomFilterType = familyDescriptor.getBloomFilterType();
       HFileContext hFileContext = new HFileContextBuilder().withCompression(compression)

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/FaultyMobStoreCompactor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/FaultyMobStoreCompactor.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
 import org.apache.hadoop.hbase.regionserver.ScannerContext;
 import org.apache.hadoop.hbase.regionserver.ShipperListener;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
+import org.apache.hadoop.hbase.regionserver.StoreUtils;
 import org.apache.hadoop.hbase.regionserver.compactions.CloseChecker;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionProgress;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequestImpl;
@@ -148,8 +149,9 @@ public class FaultyMobStoreCompactor extends DefaultMobStoreCompactor {
       .build();
     throughputController.start(compactionName);
     KeyValueScanner kvs = (scanner instanceof KeyValueScanner) ? (KeyValueScanner) scanner : null;
-    long shippedCallSizeLimit =
-      (long) request.getFiles().size() * this.store.getColumnFamilyDescriptor().getBlocksize();
+    int blockSize = StoreUtils.getBlockSize(store.getReadOnlyConfiguration(),
+      store.getColumnFamilyDescriptor().getBlocksize());
+    long shippedCallSizeLimit = (long) request.getFiles().size() * blockSize;
 
     Cell mobCell = null;
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSecureBulkLoadManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSecureBulkLoadManager.java
@@ -241,7 +241,7 @@ public class TestSecureBulkLoadManager {
       .withIncludesTags(true).withCompression(compression).withCompressTags(family.isCompressTags())
       .withChecksumType(StoreUtils.getChecksumType(conf))
       .withBytesPerCheckSum(StoreUtils.getBytesPerChecksum(conf))
-      .withBlockSize(family.getBlocksize()).withHBaseCheckSum(true)
+      .withBlockSize(StoreUtils.getBlockSize(conf, family.getBlocksize())).withHBaseCheckSum(true)
       .withDataBlockEncoding(family.getDataBlockEncoding())
       .withEncryptionContext(Encryption.Context.NONE)
       .withCreateTime(EnvironmentEdgeManager.currentTime()).build();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreUtils.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreUtils.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.io.hfile.HFile;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ RegionServerTests.class, SmallTests.class })
+public class TestStoreUtils {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestStoreUtils.class);
+
+  @Test
+  public void testGetBlockSize() throws IOException {
+    int eightK = 8 * 1024;
+    int oneM = 1024 * 1024;
+    ColumnFamilyDescriptor cfDefault = ColumnFamilyDescriptorBuilder.of("cf1");
+    ColumnFamilyDescriptor cf8K =
+      ColumnFamilyDescriptorBuilder.newBuilder("cf2".getBytes()).setBlocksize(eightK).build();
+    Configuration confDefault = new Configuration();
+    Configuration conf8K = new Configuration();
+    conf8K.setInt(HFile.BLOCK_SIZE_KEY, eightK);
+    Configuration conf1M = new Configuration();
+    conf1M.setInt(HFile.BLOCK_SIZE_KEY, oneM);
+    assertEquals("Ignore null configuration with defaults", HConstants.DEFAULT_BLOCKSIZE,
+      StoreUtils.getBlockSize(null, cfDefault.getBlocksize()));
+    assertEquals("Ignore null configuration with a non-default column family block size", eightK,
+      StoreUtils.getBlockSize(null, cf8K.getBlocksize()));
+    assertEquals("Default case should hold no surprises", HConstants.DEFAULT_BLOCKSIZE,
+      StoreUtils.getBlockSize(confDefault, cfDefault.getBlocksize()));
+    assertEquals("Configuration should not override the non-default column family block size",
+      eightK, StoreUtils.getBlockSize(confDefault, cf8K.getBlocksize()));
+    assertEquals("Configuration should not override the non-default column family block size",
+      eightK, StoreUtils.getBlockSize(conf1M, cf8K.getBlocksize()));
+    assertEquals(
+      "Default column family block size should not override a non-default size in configuration",
+      eightK, StoreUtils.getBlockSize(conf8K, cfDefault.getBlocksize()));
+    assertEquals(
+      "Default column family block size should not override a non-default size in configuration",
+      oneM, StoreUtils.getBlockSize(conf1M, cfDefault.getBlocksize()));
+    assertEquals(
+      "Non-default column family block size should override a non-default size in configuration",
+      eightK, StoreUtils.getBlockSize(conf1M, cf8K.getBlocksize()));
+  }
+
+}


### PR DESCRIPTION
Introduce a new configuration setting - "hfile.block.size" that, if set, will define the default blocksize to use when writing HFiles if a column family schema does not define its own non-default block size. This is a bit complicated but required for compatability. The rules are:
 - If the schema specifies a non default block size, use it.
 - Otherwise, if the configuration specifies a non default block size, use it.
 - Otherwise, use the default block size.
 
The default is defined by HConstants.DEFAULT_BLOCKSIZE.

Given how compound configurations work the precedence order for a non default block size is: BLOCKSIZE in the column family schema > "hfile.block.size" in CF or table level schema > "hfile.block.size" in site configuration >   HConstants.DEFAULT_BLOCKSIZE