### PR TITLE
HBASE-28783 Concurrent execution of normalizer operations on tables in RegionNormalizerWorker

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1639,4 +1639,11 @@ public final class HConstants {
   private HConstants() {
     // Can't be instantiated with this ctor.
   }
+
+  /**
+   * Number of threads used to execute table normalizer operations.
+   */
+  public static final String HBASE_NORMALIZER_WORKER_POOL_THREADS =
+    "hbase.normalizer.worker.pool.threads";
+  public static final int HBASE_NORMALIZER_WORKER_POOL_THREADS_DEFAULT = 1;
 }


### PR DESCRIPTION
Recently, I have been managing the large tables in the HBase cluster by enabling the normalizer to set the size of the regions and keep the number of regions within a reasonable range.
The current code retrieves tables from RegionNormalizerWorkQueue and performs normalization operations on the tables in series. When there are multiple large tables in a cluster that need to be managed, the efficiency will be very low.
I have confirmed that each split or merge plan generated by each table during the normalizer process will be limited by RateLimiter, so I think it is reasonable to perform table normalizers concurrently.
In terms of implementation, create a thread pool for executing tasks in RegionNormalizerWorker, with a default value of 1 for the number of thread pools, and provide a parameter that can be configured to other values.