### PR TITLE
HBASE-28517 Make properties dynamically configured

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -294,6 +294,7 @@ public class CacheConfig {
   public void setCacheDataOnWrite(boolean cacheDataOnWrite) {
     this.cacheDataOnWrite = cacheDataOnWrite;
   }
+
   /**
    * Enable cache on write including: cacheDataOnWrite cacheIndexesOnWrite cacheBloomsOnWrite
    */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -124,7 +124,7 @@ public class CacheConfig {
    * turned off on a per-family or per-request basis). If off we will STILL cache meta blocks; i.e.
    * INDEX and BLOOM types. This cannot be disabled.
    */
-  private final boolean cacheDataOnRead;
+  private boolean cacheDataOnRead;
 
   /** Whether blocks should be flagged as in-memory when being cached */
   private final boolean inMemory;
@@ -296,6 +296,14 @@ public class CacheConfig {
   }
 
   /**
+   * @param cacheDataOnRead whether data blocks should be written to the cache when an HFile is
+   *                        read
+   */
+  public void setCacheDataOnRead(boolean cacheDataOnRead) {
+    this.cacheDataOnRead = cacheDataOnRead;
+  }
+
+  /**
    * Enable cache on write including: cacheDataOnWrite cacheIndexesOnWrite cacheBloomsOnWrite
    */
   public void enableCacheOnWrite() {
@@ -463,5 +471,18 @@ public class CacheConfig {
       + ", cacheBloomsOnWrite=" + shouldCacheBloomsOnWrite() + ", cacheEvictOnClose="
       + shouldEvictOnClose() + ", cacheDataCompressed=" + shouldCacheDataCompressed()
       + ", prefetchOnOpen=" + shouldPrefetchOnOpen();
+  }
+
+  public void loadConfiguration(Configuration conf) {
+    cacheDataOnRead = conf.getBoolean(CACHE_DATA_ON_READ_KEY, DEFAULT_CACHE_DATA_ON_READ);
+    cacheDataOnWrite = conf.getBoolean(CACHE_BLOCKS_ON_WRITE_KEY, DEFAULT_CACHE_DATA_ON_WRITE);
+    evictOnClose = conf.getBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, DEFAULT_EVICT_ON_CLOSE);
+    LOG.info("Config "
+        + "hbase.block.data.cacheonread is changed to {}, "
+        + "hbase.rs.cacheblocksonwrite is changed to {}, "
+        + "hbase.rs.evictblocksonclose is changed to {},",
+      conf.getBoolean(CACHE_DATA_ON_READ_KEY, DEFAULT_CACHE_DATA_ON_READ),
+      conf.getBoolean(CACHE_BLOCKS_ON_WRITE_KEY, DEFAULT_CACHE_DATA_ON_WRITE),
+      conf.getBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, DEFAULT_EVICT_ON_CLOSE));
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -472,11 +472,9 @@ public class CacheConfig implements ConfigurationObserver {
     cacheDataOnWrite = conf.getBoolean(CACHE_BLOCKS_ON_WRITE_KEY, DEFAULT_CACHE_DATA_ON_WRITE);
     evictOnClose = conf.getBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, DEFAULT_EVICT_ON_CLOSE);
     LOG.info(
-      "Config " + "hbase.block.data.cacheonread is changed to {}, "
+      "Config hbase.block.data.cacheonread is changed to {}, "
         + "hbase.rs.cacheblocksonwrite is changed to {}, "
-        + "hbase.rs.evictblocksonclose is changed to {},",
-      conf.getBoolean(CACHE_DATA_ON_READ_KEY, DEFAULT_CACHE_DATA_ON_READ),
-      conf.getBoolean(CACHE_BLOCKS_ON_WRITE_KEY, DEFAULT_CACHE_DATA_ON_WRITE),
-      conf.getBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, DEFAULT_EVICT_ON_CLOSE));
+        + "hbase.rs.evictblocksonclose is changed to {}",
+      cacheDataOnRead, cacheDataOnWrite, evictOnClose);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -294,14 +294,6 @@ public class CacheConfig {
   public void setCacheDataOnWrite(boolean cacheDataOnWrite) {
     this.cacheDataOnWrite = cacheDataOnWrite;
   }
-
-  /**
-   * @param cacheDataOnRead whether data blocks should be written to the cache when an HFile is read
-   */
-  public void setCacheDataOnRead(boolean cacheDataOnRead) {
-    this.cacheDataOnRead = cacheDataOnRead;
-  }
-
   /**
    * Enable cache on write including: cacheDataOnWrite cacheIndexesOnWrite cacheBloomsOnWrite
    */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -296,8 +296,7 @@ public class CacheConfig {
   }
 
   /**
-   * @param cacheDataOnRead whether data blocks should be written to the cache when an HFile is
-   *                        read
+   * @param cacheDataOnRead whether data blocks should be written to the cache when an HFile is read
    */
   public void setCacheDataOnRead(boolean cacheDataOnRead) {
     this.cacheDataOnRead = cacheDataOnRead;
@@ -477,8 +476,8 @@ public class CacheConfig {
     cacheDataOnRead = conf.getBoolean(CACHE_DATA_ON_READ_KEY, DEFAULT_CACHE_DATA_ON_READ);
     cacheDataOnWrite = conf.getBoolean(CACHE_BLOCKS_ON_WRITE_KEY, DEFAULT_CACHE_DATA_ON_WRITE);
     evictOnClose = conf.getBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, DEFAULT_EVICT_ON_CLOSE);
-    LOG.info("Config "
-        + "hbase.block.data.cacheonread is changed to {}, "
+    LOG.info(
+      "Config " + "hbase.block.data.cacheonread is changed to {}, "
         + "hbase.rs.cacheblocksonwrite is changed to {}, "
         + "hbase.rs.evictblocksonclose is changed to {},",
       conf.getBoolean(CACHE_DATA_ON_READ_KEY, DEFAULT_CACHE_DATA_ON_READ),

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -70,7 +70,6 @@ import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.conf.ConfigurationManager;
-import org.apache.hadoop.hbase.conf.ConfigurationObserver;
 import org.apache.hadoop.hbase.conf.PropagatingConfigurationObserver;
 import org.apache.hadoop.hbase.coprocessor.ReadOnlyConfiguration;
 import org.apache.hadoop.hbase.io.HeapSize;
@@ -2189,9 +2188,8 @@ public class HStore
   public void registerChildren(ConfigurationManager manager) {
     // No children to register
     CacheConfig cacheConfig = this.storeContext.getCacheConf();
-    if (cacheConfig instanceof ConfigurationObserver) {
-      final ConfigurationObserver observer = cacheConfig;
-      manager.registerObserver(observer);
+    if (cacheConfig != null) {
+      manager.registerObserver(cacheConfig);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -2179,6 +2179,7 @@ public class HStore
     this.conf = storeConf;
     this.storeEngine.compactionPolicy.setConf(storeConf);
     this.offPeakHours = OffPeakHours.getInstance(storeConf);
+    this.storeContext.getCacheConf().loadConfiguration(conf);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -2186,7 +2186,6 @@ public class HStore
    */
   @Override
   public void registerChildren(ConfigurationManager manager) {
-    // No children to register
     CacheConfig cacheConfig = this.storeContext.getCacheConf();
     if (cacheConfig != null) {
       manager.registerObserver(cacheConfig);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -70,6 +70,7 @@ import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.conf.ConfigurationManager;
+import org.apache.hadoop.hbase.conf.ConfigurationObserver;
 import org.apache.hadoop.hbase.conf.PropagatingConfigurationObserver;
 import org.apache.hadoop.hbase.coprocessor.ReadOnlyConfiguration;
 import org.apache.hadoop.hbase.io.HeapSize;
@@ -2179,7 +2180,6 @@ public class HStore
     this.conf = storeConf;
     this.storeEngine.compactionPolicy.setConf(storeConf);
     this.offPeakHours = OffPeakHours.getInstance(storeConf);
-    this.storeContext.getCacheConf().loadConfiguration(conf);
   }
 
   /**
@@ -2188,6 +2188,11 @@ public class HStore
   @Override
   public void registerChildren(ConfigurationManager manager) {
     // No children to register
+    CacheConfig cacheConfig = this.storeContext.getCacheConf();
+    if (cacheConfig instanceof ConfigurationObserver) {
+      final ConfigurationObserver observer = cacheConfig;
+      manager.registerObserver(observer);
+    }
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
@@ -17,6 +17,12 @@
  */
 package org.apache.hadoop.hbase.regionserver;
 
+import static org.apache.hadoop.hbase.io.hfile.CacheConfig.CACHE_BLOCKS_ON_WRITE_KEY;
+import static org.apache.hadoop.hbase.io.hfile.CacheConfig.CACHE_DATA_ON_READ_KEY;
+import static org.apache.hadoop.hbase.io.hfile.CacheConfig.DEFAULT_CACHE_DATA_ON_READ;
+import static org.apache.hadoop.hbase.io.hfile.CacheConfig.DEFAULT_CACHE_DATA_ON_WRITE;
+import static org.apache.hadoop.hbase.io.hfile.CacheConfig.DEFAULT_EVICT_ON_CLOSE;
+import static org.apache.hadoop.hbase.io.hfile.CacheConfig.EVICT_BLOCKS_ON_CLOSE_KEY;
 import static org.apache.hadoop.hbase.regionserver.DefaultStoreEngine.DEFAULT_COMPACTION_POLICY_CLASS_KEY;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
@@ -1769,7 +1775,7 @@ public class TestHStore {
     assertEquals((10 + 100 + 1000 + 10000) / 4.0, store.getAvgStoreFileAge().getAsDouble(), 1E-4);
   }
 
-  private HStoreFile mockStoreFile(long createdTime) {
+    private HStoreFile mockStoreFile(long createdTime) {
     StoreFileInfo info = mock(StoreFileInfo.class);
     when(info.getCreatedTimestamp()).thenReturn(createdTime);
     HStoreFile sf = mock(HStoreFile.class);
@@ -2604,6 +2610,9 @@ public class TestHStore {
     Configuration conf = HBaseConfiguration.create();
     conf.setInt(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MAX_KEY,
       COMMON_MAX_FILES_TO_COMPACT);
+    conf.setBoolean(CACHE_DATA_ON_READ_KEY, false);
+    conf.setBoolean(CACHE_BLOCKS_ON_WRITE_KEY, true);
+    conf.setBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, true);
     ColumnFamilyDescriptor hcd = ColumnFamilyDescriptorBuilder.newBuilder(family)
       .setConfiguration(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MAX_KEY,
         String.valueOf(STORE_MAX_FILES_TO_COMPACT))
@@ -2614,8 +2623,19 @@ public class TestHStore {
     conf.setInt(CompactionConfiguration.HBASE_HSTORE_COMPACTION_MAX_KEY,
       NEW_COMMON_MAX_FILES_TO_COMPACT);
     this.store.onConfigurationChange(conf);
+
     assertEquals(STORE_MAX_FILES_TO_COMPACT,
       store.getStoreEngine().getCompactionPolicy().getConf().getMaxFilesToCompact());
+
+    assertEquals(conf.getBoolean(CACHE_DATA_ON_READ_KEY, DEFAULT_CACHE_DATA_ON_READ), false);
+    assertEquals(conf.getBoolean(CACHE_BLOCKS_ON_WRITE_KEY, DEFAULT_CACHE_DATA_ON_WRITE), true);
+    assertEquals(conf.getBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, DEFAULT_EVICT_ON_CLOSE), true);
+
+    // reset to default values
+    conf.getBoolean(CACHE_DATA_ON_READ_KEY, DEFAULT_CACHE_DATA_ON_READ);
+    conf.getBoolean(CACHE_BLOCKS_ON_WRITE_KEY, DEFAULT_CACHE_DATA_ON_WRITE);
+    conf.getBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, DEFAULT_EVICT_ON_CLOSE);
+    this.store.onConfigurationChange(conf);
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
@@ -1775,7 +1775,7 @@ public class TestHStore {
     assertEquals((10 + 100 + 1000 + 10000) / 4.0, store.getAvgStoreFileAge().getAsDouble(), 1E-4);
   }
 
-    private HStoreFile mockStoreFile(long createdTime) {
+  private HStoreFile mockStoreFile(long createdTime) {
     StoreFileInfo info = mock(StoreFileInfo.class);
     when(info.getCreatedTimestamp()).thenReturn(createdTime);
     HStoreFile sf = mock(HStoreFile.class);


### PR DESCRIPTION
Make following properties dynamically configured, 

  hbase.rs.evictblocksonclose
  hbase.rs.cacheblocksonwrite
  hbase.block.data.cacheonread

for use case scenarios where configuring them dynamically would help in achieving better throughput.
