### PR TITLE
Hbase 28776

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -541,6 +541,8 @@
     <java.min.version>${compileSource}</java.min.version>
     <!-- Dependencies -->
     <hadoop-two.version>2.10.0</hadoop-two.version>
+    <!--From hadoop 3.3.3 For LZ4 and Snappy compression codec, Hadoop  moves to use lz4-java and snappy-java
+    instead of requring the native libraries of these to be installed on the systems running Hadoop.-->
     <hadoop-three.version>3.3.3</hadoop-three.version>
     <!-- These must be defined here for downstream build tools that don't look at profiles.
          They ought to match the values found in our default hadoop profile, which is

--- a/pom.xml
+++ b/pom.xml
@@ -541,7 +541,7 @@
     <java.min.version>${compileSource}</java.min.version>
     <!-- Dependencies -->
     <hadoop-two.version>2.10.0</hadoop-two.version>
-    <hadoop-three.version>3.1.2</hadoop-three.version>
+    <hadoop-three.version>3.3.3</hadoop-three.version>
     <!-- These must be defined here for downstream build tools that don't look at profiles.
          They ought to match the values found in our default hadoop profile, which is
          currently "hadoop-2.0". See HBASE-15925 for more info. -->


### PR DESCRIPTION
Fixed the error: org. apache.hadoop.hbase.DoNotRetryIOException: java.lang.UnsatisfiedLinkError: org-apache.hadoop.util.NativeCodeLoader.buildSupportsSnappy()Z Set hbase.table.sanity.checks to false.The error happened when i create table compressed by snappy. The environment based on hadoop 3.3.3 and hbase2.4.16. But hbase-2.4.16 document said it is compatible with hadoop 3.3.x, I used the configuration: org.apache.hadoop.hbase.io.compress.aircompressor.SnappyCodec,org.apache.hadoop.hbase.io.compress.xerial.SnappyCodec, the error still occurs.So I changed the dependency hadoop3.1.2 to hadoop 3.3.3, the error fixed
