### PR TITLE
HBASE-28830 when a procedure on a table executed as a child procedure…

### DIFF
--- a/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/ProcedureExecutor.java
+++ b/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/ProcedureExecutor.java
@@ -1524,6 +1524,7 @@ public class ProcedureExecutor<TEnvironment> {
           procedureFinished(proc);
         } else {
           execCompletionCleanup(proc);
+          scheduler.completionCleanup(proc, true);
         }
         break;
       }

--- a/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/ProcedureScheduler.java
+++ b/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/ProcedureScheduler.java
@@ -128,4 +128,7 @@ public interface ProcedureScheduler {
    * resets its own state and calls clear() on scheduler.
    */
   void clear();
+
+  default void completionCleanup(Procedure proc, boolean isTableProcCleanupOnly) {
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MasterProcedureScheduler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MasterProcedureScheduler.java
@@ -357,7 +357,12 @@ public class MasterProcedureScheduler extends AbstractProcedureScheduler {
   }
 
   @Override
-  public void completionCleanup(final Procedure proc) {
+  public void completionCleanup(Procedure proc) {
+    completionCleanup(proc, false);
+  }
+
+  @Override
+  public void completionCleanup(final Procedure proc, boolean isTableProcCleanupOnly) {
     if (isTableProcedure(proc)) {
       TableProcedureInterface tableProc = (TableProcedureInterface) proc;
       if (shouldWaitBeforeEnqueuing(tableProc)) {
@@ -403,9 +408,9 @@ public class MasterProcedureScheduler extends AbstractProcedureScheduler {
       if (tableDeleted) {
         markTableAsDeleted(tableProc.getTableName(), proc);
       }
-    } else if (proc instanceof PeerProcedureInterface) {
+    } else if (proc instanceof PeerProcedureInterface && !isTableProcCleanupOnly) {
       tryCleanupPeerQueue(getPeerId(proc), proc);
-    } else if (proc instanceof ServerProcedureInterface) {
+    } else if (proc instanceof ServerProcedureInterface && !isTableProcCleanupOnly) {
       tryCleanupServerQueue(getServerName(proc), proc);
     } else {
       // No cleanup for other procedure types, yet.


### PR DESCRIPTION
…, further table procedure operations on that table are blocked forever waiting to acquire the table procedure lock