### PR TITLE
HBASE-28777 mTLS client hostname verification doesn't work with OptionalSslHandler

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/HBaseTrustManager.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/HBaseTrustManager.java
@@ -92,8 +92,12 @@ public class HBaseTrustManager extends X509ExtendedTrustManager {
   public void checkClientTrusted(X509Certificate[] chain, String authType, SSLEngine engine)
     throws CertificateException {
     x509ExtendedTrustManager.checkClientTrusted(chain, authType, engine);
-    if (hostnameVerificationEnabled) {
+    if (hostnameVerificationEnabled && engine != null) {
       try {
+        if (engine.getPeerHost() == null) {
+          LOG.warn("Cannot perform client hostname verification, because peer information is not available");
+          return;
+        }
         performHostVerification(InetAddress.getByName(engine.getPeerHost()), chain[0]);
       } catch (UnknownHostException e) {
         throw new CertificateException("Failed to verify host", e);

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/HBaseTrustManager.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/HBaseTrustManager.java
@@ -95,7 +95,8 @@ public class HBaseTrustManager extends X509ExtendedTrustManager {
     if (hostnameVerificationEnabled && engine != null) {
       try {
         if (engine.getPeerHost() == null) {
-          LOG.warn("Cannot perform client hostname verification, because peer information is not available");
+          LOG.warn(
+            "Cannot perform client hostname verification, because peer information is not available");
           return;
         }
         performHostVerification(InetAddress.getByName(engine.getPeerHost()), chain[0]);

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/crypto/tls/X509TestContext.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/crypto/tls/X509TestContext.java
@@ -461,12 +461,12 @@ public final class X509TestContext {
   }
 
   public void regenerateStores(X509KeyType keyStoreKeyType, X509KeyType trustStoreKeyType,
-    KeyStoreFileType keyStoreFileType, KeyStoreFileType trustStoreFileType)
+    KeyStoreFileType keyStoreFileType, KeyStoreFileType trustStoreFileType, String... subjectAltNames)
     throws GeneralSecurityException, IOException, OperatorCreationException {
 
     trustStoreKeyPair = X509TestHelpers.generateKeyPair(trustStoreKeyType);
     keyStoreKeyPair = X509TestHelpers.generateKeyPair(keyStoreKeyType);
-    createCertificates();
+    createCertificates(subjectAltNames);
 
     switch (keyStoreFileType) {
       case JKS:
@@ -499,7 +499,7 @@ public final class X509TestContext {
     }
   }
 
-  private void createCertificates()
+  private void createCertificates(String... subjectAltNames)
     throws GeneralSecurityException, IOException, OperatorCreationException {
     X500NameBuilder caNameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
     caNameBuilder.addRDN(BCStyle.CN,
@@ -510,7 +510,7 @@ public final class X509TestContext {
     X500NameBuilder nameBuilder = new X500NameBuilder(BCStyle.INSTANCE);
     nameBuilder.addRDN(BCStyle.CN,
       MethodHandles.lookup().lookupClass().getCanonicalName() + " Zookeeper Test");
-    keyStoreCertificate = newCert(nameBuilder.build());
+    keyStoreCertificate = newCert(nameBuilder.build(), subjectAltNames);
   }
 
   /**

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/crypto/tls/X509TestContext.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/crypto/tls/X509TestContext.java
@@ -461,7 +461,8 @@ public final class X509TestContext {
   }
 
   public void regenerateStores(X509KeyType keyStoreKeyType, X509KeyType trustStoreKeyType,
-    KeyStoreFileType keyStoreFileType, KeyStoreFileType trustStoreFileType, String... subjectAltNames)
+    KeyStoreFileType keyStoreFileType, KeyStoreFileType trustStoreFileType,
+    String... subjectAltNames)
     throws GeneralSecurityException, IOException, OperatorCreationException {
 
     trustStoreKeyPair = X509TestHelpers.generateKeyPair(trustStoreKeyType);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcServer.java
@@ -21,7 +21,6 @@ import static org.apache.hadoop.hbase.io.crypto.tls.X509Util.DEFAULT_HBASE_SERVE
 import static org.apache.hadoop.hbase.io.crypto.tls.X509Util.HBASE_SERVER_NETTY_TLS_ENABLED;
 import static org.apache.hadoop.hbase.io.crypto.tls.X509Util.HBASE_SERVER_NETTY_TLS_SUPPORTPLAINTEXT;
 import static org.apache.hadoop.hbase.io.crypto.tls.X509Util.HBASE_SERVER_NETTY_TLS_WRAP_SIZE;
-import static org.apache.hadoop.hbase.io.crypto.tls.X509Util.TLS_CONFIG_REVERSE_DNS_LOOKUP_ENABLED;
 
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -386,8 +385,24 @@ public class NettyRpcServer extends RpcServer {
     throws X509Exception, IOException {
     SslContext nettySslContext = getSslContext();
 
+    /*
+     * our HostnameVerifier gets the host name from SSLEngine, so we have to construct the
+     * engine properly by passing the remote address
+     */
+
     if (supportPlaintext) {
-      p.addLast("ssl", new OptionalSslHandler(nettySslContext));
+      SocketAddress remoteAddress = p.channel().remoteAddress();
+      OptionalSslHandler optionalSslHandler;
+
+      if (remoteAddress instanceof InetSocketAddress) {
+        InetSocketAddress remoteInetAddress = (InetSocketAddress) remoteAddress;
+        optionalSslHandler = new OptionalSslHandlerWithHostPort(nettySslContext,
+          remoteInetAddress.getHostString(), remoteInetAddress.getPort());
+      } else {
+        optionalSslHandler = new OptionalSslHandler(nettySslContext);
+      }
+
+      p.addLast("ssl", optionalSslHandler);
       LOG.debug("Dual mode SSL handler added for channel: {}", p.channel());
     } else {
       SocketAddress remoteAddress = p.channel().remoteAddress();
@@ -395,21 +410,8 @@ public class NettyRpcServer extends RpcServer {
 
       if (remoteAddress instanceof InetSocketAddress) {
         InetSocketAddress remoteInetAddress = (InetSocketAddress) remoteAddress;
-        String host;
-
-        if (conf.getBoolean(TLS_CONFIG_REVERSE_DNS_LOOKUP_ENABLED, true)) {
-          host = remoteInetAddress.getHostName();
-        } else {
-          host = remoteInetAddress.getHostString();
-        }
-
-        int port = remoteInetAddress.getPort();
-
-        /*
-         * our HostnameVerifier gets the host name from SSLEngine, so we have to construct the
-         * engine properly by passing the remote address
-         */
-        sslHandler = nettySslContext.newHandler(p.channel().alloc(), host, port);
+        sslHandler = nettySslContext.newHandler(p.channel().alloc(),
+          remoteInetAddress.getHostString(), remoteInetAddress.getPort());
       } else {
         sslHandler = nettySslContext.newHandler(p.channel().alloc());
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/NettyRpcServer.java
@@ -386,8 +386,8 @@ public class NettyRpcServer extends RpcServer {
     SslContext nettySslContext = getSslContext();
 
     /*
-     * our HostnameVerifier gets the host name from SSLEngine, so we have to construct the
-     * engine properly by passing the remote address
+     * our HostnameVerifier gets the host name from SSLEngine, so we have to construct the engine
+     * properly by passing the remote address
      */
 
     if (supportPlaintext) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/OptionalSslHandlerWithHostPort.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/OptionalSslHandlerWithHostPort.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.ipc;
+
+import org.apache.hbase.thirdparty.io.netty.channel.ChannelHandlerContext;
+import org.apache.hbase.thirdparty.io.netty.handler.ssl.OptionalSslHandler;
+import org.apache.hbase.thirdparty.io.netty.handler.ssl.SslContext;
+import org.apache.hbase.thirdparty.io.netty.handler.ssl.SslHandler;
+
+class OptionalSslHandlerWithHostPort extends OptionalSslHandler {
+
+  private final String host;
+  private final int port;
+
+  public OptionalSslHandlerWithHostPort(SslContext sslContext, String host, int port) {
+    super(sslContext);
+    this.host = host;
+    this.port = port;
+  }
+
+  @Override
+  protected SslHandler newSslHandler(ChannelHandlerContext context, SslContext sslContext) {
+    return sslContext.newHandler(context.alloc(), host, port);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/TestMutualTlsClientSideNonLocalhost.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/TestMutualTlsClientSideNonLocalhost.java
@@ -79,7 +79,7 @@ public class TestMutualTlsClientSideNonLocalhost {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-    HBaseClassTestRule.forClass(TestMutualTlsClientSide.class);
+    HBaseClassTestRule.forClass(TestMutualTlsClientSideNonLocalhost.class);
 
   protected static HBaseCommonTestingUtil UTIL;
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/TestMutualTlsClientSideNonLocalhost.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/TestMutualTlsClientSideNonLocalhost.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security;
+
+import org.apache.commons.io.FileUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseCommonTestingUtil;
+import org.apache.hadoop.hbase.io.crypto.tls.KeyStoreFileType;
+import org.apache.hadoop.hbase.io.crypto.tls.X509KeyType;
+import org.apache.hadoop.hbase.io.crypto.tls.X509TestContext;
+import org.apache.hadoop.hbase.io.crypto.tls.X509TestContextProvider;
+import org.apache.hadoop.hbase.io.crypto.tls.X509Util;
+import org.apache.hadoop.hbase.ipc.FifoRpcScheduler;
+import org.apache.hadoop.hbase.ipc.NettyRpcClient;
+import org.apache.hadoop.hbase.ipc.NettyRpcServer;
+import org.apache.hadoop.hbase.ipc.RpcClient;
+import org.apache.hadoop.hbase.ipc.RpcClientFactory;
+import org.apache.hadoop.hbase.ipc.RpcServer;
+import org.apache.hadoop.hbase.ipc.RpcServerFactory;
+import org.apache.hadoop.hbase.ipc.TestProtobufRpcServiceImpl;
+import org.apache.hadoop.hbase.shaded.ipc.protobuf.generated.TestProtos;
+import org.apache.hadoop.hbase.shaded.ipc.protobuf.generated.TestRpcServiceProtos;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.RPCTests;
+import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
+import org.apache.hbase.thirdparty.com.google.common.io.Closeables;
+import org.bouncycastle.jce.provider.BouncyCastleProvider;
+import org.bouncycastle.operator.OperatorCreationException;
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import java.io.File;
+import java.io.IOException;
+import java.net.InetAddress;
+import java.net.InetSocketAddress;
+import java.security.GeneralSecurityException;
+import java.security.Security;
+import java.util.List;
+import static org.apache.hadoop.hbase.ipc.TestProtobufRpcServiceImpl.SERVICE;
+
+@RunWith(Parameterized.class)
+@Category({ RPCTests.class, MediumTests.class })
+public class TestMutualTlsClientSideNonLocalhost  {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestMutualTlsClientSide.class);
+
+  protected static HBaseCommonTestingUtil UTIL;
+
+  protected static File DIR;
+
+  protected static X509TestContextProvider PROVIDER;
+
+  private X509TestContext x509TestContext;
+
+  protected RpcServer rpcServer;
+
+  protected RpcClient rpcClient;
+  private TestRpcServiceProtos.TestProtobufRpcProto.BlockingInterface stub;
+
+  @Parameterized.Parameter(0)
+  public boolean supportPlaintext;
+
+  @Parameterized.Parameters(name = "{index}: supportPlaintext={0}")
+  public static List<Boolean> data() {
+    return List.of(true, false);
+  }
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws IOException {
+    UTIL = new HBaseCommonTestingUtil();
+    Security.addProvider(new BouncyCastleProvider());
+    DIR =
+      new File(UTIL.getDataTestDir(AbstractTestTlsRejectPlainText.class.getSimpleName()).toString())
+        .getCanonicalFile();
+    FileUtils.forceMkdir(DIR);
+    Configuration conf = UTIL.getConfiguration();
+    conf.setClass(RpcClientFactory.CUSTOM_RPC_CLIENT_IMPL_CONF_KEY, NettyRpcClient.class,
+      RpcClient.class);
+    conf.setClass(RpcServerFactory.CUSTOM_RPC_SERVER_IMPL_CONF_KEY, NettyRpcServer.class,
+      RpcServer.class);
+    conf.setBoolean(X509Util.HBASE_SERVER_NETTY_TLS_ENABLED, true);
+    conf.setBoolean(X509Util.HBASE_CLIENT_NETTY_TLS_ENABLED, true);
+    PROVIDER = new X509TestContextProvider(conf, DIR);
+  }
+
+  @AfterClass
+  public static void cleanUp() {
+    Security.removeProvider(BouncyCastleProvider.PROVIDER_NAME);
+    UTIL.cleanupTestDir();
+  }
+
+  @Before
+  public void setUp() throws Exception {
+    x509TestContext = PROVIDER.get(X509KeyType.RSA, X509KeyType.RSA, "keyPassword".toCharArray());
+    x509TestContext.setConfigurations(KeyStoreFileType.JKS, KeyStoreFileType.JKS);
+
+    Configuration serverConf = new Configuration(UTIL.getConfiguration());
+    Configuration clientConf = new Configuration(UTIL.getConfiguration());
+
+    initialize(serverConf, clientConf);
+
+    InetSocketAddress isa = new InetSocketAddress(InetAddress.getLocalHost(), 0);
+
+    rpcServer = new NettyRpcServer(null, "testRpcServer",
+      Lists.newArrayList(new RpcServer.BlockingServiceAndInterface(SERVICE, null)),
+      isa, serverConf, new FifoRpcScheduler(serverConf, 1), true);
+    rpcServer.start();
+
+    rpcClient = new NettyRpcClient(clientConf);
+    stub = TestProtobufRpcServiceImpl.newBlockingStub(rpcClient, rpcServer.getListenerAddress());
+  }
+
+  private void initialize(Configuration serverConf, Configuration clientConf)
+    throws GeneralSecurityException, IOException, OperatorCreationException {
+    serverConf.setBoolean(X509Util.HBASE_SERVER_NETTY_TLS_SUPPORTPLAINTEXT, supportPlaintext);
+    clientConf.setBoolean(X509Util.HBASE_CLIENT_NETTY_TLS_VERIFY_SERVER_HOSTNAME, true);
+    x509TestContext.regenerateStores(X509KeyType.RSA, X509KeyType.RSA, KeyStoreFileType.JKS, KeyStoreFileType.JKS,
+      InetAddress.getLocalHost().getHostName());
+  }
+
+  @After
+  public void tearDown() throws IOException {
+    if (rpcServer != null) {
+      rpcServer.stop();
+    }
+    Closeables.close(rpcClient, true);
+    x509TestContext.clearConfigurations();
+    x509TestContext.getConf().unset(X509Util.TLS_CONFIG_OCSP);
+    x509TestContext.getConf().unset(X509Util.TLS_CONFIG_CLR);
+    x509TestContext.getConf().unset(X509Util.TLS_CONFIG_PROTOCOL);
+    System.clearProperty("com.sun.net.ssl.checkRevocation");
+    System.clearProperty("com.sun.security.enableCRLDP");
+    Security.setProperty("ocsp.enable", Boolean.FALSE.toString());
+    Security.setProperty("com.sun.security.enableCRLDP", Boolean.FALSE.toString());
+  }
+
+  @Test
+  public void testClientAuth() throws Exception {
+    stub.echo(null, TestProtos.EchoRequestProto.newBuilder().setMessage("hello world").build());
+  }
+}


### PR DESCRIPTION
- Added our version of `OptionalSslHandler` which carries hostport information
- Removed the (IMHO) unnecessary reverse DNS lookup from `initSSL`
- Unit test to cover plaintext and TLS-only cases