### PR TITLE
Backport "HBASE-28784 Exclude samples and release-documentation zip of jaxws-ri from output tarball" to branch-2.5

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1537,6 +1537,14 @@
             <groupId>javax.activation</groupId>
             <artifactId>javax.activation-api</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>release-documentation</artifactId>
+          </exclusion>
+          <exclusion>
+            <groupId>com.sun.xml.ws</groupId>
+            <artifactId>samples</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
Backports https://github.com/apache/hbase/pull/6157