### PR TITLE
HBASE-28614 Introduce a field to display whether the snapshot is expired

### DIFF
--- a/hbase-server/src/main/resources/hbase-webapps/master/snapshot.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/snapshot.jsp
@@ -25,6 +25,7 @@
   import="org.apache.hadoop.hbase.http.InfoServer"
   import="org.apache.hadoop.hbase.master.HMaster"
   import="org.apache.hadoop.hbase.snapshot.SnapshotInfo"
+  import="org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils"
   import="org.apache.hadoop.util.StringUtils"
   import="org.apache.hadoop.hbase.TableName"
 %>
@@ -98,6 +99,7 @@
         <th>Type</th>
         <th>Format Version</th>
         <th>State</th>
+        <th>Expired</th>
     </tr>
     <tr>
 
@@ -124,6 +126,9 @@
         <% } else { %>
           <td>ok</td>
         <% } %>
+        <td>
+          <%= SnapshotDescriptionUtils.isExpiredSnapshot(snapshotTtl, snapshot.getCreationTime(), System.currentTimeMillis()) ? "Yes" : "No" %>
+        </td>
     </tr>
   </table>
   <div class="row">

--- a/hbase-server/src/main/resources/hbase-webapps/master/snapshotsStats.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/snapshotsStats.jsp
@@ -26,6 +26,7 @@
   import="org.apache.hadoop.fs.Path"
   import="org.apache.hadoop.hbase.master.HMaster"
   import="org.apache.hadoop.hbase.snapshot.SnapshotInfo"
+  import="org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils"
   import="org.apache.hadoop.hbase.TableName"
   import="org.apache.hadoop.util.StringUtils"
   import="org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos.SnapshotDescription"
@@ -68,6 +69,7 @@
         <th>Creation Time</th>
         <th>Owner</th>
         <th>TTL</th>
+        <th>Expired</th>
         <th>Shared Storefile Size</th>
         <th>Mob Storefile Size</th>
         <th>Archived Storefile Size</th>
@@ -93,6 +95,9 @@
         <%=PrettyPrinter
           .format(String.valueOf(snapshotDesc.getTtl()), PrettyPrinter.Unit.TIME_INTERVAL)%>
         <% } %>
+      </td>
+      <td>
+        <%= SnapshotDescriptionUtils.isExpiredSnapshot(snapshotDesc.getTtl(), snapshotDesc.getCreationTime(), System.currentTimeMillis()) ? "Yes" : "No" %>
       </td>
       <td><%= StringUtils.humanReadableInt(stats.getSharedStoreFilesSize()) %></td>
       <td><%= StringUtils.humanReadableInt(stats.getMobStoreFilesSize())  %></td>

--- a/hbase-server/src/main/resources/hbase-webapps/master/userSnapshots.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/userSnapshots.jsp
@@ -20,6 +20,7 @@
 <%@ page contentType="text/plain;charset=UTF-8"
  import="java.util.List"
  import="java.util.Date"
+ import="org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils"
  import="org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos.SnapshotDescription"
  import="org.apache.hadoop.hbase.master.HMaster"
  import="org.apache.hadoop.hbase.TableName"
@@ -38,6 +39,7 @@
         <th>Creation Time</th>
         <th>Owner</th>
         <th>TTL</th>
+        <th>Expired</th>
     </tr>
     <% for (SnapshotDescription snapshotDesc : snapshots){ %>
     <% TableName snapshotTable = TableName.valueOf(snapshotDesc.getTable()); %>
@@ -50,6 +52,9 @@
 
         <td>
           <%= snapshotDesc.getTtl() == 0 ? "FOREVER": PrettyPrinter.format(String.valueOf(snapshotDesc.getTtl()), PrettyPrinter.Unit.TIME_INTERVAL) %>
+        </td>
+        <td>
+          <%= SnapshotDescriptionUtils.isExpiredSnapshot(snapshotDesc.getTtl(), snapshotDesc.getCreationTime(), System.currentTimeMillis()) ? "Yes" : "No" %>
         </td>
     </tr>
     <% } %>

--- a/hbase-shell/src/main/ruby/shell/commands/list_snapshots.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/list_snapshots.rb
@@ -18,6 +18,8 @@
 
 require 'time'
 
+java_import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils
+
 module Shell
   module Commands
     class ListSnapshots < Command
@@ -34,12 +36,25 @@ EOF
       end
 
       def command(regex = '.*')
-        formatter.header(['SNAPSHOT', 'TABLE + CREATION TIME'])
+        formatter.header(['SNAPSHOT', 'TABLE + CREATION TIME + TTL(Sec)'])
 
         list = admin.list_snapshot(regex)
         list.each do |snapshot|
           creation_time = Time.at(snapshot.getCreationTime / 1000).to_s
-          formatter.row([snapshot.getName, snapshot.getTableNameAsString + ' (' + creation_time + ')'])
+          ttl = snapshot.getTtl
+          if ttl == 0
+            ttl_info = 'FOREVER'
+          else
+            now_timestamp = (Time.now.to_f * 1000).to_i
+            expired = SnapshotDescriptionUtils.isExpiredSnapshot(ttl, snapshot.getCreationTime(), now_timestamp)
+            if expired
+              ttl_info = ttl.to_s + ' (Expired) '
+            else
+              ttl_info = ttl.to_s
+            end
+          end
+          info = snapshot.getTableNameAsString + ' (' + creation_time + ') ' + ttl_info
+          formatter.row([snapshot.getName, info])
         end
 
         formatter.footer(list.size)


### PR DESCRIPTION
Details see: [HBASE-28614](https://issues.apache.org/jira/browse/HBASE-28614)


After applying this commit.

On HBase UI:  
![image](https://github.com/apache/hbase/assets/19660320/0c2dd6e0-5aa8-44d6-8d90-1b9233350752)

![image](https://github.com/apache/hbase/assets/19660320/9f67698b-11e2-4d3b-9922-8a7310325802)

![image](https://github.com/apache/hbase/assets/19660320/d3b55ab5-2a75-4a4e-b51e-2a69a9ff8bd3)

On hbase shell:  
```
hbase:027:0> list_snapshots
SNAPSHOT                                    TABLE + CREATION TIME + TTL(Sec)
 expired_snap01                             t01 (2024-05-26 14:18:16 +0800) 10 (Expired)
 snap01                                     t01 (2024-05-25 22:28:13 +0800) FOREVER
 snap02                                     t01 (2024-05-25 22:28:37 +0800) 100000
3 row(s)
Took 0.0209 seconds
=> ["expired_snap01", "snap01", "snap02"]
```
