### PR TITLE
Backport "HBASE-28842 TestRequestAttributes should fail when expected (#6255)" to branch-2

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRequestAttributes.java
@@ -352,8 +352,7 @@ public class TestRequestAttributes {
       return null;
     }
 
-    private boolean isValidRequestAttributes(Map<String, byte[]> requestAttributes)
-      throws IOException {
+    private boolean isValidRequestAttributes(Map<String, byte[]> requestAttributes) {
       RpcCall rpcCall = RpcServer.getCurrentCall().get();
       Map<String, byte[]> attrs = rpcCall.getRequestAttributes();
       if (attrs.size() != requestAttributes.size()) {


### PR DESCRIPTION
@eab148 am I correct that this is the only change introduced by this commit to branch-2 since this bug was discovered in the backport?