### PR TITLE
HBASE-28459 HFileOutputFormat2 ClassCastException with s3 magic committer

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/HFileOutputFormat2.java
@@ -86,8 +86,8 @@ import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.OutputFormat;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-import org.apache.hadoop.mapreduce.lib.output.FileOutputCommitter;
 import org.apache.hadoop.mapreduce.lib.output.FileOutputFormat;
+import org.apache.hadoop.mapreduce.lib.output.PathOutputCommitter;
 import org.apache.hadoop.mapreduce.lib.partition.TotalOrderPartitioner;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
@@ -194,7 +194,7 @@ public class HFileOutputFormat2 extends FileOutputFormat<ImmutableBytesWritable,
     final TaskAttemptContext context, final OutputCommitter committer) throws IOException {
 
     // Get the path of the temporary output file
-    final Path outputDir = ((FileOutputCommitter) committer).getWorkPath();
+    final Path outputDir = ((PathOutputCommitter) committer).getWorkPath();
     final Configuration conf = context.getConfiguration();
     final boolean writeMultipleTables =
       conf.getBoolean(MULTI_TABLE_HFILEOUTPUTFORMAT_CONF_KEY, false);


### PR DESCRIPTION
OutputCommitter needs to be casted to PathOutputCommitter instead of FileOutputCommitter to allow S3 Magic committer as output committer. PathOutputCommitter is only available starting from Hadoop 3 so this change isn't backwards compatible with HBase using Hadoop 2. 

As similar change will be applied to branch-2, which will be compatible with Hadoop 2 as well.


