### PR TITLE
Backport "HBASE-28605 Add ErrorProne ban on Hadoop shaded thirdparty jars (#5918)" to branch-3

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2503,6 +2503,7 @@
                     <bannedImport>org.apache.commons.cli.**</bannedImport>
                     <bannedImport>org.apache.commons.collections.**</bannedImport>
                     <bannedImport>org.apache.commons.collections4.**</bannedImport>
+                    <bannedImport>org.apache.hadoop.thirdparty.**</bannedImport>
                   </bannedImports>
                 </restrictImports>
                 <restrictImports implementation="de.skuzzle.enforcer.restrictimports.rule.RestrictImports">


### PR DESCRIPTION
This change results in this error on master at `3a3dd66e21`.

```
[WARNING] Rule 2: de.skuzzle.enforcer.restrictimports.rule.RestrictImports failed with message:

Banned imports detected:
Reason: Use shaded version in hbase-thirdparty
        in file: org/apache/hadoop/hbase/backup/TestBackupDelete.java
                org.apache.hadoop.thirdparty.com.google.common.collect.Sets (Line: 34, Matched by: org.apache.hadoop.thirdparty.**)
```