### PR TITLE
HBASE-28536 Fix `Disable Stripe Compaction` run error in document

### DIFF
--- a/src/main/asciidoc/_chapters/architecture.adoc
+++ b/src/main/asciidoc/_chapters/architecture.adoc
@@ -2579,7 +2579,7 @@ create 'orders_table', 'blobs_cf', CONFIGURATION => {'hbase.hstore.engine.class'
 +
 [source,sql]
 ----
-alter 'orders_table', CONFIGURATION => {'hbase.hstore.engine.class' => 'rg.apache.hadoop.hbase.regionserver.DefaultStoreEngine'}
+alter 'orders_table', CONFIGURATION => {'hbase.hstore.engine.class' => 'org.apache.hadoop.hbase.regionserver.DefaultStoreEngine'}
 ----
 
 . Enable the table.


### PR DESCRIPTION
Disable Stripe Compaction in document is

```
alter 'orders_table', CONFIGURATION =>
{'hbase.hstore.engine.class' => 'rg.apache.hadoop.hbase.regionserver.DefaultStoreEngine'}
```
This should be 'org.apache.hadoop.hbase.regionserver.DefaultStoreEngine' 

This will cause all regions to be in the openning state.Finally, I went through the disable table and corrected it before enable it.