### PR TITLE
HBASE-28810 Improve BackupLogCleaner naming, debug logging

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/BackupLogCleaner.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/BackupLogCleaner.java
@@ -84,7 +84,8 @@ public class BackupLogCleaner extends BaseLogCleanerDelegate {
   private Map<Address, Long> getServerToLastBackupTs(List<BackupInfo> backups) throws IOException {
     if (LOG.isDebugEnabled()) {
       LOG.debug(
-        "Cleaning WALs if they are older than the latest backups. Checking WALs against {} backups: {}",
+        "Cleaning WALs if they are older than the latest backups. "
+          + "Checking WALs against {} backups: {}",
         backups.size(),
         backups.stream().map(BackupInfo::getBackupId).sorted().collect(Collectors.joining(", ")));
     }
@@ -196,7 +197,7 @@ public class BackupLogCleaner extends BaseLogCleanerDelegate {
       }
 
       Long lastBackupTs = addressToLastBackupMap.get(walServerAddress);
-      if (lastBackupTs > walTimestamp) {
+      if (lastBackupTs >= walTimestamp) {
         if (LOG.isDebugEnabled()) {
           LOG.debug(
             "Backup found for server: {}. Backup from {} is newer than file, so deleting: {}",


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-28810

While implementing HBase's incremental backups across a few hundred clusters, we continue to step on some rakes. Now and again, we find old WALs piling up due to a poorly cleaned up BackupInfo, or a bug in the BackupLogCleaner, etc.

The BackupLogCleaner is difficult to debug for a couple of reasons:

- It has a lack of useful debug logging
- It has [a misleadingly named method](https://github.com/HubSpot/hbase/blob/2d08fa67dfe9458260bc0be3ebc7bbd769850190/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/BackupLogCleaner.java#L83-L83) (this method returns the newest backup ts, not the oldest)

This small refactor improves the logging and naming

cc @ndimiduk 