### PR TITLE
HBASE-28468: Integrate the data-tiering logic into cache evictions.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -999,8 +999,17 @@ public class BucketCache implements BlockCache, HeapSize {
         if (coldFiles != null
           && coldFiles.containsKey(bucketEntryWithKey.getKey().getHfileName())) {
           int freedBlockSize = bucketEntryWithKey.getValue().getLength();
-          evictBlockIfNoRpcReferenced(bucketEntryWithKey.getKey());
-          bytesFreed += freedBlockSize;
+          if (evictBlockIfNoRpcReferenced(bucketEntryWithKey.getKey())) {
+            bytesFreed += freedBlockSize;
+          }
+          if (bytesFreed >= bytesToFreeWithExtra) {
+            if (LOG.isDebugEnabled()) {
+              LOG.debug("Bucket cache free space completed; required: " + bytesToFreeWithExtra
+                + " freed=" + StringUtils.byteDesc(bytesFreed) + " from cold data blocks.");
+            }
+            //Sufficient bytes have been freed.
+            return;
+          }
           continue;
         }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/DataTieringManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/DataTieringManager.java
@@ -20,22 +20,17 @@ package org.apache.hadoop.hbase.regionserver;
 import static org.apache.hadoop.hbase.regionserver.HStoreFile.TIMERANGE_KEY;
 
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.HashSet;
-import java.util.Iterator;
-import java.util.List;
 import java.util.Map;
 import java.util.OptionalLong;
 import java.util.Set;
-import java.util.concurrent.ConcurrentHashMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
-import org.apache.hadoop.hbase.util.Pair;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -179,12 +174,12 @@ public class DataTieringManager {
   private long getMaxTimestamp(Path hFilePath) throws DataTieringException {
     HStoreFile hStoreFile = getHStoreFile(hFilePath);
     if (hStoreFile == null) {
-      LOG.error("HStoreFile corresponding to " + hFilePath + " doesn't exist");
+      LOG.error("HStoreFile corresponding to {} doesn't exist", hFilePath);
       return Long.MAX_VALUE;
     }
     OptionalLong maxTimestamp = hStoreFile.getMaximumTimestamp();
     if (!maxTimestamp.isPresent()) {
-      LOG.error("Maximum timestamp not present for " + hFilePath);
+      LOG.error("Maximum timestamp not present for {}", hFilePath);
       return Long.MAX_VALUE;
     }
     return maxTimestamp.getAsLong();
@@ -278,8 +273,8 @@ public class DataTieringManager {
   }
 
   /*
-   * This API traverses through the list of online regions and returns a
-   * subset of these files-names that are cold.
+   * This API traverses through the list of online regions and returns a subset of these files-names
+   * that are cold.
    * @return List of names of files with cold data as per data-tiering logic.
    */
   public Map<String, String> getColdFilesList() {
@@ -296,21 +291,21 @@ public class DataTieringManager {
         for (HStoreFile hStoreFile : hStore.getStorefiles()) {
           String hFileName =
             hStoreFile.getFileInfo().getHFileInfo().getHFileContext().getHFileName();
-            OptionalLong maxTimestamp = hStoreFile.getMaximumTimestamp();
-            if (!maxTimestamp.isPresent()) {
-              LOG.warn("maxTimestamp missing for file: "
-                + hStoreFile.getFileInfo().getActiveFileName());
-              continue;
-            }
-            long currentTimestamp = EnvironmentEdgeManager.getDelegate().currentTime();
-            long fileAge = currentTimestamp - maxTimestamp.getAsLong();
-            if (fileAge > hotDataAge) {
-              // Values do not matter.
-              coldFiles.put(hFileName, null);
-            }
+          OptionalLong maxTimestamp = hStoreFile.getMaximumTimestamp();
+          if (!maxTimestamp.isPresent()) {
+            LOG.warn("maxTimestamp missing for file: {}",
+              hStoreFile.getFileInfo().getActiveFileName());
+            continue;
+          }
+          long currentTimestamp = EnvironmentEdgeManager.getDelegate().currentTime();
+          long fileAge = currentTimestamp - maxTimestamp.getAsLong();
+          if (fileAge > hotDataAge) {
+            // Values do not matter.
+            coldFiles.put(hFileName, null);
           }
         }
       }
+    }
     return coldFiles;
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
@@ -373,8 +373,8 @@ public class TestPrefetch {
     Thread.sleep(20000);
     assertFalse("Prefetch threads should not be running at this point", reader.prefetchStarted());
     while (!reader.prefetchStarted()) {
-      assertTrue("Prefetch delay has not been expired yet",
-        getElapsedTime(startTime) < PrefetchExecutor.getPrefetchDelay());
+      // Wait until the prefetch is triggered.
+      Thread.sleep(500);
     }
     if (reader.prefetchStarted()) {
       // Added some delay as we have started the timer a bit late.

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDataTieringManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDataTieringManager.java
@@ -60,13 +60,10 @@ import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.Pair;
-import org.apache.hadoop.hbase.Waiter;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * This class is used to test the functionality of the DataTieringManager.
@@ -93,8 +90,6 @@ public class TestDataTieringManager {
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestDataTieringManager.class);
-
-  private static final Logger LOG = LoggerFactory.getLogger(TestDataTieringManager.class);
 
   private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
   private static Configuration defaultConf;
@@ -258,9 +253,13 @@ public class TestDataTieringManager {
     Map<String, String> coldDataFiles = dataTieringManager.getColdFilesList();
     assertEquals(1, coldDataFiles.size());
     // hStoreFiles[3] is the cold file.
-    assert(coldDataFiles.containsKey(hStoreFiles.get(3).getFileInfo().getActiveFileName()));
+    assert (coldDataFiles.containsKey(hStoreFiles.get(3).getFileInfo().getActiveFileName()));
   }
 
+  /*
+   * Verify that two cold blocks(both) are evicted when bucket reaches its capacity. The hot file
+   * remains in the cache.
+   */
   @Test
   public void testBlockEvictions() throws Exception {
     long capacitySize = 64 * 1024;
@@ -284,7 +283,7 @@ public class TestDataTieringManager {
     CacheTestUtils.HFileBlockPair[] blocks = CacheTestUtils.generateHFileBlocks(8192, 3);
 
     int blocksIter = 0;
-    for(BlockCacheKey key: cacheKeys) {
+    for (BlockCacheKey key : cacheKeys) {
       bucketCache.cacheBlock(key, blocks[blocksIter++].getBlock());
       // Ensure that the block is persisted to the file.
       Waiter.waitFor(defaultConf, 1000000, 100,
@@ -303,15 +302,15 @@ public class TestDataTieringManager {
       () -> (bucketCache.getBackingMap().containsKey(newKey)));
 
     // Verify that the bucket cache now contains 2 hot blocks blocks only.
-    // Both cold blocks of 8KB will be evicted to make room for 1 block of 8KB + an additional space.
-    Set<BlockCacheKey> newKeys = bucketCache.getBackingMap().keySet();
-    assertEquals(2, newKeys.size());
-    Set<BlockCacheKey> expectedKeys = new HashSet<>();
-    expectedKeys.add(new BlockCacheKey(hStoreFiles.get(0).getPath(), 0, true, BlockType.DATA));
-    expectedKeys.add(new BlockCacheKey(hStoreFiles.get(2).getPath(), 0, true, BlockType.DATA));
-    assert(newKeys.equals(expectedKeys));
+    // Both cold blocks of 8KB will be evicted to make room for 1 block of 8KB + an additional
+    // space.
+    validateBlocks(bucketCache.getBackingMap().keySet(), 2, 2, 0);
   }
 
+  /*
+   * Verify that two cold blocks(both) are evicted when bucket reaches its capacity, but one cold
+   * block remains in the cache since the required space is freed.
+   */
   @Test
   public void testBlockEvictionsAllColdBlocks() throws Exception {
     long capacitySize = 64 * 1024;
@@ -335,7 +334,7 @@ public class TestDataTieringManager {
     CacheTestUtils.HFileBlockPair[] blocks = CacheTestUtils.generateHFileBlocks(8192, 3);
 
     int blocksIter = 0;
-    for(BlockCacheKey key: cacheKeys) {
+    for (BlockCacheKey key : cacheKeys) {
       bucketCache.cacheBlock(key, blocks[blocksIter++].getBlock());
       // Ensure that the block is persisted to the file.
       Waiter.waitFor(defaultConf, 1000000, 100,
@@ -354,12 +353,77 @@ public class TestDataTieringManager {
       () -> (bucketCache.getBackingMap().containsKey(newKey)));
 
     // Verify that the bucket cache now contains 1 cold block and a newly added hot block.
-    Set<BlockCacheKey> newKeys = bucketCache.getBackingMap().keySet();
-    assertEquals(2, newKeys.size());
-    Set<BlockCacheKey> expectedKeys = new HashSet<>();
-    expectedKeys.add(new BlockCacheKey(hStoreFiles.get(3).getPath(), 16384, true, BlockType.DATA));
-    expectedKeys.add(new BlockCacheKey(hStoreFiles.get(2).getPath(), 0, true, BlockType.DATA));
-    assert(newKeys.equals(expectedKeys));
+    validateBlocks(bucketCache.getBackingMap().keySet(), 2, 1, 1);
+  }
+
+  /*
+   * Verify that a hot block evicted along with a cold block when bucket reaches its capacity.
+   */
+  @Test
+  public void testBlockEvictionsHotBlocks() throws Exception {
+    long capacitySize = 64 * 1024;
+    int writeThreads = 3;
+    int writerQLen = 64;
+    int[] bucketSizes = new int[] { 8 * 1024 + 1024 };
+
+    // Setup: Create a bucket cache with lower capacity
+    BucketCache bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
+      8192, bucketSizes, writeThreads, writerQLen, testDir + "/bucket.persistence",
+      DEFAULT_ERROR_TOLERATION_DURATION, defaultConf);
+
+    // Create three Cache keys with two hot data blocks and one cold data block
+    // hStoreFiles.get(0) is a hot data file and hStoreFiles.get(3) is a cold data file.
+    Set<BlockCacheKey> cacheKeys = new HashSet<>();
+    cacheKeys.add(new BlockCacheKey(hStoreFiles.get(0).getPath(), 0, true, BlockType.DATA));
+    cacheKeys.add(new BlockCacheKey(hStoreFiles.get(0).getPath(), 8192, true, BlockType.DATA));
+    cacheKeys.add(new BlockCacheKey(hStoreFiles.get(3).getPath(), 0, true, BlockType.DATA));
+
+    // Create dummy data to be cached and fill the cache completely.
+    CacheTestUtils.HFileBlockPair[] blocks = CacheTestUtils.generateHFileBlocks(8192, 3);
+
+    int blocksIter = 0;
+    for (BlockCacheKey key : cacheKeys) {
+      bucketCache.cacheBlock(key, blocks[blocksIter++].getBlock());
+      // Ensure that the block is persisted to the file.
+      Waiter.waitFor(defaultConf, 1000000, 100,
+        () -> (bucketCache.getBackingMap().containsKey(key)));
+    }
+
+    // Verify that the bucket cache contains 3 blocks.
+    assertEquals(3, bucketCache.getBackingMap().keySet().size());
+
+    // Add an additional block which should evict the only cold block with an additional hot block.
+    BlockCacheKey newKey = new BlockCacheKey(hStoreFiles.get(2).getPath(), 0, true, BlockType.DATA);
+    CacheTestUtils.HFileBlockPair[] newBlock = CacheTestUtils.generateHFileBlocks(8192, 1);
+
+    bucketCache.cacheBlock(newKey, newBlock[0].getBlock());
+    Waiter.waitFor(defaultConf, 1000000, 100,
+      () -> (bucketCache.getBackingMap().containsKey(newKey)));
+
+    // Verify that the bucket cache now contains 2 hot blocks.
+    // Only one of the older hot blocks is retained and other one is the newly added hot block.
+    validateBlocks(bucketCache.getBackingMap().keySet(), 2, 2, 0);
+  }
+
+  private void validateBlocks(Set<BlockCacheKey> keys, int expectedTotalKeys, int expectedHotBlocks,
+    int expectedColdBlocks) {
+    int numHotBlocks = 0, numColdBlocks = 0;
+
+    assertEquals(expectedTotalKeys, keys.size());
+    int iter = 0;
+    for (BlockCacheKey key : keys) {
+      try {
+        if (dataTieringManager.isHotData(key)) {
+          numHotBlocks++;
+        } else {
+          numColdBlocks++;
+        }
+      } catch (Exception e) {
+        fail("Unexpected exception!");
+      }
+    }
+    assertEquals(expectedHotBlocks, numHotBlocks);
+    assertEquals(expectedColdBlocks, numColdBlocks);
   }
 
   private void testDataTieringMethodWithPath(DataTieringMethodCallerWithPath caller, Path path,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDataTieringManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDataTieringManager.java
@@ -262,7 +262,7 @@ public class TestDataTieringManager {
    */
   @Test
   public void testBlockEvictions() throws Exception {
-    long capacitySize = 64 * 1024;
+    long capacitySize = 40 * 1024;
     int writeThreads = 3;
     int writerQLen = 64;
     int[] bucketSizes = new int[] { 8 * 1024 + 1024 };
@@ -286,8 +286,7 @@ public class TestDataTieringManager {
     for (BlockCacheKey key : cacheKeys) {
       bucketCache.cacheBlock(key, blocks[blocksIter++].getBlock());
       // Ensure that the block is persisted to the file.
-      Waiter.waitFor(defaultConf, 1000000, 100,
-        () -> (bucketCache.getBackingMap().containsKey(key)));
+      Waiter.waitFor(defaultConf, 10000, 100, () -> (bucketCache.getBackingMap().containsKey(key)));
     }
 
     // Verify that the bucket cache contains 3 blocks.
@@ -298,7 +297,7 @@ public class TestDataTieringManager {
     CacheTestUtils.HFileBlockPair[] newBlock = CacheTestUtils.generateHFileBlocks(8192, 1);
 
     bucketCache.cacheBlock(newKey, newBlock[0].getBlock());
-    Waiter.waitFor(defaultConf, 1000000, 100,
+    Waiter.waitFor(defaultConf, 10000, 100,
       () -> (bucketCache.getBackingMap().containsKey(newKey)));
 
     // Verify that the bucket cache now contains 2 hot blocks blocks only.
@@ -313,7 +312,7 @@ public class TestDataTieringManager {
    */
   @Test
   public void testBlockEvictionsAllColdBlocks() throws Exception {
-    long capacitySize = 64 * 1024;
+    long capacitySize = 40 * 1024;
     int writeThreads = 3;
     int writerQLen = 64;
     int[] bucketSizes = new int[] { 8 * 1024 + 1024 };
@@ -337,8 +336,7 @@ public class TestDataTieringManager {
     for (BlockCacheKey key : cacheKeys) {
       bucketCache.cacheBlock(key, blocks[blocksIter++].getBlock());
       // Ensure that the block is persisted to the file.
-      Waiter.waitFor(defaultConf, 1000000, 100,
-        () -> (bucketCache.getBackingMap().containsKey(key)));
+      Waiter.waitFor(defaultConf, 10000, 100, () -> (bucketCache.getBackingMap().containsKey(key)));
     }
 
     // Verify that the bucket cache contains 3 blocks.
@@ -349,7 +347,7 @@ public class TestDataTieringManager {
     CacheTestUtils.HFileBlockPair[] newBlock = CacheTestUtils.generateHFileBlocks(8192, 1);
 
     bucketCache.cacheBlock(newKey, newBlock[0].getBlock());
-    Waiter.waitFor(defaultConf, 1000000, 100,
+    Waiter.waitFor(defaultConf, 10000, 100,
       () -> (bucketCache.getBackingMap().containsKey(newKey)));
 
     // Verify that the bucket cache now contains 1 cold block and a newly added hot block.
@@ -361,7 +359,7 @@ public class TestDataTieringManager {
    */
   @Test
   public void testBlockEvictionsHotBlocks() throws Exception {
-    long capacitySize = 64 * 1024;
+    long capacitySize = 40 * 1024;
     int writeThreads = 3;
     int writerQLen = 64;
     int[] bucketSizes = new int[] { 8 * 1024 + 1024 };
@@ -385,8 +383,7 @@ public class TestDataTieringManager {
     for (BlockCacheKey key : cacheKeys) {
       bucketCache.cacheBlock(key, blocks[blocksIter++].getBlock());
       // Ensure that the block is persisted to the file.
-      Waiter.waitFor(defaultConf, 1000000, 100,
-        () -> (bucketCache.getBackingMap().containsKey(key)));
+      Waiter.waitFor(defaultConf, 10000, 100, () -> (bucketCache.getBackingMap().containsKey(key)));
     }
 
     // Verify that the bucket cache contains 3 blocks.
@@ -397,7 +394,7 @@ public class TestDataTieringManager {
     CacheTestUtils.HFileBlockPair[] newBlock = CacheTestUtils.generateHFileBlocks(8192, 1);
 
     bucketCache.cacheBlock(newKey, newBlock[0].getBlock());
-    Waiter.waitFor(defaultConf, 1000000, 100,
+    Waiter.waitFor(defaultConf, 10000, 100,
       () -> (bucketCache.getBackingMap().containsKey(newKey)));
 
     // Verify that the bucket cache now contains 2 hot blocks.


### PR DESCRIPTION
As a part of cache blocks eviction when the cache is full,
the data-tiering logic is integrated into the freeSpace code path
to identify the cold data files and evict the blocks associated with
those files.

The list of files is traversed to identify the cold files based
on the hot-data-age configuration and also the max timestamp associated
with the files.

The blocks associated with those cold files are evicted first and then
the existing logic of LFU blocks is executed to further evict the blocks.
