### PR TITLE
HBASE-28630 fix the explanation for the configuration of hbase.ipc.sserver.callqueue.read.ratio

### DIFF
--- a/src/main/asciidoc/_chapters/performance.adoc
+++ b/src/main/asciidoc/_chapters/performance.adoc
@@ -261,7 +261,7 @@ Note that you always have at least one write queue, no matter what setting you u
   Given a value of `10` for `hbase.ipc.server.num.callqueue`, 3 queues would be used for reads and 7 for writes.
 * A value of `.5` uses the same number of read queues and write queues.
   Given a value of `10` for `hbase.ipc.server.num.callqueue`, 5 queues would be used for reads and 5 for writes.
-* A value of `.6` uses 60% of the queues for reading and 40% for reading.
+* A value of `.6` uses 60% of the queues for reading and 40% for writing.
   Given a value of `10` for `hbase.ipc.server.num.callqueue`, 6 queues would be used for reads and 4 for writes.
 * A value of `1.0` uses one queue to process write requests, and all other queues process read requests.
   A value higher than `1.0` has the same effect as a value of `1.0`.

--- a/src/main/asciidoc/_chapters/schema_design.adoc
+++ b/src/main/asciidoc/_chapters/schema_design.adoc
@@ -1120,8 +1120,8 @@ If you don't have time to build it both ways and compare, my advice would be to 
 - A value between `0` and `1` allocates the number of queues proportionally to the number of handlers. For instance, a value of `.5` shares one queue between each two handlers.
 * Use `hbase.ipc.server.callqueue.read.ratio` (`hbase.ipc.server.callqueue.read.share` in 0.98) to split the call queues into read and write queues:
 - `0.5` means there will be the same number of read and write queues
-- `< 0.5` for more read than write
-- `> 0.5` for more write than read
+- `< 0.5` for more write than read
+- `> 0.5` for more read than write
 * Set `hbase.ipc.server.callqueue.scan.ratio` (HBase 1.0+)  to split read call queues into small-read and long-read queues:
 - 0.5 means that there will be the same number of short-read and long-read queues
 - `< 0.5` for more short-read


### PR DESCRIPTION
fix the explanation for the configuration of hbase.ipc.sserver.callqueue.read.ratio