### PR TITLE
verify the first argument passed to compaction_switch

### DIFF
--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -114,6 +114,9 @@ module Hbase
     #----------------------------------------------------------------------------------------------
     # Switch compaction on/off at runtime on a region server
     def compaction_switch(on_or_off, regionserver_names)
+      unless /true|false/i.match?(on_or_off)
+        raise ArgumentError, 'compactionSwitch first argument only accepts "true" or "false"'
+      end
       region_servers = regionserver_names.flatten.compact
       servers = java.util.ArrayList.new
       if region_servers.any?


### PR DESCRIPTION
Sometimes, users may inadvertently attempt to use compaction_switch; therefore, it is advisable to implement a verification step for the first argument passed to this function, ensuring that incorrect inputs do not accidentally disable compaction.