### PR TITLE
HBASE-28669 After one RegionServer restarts, another RegionServer leaks a connection to ZooKeeper

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RecoveredReplicationSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/RecoveredReplicationSource.java
@@ -149,6 +149,7 @@ public class RecoveredReplicationSource extends ReplicationSource {
       boolean allTasksDone = workerThreads.values().stream().allMatch(w -> w.isFinished());
       if (allTasksDone) {
         this.getSourceMetrics().clear();
+        this.terminate("Finished recovering queue");
         manager.removeRecoveredSource(this);
         LOG.info("Finished recovering queue {} with the following stats: {}", queueId, getStats());
       }


### PR DESCRIPTION
fix a bug. After one RegionServer restarts, another RegionServer leaks a connection to ZooKeeper