### PR TITLE
HBASE-28535: Add a region-server wide key to enable data-tiering.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -23,6 +23,7 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
+import org.apache.hadoop.hbase.regionserver.DataTieringManager;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -40,8 +41,13 @@ public class HFilePreadReader extends HFileReaderImpl {
 
     final MutableBoolean shouldCache = new MutableBoolean(true);
 
-    // Initialize HFileInfo object with metadata for caching decisions
-    fileInfo.initMetaAndIndex(this);
+    DataTieringManager dataTieringManager = DataTieringManager.getInstance();
+    if (dataTieringManager != null) {
+      // Initialize HFileInfo object with metadata for caching decisions.
+      // Initialize the metadata only if the data-tiering is enabled.
+      // If not, the metadata will be initialized later.
+      fileInfo.initMetaAndIndex(this);
+    }
 
     cacheConf.getBlockCache().ifPresent(cache -> {
       Optional<Boolean> result = cache.shouldCacheFile(fileInfo, conf);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -23,7 +23,6 @@ import org.apache.commons.lang3.mutable.MutableBoolean;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
-import org.apache.hadoop.hbase.regionserver.DataTieringManager;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -41,13 +40,8 @@ public class HFilePreadReader extends HFileReaderImpl {
 
     final MutableBoolean shouldCache = new MutableBoolean(true);
 
-    DataTieringManager dataTieringManager = DataTieringManager.getInstance();
-    if (dataTieringManager != null) {
-      // Initialize HFileInfo object with metadata for caching decisions.
-      // Initialize the metadata only if the data-tiering is enabled.
-      // If not, the metadata will be initialized later.
-      fileInfo.initMetaAndIndex(this);
-    }
+    // Initialize HFileInfo object with metadata for caching decisions
+    fileInfo.initMetaAndIndex(this);
 
     cacheConf.getBlockCache().ifPresent(cache -> {
       Optional<Boolean> result = cache.shouldCacheFile(fileInfo, conf);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -2195,18 +2195,11 @@ public class BucketCache implements BlockCache, HeapSize {
   public Optional<Boolean> shouldCacheFile(HFileInfo hFileInfo, Configuration conf) {
     String fileName = hFileInfo.getHFileContext().getHFileName();
     DataTieringManager dataTieringManager = DataTieringManager.getInstance();
-    if (dataTieringManager != null) {
-      if (!dataTieringManager.isHotData(hFileInfo, conf)) {
-        LOG.debug("Data tiering is enabled for file: '{}' and it is not hot data", fileName);
-        return Optional.of(false);
-      } else {
-        LOG.debug("Data tiering is enabled for file: '{}' and it is hot data", fileName);
-      }
-    } else {
-      LOG.debug("Data tiering feature is not enabled. "
-        + " The file: '{}' will be loaded if not already loaded", fileName);
+    if (dataTieringManager != null && !dataTieringManager.isHotData(hFileInfo, conf)) {
+      LOG.debug("Data tiering is enabled for file: '{}' and it is not hot data", fileName);
+      return Optional.of(false);
     }
-    // if we don't have the file in fullyCachedFiles, we should cache it.
+    // if we don't have the file in fullyCachedFiles, we should cache it
     return Optional.of(!fullyCachedFiles.containsKey(fileName));
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/DataTieringManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/DataTieringManager.java
@@ -45,8 +45,9 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 public class DataTieringManager {
   private static final Logger LOG = LoggerFactory.getLogger(DataTieringManager.class);
-  public static final String DATA_TIERING_ENABLED_KEY = "hbase.hstore.datatiering.enable";
-  public static final boolean DEFAULT_DATA_TIERING_ENABLED = false; // disabled by default
+  public static final String GLOBAL_DATA_TIERING_ENABLED_KEY =
+    "hbase.regionserver.datatiering.enable";
+  public static final boolean DEFAULT_GLOBAL_DATA_TIERING_ENABLED = false; // disabled by default
   public static final String DATATIERING_KEY = "hbase.hstore.datatiering.type";
   public static final String DATATIERING_HOT_DATA_AGE_KEY =
     "hbase.hstore.datatiering.hot.age.millis";
@@ -60,26 +61,27 @@ public class DataTieringManager {
   }
 
   /**
-   * Initializes the DataTieringManager instance with the provided map of online regions.
+   * Initializes the DataTieringManager instance with the provided map of online regions, only if
+   * the configuration "hbase.regionserver.datatiering.enable" is enabled.
+   * @param conf          Configuration object.
    * @param onlineRegions A map containing online regions.
+   * @return True if the instance is instantiated successfully, false otherwise.
    */
-  public static synchronized void instantiate(Configuration conf,
+  public static synchronized boolean instantiate(Configuration conf,
     Map<String, HRegion> onlineRegions) {
-    if (isDataTieringFeatureEnabled(conf)) {
-      if (instance == null) {
-        instance = new DataTieringManager(onlineRegions);
-        LOG.info("DataTieringManager instantiated successfully.");
-      } else {
-        LOG.warn("DataTieringManager is already instantiated.");
-      }
+    if (isDataTieringFeatureEnabled(conf) && instance == null) {
+      instance = new DataTieringManager(onlineRegions);
+      LOG.info("DataTieringManager instantiated successfully.");
+      return true;
     } else {
-      LOG.info("Data-Tiering feature is not enabled.");
+      LOG.warn("DataTieringManager is already instantiated.");
     }
+    return false;
   }
 
   /**
    * Retrieves the instance of DataTieringManager.
-   * @return The instance of DataTieringManager.
+   * @return The instance of DataTieringManager, if instantiated, null otherwise.
    */
   public static synchronized DataTieringManager getInstance() {
     return instance;
@@ -311,8 +313,13 @@ public class DataTieringManager {
     return coldFiles;
   }
 
-  public static boolean isDataTieringFeatureEnabled(Configuration conf) {
-    return conf.getBoolean(DataTieringManager.DATA_TIERING_ENABLED_KEY,
-      DataTieringManager.DEFAULT_DATA_TIERING_ENABLED);
+  private static boolean isDataTieringFeatureEnabled(Configuration conf) {
+    return conf.getBoolean(DataTieringManager.GLOBAL_DATA_TIERING_ENABLED_KEY,
+      DataTieringManager.DEFAULT_GLOBAL_DATA_TIERING_ENABLED);
+  }
+
+  // Resets the instance to null. To be used only for testing.
+  public static void resetForTestingOnly() {
+    instance = null;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -534,9 +534,10 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
       regionServerAccounting = new RegionServerAccounting(conf);
 
       blockCache = BlockCacheFactory.createBlockCache(conf);
-      if (DataTieringManager.isDataTieringFeatureEnabled(conf)) {
-        DataTieringManager.instantiate(conf, onlineRegions);
-      }
+      // The call below, instantiates the DataTieringManager only when
+      // the configuration "hbase.regionserver.datatiering.enable" is set to true.
+      DataTieringManager.instantiate(conf, onlineRegions);
+
       mobFileCache = new MobFileCache(conf);
 
       rsSnapshotVerifier = new RSSnapshotVerifier(conf);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -534,7 +534,9 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
       regionServerAccounting = new RegionServerAccounting(conf);
 
       blockCache = BlockCacheFactory.createBlockCache(conf);
-      DataTieringManager.instantiate(onlineRegions);
+      if (DataTieringManager.isDataTieringFeatureEnabled(conf)) {
+        DataTieringManager.instantiate(conf, onlineRegions);
+      }
       mobFileCache = new MobFileCache(conf);
 
       rsSnapshotVerifier = new RSSnapshotVerifier(conf);


### PR DESCRIPTION
Data-tiering feature should not be enabled by default, since this feature has specific use-cases. Hence, introduce a system-wide configuration to enable the feature.

Avoid the code data-tiering code paths when this system-wide configuration is not enabled.

Change-Id: I308119884c42173cfef3b23c360a842c7f516977