### PR TITLE
HBASE-28845 table level wal appendSize and replication source metrics…

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
@@ -260,6 +260,10 @@ public final class TableName implements Comparable<TableName> {
     return qualifierAsString;
   }
 
+  public String getMetricPrefixTableName() {
+    return "Namespace_" + this.getNamespaceAsString() + "table_" + this.getQualifierAsString();
+  }
+
   /** Returns A pointer to TableName as String bytes. */
   public byte[] toBytes() {
     return name;

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/wal/MetricsWALSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/wal/MetricsWALSourceImpl.java
@@ -88,7 +88,7 @@ public class MetricsWALSourceImpl extends BaseSourceImpl implements MetricsWALSo
     if (tableAppendSizeCounter == null) {
       // Ideally putIfAbsent is atomic and we don't need a branch check but we still do it to avoid
       // expensive string construction for every append.
-      String metricsKey = String.format("%s.%s", tableName, APPEND_SIZE);
+      String metricsKey = String.format("%s.%s", tableName.getMetricPrefixTableName(), APPEND_SIZE);
       perTableAppendSize.putIfAbsent(tableName,
         getMetricsRegistry().newCounter(metricsKey, APPEND_SIZE_DESC, 0L));
       tableAppendSizeCounter = perTableAppendSize.get(tableName);
@@ -106,7 +106,8 @@ public class MetricsWALSourceImpl extends BaseSourceImpl implements MetricsWALSo
     appendCount.incr();
     MutableFastCounter tableAppendCounter = perTableAppendCount.get(tableName);
     if (tableAppendCounter == null) {
-      String metricsKey = String.format("%s.%s", tableName, APPEND_COUNT);
+      String metricsKey =
+        String.format("%s.%s", tableName.getMetricPrefixTableName(), APPEND_COUNT);
       perTableAppendCount.putIfAbsent(tableName,
         getMetricsRegistry().newCounter(metricsKey, APPEND_COUNT_DESC, 0L));
       tableAppendCounter = perTableAppendCount.get(tableName);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/MetricsSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/MetricsSource.java
@@ -99,7 +99,7 @@ public class MetricsSource implements BaseSource {
     for (Pair<Entry, Long> walEntryWithSize : walEntries) {
       Entry entry = walEntryWithSize.getFirst();
       long entrySize = walEntryWithSize.getSecond();
-      String tableName = entry.getKey().getTableName().getNameAsString();
+      String tableName = entry.getKey().getTableName().getMetricPrefixTableName();
       long writeTime = entry.getKey().getWriteTime();
       long age = EnvironmentEdgeManager.currentTime() - writeTime;
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestMetricsWAL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestMetricsWAL.java
@@ -127,11 +127,13 @@ public class TestMetricsWAL {
     // Validate the metrics
     for (int i = 0; i < numThreads; i++) {
       TableName tableName = TableName.valueOf("tab_" + i);
-      long tableAppendCount =
-        registry.getCounter(tableName + "." + MetricsWALSource.APPEND_COUNT, -1).value();
+      long tableAppendCount = registry
+        .getCounter(tableName.getMetricPrefixTableName() + "." + MetricsWALSource.APPEND_COUNT, -1)
+        .value();
       assertEquals(numIters, tableAppendCount);
-      long tableAppendSize =
-        registry.getCounter(tableName + "." + MetricsWALSource.APPEND_SIZE, -1).value();
+      long tableAppendSize = registry
+        .getCounter(tableName.getMetricPrefixTableName() + "." + MetricsWALSource.APPEND_SIZE, -1)
+        .value();
       assertEquals(i * numIters, tableAppendSize);
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationEndpoint.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationEndpoint.java
@@ -390,9 +390,12 @@ public class TestReplicationEndpoint extends TestReplicationBase {
       source.getSingleSourceSourceByTable().containsKey("RandomNewTable");
     Assert.assertEquals(false, containsRandomNewTable);
     source.updateTableLevelMetrics(createWALEntriesWithSize("RandomNewTable"));
-    containsRandomNewTable = source.getSingleSourceSourceByTable().containsKey("RandomNewTable");
+    TableName tableName1 = TableName.valueOf("RandomNewTable");
+    containsRandomNewTable =
+      source.getSingleSourceSourceByTable().containsKey(tableName1.getMetricPrefixTableName());
     Assert.assertEquals(true, containsRandomNewTable);
-    MetricsReplicationTableSource msr = source.getSingleSourceSourceByTable().get("RandomNewTable");
+    MetricsReplicationTableSource msr =
+      source.getSingleSourceSourceByTable().get(tableName1.getMetricPrefixTableName());
 
     // age should be greater than zero we created the entry with time in the past
     Assert.assertTrue(msr.getLastShippedAge() > 0);


### PR DESCRIPTION
Found 2 metrics did not display in the /jmx http interface response, table level wal appendSize and table level replication source.

I suspect it's because the metric name contains a colon : 
![image](https://github.com/user-attachments/assets/c5953aca-1705-40d6-9d34-e894463df63d)

![image](https://github.com/user-attachments/assets/e202500d-0c33-46d2-b175-57f37c831acd)

after modify the table name string to "Namespace_$namespace_table_$table, the metric really display correctly in the /jmx response

 