### PR TITLE
HBASE-28875 FSHlog closewrite closeErrorCount should increment for initial catch exception

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/FSHLog.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/FSHLog.java
@@ -460,12 +460,12 @@ public class FSHLog extends AbstractFSWAL<Writer> {
       span.addEvent("writer closed");
     } catch (IOException ioe) {
       LOG.warn("close old writer failed.", ioe);
+      int errors = closeErrorCount.incrementAndGet();
       try {
         RecoverLeaseFSUtils.recoverFileLease(fs, path, conf, null);
       } catch (IOException ex) {
         LOG.error("Unable to recover lease after several attempts. Give up.", ex);
 
-        int errors = closeErrorCount.incrementAndGet();
         boolean hasUnflushedEntries = isUnflushedEntries();
         if (syncCloseCall && (hasUnflushedEntries || (errors > this.closeErrorsTolerated))) {
           LOG.error("Close of WAL " + path + " failed. Cause=\"" + ioe.getMessage() + "\", errors="

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestFSHLog.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestFSHLog.java
@@ -324,7 +324,7 @@ public class TestFSHLog extends AbstractTestFSWAL {
   /**
    * Test for jira https://issues.apache.org/jira/browse/HBASE-28665
    */
-  public void testWALClosureFailureAndCleanup() throws IOException {
+  public void testWALClosureFailureAndCleanup() throws Exception {
 
     class FailingWriter implements WALProvider.Writer {
       @Override
@@ -380,6 +380,12 @@ public class TestFSHLog extends AbstractTestFSWAL {
       region.put(new Put(b).addColumn(b, b, b));
       region.flush(true);
       log.rollWriter();
+      TEST_UTIL.waitFor(30000, 500, new Waiter.Predicate<Exception>() {
+        @Override
+        public boolean evaluate() throws Exception {
+          return log.walFile2Props.isEmpty();
+        }
+      });
       assertEquals("WAL Files not cleaned ", 0, log.walFile2Props.size());
       region.close();
     }


### PR DESCRIPTION
During close writer for FSHlog, if any error occured then for initial exception itself need to increment the closeErrorCount counter.