### PR TITLE
HBASE-28236 Add 2.6.0 to downloads page

### DIFF
--- a/src/site/xdoc/downloads.xml
+++ b/src/site/xdoc/downloads.xml
@@ -70,6 +70,31 @@ under the License.
     </tr>
     <tr>
       <td style="test-align: left">
+        2.6.0
+      </td>
+      <td style="test-align: left">
+        2024/05/17
+      </td>
+      <td style="test-align: left">
+        <a href="https://downloads.apache.org/hbase/2.6.0/api_compare_2.5.0_to_2.6.0RC4.html">2.5.0 vs 2.6.0</a>
+      </td>
+      <td style="test-align: left">
+        <a href="https://downloads.apache.org/hbase/2.6.0/CHANGES.md">Changes</a>
+      </td>
+      <td style="test-align: left">
+        <a href="https://downloads.apache.org/hbase/2.6.0/RELEASENOTES.md">Release Notes</a>
+      </td>
+      <td style="test-align: left">
+        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.6.0/hbase-2.6.0-src.tar.gz">src</a> (<a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-src.tar.gz.sha512">sha512</a> <a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-src.tar.gz.asc">asc</a>) <br />
+        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.6.0/hbase-2.6.0-bin.tar.gz">bin</a> (<a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-bin.tar.gz.sha512">sha512</a> <a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-bin.tar.gz.asc">asc</a>) <br />
+        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.6.0/hbase-2.6.0-client-bin.tar.gz">client-bin</a> (<a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-client-bin.tar.gz.sha512">sha512</a> <a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-client-bin.tar.gz.asc">asc</a>)
+        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.6.0/hbase-2.6.0-hadoop3-bin.tar.gz">hadoop3-bin</a> (<a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-hadoop3-bin.tar.gz.sha512">sha512</a> <a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-hadoop3-bin.tar.gz.asc">asc</a>) <br />
+        <a href="https://www.apache.org/dyn/closer.lua/hbase/2.6.0/hbase-2.6.0-hadoop3-client-bin.tar.gz">hadoop3-client-bin</a> (<a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-hadoop3-client-bin.tar.gz.sha512">sha512</a> <a href="https://downloads.apache.org/hbase/2.6.0/hbase-2.6.0-hadoop3-client-bin.tar.gz.asc">asc</a>)
+      </td>
+      <td />
+    </tr>
+    <tr>
+      <td style="test-align: left">
         2.5.8
       </td>
       <td style="test-align: left">


### PR DESCRIPTION
I checked all the links here and they seem good.

One thing I noticed is that my CHANGES.md file still says `## Release 2.6.0 - Unreleased (as of 2024-04-29)`. I'm not sure if I missed a step, or if I should just manually commit another change to the file which updates that line