### PR TITLE
HBASE-28672 Ensure large batches are not indefinitely blocked by quotas

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java
@@ -114,9 +114,12 @@ public class DefaultOperationQuota implements OperationQuota {
       long maxRequestsToEstimate = limiter.getRequestNumLimit();
       long maxReadsToEstimate = Math.min(maxRequestsToEstimate, limiter.getReadNumLimit());
       long maxWritesToEstimate = Math.min(maxRequestsToEstimate, limiter.getWriteNumLimit());
+      long maxReadSizeToEstimate = Math.min(readConsumed, limiter.getReadLimit());
+      long maxWriteSizeToEstimate = Math.min(writeConsumed, limiter.getWriteLimit());
 
-      limiter.checkQuota(Math.min(maxWritesToEstimate, numWrites), writeConsumed,
-        Math.min(maxReadsToEstimate, numReads), readConsumed, writeCapacityUnitConsumed,
+      limiter.checkQuota(Math.min(maxWritesToEstimate, numWrites),
+        Math.min(maxWriteSizeToEstimate, writeConsumed), Math.min(maxReadsToEstimate, numReads),
+        Math.min(maxReadSizeToEstimate, readConsumed), writeCapacityUnitConsumed,
         readCapacityUnitConsumed);
       readAvailable = Math.min(readAvailable, limiter.getReadAvailable());
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java
@@ -111,8 +111,13 @@ public class DefaultOperationQuota implements OperationQuota {
         continue;
       }
 
-      limiter.checkQuota(numWrites, writeConsumed, numReads, readConsumed,
-        writeCapacityUnitConsumed, readCapacityUnitConsumed);
+      long maxRequestsToEstimate = limiter.getRequestNumLimit();
+      long maxReadsToEstimate = Math.min(maxRequestsToEstimate, limiter.getReadNumLimit());
+      long maxWritesToEstimate = Math.min(maxRequestsToEstimate, limiter.getWriteNumLimit());
+
+      limiter.checkQuota(Math.min(maxWritesToEstimate, numWrites), writeConsumed,
+        Math.min(maxReadsToEstimate, numReads), readConsumed, writeCapacityUnitConsumed,
+        readCapacityUnitConsumed);
       readAvailable = Math.min(readAvailable, limiter.getReadAvailable());
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopQuotaLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopQuotaLimiter.java
@@ -66,6 +66,21 @@ class NoopQuotaLimiter implements QuotaLimiter {
   }
 
   @Override
+  public long getRequestNumLimit() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
+  public long getReadNumLimit() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
+  public long getWriteNumLimit() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
   public long getReadAvailable() {
     throw new UnsupportedOperationException();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopQuotaLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/NoopQuotaLimiter.java
@@ -91,6 +91,11 @@ class NoopQuotaLimiter implements QuotaLimiter {
   }
 
   @Override
+  public long getWriteLimit() {
+    return Long.MAX_VALUE;
+  }
+
+  @Override
   public String toString() {
     return "NoopQuotaLimiter";
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaLimiter.java
@@ -79,6 +79,9 @@ public interface QuotaLimiter {
   /** Returns the maximum number of bytes ever available to read */
   long getReadLimit();
 
+  /** Returns the maximum number of bytes ever available to write */
+  long getWriteLimit();
+
   /** Returns the number of bytes available to write to avoid exceeding the quota */
   long getWriteAvailable();
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaLimiter.java
@@ -81,4 +81,14 @@ public interface QuotaLimiter {
 
   /** Returns the number of bytes available to write to avoid exceeding the quota */
   long getWriteAvailable();
+
+  /** Returns the maximum number of requests to allow per TimeUnit */
+  long getRequestNumLimit();
+
+  /** Returns the maximum number of reads to allow per TimeUnit */
+  long getReadNumLimit();
+
+  /** Returns the maximum number of writes to allow per TimeUnit */
+  long getWriteNumLimit();
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
@@ -272,6 +272,11 @@ public class TimeBasedLimiter implements QuotaLimiter {
   }
 
   @Override
+  public long getWriteLimit() {
+    return Math.min(writeSizeLimiter.getLimit(), reqSizeLimiter.getLimit());
+  }
+
+  @Override
   public String toString() {
     StringBuilder builder = new StringBuilder();
     builder.append("TimeBasedLimiter(");

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/TimeBasedLimiter.java
@@ -241,6 +241,27 @@ public class TimeBasedLimiter implements QuotaLimiter {
   }
 
   @Override
+  public long getRequestNumLimit() {
+    long readAndWriteLimit = readReqsLimiter.getLimit() + writeReqsLimiter.getLimit();
+
+    if (readAndWriteLimit < 0) { // handle overflow
+      readAndWriteLimit = Long.MAX_VALUE;
+    }
+
+    return Math.min(reqsLimiter.getLimit(), readAndWriteLimit);
+  }
+
+  @Override
+  public long getReadNumLimit() {
+    return readReqsLimiter.getLimit();
+  }
+
+  @Override
+  public long getWriteNumLimit() {
+    return writeReqsLimiter.getLimit();
+  }
+
+  @Override
   public long getReadAvailable() {
     return readSizeLimiter.getAvailable();
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestDefaultOperationQuota.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestDefaultOperationQuota.java
@@ -18,14 +18,19 @@
 package org.apache.hadoop.hbase.quotas;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.QuotaProtos;
 
 @Category({ RegionServerTests.class, SmallTests.class })
 public class TestDefaultOperationQuota {
@@ -124,5 +129,68 @@ public class TestDefaultOperationQuota {
 
     // shrinking workload should only shrink estimate to maxBBS
     assertEquals(maxBlockBytesScanned, estimate);
+  }
+
+  @Test
+  public void testLargeBatchSaturatesReadNumLimit()
+    throws RpcThrottlingException, InterruptedException {
+    int limit = 10;
+    QuotaProtos.Throttle throttle =
+      QuotaProtos.Throttle.newBuilder().setReadNum(QuotaProtos.TimedQuota.newBuilder()
+        .setSoftLimit(limit).setTimeUnit(HBaseProtos.TimeUnit.SECONDS).build()).build();
+    QuotaLimiter limiter = TimeBasedLimiter.fromThrottle(throttle);
+    DefaultOperationQuota quota = new DefaultOperationQuota(new Configuration(), 65536, limiter);
+
+    // use the whole limit
+    quota.checkBatchQuota(0, limit);
+
+    // the next request should be rejected
+    assertThrows(RpcThrottlingException.class, () -> quota.checkBatchQuota(0, 1));
+
+    Thread.sleep(1000);
+    // after the TimeUnit, the limit should be refilled
+    quota.checkBatchQuota(0, limit);
+  }
+
+  @Test
+  public void testTooLargeReadBatchIsNotBlocked()
+    throws RpcThrottlingException, InterruptedException {
+    int limit = 10;
+    QuotaProtos.Throttle throttle =
+      QuotaProtos.Throttle.newBuilder().setReadNum(QuotaProtos.TimedQuota.newBuilder()
+        .setSoftLimit(limit).setTimeUnit(HBaseProtos.TimeUnit.SECONDS).build()).build();
+    QuotaLimiter limiter = TimeBasedLimiter.fromThrottle(throttle);
+    DefaultOperationQuota quota = new DefaultOperationQuota(new Configuration(), 65536, limiter);
+
+    // use more than the limit, which should succeed rather than being indefinitely blocked
+    quota.checkBatchQuota(0, 10 + limit);
+
+    // the next request should be blocked
+    assertThrows(RpcThrottlingException.class, () -> quota.checkBatchQuota(0, 1));
+
+    Thread.sleep(1000);
+    // even after the TimeUnit, the limit should not be refilled because we oversubscribed
+    assertThrows(RpcThrottlingException.class, () -> quota.checkBatchQuota(0, limit));
+  }
+
+  @Test
+  public void testTooLargeWriteBatchIsNotBlocked()
+    throws RpcThrottlingException, InterruptedException {
+    int limit = 10;
+    QuotaProtos.Throttle throttle =
+      QuotaProtos.Throttle.newBuilder().setWriteNum(QuotaProtos.TimedQuota.newBuilder()
+        .setSoftLimit(limit).setTimeUnit(HBaseProtos.TimeUnit.SECONDS).build()).build();
+    QuotaLimiter limiter = TimeBasedLimiter.fromThrottle(throttle);
+    DefaultOperationQuota quota = new DefaultOperationQuota(new Configuration(), 65536, limiter);
+
+    // use more than the limit, which should succeed rather than being indefinitely blocked
+    quota.checkBatchQuota(10 + limit, 0);
+
+    // the next request should be blocked
+    assertThrows(RpcThrottlingException.class, () -> quota.checkBatchQuota(1, 0));
+
+    Thread.sleep(1000);
+    // even after the TimeUnit, the limit should not be refilled because we oversubscribed
+    assertThrows(RpcThrottlingException.class, () -> quota.checkBatchQuota(limit, 0));
   }
 }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-28672

At my day job we are trying to implement [default quotas](https://issues.apache.org/jira/browse/HBASE-27800) for a variety of access patterns. We began by introducing a default read IO limit per-user, per-machine — this has been very successful in reducing hotspots, even on clusters with thousands of distinct users.

While implementing a default writes/second throttle, I realized that doing so would put us in a precarious situation where large enough batches may never succeed. If your batch size is greater than your TimeLimiter's max throughput, then you will always fail in the quota estimation stage; this will stick the client in a backoff-and-retry loop until it times out. Meanwhile [IO estimates are more optimistic](https://github.com/apache/hbase/blob/bdb3f216e864e20eb2b09352707a751a5cf7460f/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/DefaultOperationQuota.java#L192-L193), deliberately, which can let large requests do targeted oversubscription of an IO quota:
```java
// assume 1 block required for reads. this is probably a low estimate, which is okay
readConsumed = numReads > 0 ? blockSizeBytes : 0;
 ```
This is okay because the Limiter's availability will go negative and force a longer backoff on subsequent requests. I believe this is preferable UX compared to a doomed throttling loop.

In this PR I introduce batch estimation that takes the limiter's max throughput into account, and I've added unit tests to validate the intended behavior.

@ndimiduk @hgromer @bozzkar