### PR TITLE
HBASE-28690 Aborting Active HMaster is not rejecting reportRegionStateTransition if procedure is initialised by next Active master

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -3097,10 +3097,11 @@ public final class ProtobufUtil {
   }
 
   public static CloseRegionRequest buildCloseRegionRequest(ServerName server, byte[] regionName,
-    ServerName destinationServer, long closeProcId, boolean evictCache) {
+    ServerName destinationServer, long closeProcId, boolean evictCache, long masterStartCode) {
     CloseRegionRequest.Builder builder =
       getBuilder(server, regionName, destinationServer, closeProcId);
     builder.setEvictCache(evictCache);
+    builder.setMasterStartCode(masterStartCode);
     return builder.build();
   }
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -3097,11 +3097,12 @@ public final class ProtobufUtil {
   }
 
   public static CloseRegionRequest buildCloseRegionRequest(ServerName server, byte[] regionName,
-    ServerName destinationServer, long closeProcId, boolean evictCache, long masterStartCode) {
+    ServerName destinationServer, long closeProcId, boolean evictCache,
+    long initiatingMasterActiveTime) {
     CloseRegionRequest.Builder builder =
       getBuilder(server, regionName, destinationServer, closeProcId);
     builder.setEvictCache(evictCache);
-    builder.setMasterStartCode(masterStartCode);
+    builder.setInitiatingMasterActiveTime(initiatingMasterActiveTime);
     return builder.build();
   }
 

--- a/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/RemoteProcedureDispatcher.java
+++ b/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/RemoteProcedureDispatcher.java
@@ -222,13 +222,21 @@ public abstract class RemoteProcedureDispatcher<TEnv, TRemote extends Comparable
    */
   public static abstract class RemoteOperation {
     private final RemoteProcedure remoteProcedure;
+    // active time of the master that sent this request, used for fencing
+    private final long initiatingMasterActiveTime;
 
-    protected RemoteOperation(final RemoteProcedure remoteProcedure) {
+    protected RemoteOperation(final RemoteProcedure remoteProcedure,
+      long initiatingMasterActiveTime) {
       this.remoteProcedure = remoteProcedure;
+      this.initiatingMasterActiveTime = initiatingMasterActiveTime;
     }
 
     public RemoteProcedure getRemoteProcedure() {
       return remoteProcedure;
+    }
+
+    public long getInitiatingMasterActiveTime() {
+      return initiatingMasterActiveTime;
     }
   }
 

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/RegionServerStatus.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/RegionServerStatus.proto
@@ -97,6 +97,9 @@ message RegionStateTransition {
   optional uint64 open_seq_num = 3;
 
   repeated int64 proc_id = 4;
+
+  // Master start code as fencing token
+  optional uint64 master_start_code = 5;
   enum TransitionCode {
     OPENED = 0;
     FAILED_OPEN = 1;
@@ -155,6 +158,8 @@ message RemoteProcedureResult {
   }
   required Status status = 2;
   optional ForeignExceptionMessage error = 3;
+  // Master start code as fencing token
+  optional uint64 master_start_code = 4;
 }
 message ReportProcedureDoneRequest {
   repeated RemoteProcedureResult result = 1;

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/RegionServerStatus.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/RegionServerStatus.proto
@@ -98,7 +98,7 @@ message RegionStateTransition {
 
   repeated int64 proc_id = 4;
 
-  // Master active code as fencing token
+  // Master active time as fencing token
   optional int64 initiating_master_active_time = 5;
   enum TransitionCode {
     OPENED = 0;
@@ -158,7 +158,7 @@ message RemoteProcedureResult {
   }
   required Status status = 2;
   optional ForeignExceptionMessage error = 3;
-  // Master active code as fencing token
+  // Master active time as fencing token
   optional int64 initiating_master_active_time = 4;
 }
 message ReportProcedureDoneRequest {

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/RegionServerStatus.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/RegionServerStatus.proto
@@ -98,8 +98,8 @@ message RegionStateTransition {
 
   repeated int64 proc_id = 4;
 
-  // Master start code as fencing token
-  optional uint64 master_start_code = 5;
+  // Master active code as fencing token
+  optional int64 initiating_master_active_time = 5;
   enum TransitionCode {
     OPENED = 0;
     FAILED_OPEN = 1;
@@ -158,8 +158,8 @@ message RemoteProcedureResult {
   }
   required Status status = 2;
   optional ForeignExceptionMessage error = 3;
-  // Master start code as fencing token
-  optional uint64 master_start_code = 4;
+  // Master active code as fencing token
+  optional int64 initiating_master_active_time = 4;
 }
 message ReportProcedureDoneRequest {
   repeated RemoteProcedureResult result = 1;

--- a/hbase-protocol-shaded/src/main/protobuf/server/region/Admin.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/region/Admin.proto
@@ -80,8 +80,8 @@ message OpenRegionRequest {
   repeated RegionOpenInfo open_info = 1;
   // the intended server for this RPC.
   optional uint64 serverStartCode = 2;
-  // Master start code as fencing token
-  optional uint64 master_start_code = 3;
+  // Master active code as fencing token
+  optional int64 initiating_master_active_time = 3;
   // wall clock time from master
   optional uint64 master_system_time = 5;
 
@@ -125,8 +125,8 @@ message CloseRegionRequest {
   optional uint64 serverStartCode = 5;
   optional int64 close_proc_id = 6 [default = -1];
   optional bool evict_cache = 7 [default = false];
-  // Master start code as fencing token
-  optional uint64 master_start_code = 8;
+  // Master active code as fencing token
+  optional int64 initiating_master_active_time = 8;
 }
 
 message CloseRegionResponse {
@@ -276,8 +276,8 @@ message RemoteProcedureRequest {
   required uint64 proc_id = 1;
   required string proc_class = 2;
   optional bytes proc_data = 3;
-  // Master start code as fencing token
-  optional uint64 master_start_code = 4;
+  // Master active code as fencing token
+  optional int64 initiating_master_active_time = 4;
 }
 
 message ExecuteProceduresRequest {

--- a/hbase-protocol-shaded/src/main/protobuf/server/region/Admin.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/region/Admin.proto
@@ -80,6 +80,8 @@ message OpenRegionRequest {
   repeated RegionOpenInfo open_info = 1;
   // the intended server for this RPC.
   optional uint64 serverStartCode = 2;
+  // Master start code as fencing token
+  optional uint64 master_start_code = 3;
   // wall clock time from master
   optional uint64 master_system_time = 5;
 
@@ -123,6 +125,8 @@ message CloseRegionRequest {
   optional uint64 serverStartCode = 5;
   optional int64 close_proc_id = 6 [default = -1];
   optional bool evict_cache = 7 [default = false];
+  // Master start code as fencing token
+  optional uint64 master_start_code = 8;
 }
 
 message CloseRegionResponse {
@@ -272,6 +276,8 @@ message RemoteProcedureRequest {
   required uint64 proc_id = 1;
   required string proc_class = 2;
   optional bytes proc_data = 3;
+  // Master start code as fencing token
+  optional uint64 master_start_code = 4;
 }
 
 message ExecuteProceduresRequest {

--- a/hbase-protocol-shaded/src/main/protobuf/server/region/Admin.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/region/Admin.proto
@@ -80,7 +80,7 @@ message OpenRegionRequest {
   repeated RegionOpenInfo open_info = 1;
   // the intended server for this RPC.
   optional uint64 serverStartCode = 2;
-  // Master active code as fencing token
+  // Master active time as fencing token
   optional int64 initiating_master_active_time = 3;
   // wall clock time from master
   optional uint64 master_system_time = 5;
@@ -125,7 +125,7 @@ message CloseRegionRequest {
   optional uint64 serverStartCode = 5;
   optional int64 close_proc_id = 6 [default = -1];
   optional bool evict_cache = 7 [default = false];
-  // Master active code as fencing token
+  // Master active time as fencing token
   optional int64 initiating_master_active_time = 8;
 }
 
@@ -276,7 +276,7 @@ message RemoteProcedureRequest {
   required uint64 proc_id = 1;
   required string proc_class = 2;
   optional bytes proc_data = 3;
-  // Master active code as fencing token
+  // Master active time as fencing token
   optional int64 initiating_master_active_time = 4;
 }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -3153,6 +3153,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   }
 
   /** Returns timestamp in millis when HMaster became the active master. */
+  @Override
   public long getMasterActiveTime() {
     return masterActiveTime;
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -2586,7 +2586,8 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   private void throwOnOldMasterStartCode(long procId, long initiatingMasterActiveTime)
     throws MasterNotRunningException {
     if (initiatingMasterActiveTime > server.getMasterActiveTime()) {
-      // procedure is initiated by new active master but report received on master with older active time
+      // procedure is initiated by new active master but report received on master with older active
+      // time
       LOG.warn(
         "Report for procedure with procId: {} and initiatingMasterActiveTime {} received on non-active master with activeTime {}",
         procId, initiatingMasterActiveTime, server.getMasterActiveTime());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -2580,8 +2580,10 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   private void throwOnOldMasterStartCode(Stream<Long> masterStartCodeStream)
     throws MasterNotRunningException {
     long masterStartCodeFromProc = masterStartCodeStream.max(Long::compare).orElse(-1L);
+    // -1 is less than any possible MasterStartCode
+
     if (masterStartCodeFromProc > server.getStartcode()) {
-      // do we need to abort the master here ?
+      // procedure is initiated by new active master but report received on different
       throw new MasterNotRunningException("Another master is active");
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -2589,7 +2589,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
       // procedure is initiated by new active master but report received on master with older active
       // time
       LOG.warn(
-        "Report for procedure with procId: {} and initiatingMasterActiveTime {} received on non-active master with activeTime {}",
+        "Report for procId: {} and initiatingMasterAT {} received on master with activeTime {}",
         procId, initiatingMasterActiveTime, server.getMasterActiveTime());
       throw new MasterNotRunningException("Another master is active");
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -1862,7 +1862,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
         long initiatingMasterActiveTime = transition.hasInitiatingMasterActiveTime()
           ? transition.getInitiatingMasterActiveTime()
           : -1;
-        throwOnOldMasterStartCode(procId, initiatingMasterActiveTime);
+        throwOnOldMaster(procId, initiatingMasterActiveTime);
       }
       return server.getAssignmentManager().reportRegionStateTransition(req);
     } catch (IOException ioe) {
@@ -2567,7 +2567,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
         // -1 is less than any possible MasterActiveCode
         long initiatingMasterActiveTime =
           result.hasInitiatingMasterActiveTime() ? result.getInitiatingMasterActiveTime() : -1;
-        throwOnOldMasterStartCode(result.getProcId(), initiatingMasterActiveTime);
+        throwOnOldMaster(result.getProcId(), initiatingMasterActiveTime);
       }
     } catch (IOException ioe) {
       throw new ServiceException(ioe);
@@ -2583,7 +2583,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
     return ReportProcedureDoneResponse.getDefaultInstance();
   }
 
-  private void throwOnOldMasterStartCode(long procId, long initiatingMasterActiveTime)
+  private void throwOnOldMaster(long procId, long initiatingMasterActiveTime)
     throws MasterNotRunningException {
     if (initiatingMasterActiveTime > server.getMasterActiveTime()) {
       // procedure is initiated by new active master but report received on master with older active

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -460,9 +460,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   private static final Logger AUDITLOG =
     LoggerFactory.getLogger("SecurityLogger." + MasterRpcServices.class.getName());
 
-  /**
-   * RPC scheduler to use for the master.
-   */
+  /** RPC scheduler to use for the master. */
   public static final String MASTER_RPC_SCHEDULER_FACTORY_CLASS =
     "hbase.master.rpc.scheduler.factory.class";
 
@@ -582,9 +580,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
     return switchBalancer(b, BalanceSwitchMode.SYNC);
   }
 
-  /**
-   * Returns list of blocking services and their security info classes that this server supports
-   */
+  /** Returns list of blocking services and their security info classes that this server supports */
   @Override
   protected List<BlockingServiceAndInterface> getServices() {
     List<BlockingServiceAndInterface> bssi = new ArrayList<>(5);
@@ -2563,8 +2559,8 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
       this.server.checkServiceStarted();
       throwOnOldMasterStartCode(
         request.getResultList().stream().map(RemoteProcedureResult::getMasterStartCode));
-    } catch (IOException snrye) {
-      throw new ServiceException(snrye);
+    } catch (IOException ioe) {
+      throw new ServiceException(ioe);
     }
     request.getResultList().forEach(result -> {
       if (result.getStatus() == RemoteProcedureResult.Status.SUCCESS) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
@@ -267,6 +267,9 @@ public interface MasterServices extends Server {
   /** Returns true if master is the active one */
   boolean isActiveMaster();
 
+  /** Returns timestamp in millis when this master became the active one. */
+  long getMasterActiveTime();
+
   /** Returns true if master is initialized */
   boolean isInitialized();
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/CloseRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/CloseRegionProcedure.java
@@ -64,8 +64,9 @@ public class CloseRegionProcedure extends RegionRemoteProcedureBase {
   }
 
   @Override
-  public RemoteOperation newRemoteOperation() {
-    return new RegionCloseOperation(this, region, getProcId(), assignCandidate, evictCache);
+  public RemoteOperation newRemoteOperation(MasterProcedureEnv env) {
+    return new RegionCloseOperation(this, region, getProcId(), assignCandidate, evictCache,
+      env.getMasterServices().getMasterActiveTime());
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/OpenRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/OpenRegionProcedure.java
@@ -57,8 +57,9 @@ public class OpenRegionProcedure extends RegionRemoteProcedureBase {
   }
 
   @Override
-  public RemoteOperation newRemoteOperation() {
-    return new RegionOpenOperation(this, region, getProcId());
+  public RemoteOperation newRemoteOperation(MasterProcedureEnv env) {
+    return new RegionOpenOperation(this, region, getProcId(),
+      env.getMasterServices().getMasterActiveTime());
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionRemoteProcedureBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionRemoteProcedureBase.java
@@ -96,10 +96,11 @@ public abstract class RegionRemoteProcedureBase extends Procedure<MasterProcedur
     if (state == RegionRemoteProcedureBaseState.REGION_REMOTE_PROCEDURE_REPORT_SUCCEED) {
       return Optional.empty();
     }
-    return Optional.of(newRemoteOperation());
+    return Optional.of(newRemoteOperation(env));
   }
 
-  protected abstract RemoteProcedureDispatcher.RemoteOperation newRemoteOperation();
+  protected abstract RemoteProcedureDispatcher.RemoteOperation
+    newRemoteOperation(MasterProcedureEnv env);
 
   @Override
   public void remoteOperationCompleted(MasterProcedureEnv env) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/FlushRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/FlushRegionProcedure.java
@@ -222,8 +222,9 @@ public class FlushRegionProcedure extends Procedure<MasterProcedureEnv>
         }
       }
     }
-    return Optional.of(new RSProcedureDispatcher.ServerOperation(this, getProcId(),
-      FlushRegionCallable.class, builder.build().toByteArray()));
+    return Optional
+      .of(new RSProcedureDispatcher.ServerOperation(this, getProcId(), FlushRegionCallable.class,
+        builder.build().toByteArray(), env.getMasterServices().getMasterActiveTime()));
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
@@ -442,7 +442,8 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     final ServerName serverName, final List<RegionOpenOperation> operations) {
     final OpenRegionRequest.Builder builder = OpenRegionRequest.newBuilder();
     builder.setServerStartCode(serverName.getStartCode());
-    operations.stream().map(RemoteOperation::getInitiatingMasterActiveTime).findAny().ifPresent(builder::setInitiatingMasterActiveTime);
+    operations.stream().map(RemoteOperation::getInitiatingMasterActiveTime).findAny()
+      .ifPresent(builder::setInitiatingMasterActiveTime);
     builder.setMasterSystemTime(EnvironmentEdgeManager.currentTime());
     for (RegionOpenOperation op : operations) {
       builder.addOpenInfo(op.buildRegionOpenInfoRequest(env));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
@@ -416,7 +416,8 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     public void dispatchCloseRequests(final MasterProcedureEnv env,
       final List<RegionCloseOperation> operations) {
       for (RegionCloseOperation op : operations) {
-        request.addCloseRegion(op.buildCloseRegionRequest(getServerName()));
+        request.addCloseRegion(op.buildCloseRegionRequest(getServerName(),
+          env.getMasterServices().getServerName().getStartCode()));
       }
     }
 
@@ -442,6 +443,7 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     final ServerName serverName, final List<RegionOpenOperation> operations) {
     final OpenRegionRequest.Builder builder = OpenRegionRequest.newBuilder();
     builder.setServerStartCode(serverName.getStartcode());
+    builder.setMasterStartCode(env.getMasterServices().getServerName().getStartCode());
     builder.setMasterSystemTime(EnvironmentEdgeManager.currentTime());
     for (RegionOpenOperation op : operations) {
       builder.addOpenInfo(op.buildRegionOpenInfoRequest(env));
@@ -517,9 +519,10 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
       return destinationServer;
     }
 
-    public CloseRegionRequest buildCloseRegionRequest(final ServerName serverName) {
+    public CloseRegionRequest buildCloseRegionRequest(final ServerName serverName,
+      long masterStartCode) {
       return ProtobufUtil.buildCloseRegionRequest(serverName, regionInfo.getRegionName(),
-        getDestinationServer(), procId, evictCache);
+        getDestinationServer(), procId, evictCache, masterStartCode);
 
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
@@ -423,7 +423,10 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
 
     @Override
     public void dispatchServerOperations(MasterProcedureEnv env, List<ServerOperation> operations) {
-      operations.stream().map(o -> o.buildRequest()).forEachOrdered(request::addProc);
+      operations.stream()
+        .map(o -> o
+          .buildRequestWithMasterStartCode(env.getMasterServices().getServerName().getStartCode()))
+        .forEachOrdered(request::addProc);
     }
 
     // will be overridden in test.
@@ -442,7 +445,7 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
   private static OpenRegionRequest buildOpenRegionRequest(final MasterProcedureEnv env,
     final ServerName serverName, final List<RegionOpenOperation> operations) {
     final OpenRegionRequest.Builder builder = OpenRegionRequest.newBuilder();
-    builder.setServerStartCode(serverName.getStartcode());
+    builder.setServerStartCode(serverName.getStartCode());
     builder.setMasterStartCode(env.getMasterServices().getServerName().getStartCode());
     builder.setMasterSystemTime(EnvironmentEdgeManager.currentTime());
     for (RegionOpenOperation op : operations) {
@@ -473,9 +476,10 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
       this.rsProcData = rsProcData;
     }
 
-    public RemoteProcedureRequest buildRequest() {
+    public RemoteProcedureRequest buildRequestWithMasterStartCode(long masterStartCode) {
       return RemoteProcedureRequest.newBuilder().setProcId(procId)
-        .setProcClass(rsProcClass.getName()).setProcData(ByteString.copyFrom(rsProcData)).build();
+        .setProcClass(rsProcClass.getName()).setProcData(ByteString.copyFrom(rsProcData))
+        .setMasterStartCode(masterStartCode).build();
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
@@ -30,7 +30,6 @@ import org.apache.hadoop.hbase.client.AsyncRegionServerAdmin;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.ipc.RpcConnectionConstants;
 import org.apache.hadoop.hbase.ipc.ServerNotRunningYetException;
-import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.hadoop.hbase.master.ServerListener;
 import org.apache.hadoop.hbase.master.ServerManager;
@@ -418,14 +417,13 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
       final List<RegionCloseOperation> operations) {
       for (RegionCloseOperation op : operations) {
         request.addCloseRegion(op.buildCloseRegionRequest(getServerName(),
-          ((HMaster) env.getMasterServices()).getMasterActiveTime()));
+          env.getMasterServices().getMasterActiveTime()));
       }
     }
 
     @Override
     public void dispatchServerOperations(MasterProcedureEnv env, List<ServerOperation> operations) {
-      operations.stream()
-        .map(o -> o.buildRequest(((HMaster) env.getMasterServices()).getMasterActiveTime()))
+      operations.stream().map(o -> o.buildRequest(env.getMasterServices().getMasterActiveTime()))
         .forEachOrdered(request::addProc);
     }
 
@@ -446,8 +444,7 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     final ServerName serverName, final List<RegionOpenOperation> operations) {
     final OpenRegionRequest.Builder builder = OpenRegionRequest.newBuilder();
     builder.setServerStartCode(serverName.getStartCode());
-    builder
-      .setInitiatingMasterActiveTime(((HMaster) env.getMasterServices()).getMasterActiveTime());
+    builder.setInitiatingMasterActiveTime(env.getMasterServices().getMasterActiveTime());
     builder.setMasterSystemTime(EnvironmentEdgeManager.currentTime());
     for (RegionOpenOperation op : operations) {
       builder.addOpenInfo(op.buildRegionOpenInfoRequest(env));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
@@ -442,8 +442,7 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     final ServerName serverName, final List<RegionOpenOperation> operations) {
     final OpenRegionRequest.Builder builder = OpenRegionRequest.newBuilder();
     builder.setServerStartCode(serverName.getStartCode());
-    builder.setInitiatingMasterActiveTime(operations.stream()
-      .map(RemoteOperation::getInitiatingMasterActiveTime).findAny().orElse(-1L));
+    operations.stream().map(RemoteOperation::getInitiatingMasterActiveTime).findAny().ifPresent(builder::setInitiatingMasterActiveTime);
     builder.setMasterSystemTime(EnvironmentEdgeManager.currentTime());
     for (RegionOpenOperation op : operations) {
       builder.addOpenInfo(op.buildRegionOpenInfoRequest(env));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RSProcedureDispatcher.java
@@ -416,15 +416,13 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     public void dispatchCloseRequests(final MasterProcedureEnv env,
       final List<RegionCloseOperation> operations) {
       for (RegionCloseOperation op : operations) {
-        request.addCloseRegion(op.buildCloseRegionRequest(getServerName(),
-          env.getMasterServices().getMasterActiveTime()));
+        request.addCloseRegion(op.buildCloseRegionRequest(getServerName()));
       }
     }
 
     @Override
     public void dispatchServerOperations(MasterProcedureEnv env, List<ServerOperation> operations) {
-      operations.stream().map(o -> o.buildRequest(env.getMasterServices().getMasterActiveTime()))
-        .forEachOrdered(request::addProc);
+      operations.stream().map(ServerOperation::buildRequest).forEachOrdered(request::addProc);
     }
 
     // will be overridden in test.
@@ -444,7 +442,8 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     final ServerName serverName, final List<RegionOpenOperation> operations) {
     final OpenRegionRequest.Builder builder = OpenRegionRequest.newBuilder();
     builder.setServerStartCode(serverName.getStartCode());
-    builder.setInitiatingMasterActiveTime(env.getMasterServices().getMasterActiveTime());
+    builder.setInitiatingMasterActiveTime(operations.stream()
+      .map(RemoteOperation::getInitiatingMasterActiveTime).findAny().orElse(-1L));
     builder.setMasterSystemTime(EnvironmentEdgeManager.currentTime());
     for (RegionOpenOperation op : operations) {
       builder.addOpenInfo(op.buildRegionOpenInfoRequest(env));
@@ -467,17 +466,17 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     private final byte[] rsProcData;
 
     public ServerOperation(RemoteProcedure remoteProcedure, long procId, Class<?> rsProcClass,
-      byte[] rsProcData) {
-      super(remoteProcedure);
+      byte[] rsProcData, long initiatingMasterActiveTime) {
+      super(remoteProcedure, initiatingMasterActiveTime);
       this.procId = procId;
       this.rsProcClass = rsProcClass;
       this.rsProcData = rsProcData;
     }
 
-    public RemoteProcedureRequest buildRequest(long initiatingMasterActiveTime) {
+    public RemoteProcedureRequest buildRequest() {
       return RemoteProcedureRequest.newBuilder().setProcId(procId)
         .setProcClass(rsProcClass.getName()).setProcData(ByteString.copyFrom(rsProcData))
-        .setInitiatingMasterActiveTime(initiatingMasterActiveTime).build();
+        .setInitiatingMasterActiveTime(getInitiatingMasterActiveTime()).build();
     }
   }
 
@@ -485,8 +484,9 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     protected final RegionInfo regionInfo;
     protected final long procId;
 
-    protected RegionOperation(RemoteProcedure remoteProcedure, RegionInfo regionInfo, long procId) {
-      super(remoteProcedure);
+    protected RegionOperation(RemoteProcedure remoteProcedure, RegionInfo regionInfo, long procId,
+      long initiatingMasterActiveTime) {
+      super(remoteProcedure, initiatingMasterActiveTime);
       this.regionInfo = regionInfo;
       this.procId = procId;
     }
@@ -494,9 +494,9 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
 
   public static class RegionOpenOperation extends RegionOperation {
 
-    public RegionOpenOperation(RemoteProcedure remoteProcedure, RegionInfo regionInfo,
-      long procId) {
-      super(remoteProcedure, regionInfo, procId);
+    public RegionOpenOperation(RemoteProcedure remoteProcedure, RegionInfo regionInfo, long procId,
+      long initiatingMasterActiveTime) {
+      super(remoteProcedure, regionInfo, procId, initiatingMasterActiveTime);
     }
 
     public OpenRegionRequest.RegionOpenInfo
@@ -511,8 +511,8 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
     private boolean evictCache;
 
     public RegionCloseOperation(RemoteProcedure remoteProcedure, RegionInfo regionInfo, long procId,
-      ServerName destinationServer, boolean evictCache) {
-      super(remoteProcedure, regionInfo, procId);
+      ServerName destinationServer, boolean evictCache, long initiatingMasterActiveTime) {
+      super(remoteProcedure, regionInfo, procId, initiatingMasterActiveTime);
       this.destinationServer = destinationServer;
       this.evictCache = evictCache;
     }
@@ -521,11 +521,9 @@ public class RSProcedureDispatcher extends RemoteProcedureDispatcher<MasterProce
       return destinationServer;
     }
 
-    public CloseRegionRequest buildCloseRegionRequest(final ServerName serverName,
-      long initiatingMasterActiveTime) {
+    public CloseRegionRequest buildCloseRegionRequest(final ServerName serverName) {
       return ProtobufUtil.buildCloseRegionRequest(serverName, regionInfo.getRegionName(),
-        getDestinationServer(), procId, evictCache, initiatingMasterActiveTime);
-
+        getDestinationServer(), procId, evictCache, getInitiatingMasterActiveTime());
     }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SnapshotRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SnapshotRegionProcedure.java
@@ -95,9 +95,11 @@ public class SnapshotRegionProcedure extends Procedure<MasterProcedureEnv>
 
   @Override
   public Optional<RemoteOperation> remoteCallBuild(MasterProcedureEnv env, ServerName serverName) {
-    return Optional.of(new RSProcedureDispatcher.ServerOperation(this, getProcId(),
-      SnapshotRegionCallable.class, MasterProcedureProtos.SnapshotRegionParameter.newBuilder()
-        .setRegion(ProtobufUtil.toRegionInfo(region)).setSnapshot(snapshot).build().toByteArray()));
+    return Optional
+      .of(new RSProcedureDispatcher.ServerOperation(this, getProcId(), SnapshotRegionCallable.class,
+        MasterProcedureProtos.SnapshotRegionParameter.newBuilder()
+          .setRegion(ProtobufUtil.toRegionInfo(region)).setSnapshot(snapshot).build().toByteArray(),
+        env.getMasterServices().getMasterActiveTime()));
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SnapshotVerifyProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SnapshotVerifyProcedure.java
@@ -224,8 +224,9 @@ public class SnapshotVerifyProcedure extends ServerRemoteProcedure
   public Optional<RemoteOperation> remoteCallBuild(MasterProcedureEnv env, ServerName serverName) {
     SnapshotVerifyParameter.Builder builder = SnapshotVerifyParameter.newBuilder();
     builder.setSnapshot(snapshot).setRegion(ProtobufUtil.toRegionInfo(region));
-    return Optional.of(new RSProcedureDispatcher.ServerOperation(this, getProcId(),
-      SnapshotVerifyCallable.class, builder.build().toByteArray()));
+    return Optional
+      .of(new RSProcedureDispatcher.ServerOperation(this, getProcId(), SnapshotVerifyCallable.class,
+        builder.build().toByteArray(), env.getMasterServices().getMasterActiveTime()));
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SplitWALRemoteProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SplitWALRemoteProcedure.java
@@ -97,9 +97,10 @@ public class SplitWALRemoteProcedure extends ServerRemoteProcedure
   @Override
   public Optional<RemoteProcedureDispatcher.RemoteOperation> remoteCallBuild(MasterProcedureEnv env,
     ServerName serverName) {
-    return Optional.of(new RSProcedureDispatcher.ServerOperation(this, getProcId(),
-      SplitWALCallable.class, MasterProcedureProtos.SplitWALParameter.newBuilder()
-        .setWalPath(walPath).build().toByteArray()));
+    return Optional.of(new RSProcedureDispatcher.ServerOperation(
+      this, getProcId(), SplitWALCallable.class, MasterProcedureProtos.SplitWALParameter
+        .newBuilder().setWalPath(walPath).build().toByteArray(),
+      env.getMasterServices().getMasterActiveTime()));
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SwitchRpcThrottleRemoteProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SwitchRpcThrottleRemoteProcedure.java
@@ -93,7 +93,8 @@ public class SwitchRpcThrottleRemoteProcedure extends ServerRemoteProcedure
       SwitchRpcThrottleRemoteCallable.class,
       SwitchRpcThrottleRemoteStateData.newBuilder()
         .setTargetServer(ProtobufUtil.toServerName(remote))
-        .setRpcThrottleEnabled(rpcThrottleEnabled).build().toByteArray()));
+        .setRpcThrottleEnabled(rpcThrottleEnabled).build().toByteArray(),
+      masterProcedureEnv.getMasterServices().getMasterActiveTime()));
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/ClaimReplicationQueueRemoteProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/ClaimReplicationQueueRemoteProcedure.java
@@ -97,7 +97,7 @@ public class ClaimReplicationQueueRemoteProcedure extends ServerRemoteProcedure
     queueId.getSourceServerName()
       .ifPresent(sourceServer -> builder.setSourceServer(ProtobufUtil.toServerName(sourceServer)));
     return Optional.of(new ServerOperation(this, getProcId(), ClaimReplicationQueueCallable.class,
-      builder.build().toByteArray()));
+      builder.build().toByteArray(), env.getMasterServices().getMasterActiveTime()));
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/RefreshPeerProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/RefreshPeerProcedure.java
@@ -119,7 +119,8 @@ public class RefreshPeerProcedure extends ServerRemoteProcedure
     assert targetServer.equals(remote);
     return Optional.of(new ServerOperation(this, getProcId(), RefreshPeerCallable.class,
       RefreshPeerParameter.newBuilder().setPeerId(peerId).setType(toPeerModificationType(type))
-        .setTargetServer(ProtobufUtil.toServerName(remote)).setStage(stage).build().toByteArray()));
+        .setTargetServer(ProtobufUtil.toServerName(remote)).setStage(stage).build().toByteArray(),
+      env.getMasterServices().getMasterActiveTime()));
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/SyncReplicationReplayWALRemoteProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/replication/SyncReplicationReplayWALRemoteProcedure.java
@@ -69,8 +69,9 @@ public class SyncReplicationReplayWALRemoteProcedure extends ServerRemoteProcedu
       ReplaySyncReplicationWALParameter.newBuilder();
     builder.setPeerId(peerId);
     wals.stream().forEach(builder::addWal);
-    return Optional.of(new ServerOperation(this, getProcId(),
-      ReplaySyncReplicationWALCallable.class, builder.build().toByteArray()));
+    return Optional
+      .of(new ServerOperation(this, getProcId(), ReplaySyncReplicationWALCallable.class,
+        builder.build().toByteArray(), env.getMasterServices().getMasterActiveTime()));
   }
 
   protected boolean complete(MasterProcedureEnv env, Throwable error) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -2231,6 +2231,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     HRegion r = context.getRegion();
     long openProcId = context.getOpenProcId();
     long masterSystemTime = context.getMasterSystemTime();
+    long masterStartCode = context.getMasterStartCode();
     rpcServices.checkOpen();
     LOG.info("Post open deploy tasks for {}, pid={}, masterSystemTime={}",
       r.getRegionInfo().getRegionNameAsString(), openProcId, masterSystemTime);
@@ -2254,7 +2255,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     // Notify master
     if (
       !reportRegionStateTransition(new RegionStateTransitionContext(TransitionCode.OPENED,
-        openSeqNum, openProcId, masterSystemTime, r.getRegionInfo()))
+        openSeqNum, openProcId, masterSystemTime, r.getRegionInfo(), masterStartCode))
     ) {
       throw new IOException(
         "Failed to report opened region to master: " + r.getRegionInfo().getRegionNameAsString());
@@ -3533,12 +3534,12 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     return true;
   }
 
-  void executeProcedure(long procId, RSProcedureCallable callable) {
-    executorService.submit(new RSProcedureHandler(this, procId, callable));
+  void executeProcedure(long procId, long masterStartCode, RSProcedureCallable callable) {
+    executorService.submit(new RSProcedureHandler(this, procId, masterStartCode, callable));
   }
 
-  public void remoteProcedureComplete(long procId, Throwable error) {
-    procedureResultReporter.complete(procId, error);
+  public void remoteProcedureComplete(long procId, long masterStartCode, Throwable error) {
+    procedureResultReporter.complete(procId, masterStartCode, error);
   }
 
   void reportProcedureDone(ReportProcedureDoneRequest request) throws IOException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -3859,6 +3859,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
   private void executeOpenRegionProcedures(OpenRegionRequest request,
     Map<TableName, TableDescriptor> tdCache) {
     long masterSystemTime = request.hasMasterSystemTime() ? request.getMasterSystemTime() : -1;
+    long masterStartCode = request.hasMasterStartCode() ? request.getMasterStartCode() : -1;
     for (RegionOpenInfo regionOpenInfo : request.getOpenInfoList()) {
       RegionInfo regionInfo = ProtobufUtil.toRegionInfo(regionOpenInfo.getRegion());
       TableName tableName = regionInfo.getTable();
@@ -3884,14 +3885,15 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
       }
       long procId = regionOpenInfo.getOpenProcId();
       if (server.submitRegionProcedure(procId)) {
-        server.getExecutorService().submit(
-          AssignRegionHandler.create(server, regionInfo, procId, tableDesc, masterSystemTime));
+        server.getExecutorService().submit(AssignRegionHandler.create(server, regionInfo, procId,
+          tableDesc, masterSystemTime, masterStartCode));
       }
     }
   }
 
   private void executeCloseRegionProcedures(CloseRegionRequest request) {
     String encodedName;
+    long masterStartCode = request.hasMasterStartCode() ? request.getMasterStartCode() : -1;
     try {
       encodedName = ProtobufUtil.getRegionEncodedName(request.getRegion());
     } catch (DoNotRetryIOException e) {
@@ -3903,8 +3905,8 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
     long procId = request.getCloseProcId();
     boolean evictCache = request.getEvictCache();
     if (server.submitRegionProcedure(procId)) {
-      server.getExecutorService().submit(
-        UnassignRegionHandler.create(server, encodedName, procId, false, destination, evictCache));
+      server.getExecutorService().submit(UnassignRegionHandler.create(server, encodedName, procId,
+        false, destination, evictCache, masterStartCode));
     }
   }
 
@@ -3916,12 +3918,12 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
     } catch (Exception e) {
       LOG.warn("Failed to instantiating remote procedure {}, pid={}", request.getProcClass(),
         request.getProcId(), e);
-      server.remoteProcedureComplete(request.getProcId(), e);
+      server.remoteProcedureComplete(request.getProcId(), request.getMasterStartCode(), e);
       return;
     }
     callable.init(request.getProcData().toByteArray(), server);
     LOG.debug("Executing remote procedure {}, pid={}", callable.getClass(), request.getProcId());
-    server.executeProcedure(request.getProcId(), callable);
+    server.executeProcedure(request.getProcId(), request.getMasterStartCode(), callable);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -3859,7 +3859,8 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
   private void executeOpenRegionProcedures(OpenRegionRequest request,
     Map<TableName, TableDescriptor> tdCache) {
     long masterSystemTime = request.hasMasterSystemTime() ? request.getMasterSystemTime() : -1;
-    long masterStartCode = request.hasMasterStartCode() ? request.getMasterStartCode() : -1;
+    long initiatingMasterActiveTime =
+      request.hasInitiatingMasterActiveTime() ? request.getInitiatingMasterActiveTime() : -1;
     for (RegionOpenInfo regionOpenInfo : request.getOpenInfoList()) {
       RegionInfo regionInfo = ProtobufUtil.toRegionInfo(regionOpenInfo.getRegion());
       TableName tableName = regionInfo.getTable();
@@ -3886,14 +3887,15 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
       long procId = regionOpenInfo.getOpenProcId();
       if (server.submitRegionProcedure(procId)) {
         server.getExecutorService().submit(AssignRegionHandler.create(server, regionInfo, procId,
-          tableDesc, masterSystemTime, masterStartCode));
+          tableDesc, masterSystemTime, initiatingMasterActiveTime));
       }
     }
   }
 
   private void executeCloseRegionProcedures(CloseRegionRequest request) {
     String encodedName;
-    long masterStartCode = request.hasMasterStartCode() ? request.getMasterStartCode() : -1;
+    long initiatingMasterActiveTime =
+      request.hasInitiatingMasterActiveTime() ? request.getInitiatingMasterActiveTime() : -1;
     try {
       encodedName = ProtobufUtil.getRegionEncodedName(request.getRegion());
     } catch (DoNotRetryIOException e) {
@@ -3906,7 +3908,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
     boolean evictCache = request.getEvictCache();
     if (server.submitRegionProcedure(procId)) {
       server.getExecutorService().submit(UnassignRegionHandler.create(server, encodedName, procId,
-        false, destination, evictCache, masterStartCode));
+        false, destination, evictCache, initiatingMasterActiveTime));
     }
   }
 
@@ -3918,12 +3920,13 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
     } catch (Exception e) {
       LOG.warn("Failed to instantiating remote procedure {}, pid={}", request.getProcClass(),
         request.getProcId(), e);
-      server.remoteProcedureComplete(request.getProcId(), request.getMasterStartCode(), e);
+      server.remoteProcedureComplete(request.getProcId(), request.getInitiatingMasterActiveTime(),
+        e);
       return;
     }
     callable.init(request.getProcData().toByteArray(), server);
     LOG.debug("Executing remote procedure {}, pid={}", callable.getClass(), request.getProcId());
-    server.executeProcedure(request.getProcId(), request.getMasterStartCode(), callable);
+    server.executeProcedure(request.getProcId(), request.getInitiatingMasterActiveTime(), callable);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerServices.java
@@ -93,11 +93,14 @@ public interface RegionServerServices extends Server, MutableOnlineRegions, Favo
     private final HRegion region;
     private final long openProcId;
     private final long masterSystemTime;
+    private final long masterStartCode;
 
-    public PostOpenDeployContext(HRegion region, long openProcId, long masterSystemTime) {
+    public PostOpenDeployContext(HRegion region, long openProcId, long masterSystemTime,
+      long masterStartCode) {
       this.region = region;
       this.openProcId = openProcId;
       this.masterSystemTime = masterSystemTime;
+      this.masterStartCode = masterStartCode;
     }
 
     public HRegion getRegion() {
@@ -111,6 +114,10 @@ public interface RegionServerServices extends Server, MutableOnlineRegions, Favo
     public long getMasterSystemTime() {
       return masterSystemTime;
     }
+
+    public long getMasterStartCode() {
+      return masterStartCode;
+    }
   }
 
   /**
@@ -123,23 +130,26 @@ public interface RegionServerServices extends Server, MutableOnlineRegions, Favo
     private final TransitionCode code;
     private final long openSeqNum;
     private final long masterSystemTime;
+    private final long masterStartCode;
     private final long[] procIds;
     private final RegionInfo[] hris;
 
     public RegionStateTransitionContext(TransitionCode code, long openSeqNum, long masterSystemTime,
-      RegionInfo... hris) {
+      long masterStartCode, RegionInfo... hris) {
       this.code = code;
       this.openSeqNum = openSeqNum;
       this.masterSystemTime = masterSystemTime;
+      this.masterStartCode = masterStartCode;
       this.hris = hris;
       this.procIds = new long[hris.length];
     }
 
     public RegionStateTransitionContext(TransitionCode code, long openSeqNum, long procId,
-      long masterSystemTime, RegionInfo hri) {
+      long masterSystemTime, RegionInfo hri, long masterStartCode) {
       this.code = code;
       this.openSeqNum = openSeqNum;
       this.masterSystemTime = masterSystemTime;
+      this.masterStartCode = masterStartCode;
       this.hris = new RegionInfo[] { hri };
       this.procIds = new long[] { procId };
     }
@@ -162,6 +172,10 @@ public interface RegionServerServices extends Server, MutableOnlineRegions, Favo
 
     public long[] getProcIds() {
       return procIds;
+    }
+
+    public long getMasterStartCode() {
+      return masterStartCode;
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RegionServerServices.java
@@ -93,14 +93,14 @@ public interface RegionServerServices extends Server, MutableOnlineRegions, Favo
     private final HRegion region;
     private final long openProcId;
     private final long masterSystemTime;
-    private final long masterStartCode;
+    private final long initiatingMasterActiveTime;
 
     public PostOpenDeployContext(HRegion region, long openProcId, long masterSystemTime,
-      long masterStartCode) {
+      long initiatingMasterActiveTime) {
       this.region = region;
       this.openProcId = openProcId;
       this.masterSystemTime = masterSystemTime;
-      this.masterStartCode = masterStartCode;
+      this.initiatingMasterActiveTime = initiatingMasterActiveTime;
     }
 
     public HRegion getRegion() {
@@ -115,8 +115,8 @@ public interface RegionServerServices extends Server, MutableOnlineRegions, Favo
       return masterSystemTime;
     }
 
-    public long getMasterStartCode() {
-      return masterStartCode;
+    public long getInitiatingMasterActiveTime() {
+      return initiatingMasterActiveTime;
     }
   }
 
@@ -130,26 +130,26 @@ public interface RegionServerServices extends Server, MutableOnlineRegions, Favo
     private final TransitionCode code;
     private final long openSeqNum;
     private final long masterSystemTime;
-    private final long masterStartCode;
+    private final long initiatingMasterActiveTime;
     private final long[] procIds;
     private final RegionInfo[] hris;
 
     public RegionStateTransitionContext(TransitionCode code, long openSeqNum, long masterSystemTime,
-      long masterStartCode, RegionInfo... hris) {
+      long initiatingMasterActiveTime, RegionInfo... hris) {
       this.code = code;
       this.openSeqNum = openSeqNum;
       this.masterSystemTime = masterSystemTime;
-      this.masterStartCode = masterStartCode;
+      this.initiatingMasterActiveTime = initiatingMasterActiveTime;
       this.hris = hris;
       this.procIds = new long[hris.length];
     }
 
     public RegionStateTransitionContext(TransitionCode code, long openSeqNum, long procId,
-      long masterSystemTime, RegionInfo hri, long masterStartCode) {
+      long masterSystemTime, RegionInfo hri, long initiatingMasterActiveTime) {
       this.code = code;
       this.openSeqNum = openSeqNum;
       this.masterSystemTime = masterSystemTime;
-      this.masterStartCode = masterStartCode;
+      this.initiatingMasterActiveTime = initiatingMasterActiveTime;
       this.hris = new RegionInfo[] { hri };
       this.procIds = new long[] { procId };
     }
@@ -174,8 +174,8 @@ public interface RegionServerServices extends Server, MutableOnlineRegions, Favo
       return procIds;
     }
 
-    public long getMasterStartCode() {
-      return masterStartCode;
+    public long getInitiatingMasterActiveTime() {
+      return initiatingMasterActiveTime;
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RemoteProcedureResultReporter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RemoteProcedureResultReporter.java
@@ -51,8 +51,9 @@ class RemoteProcedureResultReporter extends Thread {
     this.server = server;
   }
 
-  public void complete(long procId, Throwable error) {
-    RemoteProcedureResult.Builder builder = RemoteProcedureResult.newBuilder().setProcId(procId);
+  public void complete(long procId, long masterStartCode, Throwable error) {
+    RemoteProcedureResult.Builder builder =
+      RemoteProcedureResult.newBuilder().setProcId(procId).setMasterStartCode(masterStartCode);
     if (error != null) {
       LOG.debug("Failed to complete execution of pid={}", procId, error);
       builder.setStatus(RemoteProcedureResult.Status.ERROR).setError(

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RemoteProcedureResultReporter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RemoteProcedureResultReporter.java
@@ -51,9 +51,9 @@ class RemoteProcedureResultReporter extends Thread {
     this.server = server;
   }
 
-  public void complete(long procId, long masterStartCode, Throwable error) {
-    RemoteProcedureResult.Builder builder =
-      RemoteProcedureResult.newBuilder().setProcId(procId).setMasterStartCode(masterStartCode);
+  public void complete(long procId, long initiatingMasterActiveTime, Throwable error) {
+    RemoteProcedureResult.Builder builder = RemoteProcedureResult.newBuilder().setProcId(procId)
+      .setInitiatingMasterActiveTime(initiatingMasterActiveTime);
     if (error != null) {
       LOG.debug("Failed to complete execution of pid={}", procId, error);
       builder.setStatus(RemoteProcedureResult.Status.ERROR).setError(

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SplitRequest.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/SplitRequest.java
@@ -81,7 +81,7 @@ class SplitRequest implements Runnable {
     // are created just to pass the information to the reportRegionStateTransition().
     if (
       !server.reportRegionStateTransition(new RegionStateTransitionContext(
-        TransitionCode.READY_TO_SPLIT, HConstants.NO_SEQNUM, -1, parent, hri_a, hri_b))
+        TransitionCode.READY_TO_SPLIT, HConstants.NO_SEQNUM, -1, -1, parent, hri_a, hri_b))
     ) {
       LOG.error("Unable to ask master to split " + parent.getRegionNameAsString());
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
@@ -59,7 +59,7 @@ public class AssignRegionHandler extends EventHandler {
 
   private final long masterSystemTime;
 
-  // active time of the master that sent this assign request
+  // active time of the master that sent this assign request, used for fencing
   private final long initiatingMasterActiveTime;
 
   private final RetryCounter retryCounter;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/AssignRegionHandler.java
@@ -59,7 +59,7 @@ public class AssignRegionHandler extends EventHandler {
 
   private final long masterSystemTime;
 
-  //active time of the master that sent this assign request
+  // active time of the master that sent this assign request
   private final long initiatingMasterActiveTime;
 
   private final RetryCounter retryCounter;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/CloseRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/CloseRegionHandler.java
@@ -111,7 +111,7 @@ public class CloseRegionHandler extends EventHandler {
 
       this.rsServices.removeRegion(region, destination);
       rsServices.reportRegionStateTransition(new RegionStateTransitionContext(TransitionCode.CLOSED,
-        HConstants.NO_SEQNUM, Procedure.NO_PROC_ID, -1, regionInfo));
+        HConstants.NO_SEQNUM, Procedure.NO_PROC_ID, -1, regionInfo, -1));
 
       // Done! Region is closed on this RS
       LOG.debug("Closed {}", region.getRegionInfo().getRegionNameAsString());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/OpenRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/OpenRegionHandler.java
@@ -166,8 +166,9 @@ public class OpenRegionHandler extends EventHandler {
         cleanupFailedOpen(region);
       }
     } finally {
-      rsServices.reportRegionStateTransition(new RegionStateTransitionContext(
-        TransitionCode.FAILED_OPEN, HConstants.NO_SEQNUM, Procedure.NO_PROC_ID, -1, regionInfo));
+      rsServices
+        .reportRegionStateTransition(new RegionStateTransitionContext(TransitionCode.FAILED_OPEN,
+          HConstants.NO_SEQNUM, Procedure.NO_PROC_ID, -1, regionInfo, -1));
     }
   }
 
@@ -253,7 +254,7 @@ public class OpenRegionHandler extends EventHandler {
     public void run() {
       try {
         this.services.postOpenDeployTasks(
-          new PostOpenDeployContext(region, Procedure.NO_PROC_ID, masterSystemTime));
+          new PostOpenDeployContext(region, Procedure.NO_PROC_ID, masterSystemTime, -1));
       } catch (Throwable e) {
         String msg = "Exception running postOpenDeployTasks; region="
           + this.region.getRegionInfo().getEncodedName();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
@@ -35,12 +35,16 @@ public class RSProcedureHandler extends EventHandler {
 
   private final long procId;
 
+  private final long masterStartCode;
+
   private final RSProcedureCallable callable;
 
-  public RSProcedureHandler(HRegionServer rs, long procId, RSProcedureCallable callable) {
+  public RSProcedureHandler(HRegionServer rs, long procId, long masterStartCode,
+    RSProcedureCallable callable) {
     super(rs, callable.getEventType());
     this.procId = procId;
     this.callable = callable;
+    this.masterStartCode = masterStartCode;
   }
 
   @Override
@@ -53,7 +57,7 @@ public class RSProcedureHandler extends EventHandler {
       LOG.error("pid=" + this.procId, t);
       error = t;
     } finally {
-      ((HRegionServer) server).remoteProcedureComplete(procId, error);
+      ((HRegionServer) server).remoteProcedureComplete(procId, masterStartCode, error);
     }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
@@ -35,7 +35,7 @@ public class RSProcedureHandler extends EventHandler {
 
   private final long procId;
 
-  // active time of the master that sent this procedure request, used for fencing
+  // active time of the master that sent procedure request, used for fencing
   private final long initiatingMasterActiveTime;
 
   private final RSProcedureCallable callable;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
@@ -35,7 +35,7 @@ public class RSProcedureHandler extends EventHandler {
 
   private final long procId;
 
-  // active time of the master that sent this procedure request
+  // active time of the master that sent this procedure request, used for fencing
   private final long initiatingMasterActiveTime;
 
   private final RSProcedureCallable callable;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
@@ -35,7 +35,7 @@ public class RSProcedureHandler extends EventHandler {
 
   private final long procId;
 
-  //active time of the master that sent this procedure request
+  // active time of the master that sent this procedure request
   private final long initiatingMasterActiveTime;
 
   private final RSProcedureCallable callable;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
@@ -35,6 +35,7 @@ public class RSProcedureHandler extends EventHandler {
 
   private final long procId;
 
+  //active time of the master that sent this procedure request
   private final long initiatingMasterActiveTime;
 
   private final RSProcedureCallable callable;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/RSProcedureHandler.java
@@ -35,16 +35,16 @@ public class RSProcedureHandler extends EventHandler {
 
   private final long procId;
 
-  private final long masterStartCode;
+  private final long initiatingMasterActiveTime;
 
   private final RSProcedureCallable callable;
 
-  public RSProcedureHandler(HRegionServer rs, long procId, long masterStartCode,
+  public RSProcedureHandler(HRegionServer rs, long procId, long initiatingMasterActiveTime,
     RSProcedureCallable callable) {
     super(rs, callable.getEventType());
     this.procId = procId;
     this.callable = callable;
-    this.masterStartCode = masterStartCode;
+    this.initiatingMasterActiveTime = initiatingMasterActiveTime;
   }
 
   @Override
@@ -57,7 +57,7 @@ public class RSProcedureHandler extends EventHandler {
       LOG.error("pid=" + this.procId, t);
       error = t;
     } finally {
-      ((HRegionServer) server).remoteProcedureComplete(procId, masterStartCode, error);
+      ((HRegionServer) server).remoteProcedureComplete(procId, initiatingMasterActiveTime, error);
     }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
@@ -63,13 +63,8 @@ public class UnassignRegionHandler extends EventHandler {
 
   private boolean evictCache;
 
-  // active time of the master that sent this unassign request
+  // active time of the master that sent this unassign request, used for fencing
   private final long initiatingMasterActiveTime;
-
-  public UnassignRegionHandler(HRegionServer server, String encodedName, long closeProcId,
-    boolean abort, @Nullable ServerName destination, EventType eventType) {
-    this(server, encodedName, closeProcId, abort, destination, eventType, -1, false);
-  }
 
   public UnassignRegionHandler(HRegionServer server, String encodedName, long closeProcId,
     boolean abort, @Nullable ServerName destination, EventType eventType,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
@@ -63,6 +63,7 @@ public class UnassignRegionHandler extends EventHandler {
 
   private boolean evictCache;
 
+  //active time of the master that sent this unassign request
   private final long initiatingMasterActiveTime;
 
   public UnassignRegionHandler(HRegionServer server, String encodedName, long closeProcId,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/handler/UnassignRegionHandler.java
@@ -63,7 +63,7 @@ public class UnassignRegionHandler extends EventHandler {
 
   private boolean evictCache;
 
-  //active time of the master that sent this unassign request
+  // active time of the master that sent this unassign request
   private final long initiatingMasterActiveTime;
 
   public UnassignRegionHandler(HRegionServer server, String encodedName, long closeProcId,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
@@ -62,6 +62,7 @@ import org.apache.hadoop.hbase.replication.master.ReplicationLogCleanerBarrier;
 import org.apache.hadoop.hbase.rsgroup.RSGroupInfoManager;
 import org.apache.hadoop.hbase.security.access.AccessChecker;
 import org.apache.hadoop.hbase.security.access.ZKPermissionWatcher;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.zookeeper.ZKWatcher;
 
 import org.apache.hbase.thirdparty.com.google.protobuf.Service;
@@ -69,10 +70,12 @@ import org.apache.hbase.thirdparty.com.google.protobuf.Service;
 public class MockNoopMasterServices implements MasterServices {
   private final Configuration conf;
   private final MetricsMaster metricsMaster;
+  private final long masterActiveTime;
 
   public MockNoopMasterServices(final Configuration conf) {
     this.conf = conf;
     this.metricsMaster = new MetricsMaster(new MetricsMasterWrapperImpl(mock(HMaster.class)));
+    this.masterActiveTime = EnvironmentEdgeManager.currentTime();
   }
 
   @Override
@@ -325,6 +328,11 @@ public class MockNoopMasterServices implements MasterServices {
   @Override
   public boolean isActiveMaster() {
     return true;
+  }
+
+  @Override
+  public long getMasterActiveTime() {
+    return masterActiveTime;
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestServerRemoteProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestServerRemoteProcedure.java
@@ -183,8 +183,8 @@ public class TestServerRemoteProcedure {
     @Override
     public Optional<RemoteProcedureDispatcher.RemoteOperation>
       remoteCallBuild(MasterProcedureEnv env, ServerName serverName) {
-      return Optional
-        .of(new RSProcedureDispatcher.ServerOperation(null, 0L, this.getClass(), new byte[0]));
+      return Optional.of(new RSProcedureDispatcher.ServerOperation(null, 0L, this.getClass(),
+        new byte[0], env.getMasterServices().getMasterActiveTime()));
     }
 
     @Override


### PR DESCRIPTION
masterStartCode as a fencing token for remote procedures
There are 3 flows that I checked regionOpen, regionClose, and other remote Procedures. In might not be needed in the third flow but I added masterStartCode in all three.

