### PR TITLE
HBASE-28841: Modify default value of hbase.bucketcache.persistence.chunksize to 10K

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -148,7 +148,7 @@ public class BucketCache implements BlockCache, HeapSize {
   final static int DEFAULT_WRITER_THREADS = 3;
   final static int DEFAULT_WRITER_QUEUE_ITEMS = 64;
 
-  final static long DEFAULT_BACKING_MAP_PERSISTENCE_CHUNK_SIZE = 10000000;
+  final static long DEFAULT_BACKING_MAP_PERSISTENCE_CHUNK_SIZE = 10000;
 
   // Store/read block data
   transient final IOEngine ioEngine;


### PR DESCRIPTION
Currently, the default value of the configuration parameter "hbase.bucketcache.persistence.chunksize" is 10 million (10000000). This is the number of block entries that are processed during the persistence of bucket-cache backing map to the persistence file. During the testing, it was found that, this high number of chunksize resulted in high heap utilisation in region servers leading to longer GC pauses which also led to server crashes intermittently.

When the value of this configuration is set to 10K(10000), the cache remains stable. No GC delays are observed. Also no server crashes are observed. The jmap outputs collected against the regionservers showed reduced memory utilisation from 4.5-5GB to 1-1.5GB for the objects related to persistence code.

Change-Id: I83ea05e694fa9b76683a837f83162b6a72ef1a3c