### PR TITLE
HBASE-28637 asyncwal should attempt to recover lease if close fails

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
@@ -96,6 +96,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.Pair;
+import org.apache.hadoop.hbase.util.RecoverLeaseFSUtils;
 import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
 import org.apache.hadoop.hbase.wal.WAL;
 import org.apache.hadoop.hbase.wal.WALEdit;
@@ -2022,7 +2023,13 @@ public abstract class AbstractFSWAL<W extends WriterBase> implements WAL {
     }
   }
 
-  protected void recoverLease(FileSystem fs, Path p, Configuration conf) {
+  private void recoverLease(FileSystem fs, Path p, Configuration conf) {
+    try {
+      RecoverLeaseFSUtils.recoverFileLease(fs, p, conf, null);
+    } catch (IOException ex) {
+      LOG.error("Unable to recover lease after several attempts. Give up.", ex);
+      throw new RuntimeException(ex);
+    }
   }
 
   protected final void closeWriter(W writer, Path path) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
@@ -2028,7 +2028,6 @@ public abstract class AbstractFSWAL<W extends WriterBase> implements WAL {
       RecoverLeaseFSUtils.recoverFileLease(fs, p, conf, null);
     } catch (IOException ex) {
       LOG.error("Unable to recover lease after several attempts. Give up.", ex);
-      throw new RuntimeException(ex);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AbstractFSWAL.java
@@ -2022,13 +2022,17 @@ public abstract class AbstractFSWAL<W extends WriterBase> implements WAL {
     }
   }
 
+  protected void recoverLease(FileSystem fs, Path p, Configuration conf) {
+  }
+
   protected final void closeWriter(W writer, Path path) {
     inflightWALClosures.put(path.getName(), writer);
     closeExecutor.execute(() -> {
       try {
         writer.close();
       } catch (IOException e) {
-        LOG.warn("close old writer failed", e);
+        LOG.warn("close old writer failed.", e);
+        recoverLease(this.fs, path, conf);
       } finally {
         // call this even if the above close fails, as there is no other chance we can set closed to
         // true, it will not cause big problems.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AsyncFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AsyncFSWAL.java
@@ -29,7 +29,6 @@ import org.apache.hadoop.hbase.Abortable;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.io.asyncfs.AsyncFSOutput;
 import org.apache.hadoop.hbase.io.asyncfs.monitor.StreamSlowMonitor;
-import org.apache.hadoop.hbase.util.RecoverLeaseFSUtils;
 import org.apache.hadoop.hbase.wal.AsyncFSWALProvider;
 import org.apache.hadoop.hbase.wal.WALProvider.AsyncWriter;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
@@ -208,15 +207,5 @@ public class AsyncFSWAL extends AbstractFSWAL<AsyncWriter> {
   protected AsyncWriter createCombinedWriter(AsyncWriter localWriter, AsyncWriter remoteWriter) {
     // put remote writer first as usually it will cost more time to finish, so we write to it first
     return CombinedAsyncWriter.create(remoteWriter, localWriter);
-  }
-
-  @Override
-  protected void recoverLease(FileSystem fs, Path p, Configuration conf) {
-    try {
-      RecoverLeaseFSUtils.recoverFileLease(fs, p, conf, null);
-    } catch (IOException ex) {
-      LOG.warn("Unable to recover lease after several attempts. Give up.", ex);
-      throw new RuntimeException(ex);
-    }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AsyncFSWAL.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/AsyncFSWAL.java
@@ -29,6 +29,7 @@ import org.apache.hadoop.hbase.Abortable;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.io.asyncfs.AsyncFSOutput;
 import org.apache.hadoop.hbase.io.asyncfs.monitor.StreamSlowMonitor;
+import org.apache.hadoop.hbase.util.RecoverLeaseFSUtils;
 import org.apache.hadoop.hbase.wal.AsyncFSWALProvider;
 import org.apache.hadoop.hbase.wal.WALProvider.AsyncWriter;
 import org.apache.hadoop.hdfs.protocol.DatanodeInfo;
@@ -207,5 +208,15 @@ public class AsyncFSWAL extends AbstractFSWAL<AsyncWriter> {
   protected AsyncWriter createCombinedWriter(AsyncWriter localWriter, AsyncWriter remoteWriter) {
     // put remote writer first as usually it will cost more time to finish, so we write to it first
     return CombinedAsyncWriter.create(remoteWriter, localWriter);
+  }
+
+  @Override
+  protected void recoverLease(FileSystem fs, Path p, Configuration conf) {
+    try {
+      RecoverLeaseFSUtils.recoverFileLease(fs, p, conf, null);
+    } catch (IOException ex) {
+      LOG.warn("Unable to recover lease after several attempts. Give up.", ex);
+      throw new RuntimeException(ex);
+    }
   }
 }


### PR DESCRIPTION
Do lease recovery as a last resort if async wal fails to close WAL file.
This issue will make WAL on Ozone more resilient because Ozone does not support renaming open files (which happens due to WAL log archiving).