### PR TITLE
HBASE-28828 Should check if table exists firstly when executing ExpiredMobFileCleaner

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/ExpiredMobFileCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/ExpiredMobFileCleaner.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotFoundException;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.Connection;
@@ -96,7 +97,7 @@ public class ExpiredMobFileCleaner extends Configured implements Tool {
     try (Connection connection = ConnectionFactory.createConnection(getConf());
       Admin admin = connection.getAdmin()) {
       if (!admin.tableExists(tn)) {
-        throw new IOException("The table " + tableName + " doesn't exist");
+        throw new TableNotFoundException("The table " + tableName + " doesn't exist");
       }
       TableDescriptor htd = admin.getDescriptor(tn);
       ColumnFamilyDescriptor family = htd.getColumnFamily(Bytes.toBytes(familyName));


### PR DESCRIPTION
Details see: [HBASE-28828](https://issues.apache.org/jira/browse/HBASE-28828)