### PR TITLE
HBASE-28666: In WALEntryStream, always use current WALTailingReader if one exists

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStream.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/WALEntryStream.java
@@ -219,6 +219,7 @@ class WALEntryStream implements Closeable {
             // we will read from the beginning so we should always clear the compression context
             reader.resetTo(-1, true);
           }
+          return HasNext.YES;
         } catch (IOException e) {
           LOG.warn("Failed to reset reader {} to pos {}, reset compression={}", currentPath,
             currentPositionOfEntry, state.resetCompression(), e);


### PR DESCRIPTION
There was one code path within a `if (reader != null) {}` block that did not return and end the method early, thus allowing a subsequent line to re-create the `reader`. This was not the intention of the author. This PR closes this loophole.