### PR TITLE
HBASE-28575 Always printing error log when snapshot table

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
@@ -252,11 +252,11 @@ public abstract class TakeSnapshotHandler extends EventHandler
       try {
         // if the working dir is still present, the snapshot has failed. it is present we delete
         // it.
-        if (!workingDirFs.delete(workingDir, true)) {
-          LOG.error("Couldn't delete snapshot working directory:" + workingDir);
+        if (workingDirFs.exists(workingDir) && !workingDirFs.delete(workingDir, true)) {
+          LOG.error("Couldn't delete snapshot working directory: {}", workingDir);
         }
       } catch (IOException e) {
-        LOG.error("Couldn't delete snapshot working directory:" + workingDir);
+        LOG.error("Couldn't get or delete snapshot working directory: {}", workingDir, e);
       }
       if (LOG.isDebugEnabled()) {
         LOG.debug("Table snapshot journal : \n" + status.prettyPrintJournal());


### PR DESCRIPTION
Details see: [HBASE-28575](https://issues.apache.org/jira/browse/HBASE-28575)