### PR TITLE
HBASE-28839: Handle all types of exceptions during retrieval of bucket-cache from persistence.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -391,7 +391,8 @@ public class BucketCache implements BlockCache, HeapSize {
         retrieveFromFile(bucketSizes);
         LOG.info("Persistent bucket cache recovery from {} is complete.", persistencePath);
       } catch (Throwable ex) {
-        LOG.error("Can't restore from file[{}] because of ", persistencePath, ex);
+        LOG.warn("Can't restore from file[{}]. The bucket cache will be reset and rebuilt."
+          + " Exception seen: ", persistencePath, ex);
         backingMap.clear();
         fullyCachedFiles.clear();
         backingMapValidated.set(true);
@@ -1629,7 +1630,7 @@ public class BucketCache implements BlockCache, HeapSize {
   private void persistChunkedBackingMap(FileOutputStream fos) throws IOException {
     LOG.debug(
       "persistToFile: before persisting backing map size: {}, "
-        + "fullycachedFiles size: {}, chunkSize: {}, numberofChunks: {}",
+        + "fullycachedFiles size: {}, chunkSize: {}",
       backingMap.size(), fullyCachedFiles.size(), persistenceChunkSize);
 
     BucketProtoUtils.serializeAsPB(this, fos, persistenceChunkSize);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
@@ -366,8 +366,15 @@ public class TestVerifyBucketCacheFile {
   }
 
   @Test
-  public void testMultipleChunks() throws Exception {
+  public void testCompletelyFilledChunks() throws Exception {
+    // Test where the all the chunks are complete with chunkSize entries
     testChunkedBackingMapRecovery(5, 10);
+  }
+
+  @Test
+  public void testPartiallyFilledChunks() throws Exception {
+    // Test where the last chunk is not completely filled.
+    testChunkedBackingMapRecovery(5, 13);
   }
 
   private void testChunkedBackingMapRecovery(int chunkSize, int numBlocks) throws Exception {


### PR DESCRIPTION
During the retrievel of bucket-cache from persistence, it was observed that, if an exception, other than the IOException occurs, the exception is not logged and also the retrieval thread exits leaving the bucket cache in an uninitialised state, leaving it unusable.

This change, enables the retrieval thread to peint all types of exceptions and also reinitialises the bucket cache and makes it reusable.

Unfortunately, the exception was seen due to a parallel execution of eviction during the execution persistence of backing map. Hence, this use-case may not be tested via a unit test.

Change-Id: I81b7f5fe06945702bbc59df96d054f95f03de499