### PR TITLE
HBASE-28569: fix race condition during WAL splitting leading to corru…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredEditsOutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredEditsOutputSink.java
@@ -70,7 +70,7 @@ class BoundedRecoveredEditsOutputSink extends AbstractRecoveredEditsOutputSink {
       regionEditsWrittenMap.compute(Bytes.toString(buffer.encodedRegionName),
         (k, v) -> v == null ? writer.editsWritten : v + writer.editsWritten);
       List<IOException> thrown = new ArrayList<>();
-      Path dst = closeRecoveredEditsWriter(writer, thrown);
+      Path dst = closeRecoveredEditsWriterAndFinalizeEdits(writer, thrown);
       splits.add(dst);
       openingWritersNum.decrementAndGet();
       if (!thrown.isEmpty()) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestRecoveredEditsOutputSink.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/wal/TestRecoveredEditsOutputSink.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.wal;
+
+import static org.junit.Assert.assertThrows;
+
+import java.io.IOException;
+import java.io.InterruptedIOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+
+@Category({ RegionServerTests.class, SmallTests.class })
+public class TestRecoveredEditsOutputSink {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestRecoveredEditsOutputSink.class);
+
+  private static WALFactory wals;
+  private static FileSystem fs;
+  private static Path rootDir;
+  private final static HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+
+  private static RecoveredEditsOutputSink outputSink;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.set(WALFactory.WAL_PROVIDER, "filesystem");
+    rootDir = TEST_UTIL.createRootDir();
+    fs = CommonFSUtils.getRootDirFileSystem(conf);
+    wals = new WALFactory(conf, "testRecoveredEditsOutputSinkWALFactory");
+    WALSplitter splitter = new WALSplitter(wals, conf, rootDir, fs, rootDir, fs);
+    WALSplitter.PipelineController pipelineController = new WALSplitter.PipelineController();
+    EntryBuffers sink = new EntryBuffers(pipelineController, 1024 * 1024);
+    outputSink = new RecoveredEditsOutputSink(splitter, pipelineController, sink, 3);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    wals.close();
+    fs.delete(rootDir, true);
+  }
+
+  @Test
+  public void testCloseSuccess() throws IOException {
+    RecoveredEditsOutputSink spyOutputSink = Mockito.spy(outputSink);
+    spyOutputSink.close();
+    Mockito.verify(spyOutputSink, Mockito.times(1)).finishWriterThreads();
+    Mockito.verify(spyOutputSink, Mockito.times(1)).closeWriters(true);
+  }
+
+  /**
+   * When a WAL split is interrupted (ex. by a RegionServer abort), the thread join in
+   * finishWriterThreads() will get interrupted, rethrowing the exception without stopping the
+   * writer threads. Test to ensure that when this happens, RecoveredEditsOutputSink.close() does
+   * not rename the recoveredEdits WAL files as this can cause corruption. Please see HBASE-28569.
+   * However, the writers must still be closed.
+   */
+  @Test
+  public void testCloseWALSplitInterrupted() throws IOException {
+    RecoveredEditsOutputSink spyOutputSink = Mockito.spy(outputSink);
+    // The race condition will lead to an InterruptedException to be caught by finishWriterThreads()
+    // which is then rethrown as an InterruptedIOException.
+    Mockito.doThrow(new InterruptedIOException()).when(spyOutputSink).finishWriterThreads();
+    assertThrows(InterruptedIOException.class, spyOutputSink::close);
+    Mockito.verify(spyOutputSink, Mockito.times(1)).finishWriterThreads();
+    Mockito.verify(spyOutputSink, Mockito.times(1)).closeWriters(false);
+  }
+
+  /**
+   * When finishWriterThreads fails but does not throw an exception, ensure the writers are handled
+   * like in the exception case - the writers are closed but the recoveredEdits WAL files are not
+   * renamed.
+   */
+  @Test
+  public void testCloseWALFinishWriterThreadsFailed() throws IOException {
+    RecoveredEditsOutputSink spyOutputSink = Mockito.spy(outputSink);
+    Mockito.doReturn(false).when(spyOutputSink).finishWriterThreads();
+    spyOutputSink.close();
+    Mockito.verify(spyOutputSink, Mockito.times(1)).finishWriterThreads();
+    Mockito.verify(spyOutputSink, Mockito.times(1)).closeWriters(false);
+  }
+}


### PR DESCRIPTION
…pt recovered.edits

If an exception happens in the call to finishWriterThreads in the org.apache.hadoop.hbase.wal.RecoveredEditsOutputSink.close method, the call to closeWriters should not execute, as it may lead to a race condition that leads to file corruption if the regionserver aborts. The execution of closeWriters in this case would write the trailer in parallel with writer threads, causing corruption, and then the corrupt file would get renamed and finalized when it should not be. This corruption causes problems when the region is then to be assigned. By removing the try finally block, the problematic closeWriters would not execute in the case of an exception in finishWriterThreads, which should then prevent this race from occurring and causing recovered.edits corruption.