### PR TITLE
HBASE-28821: Optimise the memory-utilisation during persistence of bucketcache.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketProtoUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketProtoUtils.java
@@ -73,11 +73,15 @@ final class BucketProtoUtils {
     fos.write(Bytes.toBytes(chunkSize));
     fos.write(Bytes.toBytes(numChunks));
 
+    BucketCacheProtos.BackingMapEntry.Builder entryBuilder =
+      BucketCacheProtos.BackingMapEntry.newBuilder();
     for (Map.Entry<BlockCacheKey, BucketEntry> entry : cache.backingMap.entrySet()) {
       blockCount++;
-      builder.addEntry(
-        BucketCacheProtos.BackingMapEntry.newBuilder().setKey(BucketProtoUtils.toPB(entry.getKey()))
-          .setValue(BucketProtoUtils.toPB(entry.getValue())).build());
+      entryBuilder.clear();
+      entryBuilder.setKey(BucketProtoUtils.toPB(entry.getKey()));
+      entryBuilder.setValue(BucketProtoUtils.toPB(entry.getValue()));
+      builder.addEntry(entryBuilder.build());
+
       if (blockCount % chunkSize == 0 || (blockCount == backingMapSize)) {
         chunkCount++;
         if (chunkCount == 1) {
@@ -88,7 +92,7 @@ final class BucketProtoUtils {
           builder.build().writeDelimitedTo(fos);
         }
         if (blockCount < backingMapSize) {
-          builder = BucketCacheProtos.BackingMap.newBuilder();
+          builder.clear();
         }
       }
     }


### PR DESCRIPTION
During the serialisation of backing map of bucketcache persistence, we create a new BackingMapEntry.Builder object for every entry in the bucket map. This can be optimized by creating a single builder object and reusing it for every entry object.

Change-Id: I6f6c05dfa256ce964cd1d66e5050d9424db4be46