### PR TITLE
HBASE-28686 MapReduceBackupCopyJob should support custom DistCp options

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceBackupCopyJob.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceBackupCopyJob.java
@@ -22,6 +22,7 @@ import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.math.BigDecimal;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Objects;
@@ -45,6 +46,7 @@ import org.apache.hadoop.mapreduce.JobID;
 import org.apache.hadoop.tools.CopyListingFileStatus;
 import org.apache.hadoop.tools.DistCp;
 import org.apache.hadoop.tools.DistCpConstants;
+import org.apache.hadoop.tools.DistCpOptionSwitch;
 import org.apache.hadoop.tools.DistCpOptions;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
@@ -394,7 +396,15 @@ public class MapReduceBackupCopyJob implements BackupCopyJob {
         if (!destfs.exists(dest)) {
           destfs.mkdirs(dest);
         }
-        res = distcp.run(newOptions);
+
+        List<String> distCpOptionsFromConf = parseDistCpOptions(conf);
+        String[] finalOptions = new String[newOptions.length + distCpOptionsFromConf.size()];
+        for (int i = 0; i < distCpOptionsFromConf.size(); i++) {
+          finalOptions[i] = distCpOptionsFromConf.get(i);
+        }
+        System.arraycopy(newOptions, 0, finalOptions, distCpOptionsFromConf.size(),
+          newOptions.length);
+        res = distcp.run(finalOptions);
       }
       return res;
 
@@ -423,6 +433,27 @@ public class MapReduceBackupCopyJob implements BackupCopyJob {
     } catch (InterruptedException e) {
       throw new IOException(e);
     }
+  }
+
+  protected static List<String> parseDistCpOptions(Configuration conf) {
+    List<String> extraArgsFromConf = new ArrayList<>();
+
+    for (DistCpOptionSwitch optionSwitch : DistCpOptionSwitch.values()) {
+      String configLabel = optionSwitch.getConfigLabel();
+      if (conf.get(configLabel) != null) {
+        if (optionSwitch.getOption().hasArg()) {
+          extraArgsFromConf.add("-" + optionSwitch.getOption().getOpt());
+          extraArgsFromConf.add(conf.get(configLabel));
+        } else {
+          boolean value = conf.getBoolean(configLabel, false);
+          if (value) {
+            extraArgsFromConf.add("-" + optionSwitch.getOption().getOpt());
+          }
+        }
+      }
+    }
+
+    return extraArgsFromConf;
   }
 
 }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceBackupCopyJob.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/mapreduce/MapReduceBackupCopyJob.java
@@ -60,6 +60,10 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 public class MapReduceBackupCopyJob implements BackupCopyJob {
   public static final String NUMBER_OF_LEVELS_TO_PRESERVE_KEY = "num.levels.preserve";
+
+  // This prefix specifies the DistCp options to be used during backup copy
+  public static final String BACKUP_COPY_OPTION_PREFIX = "hbase.backup.copy.";
+
   private static final Logger LOG = LoggerFactory.getLogger(MapReduceBackupCopyJob.class);
 
   private Configuration conf;
@@ -439,7 +443,7 @@ public class MapReduceBackupCopyJob implements BackupCopyJob {
     List<String> extraArgsFromConf = new ArrayList<>();
 
     for (DistCpOptionSwitch optionSwitch : DistCpOptionSwitch.values()) {
-      String configLabel = optionSwitch.getConfigLabel();
+      String configLabel = BACKUP_COPY_OPTION_PREFIX + optionSwitch.getConfigLabel();
       if (conf.get(configLabel) != null) {
         if (optionSwitch.getOption().hasArg()) {
           extraArgsFromConf.add("-" + optionSwitch.getOption().getOpt());

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/mapreduce/TestMapReduceBackupCopyJob.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/mapreduce/TestMapReduceBackupCopyJob.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.backup.mapreduce;
 
+import static org.apache.hadoop.hbase.backup.mapreduce.MapReduceBackupCopyJob.BACKUP_COPY_OPTION_PREFIX;
 import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_DIRECT_WRITE;
 import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_MAX_MAPS;
 import static org.junit.Assert.assertEquals;
@@ -41,8 +42,8 @@ public class TestMapReduceBackupCopyJob {
   @Test
   public void testDistCpOptionParsing() {
     Configuration conf = new Configuration();
-    conf.setInt(CONF_LABEL_MAX_MAPS, 1000);
-    conf.setBoolean(CONF_LABEL_DIRECT_WRITE, true);
+    conf.setInt(BACKUP_COPY_OPTION_PREFIX + CONF_LABEL_MAX_MAPS, 1000);
+    conf.setBoolean(BACKUP_COPY_OPTION_PREFIX + CONF_LABEL_DIRECT_WRITE, true);
     List<String> args = MapReduceBackupCopyJob.parseDistCpOptions(conf);
 
     List<String> expectedArgs =

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/mapreduce/TestMapReduceBackupCopyJob.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/mapreduce/TestMapReduceBackupCopyJob.java
@@ -1,0 +1,54 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup.mapreduce;
+
+import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_DIRECT_WRITE;
+import static org.apache.hadoop.tools.DistCpConstants.CONF_LABEL_MAX_MAPS;
+import static org.junit.Assert.assertEquals;
+
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableList;
+
+@Category(SmallTests.class)
+public class TestMapReduceBackupCopyJob {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestMapReduceBackupCopyJob.class);
+
+  @Test
+  public void testDistCpOptionParsing() {
+    Configuration conf = new Configuration();
+    conf.setInt(CONF_LABEL_MAX_MAPS, 1000);
+    conf.setBoolean(CONF_LABEL_DIRECT_WRITE, true);
+    List<String> args = MapReduceBackupCopyJob.parseDistCpOptions(conf);
+
+    List<String> expectedArgs =
+      ImmutableList.<String> builder().add("-m", "1000").add("-direct").build();
+
+    assertEquals(args, expectedArgs);
+  }
+
+}


### PR DESCRIPTION
#### Problem
The MapReduceBackupCopyJob class provides no means for updating DistCp job options. This means that you're stuck with defaults, which isn't always desirable. For example, my workplace would like the freedom to deviate from at least two DistCp defaults:

`distcp.direct.write` — we would like to set this to true, because writing and renaming tmp files is expensive in S3 (where we store our backups).
we would also like control over the number of mappers that DistCp will run

#### Proposed Solution
It is not the prettiest solution, but I'm proposing that we support DistCp customizations via the given backup client configuration like [this.](https://github.com/HubSpot/hbase/compare/hubspot-2.6...HubSpot:hbase:backup-distcp-options) It's necessary to do this conf -> arg conversion because we still want to use [DistCp's run method](https://github.com/HubSpot/hadoop/blob/c4c25b0ea2be1c8bca31d86962597060b2630f62/hadoop-tools/hadoop-distcp/src/main/java/org/apache/hadoop/tools/DistCp.java#L134-L171), which expects args, so as to not change any error codes. Hadoop actually does something similar, but in the opposite direction — the DistCp job has logic to convert the args back to configurations (lol).

Further, the DistCp API is really unfortunately designed for programmatic use, so it doesn't leave us great alternatives. For example, it doesn't matter what you pass in as DistCpOptions to the constructor if you use the run method, your options will be overwritten based on the args that you pass in. Alternatively, if you pass in the DistCpOptions in the constructor and use DistCp#execute or DistCp#createAndSubmitJob, then you get none of the error specificity!

@ndimiduk @charlesconnell @hgromer 