### PR TITLE
fix : HBASE-28585. Add namespace handling method in copy_tables_desc.rb

### DIFF
--- a/bin/replication/copy_tables_desc.rb
+++ b/bin/replication/copy_tables_desc.rb
@@ -39,6 +39,17 @@ def usage
   exit!
 end
 
+def create_namespace_if_not_exists(dst, namespace)
+  begin
+    dst.getNamespaceDescriptor(namespace)
+    puts format('Namespace "%s" already exists.', namespace)
+  rescue org.apache.hadoop.hbase.NamespaceNotFoundException
+    descriptor = org.apache.hadoop.hbase.NamespaceDescriptor.create(namespace).build()
+    dst.createNamespace(descriptor)
+    puts format('Namespace "%s" was successfully created.', namespace)
+  end
+end
+
 def copy(src, dst, table)
   # verify if table exists in source cluster
   begin
@@ -48,6 +59,10 @@ def copy(src, dst, table)
     return
   end
 
+  # verify if namespace *doesn't* exists in the target cluster
+  namespace = TableName.valueOf(table).getNamespaceAsString
+  create_namespace_if_not_exists(dst, namespace)
+
   # verify if table *doesn't* exists in the target cluster
   begin
     dst.createTable(t)
@@ -56,7 +71,7 @@ def copy(src, dst, table)
     return
   end
 
-  puts format('Schema for table "%s" was succesfully copied to remote cluster.', table)
+  puts format('Schema for table "%s" was successfully copied to remote cluster.', table)
 end
 
 # disable debug/info logging on this script for clarity

--- a/bin/replication/copy_tables_desc.rb
+++ b/bin/replication/copy_tables_desc.rb
@@ -39,13 +39,13 @@ def usage
   exit!
 end
 
-def create_namespace_if_not_exists(dst, namespace)
+def create_namespace_if_not_exists(src, dst, namespace)
   begin
     dst.getNamespaceDescriptor(namespace)
     puts format('Namespace "%s" already exists.', namespace)
   rescue org.apache.hadoop.hbase.NamespaceNotFoundException
-    descriptor = org.apache.hadoop.hbase.NamespaceDescriptor.create(namespace).build()
-    dst.createNamespace(descriptor)
+    n = src.getNamespaceDescriptor(namespace)
+    dst.createNamespace(n)
     puts format('Namespace "%s" was successfully created.', namespace)
   end
 end
@@ -61,7 +61,7 @@ def copy(src, dst, table)
 
   # verify if namespace *doesn't* exists in the target cluster
   namespace = TableName.valueOf(table).getNamespaceAsString
-  create_namespace_if_not_exists(dst, namespace)
+  create_namespace_if_not_exists(src, dst, namespace)
 
   # verify if table *doesn't* exists in the target cluster
   begin


### PR DESCRIPTION
When utilizing the copy_tables_desc.rb script to duplicate tables to a target cluster, if the specified table's namespace is nonexistent in the target cluster, the script fails to execute successfully. It is recommended to incorporate logic within the script for detecting and handling scenarios where the namespace does not exist.

and fix spelling errors.