### PR TITLE
HBASE-28568 Fix incremental backup set shrinking

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
@@ -131,10 +131,11 @@ public class BackupAdminImpl implements BackupAdmin {
         List<String> affectedBackupRootDirs = new ArrayList<>();
         for (int i = 0; i < backupIds.length; i++) {
           BackupInfo info = sysTable.readBackupInfo(backupIds[i]);
-          if (info != null) {
-            affectedBackupRootDirs.add(info.getBackupRootDir());
-            totalDeleted += deleteBackup(backupIds[i], sysTable);
+          if (info == null) {
+            continue;
           }
+          affectedBackupRootDirs.add(info.getBackupRootDir());
+          totalDeleted += deleteBackup(backupIds[i], sysTable);
         }
         finalizeDelete(affectedBackupRootDirs, sysTable);
         // Finish

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
@@ -86,7 +86,8 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
  * <ul>
  * <li>1. Backup sessions rowkey= "session:"+backupId; value =serialized BackupInfo</li>
  * <li>2. Backup start code rowkey = "startcode:"+backupRoot; value = startcode</li>
- * <li>3. Incremental backup set rowkey="incrbackupset:"+backupRoot; value=[list of tables]</li>
+ * <li>3. Incremental backup set rowkey="incrbackupset:"+backupRoot; table="meta:"+tablename of
+ * include table; value=empty</li>
  * <li>4. Table-RS-timestamp map rowkey="trslm:"+backupRoot+table_name; value = map[RS-> last WAL
  * timestamp]</li>
  * <li>5. RS - WAL ts map rowkey="rslogts:"+backupRoot +server; value = last WAL timestamp</li>

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupDelete.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupDelete.java
@@ -175,7 +175,7 @@ public class TestBackupDelete extends TestBackupBase {
       backupSystemTable.getIncrementalBackupTableSet(BACKUP_ROOT_DIR));
 
     String backupId2 = fullTableBackup(Lists.newArrayList(table3));
-    assertTrue(checkSucceeded(backupId1));
+    assertTrue(checkSucceeded(backupId2));
     assertEquals(Sets.newHashSet(table1, table2, table3),
       backupSystemTable.getIncrementalBackupTableSet(BACKUP_ROOT_DIR));
 


### PR DESCRIPTION
The incremental backup set is the set of tables included when an incremental backup is created, it is managed per backup root dir and contains all tables that are present in at least one backup (in that root dir).

The incremental backup set can only shrink when backups are deleted. However, the implementation was incorrect, causing this set to never be able to shrink.