### PR TITLE
HBASE-28770: Support partial results in AggregateImplementation and AsyncAggregationClient

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hbase.client.ConnectionUtils.toCheckExistenceOnl
 import static org.apache.hadoop.hbase.util.FutureUtils.allOf;
 
 import java.util.Collections;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -707,14 +708,14 @@ public interface AsyncTable<C extends ScanResultConsumerBase> {
 
     /**
      * Subclasses should implement this such that, when the above method returns non-null, this
-     * method returns the number of milliseconds that AsyncTable should wait before sending the next
-     * request to the given region. You can use this to create a back-off behavior to reduce load on
-     * the RegionServer. If that's not desired, you can always return 0.
+     * method returns the duration that AsyncTable should wait before sending the next request to
+     * the given region. You can use this to create a back-off behavior to reduce load on the
+     * RegionServer. If that's not desired, you can always return {@link Duration.ZERO}.
      * @param response The response received from the coprocessor
      * @param region   The region the response came from
-     * @return The number of milliseconds to wait.
+     * @return The duration to wait.
      */
-    long getWaitIntervalMs(R response, RegionInfo region);
+    Duration getWaitInterval(R response, RegionInfo region);
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
@@ -21,8 +21,8 @@ import static java.util.stream.Collectors.toList;
 import static org.apache.hadoop.hbase.client.ConnectionUtils.toCheckExistenceOnly;
 import static org.apache.hadoop.hbase.util.FutureUtils.allOf;
 
-import java.util.Collections;
 import java.time.Duration;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTable.java
@@ -676,6 +676,13 @@ public interface AsyncTable<C extends ScanResultConsumerBase> {
     void onError(Throwable error);
   }
 
+  @InterfaceAudience.Public
+  interface PartialResultCoprocessorCallback<S, R> extends CoprocessorCallback<R> {
+    ServiceCaller<S, R> getNextCallable(R response, RegionInfo region);
+
+    long getWaitIntervalMs(R response, RegionInfo region);
+  }
+
   /**
    * Helper class for sending coprocessorService request that executes a coprocessor call on regions
    * which are covered by a range.
@@ -744,4 +751,10 @@ public interface AsyncTable<C extends ScanResultConsumerBase> {
    */
   <S, R> CoprocessorServiceBuilder<S, R> coprocessorService(Function<RpcChannel, S> stubMaker,
     ServiceCaller<S, R> callable, CoprocessorCallback<R> callback);
+
+  /**
+   * Similar to above. Use when your coprocessor client+endpoint supports partial results.
+   */
+  <S, R> CoprocessorServiceBuilder<S, R> coprocessorService(Function<RpcChannel, S> stubMaker,
+    ServiceCaller<S, R> callable, PartialResultCoprocessorCallback<S, R> callback);
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableImpl.java
@@ -297,49 +297,69 @@ class AsyncTableImpl implements AsyncTable<ScanResultConsumer> {
   public <S, R> CoprocessorServiceBuilder<S, R> coprocessorService(
     Function<RpcChannel, S> stubMaker, ServiceCaller<S, R> callable,
     CoprocessorCallback<R> callback) {
+    return coprocessorService(stubMaker, callable,
+      (PartialResultCoprocessorCallback<S, R>) callback);
+  }
+
+  @Override
+  public <S, R> CoprocessorServiceBuilder<S, R> coprocessorService(
+    Function<RpcChannel, S> stubMaker, ServiceCaller<S, R> callable,
+    PartialResultCoprocessorCallback<S, R> callback) {
     final Context context = Context.current();
-    CoprocessorCallback<R> wrappedCallback = new CoprocessorCallback<R>() {
+    PartialResultCoprocessorCallback<S, R> wrappedCallback =
+      new PartialResultCoprocessorCallback<S, R>() {
 
-      private final Phaser regionCompletesInProgress = new Phaser(1);
+        private final Phaser regionCompletesInProgress = new Phaser(1);
 
-      @Override
-      public void onRegionComplete(RegionInfo region, R resp) {
-        regionCompletesInProgress.register();
-        pool.execute(context.wrap(() -> {
-          try {
-            callback.onRegionComplete(region, resp);
-          } finally {
-            regionCompletesInProgress.arriveAndDeregister();
-          }
-        }));
-      }
+        @Override
+        public void onRegionComplete(RegionInfo region, R resp) {
+          regionCompletesInProgress.register();
+          pool.execute(context.wrap(() -> {
+            try {
+              callback.onRegionComplete(region, resp);
+            } finally {
+              regionCompletesInProgress.arriveAndDeregister();
+            }
+          }));
+        }
 
-      @Override
-      public void onRegionError(RegionInfo region, Throwable error) {
-        regionCompletesInProgress.register();
-        pool.execute(context.wrap(() -> {
-          try {
-            callback.onRegionError(region, error);
-          } finally {
-            regionCompletesInProgress.arriveAndDeregister();
-          }
-        }));
-      }
+        @Override
+        public void onRegionError(RegionInfo region, Throwable error) {
+          regionCompletesInProgress.register();
+          pool.execute(context.wrap(() -> {
+            try {
+              callback.onRegionError(region, error);
+            } finally {
+              regionCompletesInProgress.arriveAndDeregister();
+            }
+          }));
+        }
 
-      @Override
-      public void onComplete() {
-        pool.execute(context.wrap(() -> {
-          // Guarantee that onComplete() is called after all onRegionComplete()'s are called
-          regionCompletesInProgress.arriveAndAwaitAdvance();
-          callback.onComplete();
-        }));
-      }
+        @Override
+        public void onComplete() {
+          pool.execute(context.wrap(() -> {
+            // Guarantee that onComplete() is called after all onRegionComplete()'s are called
+            regionCompletesInProgress.arriveAndAwaitAdvance();
+            callback.onComplete();
+          }));
+        }
 
-      @Override
-      public void onError(Throwable error) {
-        pool.execute(context.wrap(() -> callback.onError(error)));
-      }
-    };
+        @Override
+        public void onError(Throwable error) {
+          pool.execute(context.wrap(() -> callback.onError(error)));
+        }
+
+        @Override
+        public ServiceCaller<S, R> getNextCallable(R response, RegionInfo region) {
+          return callback.getNextCallable(response, region);
+        }
+
+        @Override
+        public long getWaitIntervalMs(R response, RegionInfo region) {
+          return callback.getWaitIntervalMs(response, region);
+        }
+
+      };
     CoprocessorServiceBuilder<S, R> builder =
       rawTable.coprocessorService(stubMaker, callable, wrappedCallback);
     return new CoprocessorServiceBuilder<S, R>() {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableImpl.java
@@ -298,7 +298,7 @@ class AsyncTableImpl implements AsyncTable<ScanResultConsumer> {
     Function<RpcChannel, S> stubMaker, ServiceCaller<S, R> callable,
     CoprocessorCallback<R> callback) {
     return coprocessorService(stubMaker, callable,
-      (PartialResultCoprocessorCallback<S, R>) callback);
+      new NoopPartialResultCoprocessorCallback<>(callback));
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableImpl.java
@@ -23,6 +23,7 @@ import io.opentelemetry.api.trace.Span;
 import io.opentelemetry.context.Context;
 import io.opentelemetry.context.Scope;
 import java.io.IOException;
+import java.time.Duration;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletableFuture;
@@ -355,8 +356,8 @@ class AsyncTableImpl implements AsyncTable<ScanResultConsumer> {
         }
 
         @Override
-        public long getWaitIntervalMs(R response, RegionInfo region) {
-          return callback.getWaitIntervalMs(response, region);
+        public Duration getWaitInterval(R response, RegionInfo region) {
+          return callback.getWaitInterval(response, region);
         }
 
       };

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/NoopPartialResultCoprocessorCallback.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/NoopPartialResultCoprocessorCallback.java
@@ -1,0 +1,61 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class NoopPartialResultCoprocessorCallback<S, R>
+  implements AsyncTable.PartialResultCoprocessorCallback<S, R> {
+
+  private final AsyncTable.CoprocessorCallback<R> delegate;
+
+  public NoopPartialResultCoprocessorCallback(AsyncTable.CoprocessorCallback<R> delegate) {
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void onRegionComplete(RegionInfo region, R resp) {
+    delegate.onRegionComplete(region, resp);
+  }
+
+  @Override
+  public void onRegionError(RegionInfo region, Throwable error) {
+    delegate.onRegionError(region, error);
+  }
+
+  @Override
+  public void onComplete() {
+    delegate.onComplete();
+  }
+
+  @Override
+  public void onError(Throwable error) {
+    delegate.onError(error);
+  }
+
+  @Override
+  public ServiceCaller<S, R> getNextCallable(R response, RegionInfo region) {
+    return null;
+  }
+
+  @Override
+  public long getWaitIntervalMs(R response, RegionInfo region) {
+    return 0;
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/NoopPartialResultCoprocessorCallback.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/NoopPartialResultCoprocessorCallback.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.client;
 
+import java.time.Duration;
 import org.apache.yetus.audience.InterfaceAudience;
 
 @InterfaceAudience.Private
@@ -55,7 +56,7 @@ public class NoopPartialResultCoprocessorCallback<S, R>
   }
 
   @Override
-  public long getWaitIntervalMs(R response, RegionInfo region) {
-    return 0;
+  public Duration getWaitInterval(R response, RegionInfo region) {
+    return Duration.ZERO;
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
@@ -57,7 +57,6 @@ import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.ReflectionUtils;
-import org.apache.hadoop.hbase.util.Threads;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncTableImpl.java
@@ -915,46 +915,6 @@ class RawAsyncTableImpl implements AsyncTable<AdvancedScanResultConsumer> {
     }
   }
 
-  private static class NoopPartialResultCoprocessorCallback<S, R>
-    implements PartialResultCoprocessorCallback<S, R> {
-
-    private final CoprocessorCallback<R> delegate;
-
-    public NoopPartialResultCoprocessorCallback(CoprocessorCallback<R> delegate) {
-      this.delegate = delegate;
-    }
-
-    @Override
-    public void onRegionComplete(RegionInfo region, R resp) {
-      delegate.onRegionComplete(region, resp);
-    }
-
-    @Override
-    public void onRegionError(RegionInfo region, Throwable error) {
-      delegate.onRegionError(region, error);
-    }
-
-    @Override
-    public void onComplete() {
-      delegate.onComplete();
-    }
-
-    @Override
-    public void onError(Throwable error) {
-      delegate.onError(error);
-    }
-
-    @Override
-    public ServiceCaller<S, R> getNextCallable(R response, RegionInfo region) {
-      return null;
-    }
-
-    @Override
-    public long getWaitIntervalMs(R response, RegionInfo region) {
-      return 0;
-    }
-  }
-
   @Override
   public <S, R> CoprocessorServiceBuilder<S, R> coprocessorService(
     Function<RpcChannel, S> stubMaker, ServiceCaller<S, R> callable,

--- a/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AggregationClient.java
+++ b/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AggregationClient.java
@@ -227,7 +227,7 @@ public class AggregationClient implements Closeable {
    */
   public <R, S, P extends Message, Q extends Message, T extends Message> R max(final Table table,
     final ColumnInterpreter<R, S, P, Q, T> ci, final Scan scan) throws Throwable {
-    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false);
+    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false, false);
     class MaxCallBack implements Batch.Callback<R> {
       R max = null;
 
@@ -294,7 +294,7 @@ public class AggregationClient implements Closeable {
    */
   public <R, S, P extends Message, Q extends Message, T extends Message> R min(final Table table,
     final ColumnInterpreter<R, S, P, Q, T> ci, final Scan scan) throws Throwable {
-    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false);
+    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false, false);
     class MinCallBack implements Batch.Callback<R> {
       private R min = null;
 
@@ -370,7 +370,7 @@ public class AggregationClient implements Closeable {
   public <R, S, P extends Message, Q extends Message, T extends Message> long
     rowCount(final Table table, final ColumnInterpreter<R, S, P, Q, T> ci, final Scan scan)
       throws Throwable {
-    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, true);
+    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, true, false);
     class RowNumCallback implements Batch.Callback<Long> {
       private final AtomicLong rowCountL = new AtomicLong(0);
 
@@ -436,7 +436,7 @@ public class AggregationClient implements Closeable {
    */
   public <R, S, P extends Message, Q extends Message, T extends Message> S sum(final Table table,
     final ColumnInterpreter<R, S, P, Q, T> ci, final Scan scan) throws Throwable {
-    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false);
+    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false, false);
 
     class SumCallBack implements Batch.Callback<S> {
       S sumVal = null;
@@ -505,7 +505,7 @@ public class AggregationClient implements Closeable {
   private <R, S, P extends Message, Q extends Message, T extends Message> Pair<S, Long>
     getAvgArgs(final Table table, final ColumnInterpreter<R, S, P, Q, T> ci, final Scan scan)
       throws Throwable {
-    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false);
+    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false, false);
     class AvgCallBack implements Batch.Callback<Pair<S, Long>> {
       S sum = null;
       Long rowCount = 0L;
@@ -602,7 +602,7 @@ public class AggregationClient implements Closeable {
   private <R, S, P extends Message, Q extends Message, T extends Message> Pair<List<S>, Long>
     getStdArgs(final Table table, final ColumnInterpreter<R, S, P, Q, T> ci, final Scan scan)
       throws Throwable {
-    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false);
+    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false, false);
     class StdCallback implements Batch.Callback<Pair<List<S>, Long>> {
       long rowCountVal = 0L;
       S sumVal = null, sumSqVal = null;
@@ -716,7 +716,7 @@ public class AggregationClient implements Closeable {
   private <R, S, P extends Message, Q extends Message, T extends Message>
     Pair<NavigableMap<byte[], List<S>>, List<S>> getMedianArgs(final Table table,
       final ColumnInterpreter<R, S, P, Q, T> ci, final Scan scan) throws Throwable {
-    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false);
+    final AggregateRequest requestArg = validateArgAndGetPB(scan, ci, false, false);
     final NavigableMap<byte[], List<S>> map = new TreeMap<>(Bytes.BYTES_COMPARATOR);
     class StdCallback implements Batch.Callback<List<S>> {
       S sumVal = null, sumWeights = null;

--- a/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AggregationHelper.java
+++ b/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AggregationHelper.java
@@ -63,8 +63,8 @@ public final class AggregationHelper {
   }
 
   static <R, S, P extends Message, Q extends Message, T extends Message> AggregateRequest
-    validateArgAndGetPB(Scan scan, ColumnInterpreter<R, S, P, Q, T> ci, boolean canFamilyBeAbsent)
-      throws IOException {
+    validateArgAndGetPB(Scan scan, ColumnInterpreter<R, S, P, Q, T> ci, boolean canFamilyBeAbsent,
+      boolean supportPartialResults) throws IOException {
     validateParameters(scan, canFamilyBeAbsent);
     final AggregateRequest.Builder requestBuilder = AggregateRequest.newBuilder();
     requestBuilder.setInterpreterClassName(ci.getClass().getCanonicalName());
@@ -73,6 +73,7 @@ public final class AggregationHelper {
       requestBuilder.setInterpreterSpecificBytes(columnInterpreterSpecificData.toByteString());
     }
     requestBuilder.setScan(ProtobufUtil.toScan(scan));
+    requestBuilder.setClientSupportsPartialResult(supportPartialResults);
     return requestBuilder.build();
   }
 

--- a/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AsyncAggregationClient.java
+++ b/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AsyncAggregationClient.java
@@ -22,6 +22,7 @@ import static org.apache.hadoop.hbase.client.coprocessor.AggregationHelper.valid
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.Collections;
 import java.util.Map;
 import java.util.NavigableMap;
@@ -148,8 +149,8 @@ public final class AsyncAggregationClient {
     }
 
     @Override
-    public long getWaitIntervalMs(AggregateResponse response, RegionInfo region) {
-      return response.getWaitIntervalMs();
+    public Duration getWaitInterval(AggregateResponse response, RegionInfo region) {
+      return Duration.ofMillis(response.getWaitIntervalMs());
     }
   }
 

--- a/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AsyncAggregationClient.java
+++ b/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AsyncAggregationClient.java
@@ -138,7 +138,7 @@ public final class AsyncAggregationClient {
         updatedRequest.setScan(originalRequest.getScan().toBuilder()
           .setStartRow(response.getNextChunkStartRow()).build());
         if (log.isTraceEnabled()) {
-          log.trace("Got incomplete result {} for original scan {}. Sending new request {}.",
+          log.trace("Got incomplete result {} for original scan {}. Sending next request {}.",
             TextFormat.shortDebugString(response),
             TextFormat.shortDebugString(originalRequest.getScan()),
             TextFormat.shortDebugString(updatedRequest));

--- a/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AsyncAggregationClient.java
+++ b/hbase-endpoint/src/main/java/org/apache/hadoop/hbase/client/coprocessor/AsyncAggregationClient.java
@@ -22,26 +22,34 @@ import static org.apache.hadoop.hbase.client.coprocessor.AggregationHelper.valid
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 
 import java.io.IOException;
+import java.util.Collections;
 import java.util.Map;
 import java.util.NavigableMap;
 import java.util.NavigableSet;
 import java.util.NoSuchElementException;
 import java.util.TreeMap;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.atomic.AtomicLong;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.AdvancedScanResultConsumer;
 import org.apache.hadoop.hbase.client.AsyncTable;
-import org.apache.hadoop.hbase.client.AsyncTable.CoprocessorCallback;
+import org.apache.hadoop.hbase.client.AsyncTable.PartialResultCoprocessorCallback;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.ServiceCaller;
 import org.apache.hadoop.hbase.coprocessor.ColumnInterpreter;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.ReflectionUtils;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.protobuf.Message;
+import org.apache.hbase.thirdparty.com.google.protobuf.RpcCallback;
+import org.apache.hbase.thirdparty.com.google.protobuf.RpcController;
+import org.apache.hbase.thirdparty.com.google.protobuf.TextFormat;
 
 import org.apache.hadoop.hbase.shaded.protobuf.generated.AggregateProtos.AggregateRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.AggregateProtos.AggregateResponse;
@@ -54,12 +62,21 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.AggregateProtos.Aggrega
  */
 @InterfaceAudience.Public
 public final class AsyncAggregationClient {
+  private static final Logger log = LoggerFactory.getLogger(AsyncAggregationClient.class);
+
   private AsyncAggregationClient() {
   }
 
+  private interface StubCaller {
+    void call(AggregateService stub, RpcController controller, AggregateRequest request,
+      RpcCallback<AggregateResponse> rpcCallback);
+  }
+
   private static abstract class AbstractAggregationCallback<T>
-    implements CoprocessorCallback<AggregateResponse> {
+    implements PartialResultCoprocessorCallback<AggregateService, AggregateResponse> {
     private final CompletableFuture<T> future;
+    private final AggregateRequest originalRequest;
+    private final AsyncAggregationClient.StubCaller stubCaller;
 
     protected boolean finished = false;
 
@@ -71,8 +88,11 @@ public final class AsyncAggregationClient {
       future.completeExceptionally(error);
     }
 
-    protected AbstractAggregationCallback(CompletableFuture<T> future) {
+    protected AbstractAggregationCallback(CompletableFuture<T> future,
+      AggregateRequest originalRequest, AsyncAggregationClient.StubCaller stubCaller) {
       this.future = future;
+      this.originalRequest = originalRequest;
+      this.stubCaller = stubCaller;
     }
 
     @Override
@@ -106,6 +126,31 @@ public final class AsyncAggregationClient {
       finished = true;
       future.complete(getFinalResult());
     }
+
+    @Override
+    public ServiceCaller<AggregateService, AggregateResponse>
+      getNextCallable(AggregateResponse response, RegionInfo region) {
+      if (!response.hasNextChunkStartRow()) {
+        return null;
+      }
+      return (stub, controller, rpcCallback) -> {
+        AggregateRequest.Builder updatedRequest = AggregateRequest.newBuilder(originalRequest);
+        updatedRequest.setScan(originalRequest.getScan().toBuilder()
+          .setStartRow(response.getNextChunkStartRow()).build());
+        if (log.isTraceEnabled()) {
+          log.trace("Got incomplete result {} for original scan {}. Sending new request {}.",
+            TextFormat.shortDebugString(response),
+            TextFormat.shortDebugString(originalRequest.getScan()),
+            TextFormat.shortDebugString(updatedRequest));
+        }
+        stubCaller.call(stub, controller, updatedRequest.build(), rpcCallback);
+      };
+    }
+
+    @Override
+    public long getWaitIntervalMs(AggregateResponse response, RegionInfo region) {
+      return response.getWaitIntervalMs();
+    }
   }
 
   private static <R, S, P extends Message, Q extends Message, T extends Message> R
@@ -131,32 +176,38 @@ public final class AsyncAggregationClient {
     CompletableFuture<R> future = new CompletableFuture<>();
     AggregateRequest req;
     try {
-      req = validateArgAndGetPB(scan, ci, false);
+      req = validateArgAndGetPB(scan, ci, false, true);
     } catch (IOException e) {
       future.completeExceptionally(e);
       return future;
     }
-    AbstractAggregationCallback<R> callback = new AbstractAggregationCallback<R>(future) {
+    AbstractAggregationCallback<R> callback =
+      new AbstractAggregationCallback<>(future, req, AggregateService::getMax) {
 
-      private R max;
+        private R max;
+        private final Object lock = new Object();
 
-      @Override
-      protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
-        if (resp.getFirstPartCount() > 0) {
-          R result = getCellValueFromProto(ci, resp, 0);
-          if (max == null || (result != null && ci.compare(max, result) < 0)) {
-            max = result;
+        @Override
+        protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
+          if (resp.getFirstPartCount() > 0) {
+            R result = getCellValueFromProto(ci, resp, 0);
+            synchronized (lock) {
+              if (max == null || (result != null && ci.compare(max, result) < 0)) {
+                max = result;
+              }
+            }
           }
         }
-      }
 
-      @Override
-      protected R getFinalResult() {
-        return max;
-      }
-    };
+        @Override
+        protected R getFinalResult() {
+          synchronized (lock) {
+            return max;
+          }
+        }
+      };
     table
-      .<AggregateService, AggregateResponse> coprocessorService(AggregateService::newStub,
+      .coprocessorService(AggregateService::newStub,
         (stub, controller, rpcCallback) -> stub.getMax(controller, req, rpcCallback), callback)
       .fromRow(nullToEmpty(scan.getStartRow()), scan.includeStartRow())
       .toRow(nullToEmpty(scan.getStopRow()), scan.includeStopRow()).execute();
@@ -168,33 +219,39 @@ public final class AsyncAggregationClient {
     CompletableFuture<R> future = new CompletableFuture<>();
     AggregateRequest req;
     try {
-      req = validateArgAndGetPB(scan, ci, false);
+      req = validateArgAndGetPB(scan, ci, false, true);
     } catch (IOException e) {
       future.completeExceptionally(e);
       return future;
     }
 
-    AbstractAggregationCallback<R> callback = new AbstractAggregationCallback<R>(future) {
+    AbstractAggregationCallback<R> callback =
+      new AbstractAggregationCallback<>(future, req, AggregateService::getMin) {
 
-      private R min;
+        private R min;
+        private final Object lock = new Object();
 
-      @Override
-      protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
-        if (resp.getFirstPartCount() > 0) {
-          R result = getCellValueFromProto(ci, resp, 0);
-          if (min == null || (result != null && ci.compare(min, result) > 0)) {
-            min = result;
+        @Override
+        protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
+          if (resp.getFirstPartCount() > 0) {
+            R result = getCellValueFromProto(ci, resp, 0);
+            synchronized (lock) {
+              if (min == null || (result != null && ci.compare(min, result) > 0)) {
+                min = result;
+              }
+            }
           }
         }
-      }
 
-      @Override
-      protected R getFinalResult() {
-        return min;
-      }
-    };
+        @Override
+        protected R getFinalResult() {
+          synchronized (lock) {
+            return min;
+          }
+        }
+      };
     table
-      .<AggregateService, AggregateResponse> coprocessorService(AggregateService::newStub,
+      .coprocessorService(AggregateService::newStub,
         (stub, controller, rpcCallback) -> stub.getMin(controller, req, rpcCallback), callback)
       .fromRow(nullToEmpty(scan.getStartRow()), scan.includeStartRow())
       .toRow(nullToEmpty(scan.getStopRow()), scan.includeStopRow()).execute();
@@ -207,27 +264,28 @@ public final class AsyncAggregationClient {
     CompletableFuture<Long> future = new CompletableFuture<>();
     AggregateRequest req;
     try {
-      req = validateArgAndGetPB(scan, ci, true);
+      req = validateArgAndGetPB(scan, ci, true, true);
     } catch (IOException e) {
       future.completeExceptionally(e);
       return future;
     }
-    AbstractAggregationCallback<Long> callback = new AbstractAggregationCallback<Long>(future) {
+    AbstractAggregationCallback<Long> callback =
+      new AbstractAggregationCallback<>(future, req, AggregateService::getRowNum) {
 
-      private long count;
+        private final AtomicLong count = new AtomicLong(0L);
 
-      @Override
-      protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
-        count += resp.getFirstPart(0).asReadOnlyByteBuffer().getLong();
-      }
+        @Override
+        protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
+          count.addAndGet(resp.getFirstPart(0).asReadOnlyByteBuffer().getLong());
+        }
 
-      @Override
-      protected Long getFinalResult() {
-        return count;
-      }
-    };
+        @Override
+        protected Long getFinalResult() {
+          return count.get();
+        }
+      };
     table
-      .<AggregateService, AggregateResponse> coprocessorService(AggregateService::newStub,
+      .coprocessorService(AggregateService::newStub,
         (stub, controller, rpcCallback) -> stub.getRowNum(controller, req, rpcCallback), callback)
       .fromRow(nullToEmpty(scan.getStartRow()), scan.includeStartRow())
       .toRow(nullToEmpty(scan.getStopRow()), scan.includeStopRow()).execute();
@@ -239,29 +297,35 @@ public final class AsyncAggregationClient {
     CompletableFuture<S> future = new CompletableFuture<>();
     AggregateRequest req;
     try {
-      req = validateArgAndGetPB(scan, ci, false);
+      req = validateArgAndGetPB(scan, ci, false, true);
     } catch (IOException e) {
       future.completeExceptionally(e);
       return future;
     }
-    AbstractAggregationCallback<S> callback = new AbstractAggregationCallback<S>(future) {
-      private S sum;
+    AbstractAggregationCallback<S> callback =
+      new AbstractAggregationCallback<>(future, req, AggregateService::getSum) {
+        private S sum;
+        private final Object lock = new Object();
 
-      @Override
-      protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
-        if (resp.getFirstPartCount() > 0) {
-          S s = getPromotedValueFromProto(ci, resp, 0);
-          sum = ci.add(sum, s);
+        @Override
+        protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
+          if (resp.getFirstPartCount() > 0) {
+            S s = getPromotedValueFromProto(ci, resp, 0);
+            synchronized (lock) {
+              sum = ci.add(sum, s);
+            }
+          }
         }
-      }
 
-      @Override
-      protected S getFinalResult() {
-        return sum;
-      }
-    };
+        @Override
+        protected S getFinalResult() {
+          synchronized (lock) {
+            return sum;
+          }
+        }
+      };
     table
-      .<AggregateService, AggregateResponse> coprocessorService(AggregateService::newStub,
+      .coprocessorService(AggregateService::newStub,
         (stub, controller, rpcCallback) -> stub.getSum(controller, req, rpcCallback), callback)
       .fromRow(nullToEmpty(scan.getStartRow()), scan.includeStartRow())
       .toRow(nullToEmpty(scan.getStopRow()), scan.includeStopRow()).execute();
@@ -274,31 +338,36 @@ public final class AsyncAggregationClient {
     CompletableFuture<Double> future = new CompletableFuture<>();
     AggregateRequest req;
     try {
-      req = validateArgAndGetPB(scan, ci, false);
+      req = validateArgAndGetPB(scan, ci, false, true);
     } catch (IOException e) {
       future.completeExceptionally(e);
       return future;
     }
-    AbstractAggregationCallback<Double> callback = new AbstractAggregationCallback<Double>(future) {
-      private S sum;
+    AbstractAggregationCallback<Double> callback =
+      new AbstractAggregationCallback<>(future, req, AggregateService::getAvg) {
+        private S sum;
+        long count = 0L;
+        private final Object lock = new Object();
 
-      long count = 0L;
-
-      @Override
-      protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
-        if (resp.getFirstPartCount() > 0) {
-          sum = ci.add(sum, getPromotedValueFromProto(ci, resp, 0));
-          count += resp.getSecondPart().asReadOnlyByteBuffer().getLong();
+        @Override
+        protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
+          if (resp.getFirstPartCount() > 0) {
+            synchronized (lock) {
+              sum = ci.add(sum, getPromotedValueFromProto(ci, resp, 0));
+              count += resp.getSecondPart().asReadOnlyByteBuffer().getLong();
+            }
+          }
         }
-      }
 
-      @Override
-      protected Double getFinalResult() {
-        return ci.divideForAvg(sum, count);
-      }
-    };
+        @Override
+        protected Double getFinalResult() {
+          synchronized (lock) {
+            return ci.divideForAvg(sum, count);
+          }
+        }
+      };
     table
-      .<AggregateService, AggregateResponse> coprocessorService(AggregateService::newStub,
+      .coprocessorService(AggregateService::newStub,
         (stub, controller, rpcCallback) -> stub.getAvg(controller, req, rpcCallback), callback)
       .fromRow(nullToEmpty(scan.getStartRow()), scan.includeStartRow())
       .toRow(nullToEmpty(scan.getStopRow()), scan.includeStopRow()).execute();
@@ -311,37 +380,41 @@ public final class AsyncAggregationClient {
     CompletableFuture<Double> future = new CompletableFuture<>();
     AggregateRequest req;
     try {
-      req = validateArgAndGetPB(scan, ci, false);
+      req = validateArgAndGetPB(scan, ci, false, true);
     } catch (IOException e) {
       future.completeExceptionally(e);
       return future;
     }
-    AbstractAggregationCallback<Double> callback = new AbstractAggregationCallback<Double>(future) {
+    AbstractAggregationCallback<Double> callback =
+      new AbstractAggregationCallback<>(future, req, AggregateService::getStd) {
 
-      private S sum;
+        private S sum;
+        private S sumSq;
+        private long count;
+        private final Object lock = new Object();
 
-      private S sumSq;
-
-      private long count;
-
-      @Override
-      protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
-        if (resp.getFirstPartCount() > 0) {
-          sum = ci.add(sum, getPromotedValueFromProto(ci, resp, 0));
-          sumSq = ci.add(sumSq, getPromotedValueFromProto(ci, resp, 1));
-          count += resp.getSecondPart().asReadOnlyByteBuffer().getLong();
+        @Override
+        protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
+          if (resp.getFirstPartCount() > 0) {
+            synchronized (lock) {
+              sum = ci.add(sum, getPromotedValueFromProto(ci, resp, 0));
+              sumSq = ci.add(sumSq, getPromotedValueFromProto(ci, resp, 1));
+              count += resp.getSecondPart().asReadOnlyByteBuffer().getLong();
+            }
+          }
         }
-      }
 
-      @Override
-      protected Double getFinalResult() {
-        double avg = ci.divideForAvg(sum, count);
-        double avgSq = ci.divideForAvg(sumSq, count);
-        return Math.sqrt(avgSq - avg * avg);
-      }
-    };
+        @Override
+        protected Double getFinalResult() {
+          synchronized (lock) {
+            double avg = ci.divideForAvg(sum, count);
+            double avgSq = ci.divideForAvg(sumSq, count);
+            return Math.sqrt(avgSq - avg * avg);
+          }
+        }
+      };
     table
-      .<AggregateService, AggregateResponse> coprocessorService(AggregateService::newStub,
+      .coprocessorService(AggregateService::newStub,
         (stub, controller, rpcCallback) -> stub.getStd(controller, req, rpcCallback), callback)
       .fromRow(nullToEmpty(scan.getStartRow()), scan.includeStartRow())
       .toRow(nullToEmpty(scan.getStopRow()), scan.includeStopRow()).execute();
@@ -352,20 +425,20 @@ public final class AsyncAggregationClient {
   private static <R, S, P extends Message, Q extends Message, T extends Message>
     CompletableFuture<NavigableMap<byte[], S>>
     sumByRegion(AsyncTable<?> table, ColumnInterpreter<R, S, P, Q, T> ci, Scan scan) {
-    CompletableFuture<NavigableMap<byte[], S>> future =
-      new CompletableFuture<NavigableMap<byte[], S>>();
+    CompletableFuture<NavigableMap<byte[], S>> future = new CompletableFuture<>();
     AggregateRequest req;
     try {
-      req = validateArgAndGetPB(scan, ci, false);
+      req = validateArgAndGetPB(scan, ci, false, true);
     } catch (IOException e) {
       future.completeExceptionally(e);
       return future;
     }
     int firstPartIndex = scan.getFamilyMap().get(scan.getFamilies()[0]).size() - 1;
     AbstractAggregationCallback<NavigableMap<byte[], S>> callback =
-      new AbstractAggregationCallback<NavigableMap<byte[], S>>(future) {
+      new AbstractAggregationCallback<>(future, req, AggregateService::getMedian) {
 
-        private final NavigableMap<byte[], S> map = new TreeMap<>(Bytes.BYTES_COMPARATOR);
+        private final NavigableMap<byte[], S> map =
+          Collections.synchronizedNavigableMap(new TreeMap<>(Bytes.BYTES_COMPARATOR));
 
         @Override
         protected void aggregate(RegionInfo region, AggregateResponse resp) throws IOException {
@@ -380,7 +453,7 @@ public final class AsyncAggregationClient {
         }
       };
     table
-      .<AggregateService, AggregateResponse> coprocessorService(AggregateService::newStub,
+      .coprocessorService(AggregateService::newStub,
         (stub, controller, rpcCallback) -> stub.getMedian(controller, req, rpcCallback), callback)
       .fromRow(nullToEmpty(scan.getStartRow()), scan.includeStartRow())
       .toRow(nullToEmpty(scan.getStopRow()), scan.includeStopRow()).execute();

--- a/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/client/MockPartialResultAggregateImplemention.java
+++ b/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/client/MockPartialResultAggregateImplemention.java
@@ -1,0 +1,164 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import java.io.IOException;
+import java.util.Collections;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ConcurrentMap;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hbase.thirdparty.com.google.protobuf.ByteString;
+import org.apache.hbase.thirdparty.com.google.protobuf.Message;
+import org.apache.hbase.thirdparty.com.google.protobuf.RpcCallback;
+import org.apache.hbase.thirdparty.com.google.protobuf.RpcController;
+import org.apache.hbase.thirdparty.com.google.protobuf.Service;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AggregateProtos.AggregateRequest;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AggregateProtos.AggregateResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AggregateProtos.AggregateService;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
+
+@InterfaceAudience.Private
+public class MockPartialResultAggregateImplemention<T, S, P extends Message, Q extends Message,
+  R extends Message> extends AggregateService implements RegionCoprocessor {
+  private RegionCoprocessorEnvironment env;
+  private ConcurrentMap<String, Boolean> seenRegion;
+
+  /**
+   * Mocks the behavior of getMax() in the real AggregateImplementation. Makes some fake data to
+   * send back some partial results, and then finally a complete result.
+   */
+  @Override
+  public void getMax(RpcController controller, AggregateRequest request,
+    RpcCallback<AggregateResponse> done) {
+    AggregateResponse.Builder result = AggregateResponse.newBuilder();
+
+    int max;
+    boolean seenRegionBefore = seenRegion.put(env.getRegionInfo().getEncodedName(), true) != null;
+    if (seenRegionBefore) {
+      max = 10;
+    } else {
+      max = 2;
+      seenRegion.put(env.getRegionInfo().getEncodedName(), true);
+    }
+    HBaseProtos.LongMsg longMsg = HBaseProtos.LongMsg.newBuilder().setLongMsg(max).build();
+    result.addFirstPart(longMsg.toByteString());
+    if (!seenRegionBefore) {
+      result.setNextChunkStartRow(ByteString.copyFrom(env.getRegionInfo().getStartKey()));
+    }
+    done.run(result.build());
+  }
+
+  /**
+   * Mocks the behavior of getMin() in the real AggregateImplementation. Makes some fake data to
+   * send back some partial results, and then finally a complete result.
+   */
+  @Override
+  public void getMin(RpcController controller, AggregateRequest request,
+    RpcCallback<AggregateResponse> done) {
+    AggregateResponse.Builder result = AggregateResponse.newBuilder();
+    int min;
+    boolean seenRegionBefore = seenRegion.put(env.getRegionInfo().getEncodedName(), true) != null;
+    if (seenRegionBefore) {
+      min = 10;
+    } else {
+      min = 2;
+      seenRegion.put(env.getRegionInfo().getEncodedName(), true);
+    }
+    HBaseProtos.LongMsg longMsg = HBaseProtos.LongMsg.newBuilder().setLongMsg(min).build();
+    result.addFirstPart(longMsg.toByteString());
+    if (!seenRegionBefore) {
+      result.setNextChunkStartRow(ByteString.copyFrom(env.getRegionInfo().getStartKey()));
+    }
+    done.run(result.build());
+  }
+
+  @Override
+  public void getSum(RpcController controller, AggregateRequest request,
+    RpcCallback<AggregateResponse> done) {
+
+  }
+
+  /**
+   * Gives the row count for the given column family and column qualifier, in the given row range as
+   * defined in the Scan object.
+   */
+  @Override
+  public void getRowNum(RpcController controller, AggregateRequest request,
+    RpcCallback<AggregateResponse> done) {
+
+  }
+
+  /**
+   * Gives a Pair with first object as Sum and second object as row count, computed for a given
+   * combination of column qualifier and column family in the given row range as defined in the Scan
+   * object. In its current implementation, it takes one column family and one column qualifier (if
+   * provided). In case of null column qualifier, an aggregate sum over all the entire column family
+   * will be returned.
+   * <p>
+   * The average is computed in AggregationClient#avg(byte[], ColumnInterpreter, Scan) by processing
+   * results from all regions, so its "ok" to pass sum and a Long type.
+   */
+  @Override
+  public void getAvg(RpcController controller, AggregateRequest request,
+    RpcCallback<AggregateResponse> done) {
+
+  }
+
+  /**
+   * Gives a Pair with first object a List containing Sum and sum of squares, and the second object
+   * as row count. It is computed for a given combination of column qualifier and column family in
+   * the given row range as defined in the Scan object. In its current implementation, it takes one
+   * column family and one column qualifier (if provided). The idea is get the value of variance
+   * first: the average of the squares less the square of the average a standard deviation is square
+   * root of variance.
+   */
+  @Override
+  public void getStd(RpcController controller, AggregateRequest request,
+    RpcCallback<AggregateResponse> done) {
+
+  }
+
+  /**
+   * Gives a List containing sum of values and sum of weights. It is computed for the combination of
+   * column family and column qualifier(s) in the given row range as defined in the Scan object. In
+   * its current implementation, it takes one column family and two column qualifiers. The first
+   * qualifier is for values column and the second qualifier (optional) is for weight column.
+   */
+  @Override
+  public void getMedian(RpcController controller, AggregateRequest request,
+    RpcCallback<AggregateResponse> done) {
+
+  }
+
+  @Override
+  public Iterable<Service> getServices() {
+    return Collections.singleton(this);
+  }
+
+  @Override
+  public void start(CoprocessorEnvironment env) throws IOException {
+    this.env = (RegionCoprocessorEnvironment) env;
+    this.seenRegion = new ConcurrentHashMap<>();
+  }
+
+}

--- a/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/client/MockPartialResultAggregateImplemention.java
+++ b/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/client/MockPartialResultAggregateImplemention.java
@@ -98,52 +98,24 @@ public class MockPartialResultAggregateImplemention<T, S, P extends Message, Q e
 
   }
 
-  /**
-   * Gives the row count for the given column family and column qualifier, in the given row range as
-   * defined in the Scan object.
-   */
   @Override
   public void getRowNum(RpcController controller, AggregateRequest request,
     RpcCallback<AggregateResponse> done) {
 
   }
 
-  /**
-   * Gives a Pair with first object as Sum and second object as row count, computed for a given
-   * combination of column qualifier and column family in the given row range as defined in the Scan
-   * object. In its current implementation, it takes one column family and one column qualifier (if
-   * provided). In case of null column qualifier, an aggregate sum over all the entire column family
-   * will be returned.
-   * <p>
-   * The average is computed in AggregationClient#avg(byte[], ColumnInterpreter, Scan) by processing
-   * results from all regions, so its "ok" to pass sum and a Long type.
-   */
   @Override
   public void getAvg(RpcController controller, AggregateRequest request,
     RpcCallback<AggregateResponse> done) {
 
   }
 
-  /**
-   * Gives a Pair with first object a List containing Sum and sum of squares, and the second object
-   * as row count. It is computed for a given combination of column qualifier and column family in
-   * the given row range as defined in the Scan object. In its current implementation, it takes one
-   * column family and one column qualifier (if provided). The idea is get the value of variance
-   * first: the average of the squares less the square of the average a standard deviation is square
-   * root of variance.
-   */
   @Override
   public void getStd(RpcController controller, AggregateRequest request,
     RpcCallback<AggregateResponse> done) {
 
   }
 
-  /**
-   * Gives a List containing sum of values and sum of weights. It is computed for the combination of
-   * column family and column qualifier(s) in the given row range as defined in the Scan object. In
-   * its current implementation, it takes one column family and two column qualifiers. The first
-   * qualifier is for values column and the second qualifier (optional) is for weight column.
-   */
   @Override
   public void getMedian(RpcController controller, AggregateRequest request,
     RpcCallback<AggregateResponse> done) {

--- a/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/client/TestAsyncAggregationClientPartialResult.java
+++ b/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/client/TestAsyncAggregationClientPartialResult.java
@@ -1,0 +1,92 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.concurrent.ExecutionException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.coprocessor.AsyncAggregationClient;
+import org.apache.hadoop.hbase.client.coprocessor.LongColumnInterpreter;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.testclassification.CoprocessorTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ MediumTests.class, CoprocessorTests.class })
+public class TestAsyncAggregationClientPartialResult {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestAsyncAggregationClientPartialResult.class);
+
+  private static HBaseTestingUtil UTIL = new HBaseTestingUtil();
+
+  private static TableName TABLE_NAME =
+    TableName.valueOf("TestAsyncAggregationClientPartialResult");
+
+  private static byte[] CF = Bytes.toBytes("CF");
+
+  private static byte[] CQ = Bytes.toBytes("CQ");
+
+  private static AsyncConnection CONN;
+
+  private static AsyncTable<AdvancedScanResultConsumer> TABLE;
+
+  @Before
+  public void setUp() throws Exception {
+    Configuration conf = UTIL.getConfiguration();
+    conf.setStrings(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,
+      MockPartialResultAggregateImplemention.class.getName());
+    UTIL.startMiniCluster(3);
+    byte[][] splitKeys = new byte[8][];
+    for (int i = 111; i < 999; i += 111) {
+      splitKeys[i / 111 - 1] = Bytes.toBytes(String.format("%03d", i));
+    }
+    UTIL.createTable(TABLE_NAME, CF, splitKeys);
+    CONN = ConnectionFactory.createAsyncConnection(UTIL.getConfiguration()).get();
+    TABLE = CONN.getTable(TABLE_NAME);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    CONN.close();
+    UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testMax() throws InterruptedException, ExecutionException {
+    assertEquals(10, AsyncAggregationClient
+      .max(TABLE, new LongColumnInterpreter(), new Scan().addColumn(CF, CQ)).get().longValue());
+  }
+
+  @Test
+  public void testMin() throws InterruptedException, ExecutionException {
+    assertEquals(2, AsyncAggregationClient
+      .min(TABLE, new LongColumnInterpreter(), new Scan().addColumn(CF, CQ)).get().longValue());
+  }
+
+}

--- a/hbase-protocol-shaded/src/main/protobuf/server/coprocessor/Aggregate.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/coprocessor/Aggregate.proto
@@ -36,6 +36,7 @@ message AggregateRequest {
   required string interpreter_class_name = 1;
   required Scan scan = 2;
   optional bytes  interpreter_specific_bytes = 3;
+  optional bool   client_supports_partial_result = 4 [default = false];
 }
 
 message AggregateResponse {
@@ -48,6 +49,8 @@ message AggregateResponse {
    */
   repeated bytes first_part = 1;
   optional bytes second_part = 2;
+  optional bytes  next_chunk_start_row = 3;
+  optional uint64 wait_interval_ms     = 4 [default = 0];
 }
 
 /** Refer to the AggregateImplementation class for an overview of the

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyAsyncTable.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyAsyncTable.java
@@ -180,4 +180,11 @@ public class DummyAsyncTable<C extends ScanResultConsumerBase> implements AsyncT
     CoprocessorCallback<R> callback) {
     return null;
   }
+
+  @Override
+  public <S, R> CoprocessorServiceBuilder<S, R> coprocessorService(
+    Function<RpcChannel, S> stubMaker, ServiceCaller<S, R> callable,
+    PartialResultCoprocessorCallback<S, R> callback) {
+    return null;
+  }
 }


### PR DESCRIPTION
Currently there is a gap in the coverage of HBase's quota-based workload throttling. Requests sent by `[Async]AggregationClient` reach `AggregateImplementation`. This then executes Scans in a way that bypasses the quota system. We see issues with this at Hubspot where clusters suffer under this load and we don't have a good way to protect them.

In this PR I'm teaching `AggregateImplementation` to optionally stop scanning when a throttle is violated, and send back just the results it has accumulated so far. In addition, it will send back a row key to `AsyncAggregationClient`. When the client gets a response with a row key, it will sleep in order to satisfy the throttle, and then send a new request with a scan starting at that row key. This will have the effect of continuing the work where the last request stopped.

This feature will be unconditionally enabled by `AsyncAggregationClient` once this ticket is finished. `AggregateImplementation` will not assume that clients support partial results, however, so it can keep supporting older clients. For clients that do not support partial results, throttles will not be respecting, and results will always be complete.