### PR TITLE
HBASE-28599 RowTooBigException is thrown when duplicate increment RPC call is attempted

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -4036,7 +4036,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
       assert mutation instanceof Increment || mutation instanceof Append;
       Get get = new Get(mutation.getRow());
       CellScanner cellScanner = mutation.cellScanner();
-      while (!cellScanner.advance()) {
+      while (cellScanner.advance()) {
         Cell cell = cellScanner.current();
         get.addColumn(CellUtil.cloneFamily(cell), CellUtil.cloneQualifier(cell));
       }


### PR DESCRIPTION
Issue Link: https://issues.apache.org/jira/browse/HBASE-28599 ( reported by @robiee17 )
Below is written by @robiee17

```
Issue:
`RowTooBigException` is thrown when a duplicate increment RPC call is attempted.

Expected Behavior:
1. The initial RPC increment call should time out for some reason.
2. The duplicate RPC call should be converted to a GET request and fetch the result that I am trying to increment.
3. The result should contain only the qualifier that I am attempting to increment.

Actual Behavior:
1. The initial RPC increment call timed out, which is expected.
2. The duplicate RPC call is converted to a GET request but fails to clone the qualifier into the GET request.
3. Hence, the GET request attempts to retrieve all qualifiers for the given row and columnfamily, resulting in a `RowTooBigException`.

Steps to Reproduce:
1. Ensure a row with a total value size exceeding `hbase.table.max.rowsize` (default = 1073741824) exists.
2. Nonce property should be enabled `hbase.client.nonces.enabled` which is actually defaulted to true.
3. Attempt to increment a qualifier against the same row.
4. In my case, I am using a postIncrement co-processor which may cause a delay (longer than the RPC timeout property).
5. A duplicate increment call should be triggered, which tries to get the value rather than increment it.
6. The GET request actually tries to retrieve all the qualifiers for the row, resulting in a `RowTooBigException`
```

## Test 

When I print out [this get object](https://github.com/apache/hbase/blob/master/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java#L4037), there are no Column Family and Column Qualifier information in the second retry.

```
{"targetReplicaId":-1,"totalColumns":0,"families":{},"priority":-1,"consistency":"STRONG","maxVersions":1,"storeOffset":0,"checkExistenceOnly":false,"storeLimit":-1,"cacheBlocks":true,"row":"row1","timeRange":["0","9223372036854775807"]}
```

Because logic does not run this [while loop](https://github.com/apache/hbase/blob/master/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java#L4039),The GET request actually tries to retrieve all the qualifiers for the row, resulting in a RowTooBigException

**After applying this change**, I found that Column Family and Column Information is synced well and  RowTooBigException doesn't occur when Incrementing that row in the second retry .
```
{"targetReplicaId":-1,"totalColumns":1,"families":{"cf":["counter"]},"priority":-1,"consistency":"STRONG","maxVersions":1,"storeOffset":0,"checkExistenceOnly":false,"storeLimit":-1,"cacheBlocks":true,"row":"row1","timeRange":["0","9223372036854775807"]}
```

## Sugestion

To resolve this issue I deleted exclamation mark in while loop condition. Please review it and let me know if this have any problems. Thank you.