### PR TITLE
HBASE-28716: Users of QuotaRetriever should pass an existing connection (master)

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaRetriever.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaRetriever.java
@@ -57,7 +57,15 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
    */
   private final boolean isManagedConnection;
 
-  QuotaRetriever(final Connection conn, final Scan scan) throws IOException {
+  public QuotaRetriever(final Connection conn) throws IOException {
+    this(conn, (QuotaFilter) null);
+  }
+
+  public QuotaRetriever(final Connection conn, final QuotaFilter filter) throws IOException {
+    this(conn, QuotaTableUtil.makeScan(filter));
+  }
+
+  public QuotaRetriever(final Connection conn, final Scan scan) throws IOException {
     isManagedConnection = false;
     init(conn, scan);
   }
@@ -161,21 +169,12 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
    * @param conf Configuration object to use.
    * @return the QuotaRetriever
    * @throws IOException if a remote or network exception occurs
-   * @deprecated Since 3.0.0, will be removed in 4.0.0. Use {@link #open(Connection)} instead.
+   * @deprecated Since 3.0.0, will be removed in 4.0.0. Use
+   *             {@link #QuotaRetriever(Configuration, Scan)} instead.
    */
   @Deprecated
   public static QuotaRetriever open(final Configuration conf) throws IOException {
     return open(conf, null);
-  }
-
-  /**
-   * Open a QuotaRetriever with no filter, all the quota settings will be returned.
-   * @param conn Connection object to use.
-   * @return the QuotaRetriever
-   * @throws IOException if a remote or network exception occurs
-   */
-  public static QuotaRetriever open(final Connection conn) throws IOException {
-    return open(conn, null);
   }
 
   /**
@@ -184,8 +183,8 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
    * @param filter the QuotaFilter
    * @return the QuotaRetriever
    * @throws IOException if a remote or network exception occurs
-   * @deprecated Since 3.0.0, will be removed in 4.0.0. Use {@link #open(Connection, QuotaFilter)}
-   *             instead.
+   * @deprecated Since 3.0.0, will be removed in 4.0.0. Use
+   *             {@link #QuotaRetriever(Configuration, Scan)} instead.
    */
   @Deprecated
   public static QuotaRetriever open(final Configuration conf, final QuotaFilter filter)
@@ -194,16 +193,4 @@ public class QuotaRetriever implements Closeable, Iterable<QuotaSettings> {
     return new QuotaRetriever(conf, scan);
   }
 
-  /**
-   * Open a QuotaRetriever with the specified filter.
-   * @param conn   Connection object to use.
-   * @param filter the QuotaFilter
-   * @return the QuotaRetriever
-   * @throws IOException if a remote or network exception occurs
-   */
-  public static QuotaRetriever open(final Connection conn, final QuotaFilter filter)
-    throws IOException {
-    Scan scan = QuotaTableUtil.makeScan(filter);
-    return new QuotaRetriever(conn, scan);
-  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaObserverChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaObserverChore.java
@@ -475,8 +475,7 @@ public class QuotaObserverChore extends ScheduledChore {
   TablesWithQuotas fetchAllTablesWithQuotasDefined() throws IOException {
     final Scan scan = QuotaTableUtil.makeScan(null);
     final TablesWithQuotas tablesWithQuotas = new TablesWithQuotas(conn, conf);
-    try (final QuotaRetriever scanner = new QuotaRetriever()) {
-      scanner.init(conn, scan);
+    try (final QuotaRetriever scanner = new QuotaRetriever(conn, scan)) {
       for (QuotaSettings quotaSettings : scanner) {
         // Only one of namespace and tablename should be 'null'
         final String namespace = quotaSettings.getNamespace();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SnapshotQuotaObserverChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SnapshotQuotaObserverChore.java
@@ -168,19 +168,21 @@ public class SnapshotQuotaObserverChore extends ScheduledChore {
     filter.addTypeFilter(QuotaType.SPACE);
     try (Admin admin = conn.getAdmin()) {
       // Pull all of the tables that have quotas (direct, or from namespace)
-      for (QuotaSettings qs : QuotaRetriever.open(conn, filter)) {
-        if (qs.getQuotaType() == QuotaType.SPACE) {
-          String ns = qs.getNamespace();
-          TableName tn = qs.getTableName();
-          if ((null == ns && null == tn) || (null != ns && null != tn)) {
-            throw new IllegalStateException(
-              "Expected either one of namespace and tablename to be null but not both");
-          }
-          // Collect either the table name itself, or all of the tables in the namespace
-          if (null != ns) {
-            tablesToFetchSnapshotsFrom.addAll(Arrays.asList(admin.listTableNamesByNamespace(ns)));
-          } else {
-            tablesToFetchSnapshotsFrom.add(tn);
+      try (QuotaRetriever qr = new QuotaRetriever(conn, filter)) {
+        for (QuotaSettings qs : qr) {
+          if (qs.getQuotaType() == QuotaType.SPACE) {
+            String ns = qs.getNamespace();
+            TableName tn = qs.getTableName();
+            if ((null == ns && null == tn) || (null != ns && null != tn)) {
+              throw new IllegalStateException(
+                "Expected either one of namespace and tablename to be null but not both");
+            }
+            // Collect either the table name itself, or all of the tables in the namespace
+            if (null != ns) {
+              tablesToFetchSnapshotsFrom.addAll(Arrays.asList(admin.listTableNamesByNamespace(ns)));
+            } else {
+              tablesToFetchSnapshotsFrom.add(tn);
+            }
           }
         }
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SnapshotQuotaObserverChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/SnapshotQuotaObserverChore.java
@@ -168,7 +168,7 @@ public class SnapshotQuotaObserverChore extends ScheduledChore {
     filter.addTypeFilter(QuotaType.SPACE);
     try (Admin admin = conn.getAdmin()) {
       // Pull all of the tables that have quotas (direct, or from namespace)
-      for (QuotaSettings qs : QuotaRetriever.open(conf, filter)) {
+      for (QuotaSettings qs : QuotaRetriever.open(conn, filter)) {
         if (qs.getQuotaType() == QuotaType.SPACE) {
           String ns = qs.getNamespace();
           TableName tn = qs.getTableName();

--- a/hbase-server/src/main/resources/hbase-webapps/master/quotas.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/quotas.jsp
@@ -30,7 +30,6 @@
 %>
 <%
   HMaster master = (HMaster) getServletContext().getAttribute(HMaster.MASTER);
-  Configuration conf = master.getConfiguration();
   pageContext.setAttribute("pageTitle", "HBase Master Quotas: " + master.getServerName());
   List<ThrottleSettings> regionServerThrottles = new ArrayList<>();
   List<ThrottleSettings> namespaceThrottles = new ArrayList<>();
@@ -39,7 +38,7 @@
   boolean exceedThrottleQuotaEnabled = false;
   if (quotaManager != null) {
     exceedThrottleQuotaEnabled = quotaManager.isExceedThrottleQuotaEnabled();
-    try (QuotaRetriever scanner = QuotaRetriever.open(conf, null)) {
+    try (QuotaRetriever scanner = QuotaRetriever.open(master.getConnection(), null)) {
       for (QuotaSettings quota : scanner) {
         if (quota instanceof ThrottleSettings) {
           ThrottleSettings throttle = (ThrottleSettings) quota;

--- a/hbase-server/src/main/resources/hbase-webapps/master/quotas.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/quotas.jsp
@@ -38,7 +38,7 @@
   boolean exceedThrottleQuotaEnabled = false;
   if (quotaManager != null) {
     exceedThrottleQuotaEnabled = quotaManager.isExceedThrottleQuotaEnabled();
-    try (QuotaRetriever scanner = QuotaRetriever.open(master.getConnection(), null)) {
+    try (QuotaRetriever scanner = new QuotaRetriever(master.getConnection())) {
       for (QuotaSettings quota : scanner) {
         if (quota instanceof ThrottleSettings) {
           ThrottleSettings throttle = (ThrottleSettings) quota;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/SpaceQuotaHelperForTests.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/SpaceQuotaHelperForTests.java
@@ -120,7 +120,7 @@ public class SpaceQuotaHelperForTests {
    * Returns the number of quotas defined in the HBase quota table.
    */
   long listNumDefinedQuotas(Connection conn) throws IOException {
-    QuotaRetriever scanner = QuotaRetriever.open(conn.getConfiguration());
+    QuotaRetriever scanner = QuotaRetriever.open(conn);
     try {
       return Iterables.size(scanner);
     } finally {
@@ -353,7 +353,7 @@ public class SpaceQuotaHelperForTests {
       waitForQuotaTable(conn);
     } else {
       // Or, clean up any quotas from previous test runs.
-      QuotaRetriever scanner = QuotaRetriever.open(conn.getConfiguration());
+      QuotaRetriever scanner = QuotaRetriever.open(conn);
       try {
         for (QuotaSettings quotaSettings : scanner) {
           final String namespace = quotaSettings.getNamespace();
@@ -379,8 +379,8 @@ public class SpaceQuotaHelperForTests {
   }
 
   QuotaSettings getTableSpaceQuota(Connection conn, TableName tn) throws IOException {
-    try (QuotaRetriever scanner = QuotaRetriever.open(conn.getConfiguration(),
-      new QuotaFilter().setTableFilter(tn.getNameAsString()))) {
+    try (QuotaRetriever scanner =
+      QuotaRetriever.open(conn, new QuotaFilter().setTableFilter(tn.getNameAsString()))) {
       for (QuotaSettings setting : scanner) {
         if (setting.getTableName().equals(tn) && setting.getQuotaType() == QuotaType.SPACE) {
           return setting;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/SpaceQuotaHelperForTests.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/SpaceQuotaHelperForTests.java
@@ -120,13 +120,8 @@ public class SpaceQuotaHelperForTests {
    * Returns the number of quotas defined in the HBase quota table.
    */
   long listNumDefinedQuotas(Connection conn) throws IOException {
-    QuotaRetriever scanner = QuotaRetriever.open(conn);
-    try {
+    try (QuotaRetriever scanner = new QuotaRetriever(conn)) {
       return Iterables.size(scanner);
-    } finally {
-      if (scanner != null) {
-        scanner.close();
-      }
     }
   }
 
@@ -353,8 +348,7 @@ public class SpaceQuotaHelperForTests {
       waitForQuotaTable(conn);
     } else {
       // Or, clean up any quotas from previous test runs.
-      QuotaRetriever scanner = QuotaRetriever.open(conn);
-      try {
+      try (QuotaRetriever scanner = new QuotaRetriever(conn);) {
         for (QuotaSettings quotaSettings : scanner) {
           final String namespace = quotaSettings.getNamespace();
           final TableName tableName = quotaSettings.getTableName();
@@ -370,17 +364,13 @@ public class SpaceQuotaHelperForTests {
             QuotaUtil.deleteUserQuota(conn, userName);
           }
         }
-      } finally {
-        if (scanner != null) {
-          scanner.close();
-        }
       }
     }
   }
 
   QuotaSettings getTableSpaceQuota(Connection conn, TableName tn) throws IOException {
     try (QuotaRetriever scanner =
-      QuotaRetriever.open(conn, new QuotaFilter().setTableFilter(tn.getNameAsString()))) {
+      new QuotaRetriever(conn, new QuotaFilter().setTableFilter(tn.getNameAsString()))) {
       for (QuotaSettings setting : scanner) {
         if (setting.getTableName().equals(tn) && setting.getQuotaType() == QuotaType.SPACE) {
           return setting;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestMasterQuotasObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestMasterQuotasObserver.java
@@ -327,25 +327,27 @@ public class TestMasterQuotasObserver {
   }
 
   public int getNumSpaceQuotas() throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection());
-    int numSpaceQuotas = 0;
-    for (QuotaSettings quotaSettings : scanner) {
-      if (quotaSettings.getQuotaType() == QuotaType.SPACE) {
-        numSpaceQuotas++;
+    try (QuotaRetriever scanner = new QuotaRetriever(TEST_UTIL.getConnection())) {
+      int numSpaceQuotas = 0;
+      for (QuotaSettings quotaSettings : scanner) {
+        if (quotaSettings.getQuotaType() == QuotaType.SPACE) {
+          numSpaceQuotas++;
+        }
       }
+      return numSpaceQuotas;
     }
-    return numSpaceQuotas;
   }
 
   public int getThrottleQuotas() throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection());
-    int throttleQuotas = 0;
-    for (QuotaSettings quotaSettings : scanner) {
-      if (quotaSettings.getQuotaType() == QuotaType.THROTTLE) {
-        throttleQuotas++;
+    try (QuotaRetriever scanner = new QuotaRetriever(TEST_UTIL.getConnection())) {
+      int throttleQuotas = 0;
+      for (QuotaSettings quotaSettings : scanner) {
+        if (quotaSettings.getQuotaType() == QuotaType.THROTTLE) {
+          throttleQuotas++;
+        }
       }
+      return throttleQuotas;
     }
-    return throttleQuotas;
   }
 
   private void createTable(Admin admin, TableName tn) throws Exception {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestMasterQuotasObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestMasterQuotasObserver.java
@@ -327,7 +327,7 @@ public class TestMasterQuotasObserver {
   }
 
   public int getNumSpaceQuotas() throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration());
+    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection());
     int numSpaceQuotas = 0;
     for (QuotaSettings quotaSettings : scanner) {
       if (quotaSettings.getQuotaType() == QuotaType.SPACE) {
@@ -338,7 +338,7 @@ public class TestMasterQuotasObserver {
   }
 
   public int getThrottleQuotas() throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration());
+    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection());
     int throttleQuotas = 0;
     for (QuotaSettings quotaSettings : scanner) {
       if (quotaSettings.getQuotaType() == QuotaType.THROTTLE) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaAdmin.java
@@ -123,7 +123,7 @@ public class TestQuotaAdmin {
       QuotaSettingsFactory.throttleUser(userName, ThrottleType.WRITE_NUMBER, 12, TimeUnit.MINUTES));
     admin.setQuota(QuotaSettingsFactory.bypassGlobals(userName, true));
 
-    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection())) {
+    try (QuotaRetriever scanner = new QuotaRetriever(TEST_UTIL.getConnection())) {
       int countThrottle = 0;
       int countGlobalBypass = 0;
       for (QuotaSettings settings : scanner) {
@@ -169,7 +169,7 @@ public class TestQuotaAdmin {
       TimeUnit.MINUTES));
     admin.setQuota(QuotaSettingsFactory.bypassGlobals(userName, true));
 
-    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection())) {
+    try (QuotaRetriever scanner = new QuotaRetriever(TEST_UTIL.getConnection())) {
       int countThrottle = 0;
       int countGlobalBypass = 0;
       for (QuotaSettings settings : scanner) {
@@ -345,11 +345,8 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve it via the QuotaRetriever API
-    QuotaRetriever scanner = QuotaRetriever.open(admin.getConnection());
-    try {
+    try (QuotaRetriever scanner = new QuotaRetriever(admin.getConnection())) {
       assertSpaceQuota(sizeLimit, violationPolicy, Iterables.getOnlyElement(scanner));
-    } finally {
-      scanner.close();
     }
 
     // Now, remove the quota
@@ -367,11 +364,8 @@ public class TestQuotaAdmin {
     }
 
     // Verify that we can also not fetch it via the API
-    scanner = QuotaRetriever.open(admin.getConnection());
-    try {
+    try (QuotaRetriever scanner = new QuotaRetriever(admin.getConnection())) {
       assertNull("Did not expect to find a quota entry", scanner.next());
-    } finally {
-      scanner.close();
     }
   }
 
@@ -399,11 +393,8 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve it via the QuotaRetriever API
-    QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection());
-    try {
+    try (QuotaRetriever quotaScanner = new QuotaRetriever(admin.getConnection())) {
       assertSpaceQuota(originalSizeLimit, violationPolicy, Iterables.getOnlyElement(quotaScanner));
-    } finally {
-      quotaScanner.close();
     }
 
     // Setting a new size and policy should be reflected
@@ -427,11 +418,8 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve the new quota via the QuotaRetriever API
-    quotaScanner = QuotaRetriever.open(admin.getConnection());
-    try {
+    try (QuotaRetriever quotaScanner = new QuotaRetriever(admin.getConnection())) {
       assertSpaceQuota(newSizeLimit, newViolationPolicy, Iterables.getOnlyElement(quotaScanner));
-    } finally {
-      quotaScanner.close();
     }
 
     // Now, remove the quota
@@ -449,11 +437,8 @@ public class TestQuotaAdmin {
     }
 
     // Verify that we can also not fetch it via the API
-    quotaScanner = QuotaRetriever.open(admin.getConnection());
-    try {
+    try (QuotaRetriever quotaScanner = new QuotaRetriever(admin.getConnection())) {
       assertNull("Did not expect to find a quota entry", quotaScanner.next());
-    } finally {
-      quotaScanner.close();
     }
   }
 
@@ -549,8 +534,7 @@ public class TestQuotaAdmin {
     admin.setQuota(QuotaSettingsFactory.throttleRegionServer(regionServer, ThrottleType.READ_NUMBER,
       30, TimeUnit.SECONDS));
     int count = 0;
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection(), rsFilter);
-    try {
+    try (QuotaRetriever scanner = new QuotaRetriever(TEST_UTIL.getConnection(), rsFilter)) {
       for (QuotaSettings settings : scanner) {
         assertTrue(settings.getQuotaType() == QuotaType.THROTTLE);
         ThrottleSettings throttleSettings = (ThrottleSettings) settings;
@@ -564,8 +548,6 @@ public class TestQuotaAdmin {
           assertEquals(TimeUnit.SECONDS, throttleSettings.getTimeUnit());
         }
       }
-    } finally {
-      scanner.close();
     }
     assertEquals(2, count);
 
@@ -733,14 +715,14 @@ public class TestQuotaAdmin {
   private void verifyFetchableViaAPI(Admin admin, ThrottleType type, long limit, TimeUnit tu)
     throws Exception {
     // Verify we can retrieve the new quota via the QuotaRetriever API
-    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection())) {
+    try (QuotaRetriever quotaScanner = new QuotaRetriever(admin.getConnection())) {
       assertRPCQuota(type, limit, tu, Iterables.getOnlyElement(quotaScanner));
     }
   }
 
   private void verifyNotFetchableViaAPI(Admin admin) throws Exception {
     // Verify that we can also not fetch it via the API
-    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection())) {
+    try (QuotaRetriever quotaScanner = new QuotaRetriever(admin.getConnection())) {
       assertNull("Did not expect to find a quota entry", quotaScanner.next());
     }
   }
@@ -830,16 +812,13 @@ public class TestQuotaAdmin {
   }
 
   private int countResults(final QuotaFilter filter) throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection(), filter);
-    try {
+    try (QuotaRetriever scanner = new QuotaRetriever(TEST_UTIL.getConnection(), filter)) {
       int count = 0;
       for (QuotaSettings settings : scanner) {
         LOG.debug(Objects.toString(settings));
         count++;
       }
       return count;
-    } finally {
-      scanner.close();
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaAdmin.java
@@ -123,7 +123,7 @@ public class TestQuotaAdmin {
       QuotaSettingsFactory.throttleUser(userName, ThrottleType.WRITE_NUMBER, 12, TimeUnit.MINUTES));
     admin.setQuota(QuotaSettingsFactory.bypassGlobals(userName, true));
 
-    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration())) {
+    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection())) {
       int countThrottle = 0;
       int countGlobalBypass = 0;
       for (QuotaSettings settings : scanner) {
@@ -169,7 +169,7 @@ public class TestQuotaAdmin {
       TimeUnit.MINUTES));
     admin.setQuota(QuotaSettingsFactory.bypassGlobals(userName, true));
 
-    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration())) {
+    try (QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection())) {
       int countThrottle = 0;
       int countGlobalBypass = 0;
       for (QuotaSettings settings : scanner) {
@@ -345,7 +345,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve it via the QuotaRetriever API
-    QuotaRetriever scanner = QuotaRetriever.open(admin.getConfiguration());
+    QuotaRetriever scanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertSpaceQuota(sizeLimit, violationPolicy, Iterables.getOnlyElement(scanner));
     } finally {
@@ -367,7 +367,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify that we can also not fetch it via the API
-    scanner = QuotaRetriever.open(admin.getConfiguration());
+    scanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertNull("Did not expect to find a quota entry", scanner.next());
     } finally {
@@ -399,7 +399,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve it via the QuotaRetriever API
-    QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConfiguration());
+    QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertSpaceQuota(originalSizeLimit, violationPolicy, Iterables.getOnlyElement(quotaScanner));
     } finally {
@@ -427,7 +427,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify we can retrieve the new quota via the QuotaRetriever API
-    quotaScanner = QuotaRetriever.open(admin.getConfiguration());
+    quotaScanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertSpaceQuota(newSizeLimit, newViolationPolicy, Iterables.getOnlyElement(quotaScanner));
     } finally {
@@ -449,7 +449,7 @@ public class TestQuotaAdmin {
     }
 
     // Verify that we can also not fetch it via the API
-    quotaScanner = QuotaRetriever.open(admin.getConfiguration());
+    quotaScanner = QuotaRetriever.open(admin.getConnection());
     try {
       assertNull("Did not expect to find a quota entry", quotaScanner.next());
     } finally {
@@ -549,7 +549,7 @@ public class TestQuotaAdmin {
     admin.setQuota(QuotaSettingsFactory.throttleRegionServer(regionServer, ThrottleType.READ_NUMBER,
       30, TimeUnit.SECONDS));
     int count = 0;
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration(), rsFilter);
+    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection(), rsFilter);
     try {
       for (QuotaSettings settings : scanner) {
         assertTrue(settings.getQuotaType() == QuotaType.THROTTLE);
@@ -733,14 +733,14 @@ public class TestQuotaAdmin {
   private void verifyFetchableViaAPI(Admin admin, ThrottleType type, long limit, TimeUnit tu)
     throws Exception {
     // Verify we can retrieve the new quota via the QuotaRetriever API
-    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConfiguration())) {
+    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection())) {
       assertRPCQuota(type, limit, tu, Iterables.getOnlyElement(quotaScanner));
     }
   }
 
   private void verifyNotFetchableViaAPI(Admin admin) throws Exception {
     // Verify that we can also not fetch it via the API
-    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConfiguration())) {
+    try (QuotaRetriever quotaScanner = QuotaRetriever.open(admin.getConnection())) {
       assertNull("Did not expect to find a quota entry", quotaScanner.next());
     }
   }
@@ -830,7 +830,7 @@ public class TestQuotaAdmin {
   }
 
   private int countResults(final QuotaFilter filter) throws Exception {
-    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConfiguration(), filter);
+    QuotaRetriever scanner = QuotaRetriever.open(TEST_UTIL.getConnection(), filter);
     try {
       int count = 0;
       for (QuotaSettings settings : scanner) {


### PR DESCRIPTION
Every call to `HBaseAdmin#getQuota()` opens a new `Connection`, and then closes it. As far as I can tell, this is pointless, since it could use the existing `Connection` object held by the `HBaseAdmin`. Change this and other uses of QuotaRetriever to use existing Connections.