### PR TITLE
Backport "HBASE-28645 Add build information to the REST server version endpoint" to branch-2

### DIFF
--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/model/VersionModel.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/model/VersionModel.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hbase.rest.ProtobufMessageHandler;
 import org.apache.hadoop.hbase.rest.RESTServlet;
 import org.apache.hadoop.hbase.rest.RestUtil;
 import org.apache.hadoop.hbase.rest.protobuf.generated.VersionMessage.Version;
+import org.apache.hadoop.hbase.util.VersionInfo;
 import org.apache.yetus.audience.InterfaceAudience;
 
 import org.apache.hbase.thirdparty.com.google.protobuf.CodedInputStream;
@@ -53,6 +54,7 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
   private String osVersion;
   private String serverVersion;
   private String jerseyVersion;
+  private String version;
 
   /**
    * Default constructor. Do not use.
@@ -74,6 +76,8 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     jerseyVersion = ServletContainer.class.getPackage().getImplementationVersion();
     // Currently, this will always be null because the manifest doesn't have any useful information
     if (jerseyVersion == null) jerseyVersion = "";
+
+    version = VersionInfo.getVersion();
   }
 
   /** Returns the REST gateway version */
@@ -104,6 +108,12 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
   @XmlAttribute(name = "Jersey")
   public String getJerseyVersion() {
     return jerseyVersion;
+  }
+
+  /** Returns the build version of the REST server component */
+  @XmlAttribute(name = "Version")
+  public String getVersion() {
+    return version;
   }
 
   /**
@@ -141,6 +151,13 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     this.jerseyVersion = version;
   }
 
+  /**
+   * @param version the REST server component build version string
+   */
+  public void setVersion(String version) {
+    this.version = version;
+  }
+
   /*
    * (non-Javadoc)
    * @see java.lang.Object#toString()
@@ -158,6 +175,8 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     sb.append(serverVersion);
     sb.append("] [Jersey: ");
     sb.append(jerseyVersion);
+    sb.append("] [Version: ");
+    sb.append(version);
     sb.append("]\n");
     return sb.toString();
   }
@@ -170,6 +189,7 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     builder.setOsVersion(osVersion);
     builder.setServerVersion(serverVersion);
     builder.setJerseyVersion(jerseyVersion);
+    builder.setVersion(version);
     return builder.build();
   }
 
@@ -191,6 +211,9 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     }
     if (builder.hasJerseyVersion()) {
       jerseyVersion = builder.getJerseyVersion();
+    }
+    if (builder.hasVersion()) {
+      version = builder.getVersion();
     }
     return this;
   }

--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/model/VersionModel.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/model/VersionModel.java
@@ -55,6 +55,7 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
   private String serverVersion;
   private String jerseyVersion;
   private String version;
+  private String revision;
 
   /**
    * Default constructor. Do not use.
@@ -78,6 +79,7 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     if (jerseyVersion == null) jerseyVersion = "";
 
     version = VersionInfo.getVersion();
+    revision = VersionInfo.getRevision();
   }
 
   /** Returns the REST gateway version */
@@ -114,6 +116,12 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
   @XmlAttribute(name = "Version")
   public String getVersion() {
     return version;
+  }
+
+  /** Returns the source control revision of the REST server component */
+  @XmlAttribute(name = "Revision")
+  public String getRevision() {
+    return revision;
   }
 
   /**
@@ -158,6 +166,13 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     this.version = version;
   }
 
+  /**
+   * @param revision the REST server component source control revision string
+   */
+  public void setRevision(String revision) {
+    this.revision = revision;
+  }
+
   /*
    * (non-Javadoc)
    * @see java.lang.Object#toString()
@@ -177,6 +192,8 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     sb.append(jerseyVersion);
     sb.append("] [Version: ");
     sb.append(version);
+    sb.append("] [Revision: ");
+    sb.append(revision);
     sb.append("]\n");
     return sb.toString();
   }
@@ -190,6 +207,7 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     builder.setServerVersion(serverVersion);
     builder.setJerseyVersion(jerseyVersion);
     builder.setVersion(version);
+    builder.setRevision(revision);
     return builder.build();
   }
 
@@ -214,6 +232,9 @@ public class VersionModel implements Serializable, ProtobufMessageHandler {
     }
     if (builder.hasVersion()) {
       version = builder.getVersion();
+    }
+    if (builder.hasRevision()) {
+      revision = builder.getRevision();
     }
     return this;
   }

--- a/hbase-rest/src/main/protobuf/VersionMessage.proto
+++ b/hbase-rest/src/main/protobuf/VersionMessage.proto
@@ -25,4 +25,5 @@ message Version {
   optional string serverVersion = 4;
   optional string jerseyVersion = 5;
   optional string version = 6;
+  optional string revision = 7;
 }

--- a/hbase-rest/src/main/protobuf/VersionMessage.proto
+++ b/hbase-rest/src/main/protobuf/VersionMessage.proto
@@ -24,4 +24,5 @@ message Version {
   optional string osVersion = 3;
   optional string serverVersion = 4;
   optional string jerseyVersion = 5;
+  optional string version = 6;
 }

--- a/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/TestVersionResource.java
+++ b/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/TestVersionResource.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.hbase.rest.model.VersionModel;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RestTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.VersionInfo;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
@@ -77,8 +78,9 @@ public class TestVersionResource {
 
   private static void validate(VersionModel model) {
     assertNotNull(model);
-    assertNotNull(model.getRESTVersion());
-    assertEquals(RESTServlet.VERSION_STRING, model.getRESTVersion());
+    String restVersion = model.getRESTVersion();
+    assertNotNull(restVersion);
+    assertEquals(RESTServlet.VERSION_STRING, restVersion);
     String osVersion = model.getOSVersion();
     assertNotNull(osVersion);
     assertTrue(osVersion.contains(System.getProperty("os.name")));
@@ -94,6 +96,10 @@ public class TestVersionResource {
     assertNotNull(jerseyVersion);
     // TODO: fix when we actually get a jersey version
     // assertEquals(jerseyVersion, ServletContainer.class.getPackage().getImplementationVersion());
+
+    String version = model.getVersion();
+    assertNotNull(version);
+    assertEquals(VersionInfo.getVersion(), version);
   }
 
   @Test

--- a/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/TestVersionResource.java
+++ b/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/TestVersionResource.java
@@ -100,6 +100,9 @@ public class TestVersionResource {
     String version = model.getVersion();
     assertNotNull(version);
     assertEquals(VersionInfo.getVersion(), version);
+    String revision = model.getRevision();
+    assertNotNull(revision);
+    assertEquals(VersionInfo.getRevision(), revision);
   }
 
   @Test

--- a/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/model/TestVersionModel.java
+++ b/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/model/TestVersionModel.java
@@ -37,19 +37,22 @@ public class TestVersionModel extends TestModelBase<VersionModel> {
   private static final String JVM_VERSION = "Sun Microsystems Inc. 1.6.0_13-11.3-b02";
   private static final String JETTY_VERSION = "6.1.14";
   private static final String JERSEY_VERSION = "1.1.0-ea";
+  private static final String VERSION = "4.0.0-alpha-1-SNAPSHOT";
 
   public TestVersionModel() throws Exception {
     super(VersionModel.class);
     AS_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Version JVM=\"Sun "
       + "Microsystems Inc. 1.6.0_13-11.3-b02\" Jersey=\"1.1.0-ea\" "
-      + "OS=\"Linux 2.6.18-128.1.6.el5.centos.plusxen amd64\" REST=\"0.0.1\" Server=\"6.1.14\"/>";
+      + "OS=\"Linux 2.6.18-128.1.6.el5.centos.plusxen amd64\" REST=\"0.0.1\" Server=\"6.1.14\" "
+      + "Version=\"4.0.0-alpha-1-SNAPSHOT\"/>";
 
-    AS_PB = "CgUwLjAuMRInU3VuIE1pY3Jvc3lzdGVtcyBJbmMuIDEuNi4wXzEzLTExLjMtYjAyGi1MaW51eCAy"
-      + "LjYuMTgtMTI4LjEuNi5lbDUuY2VudG9zLnBsdXN4ZW4gYW1kNjQiBjYuMS4xNCoIMS4xLjAtZWE=";
+    AS_PB = "CgUwLjAuMRInU3VuIE1pY3Jvc3lzdGVtcyBJbmMuIDEuNi4wXzEzLTExLjMtYjAyGi1MaW51eCAyLjYuMTg"
+      + "tMTI4LjEuNi5lbDUuY2VudG9zLnBsdXN4ZW4gYW1kNjQiBjYuMS4xNCoIMS4xLjAtZWEyFjQuMC4wLWFscGhhLT"
+      + "EtU05BUFNIT1Q=";
 
     AS_JSON = "{\"JVM\":\"Sun Microsystems Inc. 1.6.0_13-11.3-b02\",\"Jersey\":\"1.1.0-ea\","
       + "\"OS\":\"Linux 2.6.18-128.1.6.el5.centos.plusxen amd64\",\""
-      + "REST\":\"0.0.1\",\"Server\":\"6.1.14\"}";
+      + "REST\":\"0.0.1\",\"Server\":\"6.1.14\", \"Version\":\"4.0.0-alpha-1-SNAPSHOT\"}";
   }
 
   @Override
@@ -60,6 +63,7 @@ public class TestVersionModel extends TestModelBase<VersionModel> {
     model.setJVMVersion(JVM_VERSION);
     model.setServerVersion(JETTY_VERSION);
     model.setJerseyVersion(JERSEY_VERSION);
+    model.setVersion(VERSION);
     return model;
   }
 
@@ -70,5 +74,6 @@ public class TestVersionModel extends TestModelBase<VersionModel> {
     assertEquals(JVM_VERSION, model.getJVMVersion());
     assertEquals(JETTY_VERSION, model.getServerVersion());
     assertEquals(JERSEY_VERSION, model.getJerseyVersion());
+    assertEquals(VERSION, model.getVersion());
   }
 }

--- a/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/model/TestVersionModel.java
+++ b/hbase-rest/src/test/java/org/apache/hadoop/hbase/rest/model/TestVersionModel.java
@@ -38,21 +38,24 @@ public class TestVersionModel extends TestModelBase<VersionModel> {
   private static final String JETTY_VERSION = "6.1.14";
   private static final String JERSEY_VERSION = "1.1.0-ea";
   private static final String VERSION = "4.0.0-alpha-1-SNAPSHOT";
+  private static final String REVISION = "5085d27ab17d857118a96ae3f37c00b60c925471";
 
   public TestVersionModel() throws Exception {
     super(VersionModel.class);
     AS_XML = "<?xml version=\"1.0\" encoding=\"UTF-8\" standalone=\"yes\"?><Version JVM=\"Sun "
       + "Microsystems Inc. 1.6.0_13-11.3-b02\" Jersey=\"1.1.0-ea\" "
       + "OS=\"Linux 2.6.18-128.1.6.el5.centos.plusxen amd64\" REST=\"0.0.1\" Server=\"6.1.14\" "
-      + "Version=\"4.0.0-alpha-1-SNAPSHOT\"/>";
+      + "Version=\"4.0.0-alpha-1-SNAPSHOT\" "
+      + "Revision=\"5085d27ab17d857118a96ae3f37c00b60c925471\"/>";
 
     AS_PB = "CgUwLjAuMRInU3VuIE1pY3Jvc3lzdGVtcyBJbmMuIDEuNi4wXzEzLTExLjMtYjAyGi1MaW51eCAyLjYuMTg"
       + "tMTI4LjEuNi5lbDUuY2VudG9zLnBsdXN4ZW4gYW1kNjQiBjYuMS4xNCoIMS4xLjAtZWEyFjQuMC4wLWFscGhhLT"
-      + "EtU05BUFNIT1Q=";
+      + "EtU05BUFNIT1Q6KDUwODVkMjdhYjE3ZDg1NzExOGE5NmFlM2YzN2MwMGI2MGM5MjU0NzE=";
 
     AS_JSON = "{\"JVM\":\"Sun Microsystems Inc. 1.6.0_13-11.3-b02\",\"Jersey\":\"1.1.0-ea\","
       + "\"OS\":\"Linux 2.6.18-128.1.6.el5.centos.plusxen amd64\",\""
-      + "REST\":\"0.0.1\",\"Server\":\"6.1.14\", \"Version\":\"4.0.0-alpha-1-SNAPSHOT\"}";
+      + "REST\":\"0.0.1\",\"Server\":\"6.1.14\", \"Version\":\"4.0.0-alpha-1-SNAPSHOT\","
+      + "\"Revision\":\"5085d27ab17d857118a96ae3f37c00b60c925471\"}";
   }
 
   @Override
@@ -64,6 +67,7 @@ public class TestVersionModel extends TestModelBase<VersionModel> {
     model.setServerVersion(JETTY_VERSION);
     model.setJerseyVersion(JERSEY_VERSION);
     model.setVersion(VERSION);
+    model.setRevision(REVISION);
     return model;
   }
 
@@ -75,5 +79,6 @@ public class TestVersionModel extends TestModelBase<VersionModel> {
     assertEquals(JETTY_VERSION, model.getServerVersion());
     assertEquals(JERSEY_VERSION, model.getJerseyVersion());
     assertEquals(VERSION, model.getVersion());
+    assertEquals(REVISION, model.getRevision());
   }
 }


### PR DESCRIPTION
https://github.com/apache/hbase/pull/6262

Note: Did not backported the changes to the asciidoc Reference Guide because the REST Endpoints and REST XML and protobuf Schemas sections are not present in this branch.