### PR TITLE
HBASE-28564 Refactor direct interactions of Reference file creations to SFT interface

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HFileLink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HFileLink.java
@@ -463,7 +463,7 @@ public class HFileLink extends FileLink {
    * Create the back reference name
    */
   // package-private for testing
-  static String createBackReferenceName(final String tableNameStr, final String regionName) {
+  public static String createBackReferenceName(final String tableNameStr, final String regionName) {
 
     return regionName + "." + tableNameStr.replace(TableName.NAMESPACE_DELIM, '=');
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/Reference.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/Reference.java
@@ -195,7 +195,7 @@ public class Reference {
    * delimiter, pb reads to EOF which may not be what you want).
    * @return This instance serialized as a delimited protobuf w/ a magic pb prefix.
    */
-  byte[] toByteArray() throws IOException {
+  public byte[] toByteArray() throws IOException {
     return ProtobufUtil.prependPBMagic(convert().toByteArray());
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
@@ -627,7 +627,7 @@ public class MergeTableRegionsProcedure
           // to read the hfiles.
           storeFileInfo.setConf(storeConfiguration);
           Path refFile = mergeRegionFs.mergeStoreFile(regionFs.getRegionInfo(), family,
-            new HStoreFile(storeFileInfo, hcd.getBloomFilterType(), CacheConfig.DISABLED));
+            new HStoreFile(storeFileInfo, hcd.getBloomFilterType(), CacheConfig.DISABLED), tracker);
           mergedFiles.add(refFile);
         }
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
@@ -681,8 +681,9 @@ public class SplitTableRegionProcedure
     // table dir. In case of failure, the proc would go through this again, already existing
     // region dirs and split files would just be ignored, new split files should get created.
     int nbFiles = 0;
-    final Map<String, Collection<StoreFileInfo>> files =
-      new HashMap<String, Collection<StoreFileInfo>>(htd.getColumnFamilyCount());
+    final Map<String, Pair<Collection<StoreFileInfo>, StoreFileTracker>> files =
+      new HashMap<String, Pair<Collection<StoreFileInfo>, StoreFileTracker>>(
+        htd.getColumnFamilyCount());
     for (ColumnFamilyDescriptor cfd : htd.getColumnFamilies()) {
       String family = cfd.getNameAsString();
       StoreFileTracker tracker =
@@ -705,7 +706,7 @@ public class SplitTableRegionProcedure
         }
         if (filteredSfis == null) {
           filteredSfis = new ArrayList<StoreFileInfo>(sfis.size());
-          files.put(family, filteredSfis);
+          files.put(family, new Pair(filteredSfis, tracker));
         }
         filteredSfis.add(sfi);
         nbFiles++;
@@ -728,10 +729,12 @@ public class SplitTableRegionProcedure
     final List<Future<Pair<Path, Path>>> futures = new ArrayList<Future<Pair<Path, Path>>>(nbFiles);
 
     // Split each store file.
-    for (Map.Entry<String, Collection<StoreFileInfo>> e : files.entrySet()) {
+    for (Map.Entry<String, Pair<Collection<StoreFileInfo>, StoreFileTracker>> e : files
+      .entrySet()) {
       byte[] familyName = Bytes.toBytes(e.getKey());
       final ColumnFamilyDescriptor hcd = htd.getColumnFamily(familyName);
-      final Collection<StoreFileInfo> storeFiles = e.getValue();
+      Pair<Collection<StoreFileInfo>, StoreFileTracker> storeFilesAndTracker = e.getValue();
+      final Collection<StoreFileInfo> storeFiles = storeFilesAndTracker.getFirst();
       if (storeFiles != null && storeFiles.size() > 0) {
         final Configuration storeConfiguration =
           StoreUtils.createStoreConfiguration(env.getMasterConfiguration(), htd, hcd);
@@ -742,8 +745,9 @@ public class SplitTableRegionProcedure
           // is running in a regionserver's Store context, or we might not be able
           // to read the hfiles.
           storeFileInfo.setConf(storeConfiguration);
-          StoreFileSplitter sfs = new StoreFileSplitter(regionFs, familyName,
-            new HStoreFile(storeFileInfo, hcd.getBloomFilterType(), CacheConfig.DISABLED));
+          StoreFileSplitter sfs =
+            new StoreFileSplitter(regionFs, storeFilesAndTracker.getSecond(), familyName,
+              new HStoreFile(storeFileInfo, hcd.getBloomFilterType(), CacheConfig.DISABLED));
           futures.add(threadPool.submit(sfs));
         }
       }
@@ -809,8 +813,8 @@ public class SplitTableRegionProcedure
     }
   }
 
-  private Pair<Path, Path> splitStoreFile(HRegionFileSystem regionFs, byte[] family, HStoreFile sf)
-    throws IOException {
+  private Pair<Path, Path> splitStoreFile(HRegionFileSystem regionFs, StoreFileTracker tracker,
+    byte[] family, HStoreFile sf) throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug("pid=" + getProcId() + " splitting started for store file: " + sf.getPath()
         + " for region: " + getParentRegion().getShortNameToLog());
@@ -818,10 +822,10 @@ public class SplitTableRegionProcedure
 
     final byte[] splitRow = getSplitRow();
     final String familyName = Bytes.toString(family);
-    final Path path_first =
-      regionFs.splitStoreFile(this.daughterOneRI, familyName, sf, splitRow, false, splitPolicy);
-    final Path path_second =
-      regionFs.splitStoreFile(this.daughterTwoRI, familyName, sf, splitRow, true, splitPolicy);
+    final Path path_first = regionFs.splitStoreFile(this.daughterOneRI, familyName, sf, splitRow,
+      false, splitPolicy, tracker);
+    final Path path_second = regionFs.splitStoreFile(this.daughterTwoRI, familyName, sf, splitRow,
+      true, splitPolicy, tracker);
     if (LOG.isDebugEnabled()) {
       LOG.debug("pid=" + getProcId() + " splitting complete for store file: " + sf.getPath()
         + " for region: " + getParentRegion().getShortNameToLog());
@@ -837,6 +841,7 @@ public class SplitTableRegionProcedure
     private final HRegionFileSystem regionFs;
     private final byte[] family;
     private final HStoreFile sf;
+    private final StoreFileTracker tracker;
 
     /**
      * Constructor that takes what it needs to split
@@ -844,15 +849,17 @@ public class SplitTableRegionProcedure
      * @param family   Family that contains the store file
      * @param sf       which file
      */
-    public StoreFileSplitter(HRegionFileSystem regionFs, byte[] family, HStoreFile sf) {
+    public StoreFileSplitter(HRegionFileSystem regionFs, StoreFileTracker tracker, byte[] family,
+      HStoreFile sf) {
       this.regionFs = regionFs;
       this.sf = sf;
       this.family = family;
+      this.tracker = tracker;
     }
 
     @Override
     public Pair<Path, Path> call() throws IOException {
-      return splitStoreFile(regionFs, family, sf);
+      return splitStoreFile(regionFs, tracker, family, sf);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
@@ -35,6 +35,8 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.ScheduledChore;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Get;
@@ -50,6 +52,8 @@ import org.apache.hadoop.hbase.master.assignment.GCRegionProcedure;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
 import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.Pair;
@@ -422,7 +426,16 @@ public class CatalogJanitor extends ScheduledChore {
     try {
       HRegionFileSystem regionFs = HRegionFileSystem
         .openRegionFromFileSystem(services.getConfiguration(), fs, tabledir, region, true);
-      boolean references = regionFs.hasReferences(tableDescriptor);
+      ColumnFamilyDescriptor[] families = tableDescriptor.getColumnFamilies();
+      boolean references = false;
+      for (ColumnFamilyDescriptor cfd : families) {
+        StoreFileTracker sft = StoreFileTrackerFactory.create(services.getConfiguration(),
+          tableDescriptor, ColumnFamilyDescriptorBuilder.of(cfd.getNameAsString()), regionFs);
+        references = references || sft.hasReferences();
+        if (references) {
+          break;
+        }
+      }
       return new Pair<>(Boolean.TRUE, references);
     } catch (IOException e) {
       LOG.error("Error trying to determine if region {} has references, assuming it does",

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/CachedMobFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/CachedMobFile.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.regionserver.HStoreFile;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -41,10 +42,10 @@ public class CachedMobFile extends MobFile implements Comparable<CachedMobFile> 
   }
 
   public static CachedMobFile create(FileSystem fs, Path path, Configuration conf,
-    CacheConfig cacheConf) throws IOException {
+    CacheConfig cacheConf, StoreFileTracker sft) throws IOException {
     // XXX: primaryReplica is only used for constructing the key of block cache so it is not a
     // critical problem if we pass the wrong value, so here we always pass true. Need to fix later.
-    HStoreFile sf = new HStoreFile(fs, path, conf, cacheConf, BloomType.NONE, true);
+    HStoreFile sf = new HStoreFile(fs, path, conf, cacheConf, BloomType.NONE, true, sft);
     return new CachedMobFile(sf);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/ExpiredMobFileCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/ExpiredMobFileCleaner.java
@@ -56,17 +56,17 @@ public class ExpiredMobFileCleaner extends Configured implements Tool {
    * @param tableName The current table name.
    * @param family    The current family.
    */
-  public void cleanExpiredMobFiles(String tableName, ColumnFamilyDescriptor family)
+  public void cleanExpiredMobFiles(TableDescriptor htd, ColumnFamilyDescriptor family)
     throws IOException {
     Configuration conf = getConf();
-    TableName tn = TableName.valueOf(tableName);
+    String tableName = htd.getTableName().getNameAsString();
     FileSystem fs = FileSystem.get(conf);
     LOG.info("Cleaning the expired MOB files of " + family.getNameAsString() + " in " + tableName);
     // disable the block cache.
     Configuration copyOfConf = new Configuration(conf);
     copyOfConf.setFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY, 0f);
     CacheConfig cacheConfig = new CacheConfig(copyOfConf);
-    MobUtils.cleanExpiredMobFiles(fs, conf, tn, family, cacheConfig,
+    MobUtils.cleanExpiredMobFiles(fs, conf, htd, family, cacheConfig,
       EnvironmentEdgeManager.currentTime());
   }
 
@@ -105,7 +105,7 @@ public class ExpiredMobFileCleaner extends Configured implements Tool {
         throw new IOException(
           "The minVersions of the column family is not 0, could not be handled by this cleaner");
       }
-      cleanExpiredMobFiles(tableName, family);
+      cleanExpiredMobFiles(htd, family);
       return 0;
     } finally {
       admin.close();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFile.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.regionserver.HStoreFile;
 import org.apache.hadoop.hbase.regionserver.StoreFileScanner;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -134,11 +135,11 @@ public class MobFile {
    * @param cacheConf The CacheConfig.
    * @return An instance of the MobFile.
    */
-  public static MobFile create(FileSystem fs, Path path, Configuration conf, CacheConfig cacheConf)
-    throws IOException {
+  public static MobFile create(FileSystem fs, Path path, Configuration conf, CacheConfig cacheConf,
+    StoreFileTracker sft) throws IOException {
     // XXX: primaryReplica is only used for constructing the key of block cache so it is not a
     // critical problem if we pass the wrong value, so here we always pass true. Need to fix later.
-    HStoreFile sf = new HStoreFile(fs, path, conf, cacheConf, BloomType.NONE, true);
+    HStoreFile sf = new HStoreFile(fs, path, conf, cacheConf, BloomType.NONE, true, sft);
     return new MobFile(sf);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFileCleanerChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFileCleanerChore.java
@@ -87,7 +87,7 @@ public class MobFileCleanerChore extends ScheduledChore {
       for (ColumnFamilyDescriptor hcd : htd.getColumnFamilies()) {
         if (hcd.isMobEnabled() && hcd.getMinVersions() == 0) {
           try {
-            cleaner.cleanExpiredMobFiles(htd.getTableName().getNameAsString(), hcd);
+            cleaner.cleanExpiredMobFiles(htd, hcd);
           } catch (IOException e) {
             LOG.error("Failed to clean the expired mob files table={} family={}",
               htd.getTableName().getNameAsString(), hcd.getNameAsString(), e);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobUtils.java
@@ -60,9 +60,12 @@ import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
 import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.regionserver.HStoreFile;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
 import org.apache.hadoop.hbase.regionserver.StoreUtils;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.ChecksumType;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
@@ -267,7 +270,7 @@ public final class MobUtils {
    * @param cacheConfig      The cacheConfig that disables the block cache.
    * @param current          The current time.
    */
-  public static void cleanExpiredMobFiles(FileSystem fs, Configuration conf, TableName tableName,
+  public static void cleanExpiredMobFiles(FileSystem fs, Configuration conf, TableDescriptor htd,
     ColumnFamilyDescriptor columnDescriptor, CacheConfig cacheConfig, long current)
     throws IOException {
     long timeToLive = columnDescriptor.getTimeToLive();
@@ -288,7 +291,11 @@ public final class MobUtils {
     LOG.info("MOB HFiles older than " + expireDate.toGMTString() + " will be deleted!");
 
     FileStatus[] stats = null;
+    TableName tableName = htd.getTableName();
     Path mobTableDir = CommonFSUtils.getTableDir(getMobHome(conf), tableName);
+    HRegionFileSystem regionFS =
+      HRegionFileSystem.create(conf, fs, mobTableDir, getMobRegionInfo(tableName));
+    StoreFileTracker sft = StoreFileTrackerFactory.create(conf, htd, columnDescriptor, regionFS);
     Path path = getMobFamilyPath(conf, tableName, columnDescriptor.getNameAsString());
     try {
       stats = fs.listStatus(path);
@@ -319,7 +326,7 @@ public final class MobUtils {
             LOG.debug("{} is an expired file", fileName);
           }
           filesToClean
-            .add(new HStoreFile(fs, file.getPath(), conf, cacheConfig, BloomType.NONE, true));
+            .add(new HStoreFile(fs, file.getPath(), conf, cacheConfig, BloomType.NONE, true, sft));
           if (
             filesToClean.size() >= conf.getInt(MOB_CLEANER_BATCH_SIZE_UPPER_BOUND,
               DEFAULT_MOB_CLEANER_BATCH_SIZE_UPPER_BOUND)
@@ -386,6 +393,10 @@ public final class MobUtils {
    */
   public static Path getMobTableDir(Path rootDir, TableName tableName) {
     return CommonFSUtils.getTableDir(getMobHome(rootDir), tableName);
+  }
+
+  public static Path getMobTableDir(Configuration conf, TableName tableName) {
+    return getMobTableDir(new Path(conf.get(HConstants.HBASE_DIR)), tableName);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -154,6 +154,8 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionLifeCycleTrack
 import org.apache.hadoop.hbase.regionserver.compactions.ForbidMajorCompactionChecker;
 import org.apache.hadoop.hbase.regionserver.metrics.MetricsTableRequests;
 import org.apache.hadoop.hbase.regionserver.regionreplication.RegionReplicationSink;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.regionserver.throttle.CompactionThroughputControllerFactory;
 import org.apache.hadoop.hbase.regionserver.throttle.NoLimitThroughputController;
 import org.apache.hadoop.hbase.regionserver.throttle.StoreHotnessProtector;
@@ -1348,7 +1350,9 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
         if (StoreFileInfo.isReference(p) || HFileLink.isHFileLink(p)) {
           // Only construct StoreFileInfo object if its not a hfile, save obj
           // creation
-          StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, status);
+          StoreFileTracker sft =
+            StoreFileTrackerFactory.create(conf, tableDescriptor, family, regionFs);
+          StoreFileInfo storeFileInfo = sft.getStoreFileInfo(status, status.getPath(), false);
           hdfsBlocksDistribution.add(storeFileInfo.computeHDFSBlocksDistribution(fs));
         } else if (StoreFileInfo.isHFile(p)) {
           // If its a HFile, then lets just add to the block distribution
@@ -5493,9 +5497,12 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
         // column family. Have to fake out file type too by casting our recovered.edits as
         // storefiles
         String fakeFamilyName = WALSplitUtil.getRegionDirRecoveredEditsDir(regionWALDir).getName();
+        StoreContext storeContext =
+          StoreContext.getBuilder().withRegionFileSystem(getRegionFileSystem()).build();
+        StoreFileTracker sft = StoreFileTrackerFactory.create(this.conf, true, storeContext);
         Set<HStoreFile> fakeStoreFiles = new HashSet<>(files.size());
         for (Path file : files) {
-          fakeStoreFiles.add(new HStoreFile(walFS, file, this.conf, null, null, true));
+          fakeStoreFiles.add(new HStoreFile(walFS, file, this.conf, null, null, true, sft));
         }
         getRegionWALFileSystem().archiveRecoveredEdits(fakeFamilyName, fakeStoreFiles);
       } else {
@@ -6501,17 +6508,15 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
             continue;
           }
 
-          List<String> storeFiles = storeDescriptor.getStoreFileList();
-          for (String storeFile : storeFiles) {
-            StoreFileInfo storeFileInfo = null;
+          StoreContext storeContext = store.getStoreContext();
+          StoreFileTracker sft = StoreFileTrackerFactory.create(conf, false, storeContext);
+
+          List<StoreFileInfo> storeFiles = sft.load();
+          for (StoreFileInfo storeFileInfo : storeFiles) {
             try {
-              storeFileInfo = fs.getStoreFileInfo(Bytes.toString(family), storeFile);
               store.bulkLoadHFile(storeFileInfo);
             } catch (FileNotFoundException ex) {
-              LOG.warn(getRegionInfo().getEncodedName() + " : "
-                + ((storeFileInfo != null)
-                  ? storeFileInfo.toString()
-                  : (new Path(Bytes.toString(family), storeFile)).toString())
+              LOG.warn(getRegionInfo().getEncodedName() + " : " + storeFileInfo.toString()
                 + " doesn't exist any more. Skip loading the file");
             }
           }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
@@ -257,51 +257,6 @@ public class HRegionFileSystem {
   }
 
   /**
-   * Returns the store files available for the family. This methods performs the filtering based on
-   * the valid store files.
-   * @param familyName Column Family Name
-   * @return a set of {@link StoreFileInfo} for the specified family.
-   */
-  public List<StoreFileInfo> getStoreFiles(final String familyName) throws IOException {
-    return getStoreFiles(familyName, true);
-  }
-
-  /**
-   * Returns the store files available for the family. This methods performs the filtering based on
-   * the valid store files.
-   * @param familyName Column Family Name
-   * @return a set of {@link StoreFileInfo} for the specified family.
-   */
-  public List<StoreFileInfo> getStoreFiles(final String familyName, final boolean validate)
-    throws IOException {
-    Path familyDir = getStoreDir(familyName);
-    FileStatus[] files = CommonFSUtils.listStatus(this.fs, familyDir);
-    if (files == null) {
-      if (LOG.isTraceEnabled()) {
-        LOG.trace("No StoreFiles for: " + familyDir);
-      }
-      return null;
-    }
-
-    ArrayList<StoreFileInfo> storeFiles = new ArrayList<>(files.length);
-    for (FileStatus status : files) {
-      if (validate && !StoreFileInfo.isValid(status)) {
-        // recovered.hfiles directory is expected inside CF path when hbase.wal.split.to.hfile to
-        // true, refer HBASE-23740
-        if (!HConstants.RECOVERED_HFILES_DIR.equals(status.getPath().getName())) {
-          LOG.warn("Invalid StoreFile: {}", status.getPath());
-        }
-        continue;
-      }
-      StoreFileInfo info = ServerRegionReplicaUtil.getStoreFileInfo(conf, fs, regionInfo,
-        regionInfoForFs, familyName, status.getPath());
-      storeFiles.add(info);
-
-    }
-    return storeFiles;
-  }
-
-  /**
    * Returns the store files' LocatedFileStatus which available for the family. This methods
    * performs the filtering based on the valid store files.
    * @param familyName Column Family Name
@@ -351,11 +306,11 @@ public class HRegionFileSystem {
    * @param fileName   File Name
    * @return The {@link StoreFileInfo} for the specified family/file
    */
-  StoreFileInfo getStoreFileInfo(final String familyName, final String fileName)
-    throws IOException {
+  StoreFileInfo getStoreFileInfo(final String familyName, final String fileName,
+    final StoreFileTracker tracker) throws IOException {
     Path familyDir = getStoreDir(familyName);
     return ServerRegionReplicaUtil.getStoreFileInfo(conf, fs, regionInfo, regionInfoForFs,
-      familyName, new Path(familyDir, fileName));
+      familyName, new Path(familyDir, fileName), tracker);
   }
 
   /**
@@ -375,20 +330,6 @@ public class HRegionFileSystem {
           LOG.trace("Reference {}", stat.getPath());
           return true;
         }
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Check whether region has Reference file
-   * @param htd table desciptor of the region
-   * @return true if region has reference file
-   */
-  public boolean hasReferences(final TableDescriptor htd) throws IOException {
-    for (ColumnFamilyDescriptor family : htd.getColumnFamilies()) {
-      if (hasReferences(family.getNameAsString())) {
-        return true;
       }
     }
     return false;
@@ -629,7 +570,7 @@ public class HRegionFileSystem {
         tblDesc.getColumnFamily(Bytes.toBytes(familyName)), regionFs));
       fileInfoMap.computeIfAbsent(familyName, l -> new ArrayList<>());
       List<StoreFileInfo> infos = fileInfoMap.get(familyName);
-      infos.add(new StoreFileInfo(conf, fs, file, true));
+      infos.add(trackerMap.get(familyName).getStoreFileInfo(file, true));
     }
     for (Map.Entry<String, StoreFileTracker> entry : trackerMap.entrySet()) {
       entry.getValue().add(fileInfoMap.get(entry.getKey()));
@@ -673,7 +614,7 @@ public class HRegionFileSystem {
    * @return Path to created reference.
    */
   public Path splitStoreFile(RegionInfo hri, String familyName, HStoreFile f, byte[] splitRow,
-    boolean top, RegionSplitPolicy splitPolicy) throws IOException {
+    boolean top, RegionSplitPolicy splitPolicy, StoreFileTracker tracker) throws IOException {
     Path splitDir = new Path(getSplitsDir(hri), familyName);
     // Add the referred-to regions name as a dot separated suffix.
     // See REF_NAME_REGEX regex above. The referred-to regions name is
@@ -759,7 +700,8 @@ public class HRegionFileSystem {
     // A reference to the bottom half of the hsf store file.
     Reference r =
       top ? Reference.createTopReference(splitRow) : Reference.createBottomReference(splitRow);
-    return r.write(fs, p);
+    tracker.createReference(r, p);
+    return p;
   }
 
   // ===========================================================================
@@ -800,8 +742,8 @@ public class HRegionFileSystem {
    * @return Path to created reference.
    * @throws IOException if the merge write fails.
    */
-  public Path mergeStoreFile(RegionInfo mergingRegion, String familyName, HStoreFile f)
-    throws IOException {
+  public Path mergeStoreFile(RegionInfo mergingRegion, String familyName, HStoreFile f,
+    StoreFileTracker tracker) throws IOException {
     Path referenceDir = new Path(getMergesDir(regionInfoForFs), familyName);
     // A whole reference to the store file.
     Reference r = Reference.createTopReference(mergingRegion.getStartKey());
@@ -813,7 +755,8 @@ public class HRegionFileSystem {
     // Write reference with same file id only with the other region name as
     // suffix and into the new region location (under same family).
     Path p = new Path(referenceDir, f.getPath().getName() + "." + mergingRegionName);
-    return r.write(fs, p);
+    tracker.createReference(r, p);
+    return p;
   }
 
   /**
@@ -1197,5 +1140,10 @@ public class HRegionFileSystem {
       LOG.debug(msg + ", sleeping " + baseSleepBeforeRetries + " times " + sleepMultiplier);
     }
     Thread.sleep((long) baseSleepBeforeRetries * sleepMultiplier);
+  }
+
+  public static HRegionFileSystem create(final Configuration conf, final FileSystem fs,
+    final Path tableDir, final RegionInfo regionInfo) throws IOException {
+    return new HRegionFileSystem(conf, fs, tableDir, regionInfo);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext.ReaderType;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
 import org.apache.hadoop.hbase.util.BloomFilterFactory;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -227,8 +228,8 @@ public class HStoreFile implements StoreFile {
    * @param primaryReplica true if this is a store file for primary replica, otherwise false.
    */
   public HStoreFile(FileSystem fs, Path p, Configuration conf, CacheConfig cacheConf,
-    BloomType cfBloomType, boolean primaryReplica) throws IOException {
-    this(new StoreFileInfo(conf, fs, p, primaryReplica), cfBloomType, cacheConf);
+    BloomType cfBloomType, boolean primaryReplica, StoreFileTracker sft) throws IOException {
+    this(sft.getStoreFileInfo(p, primaryReplica), cfBloomType, cacheConf);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
@@ -214,8 +214,7 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
   }
 
   public HStoreFile createStoreFileAndReader(Path p) throws IOException {
-    StoreFileInfo info = new StoreFileInfo(conf, ctx.getRegionFileSystem().getFileSystem(), p,
-      ctx.isPrimaryReplicaStore());
+    StoreFileInfo info = storeFileTracker.getStoreFileInfo(p, ctx.isPrimaryReplicaStore());
     return createStoreFileAndReader(info);
   }
 
@@ -348,8 +347,8 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
   public void refreshStoreFiles(Collection<String> newFiles) throws IOException {
     List<StoreFileInfo> storeFiles = new ArrayList<>(newFiles.size());
     for (String file : newFiles) {
-      storeFiles
-        .add(ctx.getRegionFileSystem().getStoreFileInfo(ctx.getFamily().getNameAsString(), file));
+      storeFiles.add(ctx.getRegionFileSystem().getStoreFileInfo(ctx.getFamily().getNameAsString(),
+        file, storeFileTracker));
     }
     refreshStoreFilesInternal(storeFiles);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileInfo.java
@@ -35,10 +35,12 @@ import org.apache.hadoop.hbase.io.HalfStoreFileReader;
 import org.apache.hadoop.hbase.io.Reference;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFileInfo;
+import org.apache.hadoop.hbase.io.hfile.InvalidHFileException;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext.ReaderType;
 import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
 import org.apache.hadoop.hbase.mob.MobUtils;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -111,20 +113,9 @@ public class StoreFileInfo implements Configurable {
   // done.
   private final AtomicInteger refCount = new AtomicInteger(0);
 
-  /**
-   * Create a Store File Info
-   * @param conf           the {@link Configuration} to use
-   * @param fs             The current file system to use.
-   * @param initialPath    The {@link Path} of the file
-   * @param primaryReplica true if this is a store file for primary replica, otherwise false.
-   */
-  public StoreFileInfo(final Configuration conf, final FileSystem fs, final Path initialPath,
-    final boolean primaryReplica) throws IOException {
-    this(conf, fs, null, initialPath, primaryReplica);
-  }
-
   private StoreFileInfo(final Configuration conf, final FileSystem fs, final FileStatus fileStatus,
-    final Path initialPath, final boolean primaryReplica) throws IOException {
+    final Path initialPath, final boolean primaryReplica, final StoreFileTracker sft)
+    throws IOException {
     assert fs != null;
     assert initialPath != null;
     assert conf != null;
@@ -142,7 +133,7 @@ public class StoreFileInfo implements Configurable {
       this.link = HFileLink.buildFromHFileLinkPattern(conf, p);
       LOG.trace("{} is a link", p);
     } else if (isReference(p)) {
-      this.reference = Reference.read(fs, p);
+      this.reference = sft.readReference(p);
       Path referencePath = getReferredToFile(p);
       if (HFileLink.isHFileLink(referencePath)) {
         // HFileLink Reference
@@ -167,17 +158,6 @@ public class StoreFileInfo implements Configurable {
     } else {
       throw new IOException("path=" + p + " doesn't look like a valid StoreFile");
     }
-  }
-
-  /**
-   * Create a Store File Info
-   * @param conf       the {@link Configuration} to use
-   * @param fs         The current file system to use.
-   * @param fileStatus The {@link FileStatus} of the file
-   */
-  public StoreFileInfo(final Configuration conf, final FileSystem fs, final FileStatus fileStatus)
-    throws IOException {
-    this(conf, fs, fileStatus, fileStatus.getPath(), true);
   }
 
   /**
@@ -218,6 +198,29 @@ public class StoreFileInfo implements Configurable {
     this.primaryReplica = false;
     this.initialPath = (fileStatus == null) ? null : fileStatus.getPath();
     this.createdTimestamp = (fileStatus == null) ? 0 : fileStatus.getModificationTime();
+    this.reference = reference;
+    this.link = link;
+    this.noReadahead =
+      this.conf.getBoolean(STORE_FILE_READER_NO_READAHEAD, DEFAULT_STORE_FILE_READER_NO_READAHEAD);
+  }
+
+  /**
+   * Create a Store File Info from an HFileLink and a Reference
+   * @param conf       The {@link Configuration} to use
+   * @param fs         The current file system to use
+   * @param fileStatus The {@link FileStatus} of the file
+   * @param reference  The reference instance
+   * @param link       The link instance
+   */
+  public StoreFileInfo(final Configuration conf, final FileSystem fs, final long createdTimestamp,
+    final Path initialPath, final long size, final Reference reference, final HFileLink link,
+    final boolean primaryReplica) {
+    this.fs = fs;
+    this.conf = conf;
+    this.primaryReplica = primaryReplica;
+    this.initialPath = initialPath;
+    this.createdTimestamp = createdTimestamp;
+    this.size = size;
     this.reference = reference;
     this.link = link;
     this.noReadahead =
@@ -780,6 +783,16 @@ public class StoreFileInfo implements Configurable {
 
   int decreaseRefCount() {
     return this.refCount.decrementAndGet();
+  }
+
+  public static StoreFileInfo createStoreFileInfoForHFile(final Configuration conf,
+    final FileSystem fs, final Path initialPath, final boolean primaryReplica) throws IOException {
+    if (HFileLink.isHFileLink(initialPath) || isReference(initialPath)) {
+      throw new InvalidHFileException("Path " + initialPath + " is a Hfile link or a Regerence");
+    }
+    StoreFileInfo storeFileInfo =
+      new StoreFileInfo(conf, fs, null, initialPath, primaryReplica, null);
+    return storeFileInfo;
   }
 
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/DefaultStoreFileTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/DefaultStoreFileTracker.java
@@ -18,13 +18,21 @@
 package org.apache.hadoop.hbase.regionserver.storefiletracker;
 
 import java.io.IOException;
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.regionserver.StoreContext;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.ServerRegionReplicaUtil;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * The default implementation for store file tracker, where we do not persist the store file list,
@@ -36,6 +44,8 @@ class DefaultStoreFileTracker extends StoreFileTrackerBase {
   public DefaultStoreFileTracker(Configuration conf, boolean isPrimaryReplica, StoreContext ctx) {
     super(conf, isPrimaryReplica, ctx);
   }
+
+  private static final Logger LOG = LoggerFactory.getLogger(DefaultStoreFileTracker.class);
 
   @Override
   public boolean requireWritingToTmpDirFirst() {
@@ -55,12 +65,48 @@ class DefaultStoreFileTracker extends StoreFileTrackerBase {
 
   @Override
   protected List<StoreFileInfo> doLoadStoreFiles(boolean readOnly) throws IOException {
-    List<StoreFileInfo> files =
-      ctx.getRegionFileSystem().getStoreFiles(ctx.getFamily().getNameAsString());
+    List<StoreFileInfo> files = getStoreFiles(ctx.getFamily().getNameAsString());
     return files != null ? files : Collections.emptyList();
   }
 
   @Override
   protected void doSetStoreFiles(Collection<StoreFileInfo> files) throws IOException {
+  }
+
+  /**
+   * Returns the store files available for the family. This methods performs the filtering based on
+   * the valid store files.
+   * @param familyName Column Family Name
+   * @return a set of {@link StoreFileInfo} for the specified family.
+   */
+  public List<StoreFileInfo> getStoreFiles(final String familyName) throws IOException {
+    Path familyDir = ctx.getRegionFileSystem().getStoreDir(familyName);
+    FileStatus[] files =
+      CommonFSUtils.listStatus(ctx.getRegionFileSystem().getFileSystem(), familyDir);
+    if (files == null) {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("No StoreFiles for: " + familyDir);
+      }
+      return null;
+    }
+
+    ArrayList<StoreFileInfo> storeFiles = new ArrayList<>(files.length);
+    for (FileStatus status : files) {
+      if (!StoreFileInfo.isValid(status)) {
+        // recovered.hfiles directory is expected inside CF path when
+        // hbase.wal.split.to.hfile to
+        // true, refer HBASE-23740
+        if (!HConstants.RECOVERED_HFILES_DIR.equals(status.getPath().getName())) {
+          LOG.warn("Invalid StoreFile: {}", status.getPath());
+        }
+        continue;
+      }
+      StoreFileInfo info = ServerRegionReplicaUtil.getStoreFileInfo(conf,
+        ctx.getRegionFileSystem().getFileSystem(), ctx.getRegionInfo(),
+        ctx.getRegionFileSystem().getRegionInfoForFS(), familyName, status.getPath(), this);
+      storeFiles.add(info);
+
+    }
+    return storeFiles;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTracker.java
@@ -20,7 +20,10 @@ package org.apache.hadoop.hbase.regionserver.storefiletracker;
 import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.io.Reference;
 import org.apache.hadoop.hbase.regionserver.CreateStoreFileWriterParams;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
@@ -94,4 +97,26 @@ public interface StoreFileTracker {
    * does not allow broken store files under the actual data directory.
    */
   boolean requireWritingToTmpDirFirst();
+
+  Reference createReference(Reference reference, Path path) throws IOException;
+
+  /**
+   * Reads the reference file from the given path.
+   * @param path the {@link Path} to the reference file in the file system.
+   * @return a {@link Reference} that points at top/bottom half of a an hfile
+   */
+  Reference readReference(Path path) throws IOException;
+
+  /**
+   * Returns true if the specified family has reference files
+   * @return true if family contains reference files
+   */
+  boolean hasReferences() throws IOException;
+
+  StoreFileInfo getStoreFileInfo(final FileStatus fileStatus, final Path initialPath,
+    final boolean primaryReplica) throws IOException;
+
+  StoreFileInfo getStoreFileInfo(final Path initialPath, final boolean primaryReplica)
+    throws IOException;
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerFactory.java
@@ -129,10 +129,16 @@ public final class StoreFileTrackerFactory {
    */
   public static StoreFileTracker create(Configuration conf, TableDescriptor td,
     ColumnFamilyDescriptor cfd, HRegionFileSystem regionFs) {
+    return create(conf, td, cfd, regionFs, true);
+  }
+
+  public static StoreFileTracker create(Configuration conf, TableDescriptor td,
+    ColumnFamilyDescriptor cfd, HRegionFileSystem regionFs, boolean isPrimaryReplica) {
     StoreContext ctx =
       StoreContext.getBuilder().withColumnFamilyDescriptor(cfd).withRegionFileSystem(regionFs)
         .withFamilyStoreDirectoryPath(regionFs.getStoreDir(cfd.getNameAsString())).build();
-    return StoreFileTrackerFactory.create(mergeConfigurations(conf, td, cfd), true, ctx);
+    return StoreFileTrackerFactory.create(mergeConfigurations(conf, td, cfd), isPrimaryReplica,
+      ctx);
   }
 
   private static Configuration mergeConfigurations(Configuration global, TableDescriptor table,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotManifestV1.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotManifestV1.java
@@ -30,9 +30,13 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.FSUtils;
@@ -119,7 +123,7 @@ public final class SnapshotManifestV1 {
 
   static List<SnapshotRegionManifest> loadRegionManifests(final Configuration conf,
     final Executor executor, final FileSystem fs, final Path snapshotDir,
-    final SnapshotDescription desc) throws IOException {
+    final SnapshotDescription desc, final TableDescriptor htd) throws IOException {
     FileStatus[] regions =
       CommonFSUtils.listStatus(fs, snapshotDir, new FSUtils.RegionDirFilter(fs));
     if (regions == null) {
@@ -134,7 +138,7 @@ public final class SnapshotManifestV1 {
         @Override
         public SnapshotRegionManifest call() throws IOException {
           RegionInfo hri = HRegionFileSystem.loadRegionInfoFileContent(fs, region.getPath());
-          return buildManifestFromDisk(conf, fs, snapshotDir, hri);
+          return buildManifestFromDisk(conf, fs, snapshotDir, hri, htd);
         }
       });
     }
@@ -159,7 +163,8 @@ public final class SnapshotManifestV1 {
   }
 
   static SnapshotRegionManifest buildManifestFromDisk(final Configuration conf, final FileSystem fs,
-    final Path tableDir, final RegionInfo regionInfo) throws IOException {
+    final Path tableDir, final RegionInfo regionInfo, final TableDescriptor htd)
+    throws IOException {
     HRegionFileSystem regionFs =
       HRegionFileSystem.openRegionFromFileSystem(conf, fs, tableDir, regionInfo, true);
     SnapshotRegionManifest.Builder manifest = SnapshotRegionManifest.newBuilder();
@@ -179,7 +184,9 @@ public final class SnapshotManifestV1 {
     Collection<String> familyNames = regionFs.getFamilies();
     if (familyNames != null) {
       for (String familyName : familyNames) {
-        Collection<StoreFileInfo> storeFiles = regionFs.getStoreFiles(familyName, false);
+        StoreFileTracker sft = StoreFileTrackerFactory.create(conf, htd,
+          htd.getColumnFamily(familyName.getBytes()), regionFs, false);
+        List<StoreFileInfo> storeFiles = getStoreFiles(sft, regionFs, familyName, false);
         if (storeFiles == null) {
           LOG.debug("No files under family: " + familyName);
           continue;
@@ -209,5 +216,33 @@ public final class SnapshotManifestV1 {
       }
     }
     return manifest.build();
+  }
+
+  public static List<StoreFileInfo> getStoreFiles(StoreFileTracker sft, HRegionFileSystem regionFS,
+    String familyName, boolean validate) throws IOException {
+    Path familyDir = new Path(regionFS.getRegionDir(), familyName);
+    FileStatus[] files = CommonFSUtils.listStatus(regionFS.getFileSystem(), familyDir);
+    if (files == null) {
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("No StoreFiles for: " + familyDir);
+      }
+      return null;
+    }
+
+    ArrayList<StoreFileInfo> storeFiles = new ArrayList<>(files.length);
+    for (FileStatus status : files) {
+      if (validate && !StoreFileInfo.isValid(status)) {
+        // recovered.hfiles directory is expected inside CF path when hbase.wal.split.to.hfile to
+        // true, refer HBASE-23740
+        if (!HConstants.RECOVERED_HFILES_DIR.equals(status.getPath().getName())) {
+          LOG.warn("Invalid StoreFile: {}", status.getPath());
+        }
+        continue;
+      }
+      StoreFileInfo info = sft.getStoreFileInfo(status.getPath(), false);
+      storeFiles.add(info);
+
+    }
+    return storeFiles;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ServerRegionReplicaUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ServerRegionReplicaUtil.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hbase.io.HFileLink;
 import org.apache.hadoop.hbase.io.Reference;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -119,12 +120,12 @@ public class ServerRegionReplicaUtil extends RegionReplicaUtil {
    * archive after compaction
    */
   public static StoreFileInfo getStoreFileInfo(Configuration conf, FileSystem fs,
-    RegionInfo regionInfo, RegionInfo regionInfoForFs, String familyName, Path path)
-    throws IOException {
+    RegionInfo regionInfo, RegionInfo regionInfoForFs, String familyName, Path path,
+    StoreFileTracker tracker) throws IOException {
 
     // if this is a primary region, just return the StoreFileInfo constructed from path
     if (RegionInfo.COMPARATOR.compare(regionInfo, regionInfoForFs) == 0) {
-      return new StoreFileInfo(conf, fs, path, true);
+      return tracker.getStoreFileInfo(path, true);
     }
 
     // else create a store file link. The link file does not exists on filesystem though.
@@ -133,7 +134,7 @@ public class ServerRegionReplicaUtil extends RegionReplicaUtil {
         regionInfoForFs.getEncodedName(), familyName, path.getName());
       return new StoreFileInfo(conf, fs, link.getFileStatus(fs), link);
     } else if (StoreFileInfo.isReference(path)) {
-      Reference reference = Reference.read(fs, path);
+      Reference reference = tracker.readReference(path);
       Path referencePath = StoreFileInfo.getReferredToFile(path);
       if (HFileLink.isHFileLink(referencePath)) {
         // HFileLink Reference

--- a/hbase-server/src/main/resources/hbase-webapps/regionserver/storeFile.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/regionserver/storeFile.jsp
@@ -54,7 +54,7 @@
      printer.setConf(conf);
      String[] options = {"-s"};
      printer.parseOptions(options);
-     StoreFileInfo sfi = new StoreFileInfo(conf, fs, new Path(storeFile), true);
+     StoreFileInfo sfi = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, new Path(storeFile), true);
      printer.processFile(sfi.getFileStatus().getPath(), true);
      String text = byteStream.toString();%>
      <%=

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/TestHalfStoreFileReader.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/TestHalfStoreFileReader.java
@@ -24,6 +24,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -39,7 +40,10 @@ import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.KeyValueUtil;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
@@ -49,8 +53,12 @@ import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
 import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
 import org.apache.hadoop.hbase.nio.RefCnt;
+import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.StoreContext;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.testclassification.IOTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -99,8 +107,12 @@ public class TestHalfStoreFileReader {
     String root_dir = TEST_UTIL.getDataTestDir().toString();
     Path parentPath = new Path(new Path(root_dir, "parent"), "CF");
     fs.mkdirs(parentPath);
-    Path splitAPath = new Path(new Path(root_dir, "splita"), "CF");
-    Path splitBPath = new Path(new Path(root_dir, "splitb"), "CF");
+    String tableName = Paths.get(root_dir).getFileName().toString();
+    RegionInfo splitAHri = RegionInfoBuilder.newBuilder(TableName.valueOf(tableName)).build();
+    Thread.currentThread().sleep(1000);
+    RegionInfo splitBHri = RegionInfoBuilder.newBuilder(TableName.valueOf(tableName)).build();
+    Path splitAPath = new Path(new Path(root_dir, splitAHri.getRegionNameAsString()), "CF");
+    Path splitBPath = new Path(new Path(root_dir, splitBHri.getRegionNameAsString()), "CF");
     Path filePath = StoreFileWriter.getUniqueFile(fs, parentPath);
     String ioEngineName = "file:" + TEST_UTIL.getDataTestDir() + "/bucketNoRecycler.cache";
     BucketCache bucketCache = new BucketCache(ioEngineName, 32 * 1024 * 1024, 1024,
@@ -139,12 +151,24 @@ public class TestHalfStoreFileReader {
     Path splitFileA = new Path(splitAPath, filePath.getName() + ".parent");
     Path splitFileB = new Path(splitBPath, filePath.getName() + ".parent");
 
+    HRegionFileSystem splitAregionFS =
+      HRegionFileSystem.create(conf, fs, new Path(root_dir), splitAHri);
+    StoreContext splitAStoreContext =
+      StoreContext.getBuilder().withColumnFamilyDescriptor(ColumnFamilyDescriptorBuilder.of("CF"))
+        .withFamilyStoreDirectoryPath(splitAPath).withRegionFileSystem(splitAregionFS).build();
+    StoreFileTracker splitAsft = StoreFileTrackerFactory.create(conf, false, splitAStoreContext);
     Reference bottom = new Reference(midkey, Reference.Range.bottom);
-    bottom.write(fs, splitFileA);
+    splitAsft.createReference(bottom, splitFileA);
     doTestOfScanAndReseek(splitFileA, fs, bottom, cacheConf);
 
+    HRegionFileSystem splitBregionFS =
+      HRegionFileSystem.create(conf, fs, new Path(root_dir), splitBHri);
+    StoreContext splitBStoreContext =
+      StoreContext.getBuilder().withColumnFamilyDescriptor(ColumnFamilyDescriptorBuilder.of("CF"))
+        .withFamilyStoreDirectoryPath(splitBPath).withRegionFileSystem(splitBregionFS).build();
+    StoreFileTracker splitBsft = StoreFileTrackerFactory.create(conf, false, splitBStoreContext);
     Reference top = new Reference(midkey, Reference.Range.top);
-    top.write(fs, splitFileB);
+    splitBsft.createReference(top, splitFileB);
     doTestOfScanAndReseek(splitFileB, fs, top, cacheConf);
 
     r.close();
@@ -162,7 +186,8 @@ public class TestHalfStoreFileReader {
       new ReaderContextBuilder().withInputStreamWrapper(in).withFileSize(length)
         .withReaderType(ReaderContext.ReaderType.PREAD).withFileSystem(fs).withFilePath(p);
     ReaderContext context = contextBuilder.build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(TEST_UTIL.getConfiguration(), fs, p, true);
+    StoreFileInfo storeFileInfo =
+      new StoreFileInfo(TEST_UTIL.getConfiguration(), fs, fs.getFileStatus(p), bottom);
     storeFileInfo.initHFileInfo(context);
     final HalfStoreFileReader halfreader =
       (HalfStoreFileReader) storeFileInfo.createReader(context, cacheConf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
@@ -70,9 +70,12 @@ import org.apache.hadoop.hbase.regionserver.ConstantSizeRegionSplitPolicy;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.regionserver.HStoreFile;
 import org.apache.hadoop.hbase.regionserver.PrefetchExecutorNotifier;
+import org.apache.hadoop.hbase.regionserver.StoreContext;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
 import org.apache.hadoop.hbase.regionserver.TestHStoreFile;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.testclassification.IOTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.trace.TraceUtil;
@@ -399,11 +402,14 @@ public class TestPrefetch {
     Path storeFile = fileWithSplitPoint.getFirst();
     HRegionFileSystem regionFS =
       HRegionFileSystem.createRegionOnFileSystem(conf, fs, tableDir, region);
-    HStoreFile file = new HStoreFile(fs, storeFile, conf, cacheConf, BloomType.NONE, true);
+    StoreFileTracker sft = StoreFileTrackerFactory.create(conf, true,
+      StoreContext.getBuilder().withFamilyStoreDirectoryPath(new Path(regionDir, "cf"))
+        .withRegionFileSystem(regionFS).build());
+    HStoreFile file = new HStoreFile(fs, storeFile, conf, cacheConf, BloomType.NONE, true, sft);
     Path ref = regionFS.splitStoreFile(region, "cf", file, fileWithSplitPoint.getSecond(), false,
-      new ConstantSizeRegionSplitPolicy());
+      new ConstantSizeRegionSplitPolicy(), sft);
     conf.setBoolean(HBASE_REGION_SERVER_ENABLE_COMPACTION, compactionEnabled);
-    HStoreFile refHsf = new HStoreFile(this.fs, ref, conf, cacheConf, BloomType.NONE, true);
+    HStoreFile refHsf = new HStoreFile(this.fs, ref, conf, cacheConf, BloomType.NONE, true, sft);
     refHsf.initReader();
     HFile.Reader reader = refHsf.getReader().getHFileReader();
     while (!reader.prefetchComplete()) {
@@ -440,13 +446,21 @@ public class TestPrefetch {
       Bytes.toBytes("testPrefetchWhenHFileLink"));
 
     Path storeFilePath = regionFs.commitStoreFile("cf", writer.getPath());
-    Path dstPath = new Path(regionFs.getTableDir(), new Path("test-region", "cf"));
+    final RegionInfo dstHri =
+      RegionInfoBuilder.newBuilder(TableName.valueOf("testPrefetchWhenHFileLink")).build();
+    HRegionFileSystem dstRegionFs = HRegionFileSystem.createRegionOnFileSystem(testConf, fs,
+      CommonFSUtils.getTableDir(testDir, dstHri.getTable()), dstHri);
+    Path dstPath = new Path(regionFs.getTableDir(), new Path(dstHri.getRegionNameAsString(), "cf"));
     HFileLink.create(testConf, this.fs, dstPath, hri, storeFilePath.getName());
     Path linkFilePath =
       new Path(dstPath, HFileLink.createHFileLinkName(hri, storeFilePath.getName()));
 
+    StoreFileTracker sft = StoreFileTrackerFactory.create(testConf, false,
+      StoreContext.getBuilder()
+        .withFamilyStoreDirectoryPath(new Path(dstRegionFs.getRegionDir(), "cf"))
+        .withRegionFileSystem(dstRegionFs).build());
     // Try to open store file from link
-    StoreFileInfo storeFileInfo = new StoreFileInfo(testConf, this.fs, linkFilePath, true);
+    StoreFileInfo storeFileInfo = sft.getStoreFileInfo(linkFilePath, true);
     HStoreFile hsf = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     assertTrue(storeFileInfo.isLink());
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestCachedMobFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestCachedMobFile.java
@@ -30,6 +30,9 @@ import org.apache.hadoop.hbase.KeyValue.Type;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.regionserver.HStoreFile;
+import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -69,8 +72,11 @@ public class TestCachedMobFile {
     HFileContext meta = new HFileContextBuilder().withBlockSize(8 * 1024).build();
     StoreFileWriter writer = new StoreFileWriter.Builder(conf, cacheConf, fs).withOutputDir(testDir)
       .withFileContext(meta).build();
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
     MobTestUtil.writeStoreFile(writer, caseName);
-    CachedMobFile cachedMobFile = CachedMobFile.create(fs, writer.getPath(), conf, cacheConf);
+    CachedMobFile cachedMobFile =
+      new CachedMobFile(new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf));
     assertEquals(EXPECTED_REFERENCE_ZERO, cachedMobFile.getReferenceCount());
     cachedMobFile.open();
     assertEquals(EXPECTED_REFERENCE_ONE, cachedMobFile.getReferenceCount());
@@ -93,12 +99,18 @@ public class TestCachedMobFile {
     StoreFileWriter writer1 = new StoreFileWriter.Builder(conf, cacheConf, fs)
       .withOutputDir(outputDir1).withFileContext(meta).build();
     MobTestUtil.writeStoreFile(writer1, caseName);
-    CachedMobFile cachedMobFile1 = CachedMobFile.create(fs, writer1.getPath(), conf, cacheConf);
+    StoreFileInfo storeFileInfo1 =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer1.getPath(), true);
+    CachedMobFile cachedMobFile1 =
+      new CachedMobFile(new HStoreFile(storeFileInfo1, BloomType.NONE, cacheConf));
     Path outputDir2 = new Path(testDir, FAMILY2);
     StoreFileWriter writer2 = new StoreFileWriter.Builder(conf, cacheConf, fs)
       .withOutputDir(outputDir2).withFileContext(meta).build();
     MobTestUtil.writeStoreFile(writer2, caseName);
-    CachedMobFile cachedMobFile2 = CachedMobFile.create(fs, writer2.getPath(), conf, cacheConf);
+    StoreFileInfo storeFileInfo2 =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer2.getPath(), true);
+    CachedMobFile cachedMobFile2 =
+      new CachedMobFile(new HStoreFile(storeFileInfo2, BloomType.NONE, cacheConf));
     cachedMobFile1.access(1);
     cachedMobFile2.access(2);
     assertEquals(1, cachedMobFile1.compareTo(cachedMobFile2));
@@ -115,7 +127,10 @@ public class TestCachedMobFile {
       .withFileContext(meta).build();
     String caseName = testName.getMethodName();
     MobTestUtil.writeStoreFile(writer, caseName);
-    CachedMobFile cachedMobFile = CachedMobFile.create(fs, writer.getPath(), conf, cacheConf);
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    CachedMobFile cachedMobFile =
+      new CachedMobFile(new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf));
     byte[] family = Bytes.toBytes(caseName);
     byte[] qualify = Bytes.toBytes(caseName);
     // Test the start key

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestExpiredMobFileCleaner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestExpiredMobFileCleaner.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.util.ToolRunner;
 import org.junit.After;
@@ -43,6 +44,8 @@ import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @Category(MediumTests.class)
 public class TestExpiredMobFileCleaner {
@@ -58,6 +61,7 @@ public class TestExpiredMobFileCleaner {
   private final static byte[] row2 = Bytes.toBytes("row2");
   private final static byte[] row3 = Bytes.toBytes("row3");
   private final static byte[] qf = Bytes.toBytes("qf");
+  private static final Logger LOG = LoggerFactory.getLogger(TestExpiredMobFileCleaner.class);
 
   private static BufferedMutator table;
   private static Admin admin;
@@ -135,6 +139,9 @@ public class TestExpiredMobFileCleaner {
     byte[] dummyData = makeDummyData(600);
     long ts = EnvironmentEdgeManager.currentTime() - 3 * secondsOfDay() * 1000; // 3 days before
     putKVAndFlush(table, row1, dummyData, ts);
+    LOG.info("test log to be deleted, tablename is " + tableName);
+    CommonFSUtils.logFileSystemState(TEST_UTIL.getTestFileSystem(),
+      TEST_UTIL.getDefaultRootDirPath(), LOG);
     FileStatus[] firstFiles = TEST_UTIL.getTestFileSystem().listStatus(mobDirPath);
     // the first mob file
     assertEquals("Before cleanup without delay 1", 1, firstFiles.length);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestMobFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestMobFile.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.regionserver.HStoreFile;
+import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileScanner;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
@@ -67,8 +68,9 @@ public class TestMobFile {
     String caseName = testName.getMethodName();
     MobTestUtil.writeStoreFile(writer, caseName);
 
-    MobFile mobFile =
-      new MobFile(new HStoreFile(fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true));
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    MobFile mobFile = new MobFile(new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf));
     byte[] family = Bytes.toBytes(caseName);
     byte[] qualify = Bytes.toBytes(caseName);
 
@@ -116,8 +118,9 @@ public class TestMobFile {
       .withFileContext(meta).build();
     MobTestUtil.writeStoreFile(writer, testName.getMethodName());
 
-    MobFile mobFile =
-      new MobFile(new HStoreFile(fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true));
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    MobFile mobFile = new MobFile(new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf));
     assertNotNull(mobFile.getScanner());
     assertTrue(mobFile.getScanner() instanceof StoreFileScanner);
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/AbstractTestDateTieredCompactionPolicy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/AbstractTestDateTieredCompactionPolicy.java
@@ -26,6 +26,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.hbase.regionserver.compactions.DateTieredCompactionPolicy;
 import org.apache.hadoop.hbase.regionserver.compactions.DateTieredCompactionRequest;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerForTest;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.ManualEnvironmentEdge;
 
@@ -46,9 +47,11 @@ public class AbstractTestDateTieredCompactionPolicy extends TestCompactionPolicy
     }
 
     ArrayList<HStoreFile> ret = Lists.newArrayList();
+    StoreFileTrackerForTest storeFileTrackerForTest =
+      new StoreFileTrackerForTest(conf, true, store.getStoreContext());
     for (int i = 0; i < sizes.length; i++) {
-      MockHStoreFile msf =
-        new MockHStoreFile(TEST_UTIL, TEST_FILE, sizes[i], ageInDisk.get(i), false, i);
+      MockHStoreFile msf = new MockHStoreFile(TEST_UTIL, TEST_FILE, sizes[i], ageInDisk.get(i),
+        false, i, storeFileTrackerForTest);
       msf.setTimeRangeTracker(
         TimeRangeTracker.create(TimeRangeTracker.Type.SYNC, minTimestamps[i], maxTimestamps[i]));
       ret.add(msf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DataBlockEncodingTool.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/DataBlockEncodingTool.java
@@ -582,7 +582,8 @@ public class DataBlockEncodingTool {
     Path path = new Path(hfilePath);
     CacheConfig cacheConf = new CacheConfig(conf);
     FileSystem fs = FileSystem.get(conf);
-    HStoreFile hsf = new HStoreFile(fs, path, conf, cacheConf, BloomType.NONE, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, path, true);
+    HStoreFile hsf = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     hsf.initReader();
     StoreFileReader reader = hsf.getReader();
     reader.loadFileInfo();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/EncodedSeekPerformanceTest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/EncodedSeekPerformanceTest.java
@@ -58,8 +58,9 @@ public class EncodedSeekPerformanceTest {
     List<ExtendedCell> allKeyValues = new ArrayList<>();
 
     // read all of the key values
-    HStoreFile storeFile = new HStoreFile(testingUtility.getTestFileSystem(), path, configuration,
-      cacheConf, BloomType.NONE, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(configuration,
+      testingUtility.getTestFileSystem(), path, true);
+    HStoreFile storeFile = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     storeFile.initReader();
     StoreFileReader reader = storeFile.getReader();
     StoreFileScanner scanner = reader.getStoreFileScanner(true, false, false, 0, 0, false);
@@ -87,8 +88,9 @@ public class EncodedSeekPerformanceTest {
   private void runTest(Path path, DataBlockEncoding blockEncoding, List<ExtendedCell> seeks)
     throws IOException {
     // read all of the key values
-    HStoreFile storeFile = new HStoreFile(testingUtility.getTestFileSystem(), path, configuration,
-      cacheConf, BloomType.NONE, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(configuration,
+      testingUtility.getTestFileSystem(), path, true);
+    HStoreFile storeFile = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     storeFile.initReader();
     long totalSize = 0;
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/MockHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/MockHStoreFile.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.regionserver;
 
 import java.io.IOException;
+import java.net.UnknownHostException;
 import java.util.Arrays;
 import java.util.Map;
 import java.util.Optional;
@@ -31,6 +32,7 @@ import org.apache.hadoop.hbase.ExtendedCellBuilderFactory;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HDFSBlocksDistribution;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
@@ -53,9 +55,13 @@ public class MockHStoreFile extends HStoreFile {
   boolean compactedAway;
 
   MockHStoreFile(HBaseTestingUtil testUtil, Path testPath, long length, long ageInDisk,
-    boolean isRef, long sequenceid) throws IOException {
-    super(testUtil.getTestFileSystem(), testPath, testUtil.getConfiguration(),
-      new CacheConfig(testUtil.getConfiguration()), BloomType.NONE, true);
+    boolean isRef, long sequenceid, StoreFileInfo storeFileInfo) throws IOException {
+    super(storeFileInfo, BloomType.NONE, new CacheConfig(testUtil.getConfiguration()));
+    setMockHStoreFileVals(length, isRef, ageInDisk, sequenceid, isMajor, testUtil);
+  }
+
+  private void setMockHStoreFileVals(long length, boolean isRef, long ageInDisk, long sequenceid,
+    boolean isMajor, HBaseTestingUtil testUtil) throws UnknownHostException {
     this.length = length;
     this.isRef = isRef;
     this.ageInDisk = ageInDisk;
@@ -66,6 +72,13 @@ public class MockHStoreFile extends HStoreFile {
       new String[] { DNS.getHostname(testUtil.getConfiguration(), DNS.ServerType.REGIONSERVER) },
       1);
     modificationTime = EnvironmentEdgeManager.currentTime();
+  }
+
+  MockHStoreFile(HBaseTestingUtil testUtil, Path testPath, long length, long ageInDisk,
+    boolean isRef, long sequenceid, StoreFileTracker tracker) throws IOException {
+    super(testUtil.getTestFileSystem(), testPath, testUtil.getConfiguration(),
+      new CacheConfig(testUtil.getConfiguration()), BloomType.NONE, true, tracker);
+    setMockHStoreFileVals(length, isRef, ageInDisk, sequenceid, isMajor, testUtil);
   }
 
   void setLength(long newLen) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCacheOnWriteInSchema.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCacheOnWriteInSchema.java
@@ -219,7 +219,8 @@ public class TestCacheOnWriteInSchema {
   private void readStoreFile(Path path) throws IOException {
     CacheConfig cacheConf = store.getCacheConfig();
     BlockCache cache = cacheConf.getBlockCache().get();
-    HStoreFile sf = new HStoreFile(fs, path, conf, cacheConf, BloomType.ROWCOL, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, path, true);
+    HStoreFile sf = new HStoreFile(storeFileInfo, BloomType.ROWCOL, cacheConf);
     sf.initReader();
     HFile.Reader reader = sf.getReader().getHFileReader();
     try {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompactionArchiveIOException.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompactionArchiveIOException.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerForTest;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
@@ -155,7 +156,10 @@ public class TestCompactionArchiveIOException {
     out.writeInt(1);
     out.close();
 
-    HStoreFile errStoreFile = new MockHStoreFile(testUtil, errFile, 1, 0, false, 1);
+    StoreFileTrackerForTest storeFileTrackerForTest =
+      new StoreFileTrackerForTest(store.getReadOnlyConfiguration(), true, store.getStoreContext());
+    HStoreFile errStoreFile =
+      new MockHStoreFile(testUtil, errFile, 1, 0, false, 1, storeFileTrackerForTest);
     fileManager.addCompactionResults(ImmutableList.of(errStoreFile), ImmutableList.of());
 
     // cleanup compacted files

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompactionPolicy.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompactionPolicy.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionConfiguration;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequestImpl;
 import org.apache.hadoop.hbase.regionserver.compactions.RatioBasedCompactionPolicy;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerForTest;
 import org.apache.hadoop.hbase.regionserver.wal.FSHLog;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
@@ -169,9 +170,11 @@ public class TestCompactionPolicy {
   List<HStoreFile> sfCreate(boolean isReference, ArrayList<Long> sizes, ArrayList<Long> ageInDisk)
     throws IOException {
     List<HStoreFile> ret = Lists.newArrayList();
+    StoreFileTrackerForTest storeFileTrackerForTest =
+      new StoreFileTrackerForTest(conf, true, store.getStoreContext());
     for (int i = 0; i < sizes.size(); i++) {
-      ret.add(
-        new MockHStoreFile(TEST_UTIL, TEST_FILE, sizes.get(i), ageInDisk.get(i), isReference, i));
+      ret.add(new MockHStoreFile(TEST_UTIL, TEST_FILE, sizes.get(i), ageInDisk.get(i), isReference,
+        i, storeFileTrackerForTest));
     }
     return ret;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompoundBloomFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompoundBloomFilter.java
@@ -197,7 +197,8 @@ public class TestCompoundBloomFilter {
 
   private void readStoreFile(int t, BloomType bt, List<KeyValue> kvs, Path sfPath)
     throws IOException {
-    HStoreFile sf = new HStoreFile(fs, sfPath, conf, cacheConf, bt, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, sfPath, true);
+    HStoreFile sf = new HStoreFile(storeFileInfo, bt, cacheConf);
     sf.initReader();
     StoreFileReader r = sf.getReader();
     final boolean pread = true; // does not really matter

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDirectStoreSplitsMerges.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDirectStoreSplitsMerges.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertTrue;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
@@ -34,6 +35,8 @@ import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.master.assignment.SplitTableRegionProcedure;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
 import org.apache.hadoop.hbase.procedure2.Procedure;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -84,8 +87,11 @@ public class TestDirectStoreSplitsMerges {
         .setRegionId(region.getRegionInfo().getRegionId() + EnvironmentEdgeManager.currentTime())
         .build();
     HStoreFile file = (HStoreFile) region.getStore(FAMILY_NAME).getStorefiles().toArray()[0];
+    StoreFileTracker sft =
+      StoreFileTrackerFactory.create(TEST_UTIL.getHBaseCluster().getMaster().getConfiguration(),
+        true, region.getStores().get(0).getStoreContext());
     Path result = regionFS.splitStoreFile(daughterA, Bytes.toString(FAMILY_NAME), file,
-      Bytes.toBytes("002"), false, region.getSplitPolicy());
+      Bytes.toBytes("002"), false, region.getSplitPolicy(), sft);
     // asserts the reference file naming is correct
     validateResultingFile(region.getRegionInfo().getEncodedName(), result);
     // Additionally check if split region dir was created directly under table dir, not on .tmp
@@ -113,16 +119,18 @@ public class TestDirectStoreSplitsMerges {
         .setRegionId(first.getRegionInfo().getRegionId() + EnvironmentEdgeManager.currentTime())
         .build();
 
-    HRegionFileSystem mergeRegionFs = HRegionFileSystem.createRegionOnFileSystem(
-      TEST_UTIL.getHBaseCluster().getMaster().getConfiguration(), regionFS.getFileSystem(),
-      regionFS.getTableDir(), mergeResult);
+    Configuration configuration = TEST_UTIL.getHBaseCluster().getMaster().getConfiguration();
+    HRegionFileSystem mergeRegionFs = HRegionFileSystem.createRegionOnFileSystem(configuration,
+      regionFS.getFileSystem(), regionFS.getTableDir(), mergeResult);
 
     // merge file from first region
     HStoreFile file = (HStoreFile) first.getStore(FAMILY_NAME).getStorefiles().toArray()[0];
-    mergeFileFromRegion(mergeRegionFs, first, file);
+    mergeFileFromRegion(mergeRegionFs, first, file, StoreFileTrackerFactory.create(configuration,
+      true, first.getStore(FAMILY_NAME).getStoreContext()));
     // merge file from second region
     file = (HStoreFile) second.getStore(FAMILY_NAME).getStorefiles().toArray()[0];
-    mergeFileFromRegion(mergeRegionFs, second, file);
+    mergeFileFromRegion(mergeRegionFs, second, file, StoreFileTrackerFactory.create(configuration,
+      true, second.getStore(FAMILY_NAME).getStoreContext()));
   }
 
   @Test
@@ -163,11 +171,14 @@ public class TestDirectStoreSplitsMerges {
     Path splitDirB = regionFS.getSplitsDir(daughterB);
     HStoreFile file = (HStoreFile) region.getStore(FAMILY_NAME).getStorefiles().toArray()[0];
     List<Path> filesA = new ArrayList<>();
+    StoreFileTracker sft =
+      StoreFileTrackerFactory.create(TEST_UTIL.getHBaseCluster().getMaster().getConfiguration(),
+        true, region.getStores().get(0).getStoreContext());
     filesA.add(regionFS.splitStoreFile(daughterA, Bytes.toString(FAMILY_NAME), file,
-      Bytes.toBytes("002"), false, region.getSplitPolicy()));
+      Bytes.toBytes("002"), false, region.getSplitPolicy(), sft));
     List<Path> filesB = new ArrayList<>();
     filesB.add(regionFS.splitStoreFile(daughterB, Bytes.toString(FAMILY_NAME), file,
-      Bytes.toBytes("002"), true, region.getSplitPolicy()));
+      Bytes.toBytes("002"), true, region.getSplitPolicy(), sft));
     MasterProcedureEnv env =
       TEST_UTIL.getMiniHBaseCluster().getMaster().getMasterProcedureExecutor().getEnvironment();
     Path resultA = regionFS.commitDaughterRegion(daughterA, filesA, env);
@@ -196,17 +207,19 @@ public class TestDirectStoreSplitsMerges {
         .setRegionId(first.getRegionInfo().getRegionId() + EnvironmentEdgeManager.currentTime())
         .build();
 
-    HRegionFileSystem mergeRegionFs = HRegionFileSystem.createRegionOnFileSystem(
-      TEST_UTIL.getHBaseCluster().getMaster().getConfiguration(), regionFS.getFileSystem(),
-      regionFS.getTableDir(), mergeResult);
+    Configuration configuration = TEST_UTIL.getHBaseCluster().getMaster().getConfiguration();
+    HRegionFileSystem mergeRegionFs = HRegionFileSystem.createRegionOnFileSystem(configuration,
+      regionFS.getFileSystem(), regionFS.getTableDir(), mergeResult);
 
     // merge file from first region
     HStoreFile file = (HStoreFile) first.getStore(FAMILY_NAME).getStorefiles().toArray()[0];
-    mergeFileFromRegion(mergeRegionFs, first, file);
+    mergeFileFromRegion(mergeRegionFs, first, file, StoreFileTrackerFactory.create(configuration,
+      true, first.getStore(FAMILY_NAME).getStoreContext()));
     // merge file from second region
     file = (HStoreFile) second.getStore(FAMILY_NAME).getStorefiles().toArray()[0];
     List<Path> mergedFiles = new ArrayList<>();
-    mergedFiles.add(mergeFileFromRegion(mergeRegionFs, second, file));
+    mergedFiles.add(mergeFileFromRegion(mergeRegionFs, second, file, StoreFileTrackerFactory
+      .create(configuration, true, second.getStore(FAMILY_NAME).getStoreContext())));
     MasterProcedureEnv env =
       TEST_UTIL.getMiniHBaseCluster().getMaster().getMasterProcedureExecutor().getEnvironment();
     mergeRegionFs.commitMergedRegion(mergedFiles, env);
@@ -229,9 +242,9 @@ public class TestDirectStoreSplitsMerges {
   }
 
   private Path mergeFileFromRegion(HRegionFileSystem regionFS, HRegion regionToMerge,
-    HStoreFile file) throws IOException {
-    Path mergedFile =
-      regionFS.mergeStoreFile(regionToMerge.getRegionInfo(), Bytes.toString(FAMILY_NAME), file);
+    HStoreFile file, StoreFileTracker sft) throws IOException {
+    Path mergedFile = regionFS.mergeStoreFile(regionToMerge.getRegionInfo(),
+      Bytes.toString(FAMILY_NAME), file, sft);
     validateResultingFile(regionToMerge.getRegionInfo().getEncodedName(), mergedFile);
     return mergedFile;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestFSErrorsExposed.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestFSErrorsExposed.java
@@ -95,8 +95,9 @@ public class TestFSErrorsExposed {
       .withOutputDir(hfilePath).withFileContext(meta).build();
     TestHStoreFile.writeStoreFile(writer, Bytes.toBytes("cf"), Bytes.toBytes("qual"));
 
-    HStoreFile sf = new HStoreFile(fs, writer.getPath(), util.getConfiguration(), cacheConf,
-      BloomType.NONE, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(util.getConfiguration(),
+      fs, writer.getPath(), true);
+    HStoreFile sf = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     sf.initReader();
     StoreFileReader reader = sf.getReader();
     try (HFileScanner scanner = reader.getScanner(false, true, false)) {
@@ -140,8 +141,9 @@ public class TestFSErrorsExposed {
       .withOutputDir(hfilePath).withFileContext(meta).build();
     TestHStoreFile.writeStoreFile(writer, Bytes.toBytes("cf"), Bytes.toBytes("qual"));
 
-    HStoreFile sf = new HStoreFile(fs, writer.getPath(), util.getConfiguration(), cacheConf,
-      BloomType.NONE, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(util.getConfiguration(),
+      fs, writer.getPath(), true);
+    HStoreFile sf = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
 
     List<StoreFileScanner> scanners = StoreFileScanner.getScannersForStoreFiles(
       Collections.singletonList(sf), false, true, false, false,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
@@ -149,6 +149,8 @@ import org.apache.hadoop.hbase.regionserver.Region.Operation;
 import org.apache.hadoop.hbase.regionserver.Region.RowLock;
 import org.apache.hadoop.hbase.regionserver.TestHStore.FaultyFileSystem;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequestImpl;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.regionserver.wal.AbstractFSWAL;
 import org.apache.hadoop.hbase.regionserver.wal.AsyncFSWAL;
 import org.apache.hadoop.hbase.regionserver.wal.FSHLog;
@@ -5709,8 +5711,14 @@ public class TestHRegion {
       // move the file of the primary region to the archive, simulating a compaction
       Collection<HStoreFile> storeFiles = primaryRegion.getStore(families[0]).getStorefiles();
       primaryRegion.getRegionFileSystem().removeStoreFiles(Bytes.toString(families[0]), storeFiles);
-      Collection<StoreFileInfo> storeFileInfos =
-        primaryRegion.getRegionFileSystem().getStoreFiles(Bytes.toString(families[0]));
+      HRegionFileSystem regionFs = primaryRegion.getRegionFileSystem();
+      StoreFileTracker sft = StoreFileTrackerFactory.create(primaryRegion.getBaseConf(), false,
+        StoreContext.getBuilder()
+          .withColumnFamilyDescriptor(ColumnFamilyDescriptorBuilder.newBuilder(families[0]).build())
+          .withFamilyStoreDirectoryPath(
+            new Path(regionFs.getRegionDir(), Bytes.toString(families[0])))
+          .withRegionFileSystem(regionFs).build());
+      Collection<StoreFileInfo> storeFileInfos = sft.load();
       Assert.assertTrue(storeFileInfos == null || storeFileInfos.isEmpty());
 
       verifyData(secondaryRegion, 0, 1000, cq, families);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
@@ -119,6 +119,8 @@ import org.apache.hadoop.hbase.regionserver.compactions.CompactionContext;
 import org.apache.hadoop.hbase.regionserver.compactions.DefaultCompactor;
 import org.apache.hadoop.hbase.regionserver.compactions.EverythingPolicy;
 import org.apache.hadoop.hbase.regionserver.querymatcher.ScanQueryMatcher;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.regionserver.throttle.NoLimitThroughputController;
 import org.apache.hadoop.hbase.regionserver.throttle.ThroughputController;
 import org.apache.hadoop.hbase.security.User;
@@ -786,8 +788,8 @@ public class TestHStore {
 
         LOG.info("Before flush, we should have no files");
 
-        Collection<StoreFileInfo> files =
-          store.getRegionFileSystem().getStoreFiles(store.getColumnFamilyName());
+        StoreFileTracker sft = StoreFileTrackerFactory.create(conf, false, store.getStoreContext());
+        Collection<StoreFileInfo> files = sft.load();
         assertEquals(0, files != null ? files.size() : 0);
 
         // flush
@@ -800,7 +802,7 @@ public class TestHStore {
         }
 
         LOG.info("After failed flush, we should still have no files!");
-        files = store.getRegionFileSystem().getStoreFiles(store.getColumnFamilyName());
+        files = sft.load();
         assertEquals(0, files != null ? files.size() : 0);
         store.getHRegion().getWAL().close();
         return null;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStoreFile.java
@@ -82,6 +82,8 @@ import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
 import org.apache.hadoop.hbase.io.hfile.UncompressedBlockSizePredicator;
 import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.util.BloomFilterFactory;
@@ -163,8 +165,12 @@ public class TestHStoreFile {
     writeStoreFile(writer);
 
     Path sfPath = regionFs.commitStoreFile(TEST_FAMILY, writer.getPath());
-    HStoreFile sf = new HStoreFile(this.fs, sfPath, conf, cacheConf, BloomType.NONE, true);
-    checkHalfHFile(regionFs, sf);
+    StoreFileTracker sft = StoreFileTrackerFactory.create(conf, false,
+      StoreContext.getBuilder()
+        .withFamilyStoreDirectoryPath(new Path(regionFs.getRegionDir(), TEST_FAMILY))
+        .withRegionFileSystem(regionFs).build());
+    HStoreFile sf = new HStoreFile(this.fs, sfPath, conf, cacheConf, BloomType.NONE, true, sft);
+    checkHalfHFile(regionFs, sf, sft);
   }
 
   private void writeStoreFile(final StoreFileWriter writer) throws IOException {
@@ -229,7 +235,11 @@ public class TestHStoreFile {
     writeStoreFile(writer);
 
     Path hsfPath = regionFs.commitStoreFile(TEST_FAMILY, writer.getPath());
-    HStoreFile hsf = new HStoreFile(this.fs, hsfPath, conf, cacheConf, BloomType.NONE, true);
+    StoreFileTracker sft = StoreFileTrackerFactory.create(conf, false,
+      StoreContext.getBuilder()
+        .withFamilyStoreDirectoryPath(new Path(regionFs.getRegionDir(), TEST_FAMILY))
+        .withRegionFileSystem(regionFs).build());
+    HStoreFile hsf = new HStoreFile(this.fs, hsfPath, conf, cacheConf, BloomType.NONE, true, sft);
     hsf.initReader();
     StoreFileReader reader = hsf.getReader();
     // Split on a row, not in middle of row. Midkey returned by reader
@@ -241,8 +251,9 @@ public class TestHStoreFile {
 
     // Make a reference
     RegionInfo splitHri = RegionInfoBuilder.newBuilder(hri.getTable()).setEndKey(midRow).build();
-    Path refPath = splitStoreFile(regionFs, splitHri, TEST_FAMILY, hsf, midRow, true);
-    HStoreFile refHsf = new HStoreFile(this.fs, refPath, conf, cacheConf, BloomType.NONE, true);
+    Path refPath = splitStoreFile(regionFs, splitHri, TEST_FAMILY, hsf, midRow, true, sft);
+    HStoreFile refHsf =
+      new HStoreFile(this.fs, refPath, conf, cacheConf, BloomType.NONE, true, sft);
     refHsf.initReader();
     // Now confirm that I can read from the reference and that it only gets
     // keys from top half of the file.
@@ -276,8 +287,11 @@ public class TestHStoreFile {
     writeStoreFile(writer);
     Path hsfPath = regionFs.commitStoreFile(TEST_FAMILY, writer.getPath());
     writer.close();
-
-    HStoreFile file = new HStoreFile(this.fs, hsfPath, conf, cacheConf, BloomType.NONE, true);
+    StoreFileTracker sft = StoreFileTrackerFactory.create(conf, false,
+      StoreContext.getBuilder()
+        .withFamilyStoreDirectoryPath(new Path(regionFs.getRegionDir(), TEST_FAMILY))
+        .withRegionFileSystem(regionFs).build());
+    HStoreFile file = new HStoreFile(this.fs, hsfPath, conf, cacheConf, BloomType.NONE, true, sft);
     file.initReader();
     StoreFileReader r = file.getReader();
     assertNotNull(r);
@@ -315,6 +329,10 @@ public class TestHStoreFile {
     CommonFSUtils.setRootDir(testConf, testDir);
     HRegionFileSystem regionFs = HRegionFileSystem.createRegionOnFileSystem(testConf, fs,
       CommonFSUtils.getTableDir(testDir, hri.getTable()), hri);
+    final RegionInfo dstHri =
+      RegionInfoBuilder.newBuilder(TableName.valueOf("testHFileLinkTb")).build();
+    HRegionFileSystem dstRegionFs = HRegionFileSystem.createRegionOnFileSystem(testConf, fs,
+      CommonFSUtils.getTableDir(testDir, dstHri.getTable()), dstHri);
     HFileContext meta = new HFileContextBuilder().withBlockSize(8 * 1024).build();
 
     // Make a store file and write data to it.
@@ -323,13 +341,22 @@ public class TestHStoreFile {
     writeStoreFile(writer);
 
     Path storeFilePath = regionFs.commitStoreFile(TEST_FAMILY, writer.getPath());
-    Path dstPath = new Path(regionFs.getTableDir(), new Path("test-region", TEST_FAMILY));
+    Path dstPath =
+      new Path(regionFs.getTableDir(), new Path(dstHri.getRegionNameAsString(), TEST_FAMILY));
     HFileLink.create(testConf, this.fs, dstPath, hri, storeFilePath.getName());
     Path linkFilePath =
       new Path(dstPath, HFileLink.createHFileLinkName(hri, storeFilePath.getName()));
 
     // Try to open store file from link
-    StoreFileInfo storeFileInfo = new StoreFileInfo(testConf, this.fs, linkFilePath, true);
+
+    // this should be the SFT for the destination link file path, though it is not
+    // being used right now, for the next patch file link creation logic also would
+    // move to SFT interface.
+    StoreFileTracker sft = StoreFileTrackerFactory.create(testConf, false,
+      StoreContext.getBuilder()
+        .withFamilyStoreDirectoryPath(new Path(dstHri.getRegionNameAsString(), TEST_FAMILY))
+        .withRegionFileSystem(dstRegionFs).build());
+    StoreFileInfo storeFileInfo = sft.getStoreFileInfo(linkFilePath, true);
     HStoreFile hsf = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     assertTrue(storeFileInfo.isLink());
     hsf.initReader();
@@ -343,6 +370,13 @@ public class TestHStoreFile {
       }
     }
     assertEquals((LAST_CHAR - FIRST_CHAR + 1) * (LAST_CHAR - FIRST_CHAR + 1), count);
+  }
+
+  @Test
+  public void testsample() {
+    Path p1 = new Path("/r1/c1");
+    Path p2 = new Path("f1");
+    System.out.println(new Path(p1, p2).toString());
   }
 
   /**
@@ -382,10 +416,30 @@ public class TestHStoreFile {
     RegionInfo splitHriA = RegionInfoBuilder.newBuilder(hri.getTable()).setEndKey(SPLITKEY).build();
     RegionInfo splitHriB =
       RegionInfoBuilder.newBuilder(hri.getTable()).setStartKey(SPLITKEY).build();
-    HStoreFile f = new HStoreFile(fs, linkFilePath, testConf, cacheConf, BloomType.NONE, true);
+
+    StoreFileTracker sft = StoreFileTrackerFactory.create(testConf, true,
+      StoreContext.getBuilder()
+        .withFamilyStoreDirectoryPath(new Path(hriClone.getRegionNameAsString(), TEST_FAMILY))
+        .withRegionFileSystem(cloneRegionFs).build());
+
+    HRegionFileSystem splitRegionAFs = HRegionFileSystem.createRegionOnFileSystem(testConf, fs,
+      CommonFSUtils.getTableDir(testDir, splitHriA.getTable()), splitHriA);
+    StoreFileTracker sftA = StoreFileTrackerFactory.create(testConf, true,
+      StoreContext.getBuilder()
+        .withFamilyStoreDirectoryPath(new Path(splitHriA.getRegionNameAsString(), TEST_FAMILY))
+        .withRegionFileSystem(splitRegionAFs).build());
+    HRegionFileSystem splitRegionBFs = HRegionFileSystem.createRegionOnFileSystem(testConf, fs,
+      CommonFSUtils.getTableDir(testDir, splitHriB.getTable()), splitHriB);
+    StoreFileTracker sftB = StoreFileTrackerFactory.create(testConf, true,
+      StoreContext.getBuilder()
+        .withFamilyStoreDirectoryPath(new Path(splitHriB.getRegionNameAsString(), TEST_FAMILY))
+        .withRegionFileSystem(splitRegionBFs).build());
+    HStoreFile f = new HStoreFile(fs, linkFilePath, testConf, cacheConf, BloomType.NONE, true, sft);
     f.initReader();
-    Path pathA = splitStoreFile(cloneRegionFs, splitHriA, TEST_FAMILY, f, SPLITKEY, true); // top
-    Path pathB = splitStoreFile(cloneRegionFs, splitHriB, TEST_FAMILY, f, SPLITKEY, false);// bottom
+    // top
+    Path pathA = splitStoreFile(cloneRegionFs, splitHriA, TEST_FAMILY, f, SPLITKEY, true, sft);
+    // bottom
+    Path pathB = splitStoreFile(cloneRegionFs, splitHriB, TEST_FAMILY, f, SPLITKEY, false, sft);
     f.closeStoreFile(true);
     // OK test the thing
     CommonFSUtils.logFileSystemState(fs, testDir, LOG);
@@ -394,7 +448,8 @@ public class TestHStoreFile {
     // reference to a hfile link. This code in StoreFile that handles this case.
 
     // Try to open store file from link
-    HStoreFile hsfA = new HStoreFile(this.fs, pathA, testConf, cacheConf, BloomType.NONE, true);
+    HStoreFile hsfA =
+      new HStoreFile(this.fs, pathA, testConf, cacheConf, BloomType.NONE, true, sftA);
     hsfA.initReader();
 
     // Now confirm that I can read from the ref to link
@@ -408,7 +463,8 @@ public class TestHStoreFile {
     }
 
     // Try to open store file from link
-    HStoreFile hsfB = new HStoreFile(this.fs, pathB, testConf, cacheConf, BloomType.NONE, true);
+    HStoreFile hsfB =
+      new HStoreFile(this.fs, pathB, testConf, cacheConf, BloomType.NONE, true, sftB);
     hsfB.initReader();
 
     // Now confirm that I can read from the ref to link
@@ -423,8 +479,8 @@ public class TestHStoreFile {
     assertEquals((LAST_CHAR - FIRST_CHAR + 1) * (LAST_CHAR - FIRST_CHAR + 1), count);
   }
 
-  private void checkHalfHFile(final HRegionFileSystem regionFs, final HStoreFile f)
-    throws IOException {
+  private void checkHalfHFile(final HRegionFileSystem regionFs, final HStoreFile f,
+    StoreFileTracker sft) throws IOException {
     f.initReader();
     Cell midkey = f.getReader().midKey().get();
     KeyValue midKV = (KeyValue) midkey;
@@ -434,16 +490,17 @@ public class TestHStoreFile {
     // Create top split.
     RegionInfo topHri =
       RegionInfoBuilder.newBuilder(regionFs.getRegionInfo().getTable()).setEndKey(SPLITKEY).build();
-    Path topPath = splitStoreFile(regionFs, topHri, TEST_FAMILY, f, midRow, true);
+    Path topPath = splitStoreFile(regionFs, topHri, TEST_FAMILY, f, midRow, true, sft);
     // Create bottom split.
     RegionInfo bottomHri = RegionInfoBuilder.newBuilder(regionFs.getRegionInfo().getTable())
       .setStartKey(SPLITKEY).build();
-    Path bottomPath = splitStoreFile(regionFs, bottomHri, TEST_FAMILY, f, midRow, false);
+    Path bottomPath = splitStoreFile(regionFs, bottomHri, TEST_FAMILY, f, midRow, false, sft);
     // Make readers on top and bottom.
-    HStoreFile topF = new HStoreFile(this.fs, topPath, conf, cacheConf, BloomType.NONE, true);
+    HStoreFile topF = new HStoreFile(this.fs, topPath, conf, cacheConf, BloomType.NONE, true, sft);
     topF.initReader();
     StoreFileReader top = topF.getReader();
-    HStoreFile bottomF = new HStoreFile(this.fs, bottomPath, conf, cacheConf, BloomType.NONE, true);
+    HStoreFile bottomF =
+      new HStoreFile(this.fs, bottomPath, conf, cacheConf, BloomType.NONE, true, sft);
     bottomF.initReader();
     StoreFileReader bottom = bottomF.getReader();
     ByteBuffer previous = null;
@@ -501,12 +558,12 @@ public class TestHStoreFile {
       // properly.
       byte[] badmidkey = Bytes.toBytes("  .");
       assertTrue(fs.exists(f.getPath()));
-      topPath = splitStoreFile(regionFs, topHri, TEST_FAMILY, f, badmidkey, true);
-      bottomPath = splitStoreFile(regionFs, bottomHri, TEST_FAMILY, f, badmidkey, false);
+      topPath = splitStoreFile(regionFs, topHri, TEST_FAMILY, f, badmidkey, true, sft);
+      bottomPath = splitStoreFile(regionFs, bottomHri, TEST_FAMILY, f, badmidkey, false, sft);
 
       assertNull(bottomPath);
 
-      topF = new HStoreFile(this.fs, topPath, conf, cacheConf, BloomType.NONE, true);
+      topF = new HStoreFile(this.fs, topPath, conf, cacheConf, BloomType.NONE, true, sft);
       topF.initReader();
       top = topF.getReader();
       // Now read from the top.
@@ -543,11 +600,11 @@ public class TestHStoreFile {
 
       // Test when badkey is > than last key in file ('||' > 'zz').
       badmidkey = Bytes.toBytes("|||");
-      topPath = splitStoreFile(regionFs, topHri, TEST_FAMILY, f, badmidkey, true);
-      bottomPath = splitStoreFile(regionFs, bottomHri, TEST_FAMILY, f, badmidkey, false);
+      topPath = splitStoreFile(regionFs, topHri, TEST_FAMILY, f, badmidkey, true, sft);
+      bottomPath = splitStoreFile(regionFs, bottomHri, TEST_FAMILY, f, badmidkey, false, sft);
       assertNull(topPath);
 
-      bottomF = new HStoreFile(this.fs, bottomPath, conf, cacheConf, BloomType.NONE, true);
+      bottomF = new HStoreFile(this.fs, bottomPath, conf, cacheConf, BloomType.NONE, true, sft);
       bottomF.initReader();
       bottom = bottomF.getReader();
       first = true;
@@ -605,7 +662,7 @@ public class TestHStoreFile {
     writer.close();
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, f, true);
     storeFileInfo.initHFileInfo(context);
     StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
     storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
@@ -694,7 +751,7 @@ public class TestHStoreFile {
     writer.close();
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, f, true);
     storeFileInfo.initHFileInfo(context);
     StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
     storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
@@ -747,7 +804,7 @@ public class TestHStoreFile {
     writer.close();
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, f, true);
     storeFileInfo.initHFileInfo(context);
     StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
     storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
@@ -811,7 +868,7 @@ public class TestHStoreFile {
       ReaderContext context =
         new ReaderContextBuilder().withFilePath(f).withFileSize(fs.getFileStatus(f).getLen())
           .withFileSystem(fs).withInputStreamWrapper(new FSDataInputStreamWrapper(fs, f)).build();
-      StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
+      StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, f, true);
       storeFileInfo.initHFileInfo(context);
       StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
       storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
@@ -949,8 +1006,9 @@ public class TestHStoreFile {
     writer.appendMetadata(0, false);
     writer.close();
 
-    HStoreFile hsf =
-      new HStoreFile(this.fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true);
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    HStoreFile hsf = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     HStore store = mock(HStore.class);
     when(store.getColumnFamilyDescriptor()).thenReturn(ColumnFamilyDescriptorBuilder.of(family));
     hsf.initReader();
@@ -1004,13 +1062,14 @@ public class TestHStoreFile {
     CacheConfig cacheConf = new CacheConfig(conf, bc);
     Path pathCowOff = new Path(baseDir, "123456789");
     StoreFileWriter writer = writeStoreFile(conf, cacheConf, pathCowOff, 3);
-    HStoreFile hsf =
-      new HStoreFile(this.fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true);
-    LOG.debug(hsf.getPath().toString());
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    HStoreFile hsfCowOff = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
+    LOG.debug(hsfCowOff.getPath().toString());
 
     // Read this file, we should see 3 misses
-    hsf.initReader();
-    StoreFileReader reader = hsf.getReader();
+    hsfCowOff.initReader();
+    StoreFileReader reader = hsfCowOff.getReader();
     reader.loadFileInfo();
     StoreFileScanner scanner = getStoreFileScanner(reader, true, true);
     scanner.seek(KeyValue.LOWESTKEY);
@@ -1029,11 +1088,12 @@ public class TestHStoreFile {
     cacheConf = new CacheConfig(conf, bc);
     Path pathCowOn = new Path(baseDir, "123456788");
     writer = writeStoreFile(conf, cacheConf, pathCowOn, 3);
-    hsf = new HStoreFile(this.fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true);
+    storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    HStoreFile hsfCowOn = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
 
     // Read this file, we should see 3 hits
-    hsf.initReader();
-    reader = hsf.getReader();
+    hsfCowOn.initReader();
+    reader = hsfCowOn.getReader();
     scanner = getStoreFileScanner(reader, true, true);
     scanner.seek(KeyValue.LOWESTKEY);
     while (scanner.next() != null) {
@@ -1047,15 +1107,13 @@ public class TestHStoreFile {
     reader.close(cacheConf.shouldEvictOnClose());
 
     // Let's read back the two files to ensure the blocks exactly match
-    hsf = new HStoreFile(this.fs, pathCowOff, conf, cacheConf, BloomType.NONE, true);
-    hsf.initReader();
-    StoreFileReader readerOne = hsf.getReader();
+    hsfCowOff.initReader();
+    StoreFileReader readerOne = hsfCowOff.getReader();
     readerOne.loadFileInfo();
     StoreFileScanner scannerOne = getStoreFileScanner(readerOne, true, true);
     scannerOne.seek(KeyValue.LOWESTKEY);
-    hsf = new HStoreFile(this.fs, pathCowOn, conf, cacheConf, BloomType.NONE, true);
-    hsf.initReader();
-    StoreFileReader readerTwo = hsf.getReader();
+    hsfCowOn.initReader();
+    StoreFileReader readerTwo = hsfCowOn.getReader();
     readerTwo.loadFileInfo();
     StoreFileScanner scannerTwo = getStoreFileScanner(readerTwo, true, true);
     scannerTwo.seek(KeyValue.LOWESTKEY);
@@ -1084,9 +1142,8 @@ public class TestHStoreFile {
     // Let's close the first file with evict on close turned on
     conf.setBoolean("hbase.rs.evictblocksonclose", true);
     cacheConf = new CacheConfig(conf, bc);
-    hsf = new HStoreFile(this.fs, pathCowOff, conf, cacheConf, BloomType.NONE, true);
-    hsf.initReader();
-    reader = hsf.getReader();
+    hsfCowOff.initReader();
+    reader = hsfCowOff.getReader();
     reader.close(cacheConf.shouldEvictOnClose());
 
     // We should have 3 new evictions but the evict count stat should not change. Eviction because
@@ -1098,9 +1155,8 @@ public class TestHStoreFile {
     // Let's close the second file with evict on close turned off
     conf.setBoolean("hbase.rs.evictblocksonclose", false);
     cacheConf = new CacheConfig(conf, bc);
-    hsf = new HStoreFile(this.fs, pathCowOn, conf, cacheConf, BloomType.NONE, true);
-    hsf.initReader();
-    reader = hsf.getReader();
+    hsfCowOn.initReader();
+    reader = hsfCowOn.getReader();
     reader.close(cacheConf.shouldEvictOnClose());
 
     // We expect no changes
@@ -1110,9 +1166,9 @@ public class TestHStoreFile {
   }
 
   private Path splitStoreFile(final HRegionFileSystem regionFs, final RegionInfo hri,
-    final String family, final HStoreFile sf, final byte[] splitKey, boolean isTopRef)
-    throws IOException {
-    Path path = regionFs.splitStoreFile(hri, family, sf, splitKey, isTopRef, null);
+    final String family, final HStoreFile sf, final byte[] splitKey, boolean isTopRef,
+    StoreFileTracker sft) throws IOException {
+    Path path = regionFs.splitStoreFile(hri, family, sf, splitKey, isTopRef, null, sft);
     if (null == path) {
       return null;
     }
@@ -1179,8 +1235,9 @@ public class TestHStoreFile {
       .withFilePath(path).withMaxKeyCount(2000).withFileContext(meta).build();
     writer.close();
 
-    HStoreFile storeFile =
-      new HStoreFile(fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true);
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    HStoreFile storeFile = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     storeFile.initReader();
     StoreFileReader reader = storeFile.getReader();
 
@@ -1208,8 +1265,9 @@ public class TestHStoreFile {
       .withFilePath(path).withMaxKeyCount(2000).withFileContext(meta).build();
     writeStoreFile(writer);
 
-    HStoreFile storeFile =
-      new HStoreFile(fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true);
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    HStoreFile storeFile = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     storeFile.initReader();
     StoreFileReader reader = storeFile.getReader();
 
@@ -1267,8 +1325,9 @@ public class TestHStoreFile {
     writeLargeStoreFile(writer, Bytes.toBytes(name.getMethodName()),
       Bytes.toBytes(name.getMethodName()), 200);
     writer.close();
-    HStoreFile storeFile =
-      new HStoreFile(fs, writer.getPath(), conf, cacheConf, BloomType.NONE, true);
+    StoreFileInfo storeFileInfo =
+      StoreFileInfo.createStoreFileInfoForHFile(conf, fs, writer.getPath(), true);
+    HStoreFile storeFile = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
     storeFile.initReader();
     HFile.Reader fReader =
       HFile.createReader(fs, writer.getPath(), storeFile.getCacheConf(), true, conf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestReversibleScanners.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestReversibleScanners.java
@@ -122,8 +122,9 @@ public class TestReversibleScanners {
           .withOutputDir(hfilePath).withFileContext(hFileContext).build();
       writeStoreFile(writer);
 
-      HStoreFile sf = new HStoreFile(fs, writer.getPath(), TEST_UTIL.getConfiguration(), cacheConf,
-        BloomType.NONE, true);
+      StoreFileInfo storeFileInfo = StoreFileInfo
+        .createStoreFileInfoForHFile(TEST_UTIL.getConfiguration(), fs, writer.getPath(), true);
+      HStoreFile sf = new HStoreFile(storeFileInfo, BloomType.NONE, cacheConf);
 
       List<StoreFileScanner> scanners = StoreFileScanner.getScannersForStoreFiles(
         Collections.singletonList(sf), false, true, false, false, Long.MAX_VALUE);
@@ -173,11 +174,13 @@ public class TestReversibleScanners {
     MemStore memstore = new DefaultMemStore();
     writeMemstoreAndStoreFiles(memstore, new StoreFileWriter[] { writer1, writer2 });
 
-    HStoreFile sf1 = new HStoreFile(fs, writer1.getPath(), TEST_UTIL.getConfiguration(), cacheConf,
-      BloomType.NONE, true);
+    StoreFileInfo storeFileInfo1 = StoreFileInfo
+      .createStoreFileInfoForHFile(TEST_UTIL.getConfiguration(), fs, writer1.getPath(), true);
+    HStoreFile sf1 = new HStoreFile(storeFileInfo1, BloomType.NONE, cacheConf);
 
-    HStoreFile sf2 = new HStoreFile(fs, writer2.getPath(), TEST_UTIL.getConfiguration(), cacheConf,
-      BloomType.NONE, true);
+    StoreFileInfo storeFileInfo2 = StoreFileInfo
+      .createStoreFileInfoForHFile(TEST_UTIL.getConfiguration(), fs, writer2.getPath(), true);
+    HStoreFile sf2 = new HStoreFile(storeFileInfo2, BloomType.NONE, cacheConf);
     /**
      * Test without MVCC
      */
@@ -253,11 +256,13 @@ public class TestReversibleScanners {
     MemStore memstore = new DefaultMemStore();
     writeMemstoreAndStoreFiles(memstore, new StoreFileWriter[] { writer1, writer2 });
 
-    HStoreFile sf1 = new HStoreFile(fs, writer1.getPath(), TEST_UTIL.getConfiguration(), cacheConf,
-      BloomType.NONE, true);
+    StoreFileInfo storeFileInfo1 = StoreFileInfo
+      .createStoreFileInfoForHFile(TEST_UTIL.getConfiguration(), fs, writer1.getPath(), true);
+    HStoreFile sf1 = new HStoreFile(storeFileInfo1, BloomType.NONE, cacheConf);
 
-    HStoreFile sf2 = new HStoreFile(fs, writer2.getPath(), TEST_UTIL.getConfiguration(), cacheConf,
-      BloomType.NONE, true);
+    StoreFileInfo storeFileInfo2 = StoreFileInfo
+      .createStoreFileInfoForHFile(TEST_UTIL.getConfiguration(), fs, writer2.getPath(), true);
+    HStoreFile sf2 = new HStoreFile(storeFileInfo2, BloomType.NONE, cacheConf);
 
     ScanInfo scanInfo = new ScanInfo(TEST_UTIL.getConfiguration(), FAMILYNAME, 0, Integer.MAX_VALUE,
       Long.MAX_VALUE, KeepDeletedCells.FALSE, HConstants.DEFAULT_BLOCKSIZE, 0,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRowPrefixBloomFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestRowPrefixBloomFilter.java
@@ -186,7 +186,7 @@ public class TestRowPrefixBloomFilter {
 
     // read the file
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, f, true);
     storeFileInfo.initHFileInfo(context);
     StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
     storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
@@ -259,7 +259,7 @@ public class TestRowPrefixBloomFilter {
     writeStoreFile(f, bt, expKeys);
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, f, true);
     storeFileInfo.initHFileInfo(context);
     StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
     storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
@@ -315,7 +315,7 @@ public class TestRowPrefixBloomFilter {
     writeStoreFile(f, bt, expKeys);
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, f, true);
     storeFileInfo.initHFileInfo(context);
     StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
     storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSplitTransactionOnCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSplitTransactionOnCluster.java
@@ -89,6 +89,8 @@ import org.apache.hadoop.hbase.master.assignment.RegionStates;
 import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionContext;
 import org.apache.hadoop.hbase.regionserver.compactions.CompactionLifeCycleTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.regionserver.throttle.NoLimitThroughputController;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
@@ -952,11 +954,14 @@ public class TestSplitTransactionOnCluster {
       Collection<HStoreFile> storefiles = store.getStorefiles();
       assertEquals(1, storefiles.size());
       assertFalse(region.hasReferences());
-      Path referencePath = region.getRegionFileSystem().splitStoreFile(region.getRegionInfo(), "f",
-        storefiles.iterator().next(), Bytes.toBytes("row1"), false, region.getSplitPolicy());
+      HRegionFileSystem hfs = region.getRegionFileSystem();
+      StoreFileTracker sft = StoreFileTrackerFactory.create(TESTING_UTIL.getConfiguration(), true,
+        store.getStoreContext());
+      Path referencePath = hfs.splitStoreFile(region.getRegionInfo(), "f",
+        storefiles.iterator().next(), Bytes.toBytes("row1"), false, region.getSplitPolicy(), sft);
       assertNull(referencePath);
-      referencePath = region.getRegionFileSystem().splitStoreFile(region.getRegionInfo(), "i_f",
-        storefiles.iterator().next(), Bytes.toBytes("row1"), false, region.getSplitPolicy());
+      referencePath = hfs.splitStoreFile(region.getRegionInfo(), "i_f",
+        storefiles.iterator().next(), Bytes.toBytes("row1"), false, region.getSplitPolicy(), sft);
       assertNotNull(referencePath);
     } finally {
       TESTING_UTIL.deleteTable(tableName);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileInfo.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileInfo.java
@@ -28,10 +28,15 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.io.HFileLink;
 import org.apache.hadoop.hbase.io.Reference;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext.ReaderType;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerForTest;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.junit.ClassRule;
@@ -98,23 +103,6 @@ public class TestStoreFileInfo {
   }
 
   @Test
-  public void testOpenErrorMessageHFileLink() throws IOException, IllegalStateException {
-    // Test file link exception
-    // Try to open nonsense hfilelink. Make sure exception is from HFileLink.
-    Path p = new Path("/hbase/test/0123/cf/testtb=4567-abcd");
-    try (FileSystem fs = FileSystem.get(TEST_UTIL.getConfiguration())) {
-      StoreFileInfo sfi = new StoreFileInfo(TEST_UTIL.getConfiguration(), fs, p, true);
-      try {
-        ReaderContext context = sfi.createReaderContext(false, 1000, ReaderType.PREAD);
-        sfi.createReader(context, null);
-        throw new IllegalStateException();
-      } catch (FileNotFoundException fnfe) {
-        assertTrue(fnfe.getMessage().contains(HFileLink.class.getSimpleName()));
-      }
-    }
-  }
-
-  @Test
   public void testOpenErrorMessageReference() throws IOException {
     // Test file link exception
     // Try to open nonsense hfilelink. Make sure exception is from HFileLink.
@@ -122,8 +110,17 @@ public class TestStoreFileInfo {
     FileSystem fs = FileSystem.get(TEST_UTIL.getConfiguration());
     fs.mkdirs(p.getParent());
     Reference r = Reference.createBottomReference(HConstants.EMPTY_START_ROW);
-    r.write(fs, p);
-    StoreFileInfo sfi = new StoreFileInfo(TEST_UTIL.getConfiguration(), fs, p, true);
+    RegionInfo regionInfo = RegionInfoBuilder.newBuilder(TableName.valueOf("table1")).build();
+    StoreContext storeContext = StoreContext.getBuilder()
+      .withRegionFileSystem(HRegionFileSystem.create(TEST_UTIL.getConfiguration(), fs,
+        TEST_UTIL.getDataTestDirOnTestFS(), regionInfo))
+      .withColumnFamilyDescriptor(
+        ColumnFamilyDescriptorBuilder.newBuilder("cf1".getBytes()).build())
+      .build();
+    StoreFileTrackerForTest storeFileTrackerForTest =
+      new StoreFileTrackerForTest(TEST_UTIL.getConfiguration(), true, storeContext);
+    storeFileTrackerForTest.createReference(r, p);
+    StoreFileInfo sfi = storeFileTrackerForTest.getStoreFileInfo(p, true);
     try {
       ReaderContext context = sfi.createReaderContext(false, 1000, ReaderType.PREAD);
       sfi.createReader(context, null);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileScannerWithTagCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileScannerWithTagCompression.java
@@ -84,7 +84,7 @@ public class TestStoreFileScannerWithTagCompression {
     writer.close();
 
     ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, f).build();
-    StoreFileInfo storeFileInfo = new StoreFileInfo(conf, fs, f, true);
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, f, true);
     storeFileInfo.initHFileInfo(context);
     StoreFileReader reader = storeFileInfo.createReader(context, cacheConf);
     storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScannerClosure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScannerClosure.java
@@ -130,7 +130,8 @@ public class TestStoreScannerClosure {
       region.put(p);
       HStore store = region.getStore(fam);
       // use the lock to manually get a new memstore scanner. this is what
-      // HStore#notifyChangedReadersObservers does under the lock.(lock is not needed here
+      // HStore#notifyChangedReadersObservers does under the lock.(lock is not needed
+      // here
       // since it is just a testcase).
       store.getStoreEngine().readLock();
       final List<KeyValueScanner> memScanners = store.memstore.getScanners(Long.MAX_VALUE);
@@ -215,9 +216,9 @@ public class TestStoreScannerClosure {
     }
   }
 
-  private HStoreFile readStoreFile(Path storeFilePath, Configuration conf) throws Exception {
+  private HStoreFile readStoreFile(StoreFileInfo fileinfo) throws Exception {
     // Open the file reader with block cache disabled.
-    HStoreFile file = new HStoreFile(fs, storeFilePath, conf, cacheConf, BloomType.NONE, true);
+    HStoreFile file = new HStoreFile(fileinfo, BloomType.NONE, cacheConf);
     return file;
   }
 
@@ -228,7 +229,8 @@ public class TestStoreScannerClosure {
     HStoreFile file = null;
     List<HStoreFile> files = new ArrayList<HStoreFile>();
     try {
-      file = readStoreFile(path, CONF);
+      StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(CONF, fs, path, true);
+      file = readStoreFile(storeFileInfo);
       files.add(file);
     } catch (Exception e) {
       // fail test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStripeStoreFileManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStripeStoreFileManager.java
@@ -574,7 +574,10 @@ public class TestStripeStoreFileManager {
     FileSystem fs = TEST_UTIL.getTestFileSystem();
     Path testFilePath = StoreFileWriter.getUniqueFile(fs, CFDIR);
     fs.create(testFilePath).close();
-    MockHStoreFile sf = new MockHStoreFile(TEST_UTIL, testFilePath, size, 0, false, seqNum);
+    StoreFileInfo storeFileInfo = StoreFileInfo
+      .createStoreFileInfoForHFile(TEST_UTIL.getConfiguration(), fs, testFilePath, true);
+    MockHStoreFile sf =
+      new MockHStoreFile(TEST_UTIL, testFilePath, size, 0, false, seqNum, storeFileInfo);
     if (startKey != null) {
       sf.setMetadataValue(StripeStoreFileManager.STRIPE_START_KEY, startKey);
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/FailingStoreFileTrackerForTest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/FailingStoreFileTrackerForTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver.storefiletracker;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.regionserver.StoreContext;
+import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.regionserver.TestStoreFileRefresherChore.FailingHRegionFileSystem;
+
+public class FailingStoreFileTrackerForTest extends DefaultStoreFileTracker {
+
+  FailingStoreFileTrackerForTest(Configuration conf, boolean isPrimaryReplica, StoreContext ctx) {
+    super(conf, isPrimaryReplica, ctx);
+  }
+
+  @Override
+  protected List<StoreFileInfo> doLoadStoreFiles(boolean readOnly) throws IOException {
+    if (ctx.getRegionFileSystem() instanceof FailingHRegionFileSystem) {
+      if (((FailingHRegionFileSystem) ctx.getRegionFileSystem()).fail) {
+        throw new IOException("simulating FS failure");
+      }
+    }
+    return super.doLoadStoreFiles(readOnly);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerForTest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerForTest.java
@@ -27,6 +27,7 @@ import java.util.concurrent.ConcurrentMap;
 import java.util.concurrent.LinkedBlockingQueue;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.io.Reference;
 import org.apache.hadoop.hbase.regionserver.StoreContext;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.slf4j.Logger;
@@ -69,4 +70,10 @@ public class StoreFileTrackerForTest extends DefaultStoreFileTracker {
   public static void clear() {
     trackedFiles.clear();
   }
+
+  @Override
+  public Reference readReference(Path p) throws IOException {
+    return super.readReference(p);
+  }
+
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/snapshot/TestSnapshotStoreFileSize.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/snapshot/TestSnapshotStoreFileSize.java
@@ -31,11 +31,15 @@ import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.master.snapshot.SnapshotManager;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTracker;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
@@ -111,7 +115,10 @@ public class TestSnapshotStoreFileSize {
     for (RegionInfo regionInfo : regionsInfo) {
       HRegionFileSystem hRegionFileSystem =
         HRegionFileSystem.openRegionFromFileSystem(conf, fs, path, regionInfo, true);
-      Collection<StoreFileInfo> storeFilesFS = hRegionFileSystem.getStoreFiles(FAMILY_NAME);
+      ColumnFamilyDescriptor hcd = ColumnFamilyDescriptorBuilder.of(FAMILY_NAME);
+      StoreFileTracker sft =
+        StoreFileTrackerFactory.create(conf, table.getDescriptor(), hcd, hRegionFileSystem);
+      Collection<StoreFileInfo> storeFilesFS = sft.load();
       Iterator<StoreFileInfo> sfIterator = storeFilesFS.iterator();
       while (sfIterator.hasNext()) {
         StoreFileInfo sfi = sfIterator.next();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/compaction/TestMajorCompactionRequest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/compaction/TestMajorCompactionRequest.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerForTest;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.Before;
@@ -95,8 +96,8 @@ public class TestMajorCompactionRequest {
   public void testIfWeHaveNewReferenceFilesButOldStoreFiles() throws Exception {
     // this tests that reference files that are new, but have older timestamps for the files
     // they reference still will get compacted.
-    TableName table = TableName.valueOf("TestMajorCompactor");
-    TableDescriptor htd = UTILITY.createTableDescriptor(table, Bytes.toBytes(FAMILY));
+    TableName tableName = TableName.valueOf("TestMajorCompactor");
+    TableDescriptor htd = UTILITY.createTableDescriptor(tableName, Bytes.toBytes(FAMILY));
     RegionInfo hri = RegionInfoBuilder.newBuilder(htd.getTableName()).build();
     HRegion region =
       HBaseTestingUtil.createRegionAndWAL(hri, rootRegionDir, UTILITY.getConfiguration(), htd);
@@ -111,10 +112,21 @@ public class TestMajorCompactionRequest {
       spy(new MajorCompactionRequest(connection, region.getRegionInfo(), Sets.newHashSet(FAMILY)));
     doReturn(paths).when(majorCompactionRequest).getReferenceFilePaths(any(FileSystem.class),
       any(Path.class));
+    StoreFileTrackerForTest sft = mockSFT(true, storeFiles);
     doReturn(fileSystem).when(majorCompactionRequest).getFileSystem();
+    doReturn(sft).when(majorCompactionRequest).getStoreFileTracker(any(), any());
+    doReturn(UTILITY.getConfiguration()).when(connection).getConfiguration();
     Set<String> result =
       majorCompactionRequest.getStoresRequiringCompaction(Sets.newHashSet("a"), 100);
     assertEquals(FAMILY, Iterables.getOnlyElement(result));
+  }
+
+  protected StoreFileTrackerForTest mockSFT(boolean references, List<StoreFileInfo> storeFiles)
+    throws IOException {
+    StoreFileTrackerForTest sft = mock(StoreFileTrackerForTest.class);
+    doReturn(references).when(sft).hasReferences();
+    doReturn(storeFiles).when(sft).load();
+    return sft;
   }
 
   protected HRegionFileSystem mockFileSystem(RegionInfo info, boolean hasReferenceFiles,
@@ -135,7 +147,6 @@ public class TestMajorCompactionRequest {
     doReturn(info).when(mockSystem).getRegionInfo();
     doReturn(regionStoreDir).when(mockSystem).getStoreDir(FAMILY);
     doReturn(hasReferenceFiles).when(mockSystem).hasReferences(anyString());
-    doReturn(storeFiles).when(mockSystem).getStoreFiles(anyString());
     doReturn(fileSystem).when(mockSystem).getFileSystem();
     return mockSystem;
   }
@@ -165,6 +176,8 @@ public class TestMajorCompactionRequest {
       new MajorCompactionRequest(connection, regionInfo, Sets.newHashSet("a"));
     MajorCompactionRequest spy = spy(request);
     HRegionFileSystem fileSystem = mockFileSystem(regionInfo, references, storeFiles);
+    StoreFileTrackerForTest sft = mockSFT(references, storeFiles);
+    doReturn(sft).when(spy).getStoreFileTracker(any(), any());
     doReturn(fileSystem).when(spy).getFileSystem();
     return spy;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/compaction/TestMajorCompactionTTLRequest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/compaction/TestMajorCompactionTTLRequest.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.util.compaction;
 
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.spy;
@@ -34,6 +35,7 @@ import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerForTest;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.junit.Before;
 import org.junit.ClassRule;
@@ -89,6 +91,8 @@ public class TestMajorCompactionTTLRequest extends TestMajorCompactionRequest {
     MajorCompactionTTLRequest request = new MajorCompactionTTLRequest(connection, regionInfo);
     MajorCompactionTTLRequest spy = spy(request);
     HRegionFileSystem fileSystem = mockFileSystem(regionInfo, false, storeFiles);
+    StoreFileTrackerForTest sft = mockSFT(false, storeFiles);
+    doReturn(sft).when(spy).getStoreFileTracker(any(), any());
     doReturn(fileSystem).when(spy).getFileSystem();
     return spy;
   }


### PR DESCRIPTION
[HBASE-27826](https://issues.apache.org/jira/browse/HBASE-27826) introduces tracking of Link/Reference files with StoreFileTracker interface and with that, we can have the FileBasedStoreFileTracker implementation to track Link/Reference files only using .filelist file itself and not create actual link/ref files (virtual links).

To support the same, we need to refactor all the direct interactions of Ref/Link file creations to SFT layer and this changes starts off with moving the current Reference file operations/logic to StoreFileTrackerBase.
Post that we should be able to override/evolve the representation to handle Virtual Links.

Change detail
1. Modifies HStoreFile constructors to take SFT instance as a parameter.
2. Add apis in SFT to create StoreFileInfo objects and use that everywhere
3. Removes HRegionFileSystem.getStoreFiles(final String familyName, final boolean validate) and helper methods in Snapshot apis itself.
4. Adds hasReferences api in SFT, the idea is to use SFT.hasReferences() instead of HRegionFileSystem.hasReferences(), we haven't moved all file listing to SFT yet and will be handled in a different JIRA.
5. Adds a helper method to create StoreFileInfo for a HFile which is not Reference/HFileLink used for uts.

6. StoreFile.jsp fails to print data for Reference/Link files, this needs a minor refactor, which can be accommodated in the same PR or as part of another jira