### PR TITLE
HBASE-28743 Fixes NPE for TableSnapshotScanner by disabling mslab

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/TableSnapshotScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/TableSnapshotScanner.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.regionserver.MemStoreLAB;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotHelper;
 import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.SnapshotManifest;
@@ -122,6 +123,7 @@ public class TableSnapshotScanner extends AbstractClientScanner {
     this.scan = scan;
     this.snapshotAlreadyRestored = snapshotAlreadyRestored;
     this.fs = rootDir.getFileSystem(conf);
+    conf.setBoolean(MemStoreLAB.USEMSLAB_KEY, false);
 
     if (snapshotAlreadyRestored) {
       this.restoreDir = restoreDir;


### PR DESCRIPTION
Disable the mslab altogether (via hbase.hregion.memstore.mslab.enabled set to false) within snapshot based mapper