### PR TITLE
HBASE-28754 verify the first argument passed to compaction_switch

### DIFF
--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -114,7 +114,7 @@ module Hbase
     #----------------------------------------------------------------------------------------------
     # Switch compaction on/off at runtime on a region server
     def compaction_switch(on_or_off, regionserver_names)
-      unless /true|false/i.match?(on_or_off)
+      unless /true|false/i.match(on_or_off.to_s)
         raise ArgumentError, 'compaction_switch first argument only accepts "true" or "false"'
       end
       region_servers = regionserver_names.flatten.compact

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -114,6 +114,9 @@ module Hbase
     #----------------------------------------------------------------------------------------------
     # Switch compaction on/off at runtime on a region server
     def compaction_switch(on_or_off, regionserver_names)
+      unless /true|false/i.match?(on_or_off)
+        raise ArgumentError, 'compactionSwitch first argument only accepts "true" or "false"'
+      end
       region_servers = regionserver_names.flatten.compact
       servers = java.util.ArrayList.new
       if region_servers.any?

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -115,7 +115,7 @@ module Hbase
     # Switch compaction on/off at runtime on a region server
     def compaction_switch(on_or_off, regionserver_names)
       unless /true|false/i.match?(on_or_off)
-        raise ArgumentError, 'compactionSwitch first argument only accepts "true" or "false"'
+        raise ArgumentError, 'compaction_switch first argument only accepts "true" or "false"'
       end
       region_servers = regionserver_names.flatten.compact
       servers = java.util.ArrayList.new

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -154,7 +154,7 @@ module Hbase
     define_test "compaction_switch should work" do
       output = capture_stdout { command(:compaction_switch, false) }
       assert(output.include?('PREV_STATE'))
-      output = capture_stdout { command(:compaction_switch, true) }
+      output = capture_stdout { command(:compaction_switch, 'true') }
       assert(output.include?('PREV_STATE'))
     end
 

--- a/hbase-shell/src/test/ruby/hbase/admin_test.rb
+++ b/hbase-shell/src/test/ruby/hbase/admin_test.rb
@@ -151,6 +151,14 @@ module Hbase
     end
 
     #-------------------------------------------------------------------------------
+    define_test "compaction_switch should work" do
+      output = capture_stdout { command(:compaction_switch, false) }
+      assert(output.include?('PREV_STATE'))
+      output = capture_stdout { command(:compaction_switch, true) }
+      assert(output.include?('PREV_STATE'))
+    end
+
+    #-------------------------------------------------------------------------------
 
     define_test "major_compact should work" do
       command(:major_compact, 'hbase:meta')

--- a/hbase-shell/src/test/ruby/shell/commands_test.rb
+++ b/hbase-shell/src/test/ruby/shell/commands_test.rb
@@ -69,6 +69,12 @@ class ShellCommandsErrorTest < Test::Unit::TestCase
     output = capture_stdout { @shell.command(name) }
     assert_match(/For usage try 'help "#{name}"'/, output)
   end
+
+  define_test 'Erroneous first argument for compaction_switch should indicate correct usage' do
+    name = :compaction_switch
+    output = capture_stdout { @shell.command(name, 'test') }
+    assert_match(/compaction_switch first argument only accepts "true" or "false"/, output)
+  end
 end
 
 ##


### PR DESCRIPTION
Sometimes, users may inadvertently attempt to use compaction_switch; therefore, it is advisable to implement a verification step for the first argument passed to this function, ensuring that incorrect inputs do not accidentally disable compaction.