### PR TITLE
HBASE-27903 Skip submitting Split/Merge procedure when split/merge is…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -2256,21 +2256,26 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     final long nonce) throws IOException {
     checkInitialized();
 
+    final String regionNamesToLog = RegionInfo.getShortNameToLog(regionsToMerge);
+
     if (!isSplitOrMergeEnabled(MasterSwitchType.MERGE)) {
-      String regionsStr = Arrays.deepToString(regionsToMerge);
-      LOG.warn("Merge switch is off! skip merge of " + regionsStr);
+      LOG.warn("Merge switch is off! skip merge of " + regionNamesToLog);
       throw new DoNotRetryIOException(
-        "Merge of " + regionsStr + " failed because merge switch is off");
+        "Merge of " + regionNamesToLog + " failed because merge switch is off");
     }
 
-    final String mergeRegionsStr = Arrays.stream(regionsToMerge).map(RegionInfo::getEncodedName)
-      .collect(Collectors.joining(", "));
+    if (!getTableDescriptors().get(regionsToMerge[0].getTable()).isMergeEnabled()) {
+      LOG.warn("Merge is disabled for the table! Skipping merge of {}", regionNamesToLog);
+      throw new DoNotRetryIOException(
+        "Merge of " + regionNamesToLog + " failed as region merge is disabled for the table");
+    }
+
     return MasterProcedureUtil.submitProcedure(new NonceProcedureRunnable(this, ng, nonce) {
       @Override
       protected void run() throws IOException {
         getMaster().getMasterCoprocessorHost().preMergeRegions(regionsToMerge);
         String aid = getClientIdAuditPrefix();
-        LOG.info("{} merge regions {}", aid, mergeRegionsStr);
+        LOG.info("{} merge regions {}", aid, regionNamesToLog);
         submitProcedure(new MergeTableRegionsProcedure(procedureExecutor.getEnvironment(),
           regionsToMerge, forcible));
         getMaster().getMasterCoprocessorHost().postMergeRegions(regionsToMerge);
@@ -2292,6 +2297,12 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
       LOG.warn("Split switch is off! skip split of " + regionInfo);
       throw new DoNotRetryIOException(
         "Split region " + regionInfo.getRegionNameAsString() + " failed due to split switch off");
+    }
+
+    if (!getTableDescriptors().get(regionInfo.getTable()).isSplitEnabled()) {
+      LOG.warn("Split is disabled for the table! Skipping split of {}", regionInfo);
+      throw new DoNotRetryIOException("Split region " + regionInfo.getRegionNameAsString()
+        + " failed as region split is disabled for the table");
     }
 
     return MasterProcedureUtil

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
@@ -443,27 +443,28 @@ public class MergeTableRegionsProcedure
   private boolean prepareMergeRegion(final MasterProcedureEnv env) throws IOException {
     // Fail if we are taking snapshot for the given table
     TableName tn = regionsToMerge[0].getTable();
+    final String regionNamesToLog = RegionInfo.getShortNameToLog(regionsToMerge);
     if (env.getMasterServices().getSnapshotManager().isTableTakingAnySnapshot(tn)) {
-      throw new MergeRegionException("Skip merging regions "
-        + RegionInfo.getShortNameToLog(regionsToMerge) + ", because we are snapshotting " + tn);
+      throw new MergeRegionException(
+        "Skip merging regions " + regionNamesToLog + ", because we are snapshotting " + tn);
     }
 
-    // Mostly this check is not used because we already check the switch before submit a merge
-    // procedure. Just for safe, check the switch again. This procedure can be rollbacked if
-    // the switch was set to false after submit.
+    // Mostly the below two checks are not used because we already check the switches before
+    // submitting the merge procedure. Just for safety, we are checking the switch again here.
+    // Also, in case the switch was set to false after submission, this procedure can be rollbacked,
+    // thanks to this double check!
+    // case 1: check for cluster level switch
     if (!env.getMasterServices().isSplitOrMergeEnabled(MasterSwitchType.MERGE)) {
-      String regionsStr = Arrays.deepToString(this.regionsToMerge);
-      LOG.warn("Merge switch is off! skip merge of " + regionsStr);
+      LOG.warn("Merge switch is off! skip merge of " + regionNamesToLog);
       setFailure(getClass().getSimpleName(),
-        new IOException("Merge of " + regionsStr + " failed because merge switch is off"));
+        new IOException("Merge of " + regionNamesToLog + " failed because merge switch is off"));
       return false;
     }
-
+    // case 2: check for table level switch
     if (!env.getMasterServices().getTableDescriptors().get(getTableName()).isMergeEnabled()) {
-      String regionsStr = Arrays.deepToString(regionsToMerge);
-      LOG.warn("Merge is disabled for the table! Skipping merge of {}", regionsStr);
+      LOG.warn("Merge is disabled for the table! Skipping merge of {}", regionNamesToLog);
       setFailure(getClass().getSimpleName(), new IOException(
-        "Merge of " + regionsStr + " failed as region merge is disabled for the table"));
+        "Merge of " + regionNamesToLog + " failed as region merge is disabled for the table"));
       return false;
     }
 
@@ -471,8 +472,8 @@ public class MergeTableRegionsProcedure
     RegionStateStore regionStateStore = env.getAssignmentManager().getRegionStateStore();
     for (RegionInfo ri : this.regionsToMerge) {
       if (regionStateStore.hasMergeRegions(ri)) {
-        String msg = "Skip merging " + RegionInfo.getShortNameToLog(regionsToMerge)
-          + ", because a parent, " + RegionInfo.getShortNameToLog(ri) + ", has a merge qualifier "
+        String msg = "Skip merging " + regionNamesToLog + ", because a parent, "
+          + RegionInfo.getShortNameToLog(ri) + ", has a merge qualifier "
           + "(if a 'merge column' in parent, it was recently merged but still has outstanding "
           + "references to its parents that must be cleared before it can participate in merge -- "
           + "major compact it to hurry clearing of its references)";
@@ -492,8 +493,8 @@ public class MergeTableRegionsProcedure
       try {
         if (!isMergeable(env, state)) {
           setFailure(getClass().getSimpleName(),
-            new MergeRegionException("Skip merging " + RegionInfo.getShortNameToLog(regionsToMerge)
-              + ", because a parent, " + RegionInfo.getShortNameToLog(ri) + ", is not mergeable"));
+            new MergeRegionException("Skip merging " + regionNamesToLog + ", because a parent, "
+              + RegionInfo.getShortNameToLog(ri) + ", is not mergeable"));
           return false;
         }
       } catch (IOException e) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
@@ -547,16 +547,18 @@ public class SplitTableRegionProcedure
       return false;
     }
 
-    // Mostly this check is not used because we already check the switch before submit a split
-    // procedure. Just for safe, check the switch again. This procedure can be rollbacked if
-    // the switch was set to false after submit.
+    // Mostly the below two checks are not used because we already check the switches before
+    // submitting the split procedure. Just for safety, we are checking the switch again here.
+    // Also, in case the switch was set to false after submission, this procedure can be rollbacked,
+    // thanks to this double check!
+    // case 1: check for cluster level switch
     if (!env.getMasterServices().isSplitOrMergeEnabled(MasterSwitchType.SPLIT)) {
       LOG.warn("pid=" + getProcId() + " split switch is off! skip split of " + parentHRI);
       setFailure(new IOException(
         "Split region " + parentHRI.getRegionNameAsString() + " failed due to split switch off"));
       return false;
     }
-
+    // case 2: check for table level switch
     if (!env.getMasterServices().getTableDescriptors().get(getTableName()).isSplitEnabled()) {
       LOG.warn("pid={}, split is disabled for the table! Skipping split of {}", getProcId(),
         parentHRI);


### PR DESCRIPTION
… disabled at table level

- Fail fast by adding a check before even submitting a procedure
- Update test cases to assert for expected exception post this change
- Remove deprecated method mergeRegionsAsync's usage in test
- Make use of RegionInfo.getShortNameToLog instead of logging complete region info
- Update comments in procedure implementation