### PR TITLE
HBASE-28643 An unbounded backup failure message can cause an irrecoverable state for the given backup

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
@@ -44,6 +44,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.BackupProtos;
 @InterfaceAudience.Private
 public class BackupInfo implements Comparable<BackupInfo> {
   private static final Logger LOG = LoggerFactory.getLogger(BackupInfo.class);
+  private static final int MAX_FAILED_MESSAGE_LENGTH = 1024;
 
   public interface Filter {
     /**
@@ -253,6 +254,9 @@ public class BackupInfo implements Comparable<BackupInfo> {
   }
 
   public void setFailedMsg(String failedMsg) {
+    if (failedMsg.length() > MAX_FAILED_MESSAGE_LENGTH) {
+      failedMsg = failedMsg.substring(0, MAX_FAILED_MESSAGE_LENGTH);
+    }
     this.failedMsg = failedMsg;
   }
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
@@ -293,19 +293,7 @@ public final class BackupSystemTable implements Closeable {
     }
     try (Table table = connection.getTable(tableName)) {
       Put put = createPutForBackupInfo(info);
-      try {
-        table.put(put);
-      } catch (Exception e) {
-        // If the BackupInfo update can't be processed, then we should fall back to
-        // the previous BackupInfo, but also update it to reflect the failure.
-        LOG.error("Failed to update BackupInfo for {}. Marking as failed", info.getBackupId(), e);
-        BackupInfo legacyInfo = readBackupInfo(info.getBackupId());
-        if (legacyInfo != null) {
-          legacyInfo.setFailedMsg("Failed to update BackupInfo. Error: " + e.getMessage());
-          table.put(createPutForBackupInfo(legacyInfo));
-        }
-        throw e;
-      }
+      table.put(put);
     }
   }
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
@@ -293,7 +293,19 @@ public final class BackupSystemTable implements Closeable {
     }
     try (Table table = connection.getTable(tableName)) {
       Put put = createPutForBackupInfo(info);
-      table.put(put);
+      try {
+        table.put(put);
+      } catch (Exception e) {
+        // If the BackupInfo update can't be processed, then we should fall back to
+        // the previous BackupInfo, but also update it to reflect the failure.
+        LOG.error("Failed to update BackupInfo for {}. Marking as failed", info.getBackupId(), e);
+        BackupInfo legacyInfo = readBackupInfo(info.getBackupId());
+        if (legacyInfo != null) {
+          legacyInfo.setFailedMsg("Failed to update BackupInfo. Error: " + e.getMessage());
+          table.put(createPutForBackupInfo(legacyInfo));
+        }
+        throw e;
+      }
     }
   }
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-28643

The BackupInfo class has a failedMsg field which is a string of unbounded length. When a DistCp job fails then its failure message contains all of its source paths, and its failure message gets propagated to this failedMsg field on the given BackupInfo.

If a DistCp job has enough source paths, then this will result in backup status updates being rejected:
```
java.lang.IllegalArgumentException: KeyValue size too large
        at org.apache.hadoop.hbase.client.ConnectionUtils.validatePut(ConnectionUtils.java:513)
        at org.apache.hadoop.hbase.client.HTable.validatePut(HTable.java:1095)
        at org.apache.hadoop.hbase.client.HTable.lambda$put$3(HTable.java:564)
        at org.apache.hadoop.hbase.trace.TraceUtil.trace(TraceUtil.java:187)
        at org.apache.hadoop.hbase.client.HTable.put(HTable.java:563)
        at org.apache.hadoop.hbase.backup.impl.BackupSystemTable.updateBackupInfo(BackupSystemTable.java:292)
        at org.apache.hadoop.hbase.backup.impl.BackupManager.updateBackupInfo(BackupManager.java:376)
        at org.apache.hadoop.hbase.backup.impl.TableBackupClient.failBackup(TableBackupClient.java:243)
        at org.apache.hadoop.hbase.backup.impl.IncrementalTableBackupClient.execute(IncrementalTableBackupClient.java:317)
        at org.apache.hadoop.hbase.backup.impl.BackupAdminImpl.backupTables(BackupAdminImpl.java:603)
```
Without the ability to update the backup's state, it will never be returned as a failed backup by the client. This means that any mechanisms designed for repairing or cleaning failed backups won't work properly.

I think that a simple fix here would be fine: we should truncate the failedMsg field to a reasonable maximum size.

I've also tried to ensure that we'll propagate the failure if we ever fail to update the BackupInfo, for whatever reason

cc @hgromer @ndimiduk @DieterDP-ng 