### PR TITLE
HBASE-27915: Fixed hadolint check in nightly build.

### DIFF
--- a/dev-support/hbase_docker/m1/Dockerfile
+++ b/dev-support/hbase_docker/m1/Dockerfile
@@ -14,7 +14,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-FROM --platform=linux/amd64 ubuntu:22.04 AS base_image
+FROM amd64/ubuntu:22.04 AS base_image
 SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 
 RUN DEBIAN_FRONTEND=noninteractive apt-get -qq update && \


### PR DESCRIPTION
Tested `hadolint <Dockerfile>` and verified that it doesn't throw any error. 