### PR TITLE
Backport "HBASE-28786 Fix classname for command: copyreppeers in bin/hbase" to branch-2.6

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -772,7 +772,7 @@ elif [ "$COMMAND" = "hbtop" ] ; then
 elif [ "$COMMAND" = "credential" ] ; then
   CLASS='org.apache.hadoop.security.alias.CredentialShell'
 elif [ "$COMMAND" = "copyreppeers" ] ; then
-  CLASS='org.apache.hadoop.hbase.replication.ReplicationPeerMigrationTool'
+  CLASS='org.apache.hadoop.hbase.replication.CopyReplicationPeers'
 else
   CLASS=$COMMAND
 if [[ "$CLASS" =~ .*IntegrationTest.* ]] ; then


### PR DESCRIPTION
Backports https://github.com/apache/hbase/pull/6162