### PR TITLE
HBASE-28802 Log the IP when hbase.server.useip.enabled is set to true

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -1705,7 +1705,7 @@ public class HRegionServer extends Thread
           if (!isHostnameConsist) {
             String msg = "Master passed us a different hostname to use; was="
               + (StringUtils.isBlank(useThisHostnameInstead)
-                ? rpcServices.getSocketAddress().getHostName()
+                ? expectedHostName
                 : this.useThisHostnameInstead)
               + ", but now=" + hostnameFromMasterPOV;
             LOG.error(msg);


### PR DESCRIPTION
For HRegionServer#handleReportForDutyResponse, when the hostname is different from the regionserver and master side, both the two conditions should abort RS error message is corrected.