### PR TITLE
HBASE-28793 Update hbase-thirdparty to 4.1.8

### DIFF
--- a/hbase-examples/pom.xml
+++ b/hbase-examples/pom.xml
@@ -33,7 +33,7 @@
     <!--Version of protobuf that hbase uses internally (we shade our pb)
          Must match what is out in hbase-thirdparty include.
     -->
-    <internal.protobuf.version>4.26.1</internal.protobuf.version>
+    <internal.protobuf.version>4.27.3</internal.protobuf.version>
   </properties>
   <dependencies>
     <dependency>

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestsDriver.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestsDriver.java
@@ -77,7 +77,7 @@ public class IntegrationTestsDriver extends AbstractHBaseTool {
 
   @Override
   protected void processOptions(CommandLine cmd) {
-    String testFilterString = cmd.getOptionValue(SHORT_REGEX_ARG, null);
+    String testFilterString = cmd.getOptionValue(SHORT_REGEX_ARG);
     if (testFilterString != null) {
       intTestFilter.setPattern(testFilterString);
     }

--- a/hbase-protocol-shaded/pom.xml
+++ b/hbase-protocol-shaded/pom.xml
@@ -34,7 +34,7 @@
     <!--Version of protobuf that hbase uses internally (we shade our pb)
          Must match what is out in hbase-thirdparty include.
     -->
-    <internal.protobuf.version>4.26.1</internal.protobuf.version>
+    <internal.protobuf.version>4.27.3</internal.protobuf.version>
   </properties>
   <dependencies>
     <!--BE CAREFUL! Any dependency added here needs to be

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactor.java
@@ -420,7 +420,7 @@ public class MajorCompactor extends Configured implements Tool {
       return -1;
     }
     String tableName = commandLine.getOptionValue("table");
-    String cf = commandLine.getOptionValue("cf", null);
+    String cf = commandLine.getOptionValue("cf");
     Set<String> families = Sets.newHashSet();
     if (cf != null) {
       Iterables.addAll(families, Splitter.on(",").split(cf));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotasWithSnapshots.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotasWithSnapshots.java
@@ -164,7 +164,7 @@ public class TestSpaceQuotasWithSnapshots {
     // Make sure we see the "final" new size for the table, not some intermediate
     waitForStableRegionSizeReport(conn, tn);
     final long finalSize = getRegionSizeReportForTable(conn, tn);
-    assertNotNull("Did not expect to see a null size", finalSize);
+    assertTrue("Table data size must be greater than zero", finalSize > 0);
     LOG.info("Last seen size: " + finalSize);
 
     // Make sure the QuotaObserverChore has time to reflect the new region size reports
@@ -263,7 +263,7 @@ public class TestSpaceQuotasWithSnapshots {
     // Make sure we see the "final" new size for the table, not some intermediate
     waitForStableRegionSizeReport(conn, tn);
     final long finalSize = getRegionSizeReportForTable(conn, tn);
-    assertNotNull("Did not expect to see a null size", finalSize);
+    assertTrue("Table data size must be greater than zero", finalSize > 0);
     LOG.info("Final observed size of table: " + finalSize);
 
     // Make sure the QuotaObserverChore has time to reflect the new region size reports

--- a/pom.xml
+++ b/pom.xml
@@ -1844,13 +1844,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <id>staging</id>
-      <name>staging</name>
-      <url>https://repository.apache.org/content/repositories/orgapachehbase-1555</url>
-    </repository>
-  </repositories>
   <build>
     <!-- Plugin versions are inherited from ASF parent pom: https://maven.apache.org/pom/asf/
          For specific version use a property and define it in the parent pom.

--- a/pom.xml
+++ b/pom.xml
@@ -832,7 +832,7 @@
       modules and cause trouble if we only rely on transitive dependencies.
     -->
     <netty3.version>3.10.6.Final</netty3.version>
-    <netty4.version>4.1.108.Final</netty4.version>
+    <netty4.version>4.1.112.Final</netty4.version>
     <!-- end HBASE-15925 default hadoop compatibility values -->
     <audience-annotations.version>0.15.0</audience-annotations.version>
     <javadoc.audience-annotations.version>0.15.0</javadoc.audience-annotations.version>
@@ -852,8 +852,8 @@
       Note that the version of jackson-[annotations,core,databind] must be kept in sync with the
       version of jackson-jaxrs-json-provider shipped in hbase-thirdparty.
     -->
-    <jackson.version>2.17.0</jackson.version>
-    <jackson.databind.version>2.17.0</jackson.databind.version>
+    <jackson.version>2.17.2</jackson.version>
+    <jackson.databind.version>2.17.2</jackson.databind.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
@@ -894,7 +894,7 @@
     -->
     <checkstyle.version>8.29</checkstyle.version>
     <exec.maven.version>3.1.0</exec.maven.version>
-    <error-prone.version>2.26.1</error-prone.version>
+    <error-prone.version>2.28.0</error-prone.version>
     <jamon.plugin.version>2.4.2</jamon.plugin.version>
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
     <maven.antrun.version>1.8</maven.antrun.version>
@@ -926,7 +926,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.7</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.8</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>
@@ -1844,6 +1844,13 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <repositories>
+    <repository>
+      <id>staging</id>
+      <name>staging</name>
+      <url>https://repository.apache.org/content/repositories/orgapachehbase-1555</url>
+    </repository>
+  </repositories>
   <build>
     <!-- Plugin versions are inherited from ASF parent pom: https://maven.apache.org/pom/asf/
          For specific version use a property and define it in the parent pom.


### PR DESCRIPTION
Update hbase-thirdparty to 4.1.8.

Added staging repository for compilation and build, will remove it when 4.1.8 is officially released.