### PR TITLE
HBASE-28655 IllegalArgumentException: Illegal bufferSize thrown when hbase.io.compress.zstd.buffersize is not configured 

### DIFF
--- a/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/ZstdCodec.java
+++ b/hbase-compression/hbase-compression-aircompressor/src/main/java/org/apache/hadoop/hbase/io/compress/aircompressor/ZstdCodec.java
@@ -159,10 +159,10 @@ public class ZstdCodec implements Configurable, CompressionCodec {
   // Package private
 
   static int getBufferSize(Configuration conf) {
-    return conf.getInt(ZSTD_BUFFER_SIZE_KEY,
+    int size = conf.getInt(ZSTD_BUFFER_SIZE_KEY,
       conf.getInt(CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_KEY,
-        // IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT is 0! We can't allow that.
-        ZSTD_BUFFER_SIZE_DEFAULT));
+        CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT));
+    return size > 0 ? size : ZSTD_BUFFER_SIZE_DEFAULT;
   }
 
 }

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdCodec.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdCodec.java
@@ -127,10 +127,10 @@ public class ZstdCodec implements Configurable, CompressionCodec {
   }
 
   static int getBufferSize(Configuration conf) {
-    return conf.getInt(ZSTD_BUFFER_SIZE_KEY,
+    int size = conf.getInt(ZSTD_BUFFER_SIZE_KEY,
       conf.getInt(CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_KEY,
-        // IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT is 0! We can't allow that.
-        ZSTD_BUFFER_SIZE_DEFAULT));
+        CommonConfigurationKeys.IO_COMPRESSION_CODEC_ZSTD_BUFFER_SIZE_DEFAULT));
+    return size > 0 ? size : ZSTD_BUFFER_SIZE_DEFAULT;
   }
 
   static byte[] getDictionary(final Configuration conf) {


### PR DESCRIPTION
HADOOP-18810 added io.compression.codec.zstd.buffersize in core-default.xml with default value as 0, so default value of hbase.io.compress.zstd.buffersize will become 0 instead of ZSTD_BUFFER_SIZE_DEFAULT (256 * 1024) when not configured in hbase-site.xml.

(cherry picked from commit 73f2710e47557218dcf92cc3e7b1788dfbb57fd2)