### PR TITLE
HBASE-28584 RS SIGSEGV under heavy replication load

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/PrivateCellUtil.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/PrivateCellUtil.java
@@ -2262,6 +2262,18 @@ public final class PrivateCellUtil {
   }
 
   /**
+   * Deep clones the given cell if the cell supports deep cloning
+   * @param cell the cell to be cloned
+   * @return the cloned cell
+   */
+  public static Cell deepClone(Cell cell) throws CloneNotSupportedException {
+    if (cell instanceof ExtendedCell) {
+      return ((ExtendedCell) cell).deepClone();
+    }
+    throw new CloneNotSupportedException();
+  }
+
+  /**
    * Sets the given seqId to the cell. Marked as audience Private as of 1.2.0. Setting a Cell
    * sequenceid is an internal implementation detail not for general public use.
    * @throws IOException when the passed cell is not of type {@link ExtendedCell}


### PR DESCRIPTION
Clone the cells that are used to apply mutations on the local cluster. Some operations may still be in flight even as we fail to apply some other in-flight mutations and trigger failure handling including a release of the buffer underlying the cellScanner that is sourcing the cells.