### PR TITLE
HBASE-28716: Users of QuotaRetriever should pass an existing connection (branch-2)

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
@@ -3153,7 +3153,7 @@ public class HBaseAdmin implements Admin {
 
   @Override
   public QuotaRetriever getQuotaRetriever(final QuotaFilter filter) throws IOException {
-    return QuotaRetriever.open(conf, filter);
+    return QuotaRetriever.open(connection, filter);
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/HBaseAdmin.java
@@ -3159,7 +3159,7 @@ public class HBaseAdmin implements Admin {
   @Override
   public List<QuotaSettings> getQuota(QuotaFilter filter) throws IOException {
     List<QuotaSettings> quotas = new ArrayList<>();
-    try (QuotaRetriever retriever = QuotaRetriever.open(conf, filter)) {
+    try (QuotaRetriever retriever = QuotaRetriever.open(connection, filter)) {
       Iterator<QuotaSettings> iterator = retriever.iterator();
       while (iterator.hasNext()) {
         quotas.add(iterator.next());

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaRetriever.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaRetriever.java
@@ -178,4 +178,19 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
     scanner.init(conf, scan);
     return scanner;
   }
+
+  /**
+   * Open a QuotaRetriever with the specified filter using an existing Connection
+   * @param conn   Connection object to use.
+   * @param filter the QuotaFilter
+   * @return the QuotaRetriever
+   * @throws IOException if a remote or network exception occurs
+   */
+  public static QuotaRetriever open(final Connection conn, final QuotaFilter filter)
+    throws IOException {
+    Scan scan = QuotaTableUtil.makeScan(filter);
+    QuotaRetriever scanner = new QuotaRetriever();
+    scanner.init(conn, scan);
+    return scanner;
+  }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaRetriever.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaRetriever.java
@@ -23,9 +23,7 @@ import java.util.ArrayDeque;
 import java.util.Iterator;
 import java.util.Objects;
 import java.util.Queue;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Connection;
-import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
@@ -52,19 +50,7 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
   private Connection connection;
   private Table table;
 
-  /**
-   * Should QutoaRetriever manage the state of the connection, or leave it be.
-   */
-  private boolean isManagedConnection = false;
-
   QuotaRetriever() {
-  }
-
-  void init(final Configuration conf, final Scan scan) throws IOException {
-    // Set this before creating the connection and passing it down to make sure
-    // it's cleaned up if we fail to construct the Scanner.
-    this.isManagedConnection = true;
-    init(ConnectionFactory.createConnection(conf), scan);
   }
 
   void init(final Connection conn, final Scan scan) throws IOException {
@@ -88,13 +74,8 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
       this.table.close();
       this.table = null;
     }
-    // Null out the connection on close() even if we didn't explicitly close it
+    // Null out the connection on close() even though we don't explicitly close it
     // to maintain typical semantics.
-    if (isManagedConnection) {
-      if (this.connection != null) {
-        this.connection.close();
-      }
-    }
     this.connection = null;
   }
 
@@ -156,27 +137,12 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
 
   /**
    * Open a QuotaRetriever with no filter, all the quota settings will be returned.
-   * @param conf Configuration object to use.
+   * @param conn Connection object to use.
    * @return the QuotaRetriever
    * @throws IOException if a remote or network exception occurs
    */
-  public static QuotaRetriever open(final Configuration conf) throws IOException {
-    return open(conf, null);
-  }
-
-  /**
-   * Open a QuotaRetriever with the specified filter.
-   * @param conf   Configuration object to use.
-   * @param filter the QuotaFilter
-   * @return the QuotaRetriever
-   * @throws IOException if a remote or network exception occurs
-   */
-  public static QuotaRetriever open(final Configuration conf, final QuotaFilter filter)
-    throws IOException {
-    Scan scan = QuotaTableUtil.makeScan(filter);
-    QuotaRetriever scanner = new QuotaRetriever();
-    scanner.init(conf, scan);
-    return scanner;
+  public static QuotaRetriever open(final Connection conn) throws IOException {
+    return open(conn, null);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SnapshotQuotaObserverChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SnapshotQuotaObserverChore.java
@@ -168,7 +168,7 @@ public class SnapshotQuotaObserverChore extends ScheduledChore {
     filter.addTypeFilter(QuotaType.SPACE);
     try (Admin admin = conn.getAdmin()) {
       // Pull all of the tables that have quotas (direct, or from namespace)
-      for (QuotaSettings qs : QuotaRetriever.open(conf, filter)) {
+      for (QuotaSettings qs : QuotaRetriever.open(conn, filter)) {
         if (qs.getQuotaType() == QuotaType.SPACE) {
           String ns = qs.getNamespace();
           TableName tn = qs.getTableName();

--- a/hbase-server/src/main/resources/hbase-webapps/master/quotas.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/quotas.jsp
@@ -30,7 +30,6 @@
 %>
 <%
   HMaster master = (HMaster) getServletContext().getAttribute(HMaster.MASTER);
-  Configuration conf = master.getConfiguration();
   pageContext.setAttribute("pageTitle", "HBase Master Quotas: " + master.getServerName());
   List<ThrottleSettings> regionServerThrottles = new ArrayList<>();
   List<ThrottleSettings> namespaceThrottles = new ArrayList<>();
@@ -39,7 +38,7 @@
   boolean exceedThrottleQuotaEnabled = false;
   if (quotaManager != null) {
     exceedThrottleQuotaEnabled = quotaManager.isExceedThrottleQuotaEnabled();
-    try (QuotaRetriever scanner = QuotaRetriever.open(conf, null)) {
+    try (QuotaRetriever scanner = QuotaRetriever.open(master.getConnection(), null)) {
       for (QuotaSettings quota : scanner) {
         if (quota instanceof ThrottleSettings) {
           ThrottleSettings throttle = (ThrottleSettings) quota;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/SpaceQuotaHelperForTests.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/SpaceQuotaHelperForTests.java
@@ -124,7 +124,7 @@ public class SpaceQuotaHelperForTests {
    * Returns the number of quotas defined in the HBase quota table.
    */
   long listNumDefinedQuotas(Connection conn) throws IOException {
-    QuotaRetriever scanner = QuotaRetriever.open(conn.getConfiguration());
+    QuotaRetriever scanner = QuotaRetriever.open(conn);
     try {
       return Iterables.size(scanner);
     } finally {
@@ -436,7 +436,7 @@ public class SpaceQuotaHelperForTests {
       waitForQuotaTable(conn);
     } else {
       // Or, clean up any quotas from previous test runs.
-      QuotaRetriever scanner = QuotaRetriever.open(conn.getConfiguration());
+      QuotaRetriever scanner = QuotaRetriever.open(conn);
       try {
         for (QuotaSettings quotaSettings : scanner) {
           final String namespace = quotaSettings.getNamespace();
@@ -462,8 +462,8 @@ public class SpaceQuotaHelperForTests {
   }
 
   QuotaSettings getTableSpaceQuota(Connection conn, TableName tn) throws IOException {
-    try (QuotaRetriever scanner = QuotaRetriever.open(conn.getConfiguration(),
-      new QuotaFilter().setTableFilter(tn.getNameAsString()))) {
+    try (QuotaRetriever scanner =
+      QuotaRetriever.open(conn, new QuotaFilter().setTableFilter(tn.getNameAsString()))) {
       for (QuotaSettings setting : scanner) {
         if (setting.getTableName().equals(tn) && setting.getQuotaType() == QuotaType.SPACE) {
           return setting;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestMasterQuotasObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestMasterQuotasObserver.java
@@ -325,7 +325,7 @@ public class TestMasterQuotasObserver {
   }
 
   public int getNumSpaceQuotas() throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration());
+    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection());
     int numSpaceQuotas = 0;
     for (QuotaSettings quotaSettings : scanner) {
       if (quotaSettings.getQuotaType() == QuotaType.SPACE) {
@@ -336,7 +336,7 @@ public class TestMasterQuotasObserver {
   }
 
   public int getThrottleQuotas() throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration());
+    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection());
     int throttleQuotas = 0;
     for (QuotaSettings quotaSettings : scanner) {
       if (quotaSettings.getQuotaType() == QuotaType.THROTTLE) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaAdmin.java
@@ -123,7 +123,7 @@ public class TestQuotaAdmin {
       QuotaSettingsFactory.throttleUser(userName, ThrottleType.WRITE_NUMBER, 12, TimeUnit.MINUTES));
     admin.setQuota(QuotaSettingsFactory.bypassGlobals(userName, true));
 
-    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration())) {
+    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection())) {
       int countThrottle = 0;
       int countGlobalBypass = 0;
       for (QuotaSettings settings : scanner) {
@@ -169,7 +169,7 @@ public class TestQuotaAdmin {
       TimeUnit.MINUTES));
     admin.setQuota(QuotaSettingsFactory.bypassGlobals(userName, true));
 
-    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration())) {
+    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection())) {
       int countThrottle = 0;
       int countGlobalBypass = 0;
       for (QuotaSettings settings : scanner) {
@@ -345,7 +345,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve it via the QuotaRetriever API
-    QuotaRetriever scanner = QuotaRetriever.open(admin.getConfiguration());
+    QuotaRetriever scanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertSpaceQuota(sizeLimit, violationPolicy, Iterables.getOnlyElement(scanner));
     } finally {
@@ -367,7 +367,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify that we can also not fetch it via the API
-    scanner = QuotaRetriever.open(admin.getConfiguration());
+    scanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertNull("Did not expect to find a quota entry", scanner.next());
     } finally {
@@ -399,7 +399,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve it via the QuotaRetriever API
-    QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConfiguration());
+    QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertSpaceQuota(originalSizeLimit, violationPolicy, Iterables.getOnlyElement(quotaScanner));
     } finally {
@@ -427,7 +427,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve the new quota via the QuotaRetriever API
-    quotaScanner = QuotaRetriever.open(admin.getConfiguration());
+    quotaScanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertSpaceQuota(newSizeLimit, newViolationPolicy, Iterables.getOnlyElement(quotaScanner));
     } finally {
@@ -449,7 +449,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify that we can also not fetch it via the API
-    quotaScanner = QuotaRetriever.open(admin.getConfiguration());
+    quotaScanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertNull("Did not expect to find a quota entry", quotaScanner.next());
     } finally {
@@ -549,7 +549,7 @@ public class TestQuotaAdmin {
     admin.setQuota(QuotaSettingsFactory.throttleRegionServer(regionServer, ThrottleType.READ_NUMBER,
       30, TimeUnit.SECONDS));
     int count = 0;
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration(), rsFilter);
+    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection(), rsFilter);
     try {
       for (QuotaSettings settings : scanner) {
         assertTrue(settings.getQuotaType() == QuotaType.THROTTLE);
@@ -733,14 +733,14 @@ public class TestQuotaAdmin {
   private void verifyFetchableViaAPI(Admin admin, ThrottleType type, long limit, TimeUnit tu)
     throws Exception {
     // Verify we can retrieve the new quota via the QuotaRetriever API
-    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConfiguration())) {
+    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection())) {
       assertRPCQuota(type, limit, tu, Iterables.getOnlyElement(quotaScanner));
     }
   }
 
   private void verifyNotFetchableViaAPI(Admin admin) throws Exception {
     // Verify that we can also not fetch it via the API
-    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConfiguration())) {
+    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection())) {
       assertNull("Did not expect to find a quota entry", quotaScanner.next());
     }
   }
@@ -830,7 +830,7 @@ public class TestQuotaAdmin {
   }
 
   private int countResults(final QuotaFilter filter) throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration(), filter);
+    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection(), filter);
     try {
       int count = 0;
       for (QuotaSettings settings : scanner) {


### PR DESCRIPTION
Every call to `HBaseAdmin#getQuota()` opens a new `Connection`, and then closes it. As far as I can tell, this is pointless, since it could use the existing `Connection` object held by the `HBaseAdmin`. Change this and other uses of QuotaRetriever to use existing Connections.