### PR TITLE
Backport HBASE-28804 to branch-2

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCache.java
@@ -246,4 +246,21 @@ public interface BlockCache extends Iterable<CachedBlock> {
   default int evictBlocksRangeByHfileName(String hfileName, long initOffset, long endOffset) {
     return 0;
   }
+
+  /**
+   * API to check whether or not, the cache is enabled.
+   * @return returns true if the cache is enabled, false otherwise.
+   */
+  default boolean isCacheEnabled() {
+    return true;
+  }
+
+  /**
+   * Wait for the bucket cache to be enabled while server restart
+   * @param timeout time to wait for the bucket cache to be enable
+   * @return boolean true if the bucket cache is enabled, false otherwise
+   */
+  default boolean waitForCacheInitialization(long timeout) {
+    return true;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CombinedBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CombinedBlockCache.java
@@ -497,4 +497,15 @@ public class CombinedBlockCache implements ResizableBlockCache, HeapSize {
     return l1Cache.evictBlocksRangeByHfileName(hfileName, initOffset, endOffset)
       + l2Cache.evictBlocksRangeByHfileName(hfileName, initOffset, endOffset);
   }
+
+  @Override
+  public boolean waitForCacheInitialization(long timeout) {
+    return this.l1Cache.waitForCacheInitialization(timeout)
+      && this.l2Cache.waitForCacheInitialization(timeout);
+  }
+
+  @Override
+  public boolean isCacheEnabled() {
+    return l1Cache.isCacheEnabled() && l2Cache.isCacheEnabled();
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -34,12 +34,15 @@ import org.slf4j.LoggerFactory;
 public class HFilePreadReader extends HFileReaderImpl {
   private static final Logger LOG = LoggerFactory.getLogger(HFileReaderImpl.class);
 
+  private static final int WAIT_TIME_FOR_CACHE_INITIALIZATION = 10 * 60 * 1000;
+
   public HFilePreadReader(ReaderContext context, HFileInfo fileInfo, CacheConfig cacheConf,
     Configuration conf) throws IOException {
     super(context, fileInfo, cacheConf, conf);
     final MutableBoolean shouldCache = new MutableBoolean(true);
 
     cacheConf.getBlockCache().ifPresent(cache -> {
+      cache.waitForCacheInitialization(WAIT_TIME_FOR_CACHE_INITIALIZATION);
       Optional<Boolean> result = cache.shouldCacheFile(path.getName());
       shouldCache.setValue(result.isPresent() ? result.get().booleanValue() : true);
     });
@@ -110,8 +113,8 @@ public class HFilePreadReader extends HFileReaderImpl {
                   if (!cache.blockFitsIntoTheCache(block).orElse(true)) {
                     LOG.warn(
                       "Interrupting prefetch for file {} because block {} of size {} "
-                        + "doesn't fit in the available cache space.",
-                      path, cacheKey, block.getOnDiskSizeWithHeader());
+                        + "doesn't fit in the available cache space. isCacheEnabled: {}",
+                      path, cacheKey, block.getOnDiskSizeWithHeader(), cache.isCacheEnabled());
                     interrupted = true;
                     break;
                   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -171,10 +171,22 @@ public class BucketCache implements BlockCache, HeapSize {
   private BucketCachePersister cachePersister;
 
   /**
+   * Enum to represent the state of cache
+   */
+  protected enum CacheState {
+    // Initializing: State when the cache is being initialised from persistence.
+    INITIALIZING,
+    // Enabled: State when cache is initialised and is ready.
+    ENABLED,
+    // Disabled: State when the cache is disabled.
+    DISABLED
+  }
+
+  /**
    * Flag if the cache is enabled or not... We shut it off if there are IO errors for some time, so
    * that Bucket IO exceptions/errors don't bring down the HBase server.
    */
-  private volatile boolean cacheEnabled;
+  private volatile CacheState cacheState;
 
   /**
    * A list of writer queues. We have a queue per {@link WriterThread} we have running. In other
@@ -325,6 +337,7 @@ public class BucketCache implements BlockCache, HeapSize {
     this.persistencePath = persistencePath;
     this.blockSize = blockSize;
     this.ioErrorsTolerationDuration = ioErrorsTolerationDuration;
+    this.cacheState = CacheState.INITIALIZING;
 
     this.allocFailLogPrevTs = 0;
 
@@ -336,32 +349,18 @@ public class BucketCache implements BlockCache, HeapSize {
     this.ramCache = new RAMCache();
 
     this.backingMap = new ConcurrentHashMap<>((int) blockNumCapacity);
+    instantiateWriterThreads();
 
     if (isCachePersistent()) {
       if (ioEngine instanceof FileIOEngine) {
         startBucketCachePersisterThread();
       }
-      try {
-        retrieveFromFile(bucketSizes);
-      } catch (IOException ioex) {
-        LOG.error("Can't restore from file[{}] because of ", persistencePath, ioex);
-        backingMap.clear();
-        fullyCachedFiles.clear();
-        backingMapValidated.set(true);
-        bucketAllocator = new BucketAllocator(capacity, bucketSizes);
-        regionCachedSize.clear();
-      }
+      startPersistenceRetriever(bucketSizes, capacity);
     } else {
       bucketAllocator = new BucketAllocator(capacity, bucketSizes);
+      this.cacheState = CacheState.ENABLED;
+      startWriterThreads();
     }
-    final String threadName = Thread.currentThread().getName();
-    this.cacheEnabled = true;
-    for (int i = 0; i < writerThreads.length; ++i) {
-      writerThreads[i] = new WriterThread(writerQueues.get(i));
-      writerThreads[i].setName(threadName + "-BucketCacheWriter-" + i);
-      writerThreads[i].setDaemon(true);
-    }
-    startWriterThreads();
 
     // Run the statistics thread periodically to print the cache statistics log
     // TODO: Add means of turning this off. Bit obnoxious running thread just to make a log
@@ -371,7 +370,32 @@ public class BucketCache implements BlockCache, HeapSize {
     LOG.info("Started bucket cache; ioengine=" + ioEngineName + ", capacity="
       + StringUtils.byteDesc(capacity) + ", blockSize=" + StringUtils.byteDesc(blockSize)
       + ", writerThreadNum=" + writerThreadNum + ", writerQLen=" + writerQLen + ", persistencePath="
-      + persistencePath + ", bucketAllocator=" + this.bucketAllocator.getClass().getName());
+      + persistencePath + ", bucketAllocator=" + BucketAllocator.class.getName());
+  }
+
+  private void startPersistenceRetriever(int[] bucketSizes, long capacity) {
+    Runnable persistentCacheRetriever = () -> {
+      try {
+        retrieveFromFile(bucketSizes);
+        LOG.info("Persistent bucket cache recovery from {} is complete.", persistencePath);
+      } catch (IOException ioex) {
+        LOG.error("Can't restore from file[{}] because of ", persistencePath, ioex);
+        backingMap.clear();
+        fullyCachedFiles.clear();
+        backingMapValidated.set(true);
+        try {
+          bucketAllocator = new BucketAllocator(capacity, bucketSizes);
+        } catch (BucketAllocatorException ex) {
+          LOG.error("Exception during Bucket Allocation", ex);
+        }
+        regionCachedSize.clear();
+      } finally {
+        this.cacheState = CacheState.ENABLED;
+        startWriterThreads();
+      }
+    };
+    Thread t = new Thread(persistentCacheRetriever);
+    t.start();
   }
 
   private void sanityCheckConfigs() {
@@ -395,6 +419,18 @@ public class BucketCache implements BlockCache, HeapSize {
   }
 
   /**
+   * Called by the constructor to instantiate the writer threads.
+   */
+  private void instantiateWriterThreads() {
+    final String threadName = Thread.currentThread().getName();
+    for (int i = 0; i < this.writerThreads.length; ++i) {
+      this.writerThreads[i] = new WriterThread(this.writerQueues.get(i));
+      this.writerThreads[i].setName(threadName + "-BucketCacheWriter-" + i);
+      this.writerThreads[i].setDaemon(true);
+    }
+  }
+
+  /**
    * Called by the constructor to start the writer threads. Used by tests that need to override
    * starting the threads.
    */
@@ -411,8 +447,9 @@ public class BucketCache implements BlockCache, HeapSize {
     cachePersister.start();
   }
 
-  boolean isCacheEnabled() {
-    return this.cacheEnabled;
+  @Override
+  public boolean isCacheEnabled() {
+    return this.cacheState == CacheState.ENABLED;
   }
 
   @Override
@@ -501,7 +538,7 @@ public class BucketCache implements BlockCache, HeapSize {
    */
   public void cacheBlockWithWait(BlockCacheKey cacheKey, Cacheable cachedItem, boolean inMemory,
     boolean wait) {
-    if (cacheEnabled) {
+    if (isCacheEnabled()) {
       if (backingMap.containsKey(cacheKey) || ramCache.containsKey(cacheKey)) {
         if (shouldReplaceExistingCacheBlock(cacheKey, cachedItem)) {
           BucketEntry bucketEntry = backingMap.get(cacheKey);
@@ -523,7 +560,7 @@ public class BucketCache implements BlockCache, HeapSize {
 
   protected void cacheBlockWithWaitInternal(BlockCacheKey cacheKey, Cacheable cachedItem,
     boolean inMemory, boolean wait) {
-    if (!cacheEnabled) {
+    if (!isCacheEnabled()) {
       return;
     }
     if (cacheKey.getBlockType() == null && cachedItem.getBlockType() != null) {
@@ -599,7 +636,7 @@ public class BucketCache implements BlockCache, HeapSize {
   @Override
   public Cacheable getBlock(BlockCacheKey key, boolean caching, boolean repeat,
     boolean updateCacheMetrics) {
-    if (!cacheEnabled) {
+    if (!isCacheEnabled()) {
       return null;
     }
     RAMQueueEntry re = ramCache.get(key);
@@ -763,7 +800,7 @@ public class BucketCache implements BlockCache, HeapSize {
    */
   private boolean doEvictBlock(BlockCacheKey cacheKey, BucketEntry bucketEntry,
     boolean evictedByEvictionProcess) {
-    if (!cacheEnabled) {
+    if (!isCacheEnabled()) {
       return false;
     }
     boolean existedInRamCache = removeFromRamCache(cacheKey);
@@ -854,6 +891,10 @@ public class BucketCache implements BlockCache, HeapSize {
     isCacheInconsistent.set(setCacheInconsistent);
   }
 
+  protected void setCacheState(CacheState state) {
+    cacheState = state;
+  }
+
   /*
    * Statistics thread. Periodically output cache statistics to the log.
    */
@@ -873,6 +914,10 @@ public class BucketCache implements BlockCache, HeapSize {
   }
 
   public void logStats() {
+    if (!isCacheInitialized("BucketCache::logStats")) {
+      return;
+    }
+
     long totalSize = bucketAllocator.getTotalSize();
     long usedSize = bucketAllocator.getUsedSize();
     long freeSize = totalSize - usedSize;
@@ -905,10 +950,17 @@ public class BucketCache implements BlockCache, HeapSize {
   }
 
   public long acceptableSize() {
+    if (!isCacheInitialized("BucketCache::acceptableSize")) {
+      return 0;
+    }
     return (long) Math.floor(bucketAllocator.getTotalSize() * acceptableFactor);
   }
 
   long getPartitionSize(float partitionFactor) {
+    if (!isCacheInitialized("BucketCache::getPartitionSize")) {
+      return 0;
+    }
+
     return (long) Math.floor(bucketAllocator.getTotalSize() * partitionFactor * minFactor);
   }
 
@@ -916,6 +968,10 @@ public class BucketCache implements BlockCache, HeapSize {
    * Return the count of bucketSizeinfos still need free space
    */
   private int bucketSizesAboveThresholdCount(float minFactor) {
+    if (!isCacheInitialized("BucketCache::bucketSizesAboveThresholdCount")) {
+      return 0;
+    }
+
     BucketAllocator.IndexStatistics[] stats = bucketAllocator.getIndexStatistics();
     int fullCount = 0;
     for (int i = 0; i < stats.length; i++) {
@@ -936,6 +992,10 @@ public class BucketCache implements BlockCache, HeapSize {
    * @param completelyFreeBucketsNeeded number of buckets to free
    **/
   private void freeEntireBuckets(int completelyFreeBucketsNeeded) {
+    if (!isCacheInitialized("BucketCache::freeEntireBuckets")) {
+      return;
+    }
+
     if (completelyFreeBucketsNeeded != 0) {
       // First we will build a set where the offsets are reference counted, usually
       // this set is small around O(Handler Count) unless something else is wrong
@@ -962,6 +1022,9 @@ public class BucketCache implements BlockCache, HeapSize {
    * @param why Why we are being called
    */
   void freeSpace(final String why) {
+    if (!isCacheInitialized("BucketCache::freeSpace")) {
+      return;
+    }
     // Ensure only one freeSpace progress at a time
     if (!freeSpaceLock.tryLock()) {
       return;
@@ -1117,13 +1180,13 @@ public class BucketCache implements BlockCache, HeapSize {
     public void run() {
       List<RAMQueueEntry> entries = new ArrayList<>();
       try {
-        while (cacheEnabled && writerEnabled) {
+        while (isCacheEnabled() && writerEnabled) {
           try {
             try {
               // Blocks
               entries = getRAMQueueEntries(inputQueue, entries);
             } catch (InterruptedException ie) {
-              if (!cacheEnabled || !writerEnabled) {
+              if (!isCacheEnabled() || !writerEnabled) {
                 break;
               }
             }
@@ -1135,7 +1198,7 @@ public class BucketCache implements BlockCache, HeapSize {
       } catch (Throwable t) {
         LOG.warn("Failed doing drain", t);
       }
-      LOG.info(this.getName() + " exiting, cacheEnabled=" + cacheEnabled);
+      LOG.info(this.getName() + " exiting, cacheEnabled=" + isCacheEnabled());
     }
   }
 
@@ -1226,7 +1289,7 @@ public class BucketCache implements BlockCache, HeapSize {
     // Index updated inside loop if success or if we can't succeed. We retry if cache is full
     // when we go to add an entry by going around the loop again without upping the index.
     int index = 0;
-    while (cacheEnabled && index < size) {
+    while (isCacheEnabled() && index < size) {
       RAMQueueEntry re = null;
       try {
         re = entries.get(index);
@@ -1359,9 +1422,18 @@ public class BucketCache implements BlockCache, HeapSize {
     File tempPersistencePath = new File(persistencePath + EnvironmentEdgeManager.currentTime());
     try (FileOutputStream fos = new FileOutputStream(tempPersistencePath, false)) {
       LOG.debug("Persist in new chunked persistence format.");
+
       persistChunkedBackingMap(fos);
+
+      LOG.debug(
+        "PersistToFile: after persisting backing map size: {}, fullycachedFiles size: {},"
+          + " file name: {}",
+        backingMap.size(), fullyCachedFiles.size(), tempPersistencePath.getName());
     } catch (IOException e) {
       LOG.error("Failed to persist bucket cache to file", e);
+      throw e;
+    } catch (Throwable e) {
+      LOG.error("Failed during persist bucket cache to file: ", e);
       throw e;
     }
     LOG.debug("Thread {} finished persisting bucket cache to file, renaming",
@@ -1395,7 +1467,7 @@ public class BucketCache implements BlockCache, HeapSize {
       backingMapValidated.set(true);
       return;
     }
-    assert !cacheEnabled;
+    assert !isCacheEnabled();
 
     try (FileInputStream in = new FileInputStream(persistenceFile)) {
       int pblen = ProtobufMagic.lengthOfPBMagic();
@@ -1538,6 +1610,10 @@ public class BucketCache implements BlockCache, HeapSize {
     blocksByHFile = pair.getSecond();
     fullyCachedFiles.clear();
     fullyCachedFiles.putAll(BucketProtoUtils.fromPB(proto.getCachedFilesMap()));
+
+    LOG.info("After retrieval Backing map size: {}, fullyCachedFiles size: {}", backingMap.size(),
+      fullyCachedFiles.size());
+
     verifyFileIntegrity(proto);
     updateRegionSizeMapWhileRetrievingFromFile();
     verifyCapacityAndClasses(proto.getCacheCapacity(), proto.getIoClass(), proto.getMapClass());
@@ -1601,7 +1677,7 @@ public class BucketCache implements BlockCache, HeapSize {
     // Do a single read to a local variable to avoid timing issue - HBASE-24454
     long ioErrorStartTimeTmp = this.ioErrorStartTime;
     if (ioErrorStartTimeTmp > 0) {
-      if (cacheEnabled && (now - ioErrorStartTimeTmp) > this.ioErrorsTolerationDuration) {
+      if (isCacheEnabled() && (now - ioErrorStartTimeTmp) > this.ioErrorsTolerationDuration) {
         LOG.error("IO errors duration time has exceeded " + ioErrorsTolerationDuration
           + "ms, disabling cache, please check your IOEngine");
         disableCache();
@@ -1615,9 +1691,11 @@ public class BucketCache implements BlockCache, HeapSize {
    * Used to shut down the cache -or- turn it off in the case of something broken.
    */
   private void disableCache() {
-    if (!cacheEnabled) return;
+    if (!isCacheEnabled()) {
+      return;
+    }
     LOG.info("Disabling cache");
-    cacheEnabled = false;
+    cacheState = CacheState.DISABLED;
     ioEngine.shutdown();
     this.scheduleThreadPool.shutdown();
     for (int i = 0; i < writerThreads.length; ++i)
@@ -1698,6 +1776,9 @@ public class BucketCache implements BlockCache, HeapSize {
 
   @Override
   public long getFreeSize() {
+    if (!isCacheInitialized("BucketCache:getFreeSize")) {
+      return 0;
+    }
     return this.bucketAllocator.getFreeSize();
   }
 
@@ -1713,6 +1794,9 @@ public class BucketCache implements BlockCache, HeapSize {
 
   @Override
   public long getCurrentSize() {
+    if (!isCacheInitialized("BucketCache::getCurrentSize")) {
+      return 0;
+    }
     return this.bucketAllocator.getUsedSize();
   }
 
@@ -2219,6 +2303,10 @@ public class BucketCache implements BlockCache, HeapSize {
 
   @Override
   public Optional<Boolean> blockFitsIntoTheCache(HFileBlock block) {
+    if (!isCacheInitialized("blockFitsIntoTheCache")) {
+      return Optional.of(false);
+    }
+
     long currentUsed = bucketAllocator.getUsedSize();
     boolean result = (currentUsed + block.getOnDiskSizeWithHeader()) < acceptableSize();
     return Optional.of(result);
@@ -2250,5 +2338,28 @@ public class BucketCache implements BlockCache, HeapSize {
       return Optional.of(entry.getOnDiskSizeWithHeader());
     }
 
+  }
+
+  boolean isCacheInitialized(String api) {
+    if (cacheState == CacheState.INITIALIZING) {
+      LOG.warn("Bucket initialisation pending at {}", api);
+      return false;
+    }
+    return true;
+  }
+
+  @Override
+  public boolean waitForCacheInitialization(long timeout) {
+    try {
+      while (cacheState == CacheState.INITIALIZING) {
+        if (timeout <= 0) {
+          break;
+        }
+        Thread.sleep(100);
+        timeout -= 100;
+      }
+    } finally {
+      return isCacheEnabled();
+    }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCachePersister.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCachePersister.java
@@ -62,6 +62,8 @@ public class BucketCachePersister extends Thread {
       LOG.info("Finishing cache persister thread.");
     } catch (InterruptedException e) {
       LOG.warn("Interrupting BucketCachePersister thread.", e);
+    } catch (Throwable e) {
+      LOG.error("Failed during persisting bucket cache to file: ", e);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/CacheAwareLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/CacheAwareLoadBalancer.java
@@ -28,6 +28,7 @@ package org.apache.hadoop.hbase.master.balancer;
 
 import static org.apache.hadoop.hbase.HConstants.BUCKET_CACHE_PERSISTENT_PATH_KEY;
 
+import java.text.DecimalFormat;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -221,6 +222,9 @@ public class CacheAwareLoadBalancer extends StochasticLoadBalancer {
         return false;
       }
 
+      DecimalFormat df = new DecimalFormat("#");
+      df.setMaximumFractionDigits(4);
+
       float cacheRatioDiffThreshold = 0.6f;
 
       // Conditions for moving the region
@@ -240,7 +244,7 @@ public class CacheAwareLoadBalancer extends StochasticLoadBalancer {
           LOG.debug(
             "Region {} moved from {} to {} as the region is cached {} equally on both servers",
             cluster.regions[regionIndex].getEncodedName(), cluster.servers[currentServerIndex],
-            cluster.servers[oldServerIndex], cacheRatioOnCurrentServer);
+            cluster.servers[oldServerIndex], df.format(cacheRatioOnCurrentServer));
         }
         return true;
       }
@@ -257,7 +261,8 @@ public class CacheAwareLoadBalancer extends StochasticLoadBalancer {
             "Region {} moved from {} to {} as region cache ratio {} is better than the current "
               + "cache ratio {}",
             cluster.regions[regionIndex].getEncodedName(), cluster.servers[currentServerIndex],
-            cluster.servers[oldServerIndex], cacheRatioOnCurrentServer, cacheRatioOnOldServer);
+            cluster.servers[oldServerIndex], cacheRatioOnCurrentServer,
+            df.format(cacheRatioOnCurrentServer));
         }
         return true;
       }
@@ -266,7 +271,8 @@ public class CacheAwareLoadBalancer extends StochasticLoadBalancer {
         LOG.debug(
           "Region {} not moved from {} to {} with current cache ratio {} and old cache ratio {}",
           cluster.regions[regionIndex], cluster.servers[currentServerIndex],
-          cluster.servers[oldServerIndex], cacheRatioOnCurrentServer, cacheRatioOnOldServer);
+          cluster.servers[oldServerIndex], cacheRatioOnCurrentServer,
+          df.format(cacheRatioOnCurrentServer));
       }
       return false;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -1602,9 +1602,9 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
     boolean isGracefulStop) throws IOException {
     // Only allow one thread to close at a time. Serialize them so dual
     // threads attempting to close will run up against each other.
-    MonitoredTask status = TaskMonitor.get().createStatus(
-      "Closing region " + this.getRegionInfo().getEncodedName() + (abort ? " due to abort" : ""),
-      true);
+    MonitoredTask status =
+      TaskMonitor.get().createStatus("Closing region " + this.getRegionInfo().getEncodedName()
+        + (abort ? " due to abort" : " as it is being closed"), true);
     status.setStatus("Waiting for close lock");
     try {
       synchronized (closeLock) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestBlockEvictionOnRegionMovement.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestBlockEvictionOnRegionMovement.java
@@ -132,6 +132,7 @@ public class TestBlockEvictionOnRegionMovement {
     cluster.startRegionServer();
     Thread.sleep(500);
 
+    regionServingRS.getBlockCache().get().waitForCacheInitialization(10000);
     long newUsedCacheSize =
       regionServingRS.getBlockCache().get().getBlockCaches()[1].getCurrentSize();
     assertEquals(oldUsedCacheSize, newUsedCacheSize);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestBucketWriterThread.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestBucketWriterThread.java
@@ -84,6 +84,7 @@ public class TestBucketWriterThread {
     final int writerThreadsCount = 1;
     this.bc = new MockBucketCache("offheap", capacity, 1, new int[] { 1 }, writerThreadsCount,
       capacity, null, 100/* Tolerate ioerrors for 100ms */);
+    this.bc.waitForCacheInitialization(10000);
     assertEquals(writerThreadsCount, bc.writerThreads.length);
     assertEquals(writerThreadsCount, bc.writerQueues.size());
     // Get reference to our single WriterThread instance.

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestPrefetchPersistence.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestPrefetchPersistence.java
@@ -109,6 +109,7 @@ public class TestPrefetchPersistence {
     bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen,
       testDir + "/bucket.persistence", 60 * 1000, conf);
+    bucketCache.waitForCacheInitialization(10000);
     cacheConf = new CacheConfig(conf, bucketCache);
 
     long usedSize = bucketCache.getAllocator().getUsedSize();
@@ -127,6 +128,7 @@ public class TestPrefetchPersistence {
     bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen,
       testDir + "/bucket.persistence", 60 * 1000, conf);
+    bucketCache.waitForCacheInitialization(10000);
     cacheConf = new CacheConfig(conf, bucketCache);
     assertTrue(usedSize != 0);
     assertTrue(bucketCache.fullyCachedFiles.containsKey(storeFile.getName()));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestRecoveryPersistentBucketCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestRecoveryPersistentBucketCache.java
@@ -21,12 +21,14 @@ import static org.apache.hadoop.hbase.io.hfile.CacheConfig.BUCKETCACHE_PERSIST_I
 import static org.apache.hadoop.hbase.io.hfile.bucket.BucketCache.DEFAULT_ERROR_TOLERATION_DURATION;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.CacheTestUtils;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
@@ -60,6 +62,9 @@ public class TestRecoveryPersistentBucketCache {
     BucketCache bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       8192, bucketSizes, writeThreads, writerQLen, testDir + "/bucket.persistence",
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    assertTrue(bucketCache.waitForCacheInitialization(1000));
+    assertTrue(
+      bucketCache.isCacheInitialized("testBucketCacheRecovery") && bucketCache.isCacheEnabled());
 
     CacheTestUtils.HFileBlockPair[] blocks = CacheTestUtils.generateHFileBlocks(8192, 4);
 
@@ -95,7 +100,8 @@ public class TestRecoveryPersistentBucketCache {
     BucketCache newBucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       8192, bucketSizes, writeThreads, writerQLen, testDir + "/bucket.persistence",
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
-    Thread.sleep(100);
+    assertTrue(newBucketCache.waitForCacheInitialization(1000));
+
     assertEquals(3, newBucketCache.backingMap.size());
     assertNull(newBucketCache.getBlock(blocks[3].getBlockName(), false, false, false));
     assertNull(newBucketCache.getBlock(smallerBlocks[0].getBlockName(), false, false, false));
@@ -120,6 +126,7 @@ public class TestRecoveryPersistentBucketCache {
     BucketCache bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       8192, bucketSizes, writeThreads, writerQLen, testDir + "/bucket.persistence",
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
 
     CacheTestUtils.HFileBlockPair[] blocks = CacheTestUtils.generateHFileBlocks(8192, 4);
 
@@ -134,18 +141,68 @@ public class TestRecoveryPersistentBucketCache {
     BucketCache newBucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       8192, bucketSizes, writeThreads, writerQLen, testDir + "/bucket.persistence",
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
-    Thread.sleep(100);
+    assertTrue(newBucketCache.waitForCacheInitialization(10000));
     assertEquals(4, newBucketCache.backingMap.size());
     newBucketCache.evictBlocksByHfileName(blocks[0].getBlockName().getHfileName());
     assertEquals(3, newBucketCache.backingMap.size());
     TEST_UTIL.cleanupTestDir();
   }
 
+  @Test
+  public void testValidateCacheInitialization() throws Exception {
+    HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+    Path testDir = TEST_UTIL.getDataTestDir();
+    TEST_UTIL.getTestFileSystem().mkdirs(testDir);
+    Configuration conf = HBaseConfiguration.create();
+    // Disables the persister thread by setting its interval to MAX_VALUE
+    conf.setLong(BUCKETCACHE_PERSIST_INTERVAL_KEY, Long.MAX_VALUE);
+    int[] bucketSizes = new int[] { 8 * 1024 + 1024 };
+    BucketCache bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
+      8192, bucketSizes, writeThreads, writerQLen, testDir + "/bucket.persistence",
+      DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
+
+    CacheTestUtils.HFileBlockPair[] blocks = CacheTestUtils.generateHFileBlocks(8192, 4);
+
+    // Add four blocks
+    cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[0].getBlockName(), blocks[0].getBlock());
+    cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[1].getBlockName(), blocks[1].getBlock());
+    cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[2].getBlockName(), blocks[2].getBlock());
+    cacheAndWaitUntilFlushedToBucket(bucketCache, blocks[3].getBlockName(), blocks[3].getBlock());
+    // saves the current state of the cache
+    bucketCache.persistToFile();
+
+    BucketCache newBucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
+      8192, bucketSizes, writeThreads, writerQLen, testDir + "/bucket.persistence",
+      DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    assertTrue(newBucketCache.waitForCacheInitialization(10000));
+
+    // Set the state of bucket cache to INITIALIZING
+    newBucketCache.setCacheState(BucketCache.CacheState.INITIALIZING);
+
+    // Validate that zero values are returned for the cache being initialized.
+    assertEquals(0, newBucketCache.acceptableSize());
+    assertEquals(0, newBucketCache.getPartitionSize(1));
+    assertEquals(0, newBucketCache.getFreeSize());
+    assertEquals(0, newBucketCache.getCurrentSize());
+    assertEquals(false, newBucketCache.blockFitsIntoTheCache(blocks[0].getBlock()).get());
+
+    newBucketCache.setCacheState(BucketCache.CacheState.ENABLED);
+
+    // Validate that non-zero values are returned for enabled cache
+    assertTrue(newBucketCache.acceptableSize() > 0);
+    assertTrue(newBucketCache.getPartitionSize(1) > 0);
+    assertTrue(newBucketCache.getFreeSize() > 0);
+    assertTrue(newBucketCache.getCurrentSize() > 0);
+    assertTrue(newBucketCache.blockFitsIntoTheCache(blocks[0].getBlock()).get());
+
+    TEST_UTIL.cleanupTestDir();
+  }
+
   private void waitUntilFlushedToBucket(BucketCache cache, BlockCacheKey cacheKey)
     throws InterruptedException {
-    while (!cache.backingMap.containsKey(cacheKey) || cache.ramCache.containsKey(cacheKey)) {
-      Thread.sleep(100);
-    }
+    Waiter.waitFor(HBaseConfiguration.create(), 12000,
+      () -> (cache.backingMap.containsKey(cacheKey) && !cache.ramCache.containsKey(cacheKey)));
   }
 
   // BucketCache.cacheBlock is async, it first adds block to ramCache and writeQueue, then writer

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
@@ -100,6 +100,7 @@ public class TestVerifyBucketCacheFile {
     BucketCache bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     long usedSize = bucketCache.getAllocator().getUsedSize();
     assertEquals(0, usedSize);
     CacheTestUtils.HFileBlockPair[] blocks =
@@ -116,6 +117,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     assertEquals(usedSize, bucketCache.getAllocator().getUsedSize());
     // persist cache to file
     bucketCache.shutdown();
@@ -128,7 +130,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
-    Thread.sleep(100);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     assertEquals(0, bucketCache.getAllocator().getUsedSize());
     assertEquals(0, bucketCache.backingMap.size());
     // Add blocks
@@ -148,7 +150,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
-    Thread.sleep(100);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     assertEquals(0, bucketCache.getAllocator().getUsedSize());
     assertEquals(0, bucketCache.backingMap.size());
 
@@ -167,6 +169,7 @@ public class TestVerifyBucketCacheFile {
     BucketCache bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, mapFileName, 60 * 1000, conf);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
 
     long usedSize = bucketCache.getAllocator().getUsedSize();
     assertEquals(0, usedSize);
@@ -188,6 +191,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, mapFileName, 60 * 1000, conf);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     assertEquals(0, bucketCache.getAllocator().getUsedSize());
     assertEquals(0, bucketCache.backingMap.size());
   }
@@ -211,6 +215,7 @@ public class TestVerifyBucketCacheFile {
     BucketCache bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen,
       testDir + "/bucket.persistence", DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     long usedSize = bucketCache.getAllocator().getUsedSize();
     assertEquals(0, usedSize);
 
@@ -235,7 +240,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
-    Thread.sleep(100);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     assertEquals(0, bucketCache.getAllocator().getUsedSize());
     assertEquals(0, bucketCache.backingMap.size());
 
@@ -265,6 +270,7 @@ public class TestVerifyBucketCacheFile {
     BucketCache bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     long usedSize = bucketCache.getAllocator().getUsedSize();
     assertEquals(0, usedSize);
 
@@ -291,6 +297,7 @@ public class TestVerifyBucketCacheFile {
     bucketCache =
       new BucketCache("file:" + testDir + "/bucket.cache", capacitySize, constructedBlockSize,
         constructedBlockSizes, writeThreads, writerQLen, testDir + "/bucket.persistence");
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
     assertEquals(usedSize, bucketCache.getAllocator().getUsedSize());
     assertEquals(blockCount, bucketCache.backingMap.size());
 
@@ -317,6 +324,7 @@ public class TestVerifyBucketCacheFile {
     BucketCache bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen, mapFileName,
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
 
     CacheTestUtils.HFileBlockPair[] blocks =
       CacheTestUtils.generateHFileBlocks(constructedBlockSize, 4);
@@ -341,6 +349,7 @@ public class TestVerifyBucketCacheFile {
     BucketCache newBucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen, mapFileName,
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    assertTrue(newBucketCache.waitForCacheInitialization(10000));
 
     assertNull(newBucketCache.getBlock(blocks[0].getBlockName(), false, false, false));
     assertEquals(blocks[1].getBlock(),
@@ -373,6 +382,7 @@ public class TestVerifyBucketCacheFile {
     BucketCache bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen, mapFileName,
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
+    assertTrue(bucketCache.waitForCacheInitialization(10000));
 
     CacheTestUtils.HFileBlockPair[] blocks =
       CacheTestUtils.generateHFileBlocks(constructedBlockSize, numBlocks);
@@ -388,7 +398,7 @@ public class TestVerifyBucketCacheFile {
     BucketCache newBucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
       constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen, mapFileName,
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
-
+    assertTrue(newBucketCache.waitForCacheInitialization(10000));
     assertEquals(numBlocks, newBucketCache.backingMap.size());
 
     for (int i = 0; i < numBlocks; i++) {


### PR DESCRIPTION
[HBASE-28804: Implement asynchronous retrieval of bucket-cache data from persistence

During the retrieval of data from bucket cache persistence file, a transient structure that stores the blocks ordered by filename is constructed from the backing map entries. The  population of this transient structure is done during the server start-up. This process increases the region-server startup time, if the bucketcache has large number of blocks.

This population happens inline with the server restart and blocks the server for several minutes. This makes the server restart inconvenient for the external users. Restarts during upgrade can run into timeout issues due to this delay in the server startup.

Hence, the recommendation in this Jira is to make the cache-retrieval asynchronous to the server startup. During a server startup, a new thread is spawn that reads the persistence file and creates the required structures from persistence file. The server continues with the restart and does not wait for the bucket-cache initialisation to complete.

Note that the bucket cache is not available immediately for usage and will only be ready to use after the data is repopulated from persistence into memory.

The prefetch thread that may start before the bucket-cache is initialized is modified to wait until the bucket cache is initialized.

Change-Id: I2c136d7b1d884f74642d29923172a1ad4ada36e4

HBASE-28804: Apply splotless and spotbugs changes.

 Change-Id: I239c357a135a058650a20c5707c7c7303a248c85

HBASE-28804: Addressing first round of review comments.

 Change-Id: Ie160b249f6a2bff18fd8a577ae32a263b7de25ea

HBASE-28804: Added unit tests for validation of cache in initialization state.

 Change-Id: Ib54f565152c391da727be7413dd775fb507daea7

HBASE-28804: Address further review comments.

 Change-Id: I446475dc84d52403f67762b878af874b9cbe1937

HBASE-28804: Fix unit test.

 Change-Id: I391e5e453e077b7e5733cd997130467b356a3e66

HBASE-28804: Fixed check-style warnings

 Change-Id: Ieb6b5841cb7b23d919fbebbe420c0083167d6d0b

Change-Id: I690e840b866795484d2a1463ff47d885d43fc7dc