### PR TITLE
HBASE-28866 Setting hbase.oldwals.cleaner.thread.size to negative value will brea…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/LogCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/LogCleaner.java
@@ -79,9 +79,11 @@ public class LogCleaner extends CleanerChore<BaseLogCleanerDelegate>
     this.pendingDelete = new LinkedBlockingQueue<>();
     int size = conf.getInt(OLD_WALS_CLEANER_THREAD_SIZE, DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE);
     if (size <= 0) {
-      LOG.warn("The configuration {} has been set to an invalid value {}, "
-          + "the default value {} will be used.", OLD_WALS_CLEANER_THREAD_SIZE,
-              size, DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE);
+      LOG.warn(
+        "The configuration {} has been set to an invalid value {}, "
+          + "the default value {} will be used.",
+        OLD_WALS_CLEANER_THREAD_SIZE, size, DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE);
+      size = DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE;
     }
     this.oldWALsCleaner = createOldWalsCleaner(size);
     this.cleanerThreadTimeoutMsec = conf.getLong(OLD_WALS_CLEANER_THREAD_TIMEOUT_MSEC,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/LogCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/LogCleaner.java
@@ -79,9 +79,9 @@ public class LogCleaner extends CleanerChore<BaseLogCleanerDelegate>
     this.pendingDelete = new LinkedBlockingQueue<>();
     int size = conf.getInt(OLD_WALS_CLEANER_THREAD_SIZE, DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE);
     if (size <= 0) {
-      LOG.warn("The size of old WALs cleaner thread is {}, which is invalid, "
-          + "the default value will be used.", size);
-      size = DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE;
+      LOG.warn("The configuration {} has been set to an invalid value {}, "
+          + "the default value {} will be used.", OLD_WALS_CLEANER_THREAD_SIZE,
+              size, DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE);
     }
     this.oldWALsCleaner = createOldWalsCleaner(size);
     this.cleanerThreadTimeoutMsec = conf.getLong(OLD_WALS_CLEANER_THREAD_TIMEOUT_MSEC,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/LogCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/LogCleaner.java
@@ -79,11 +79,11 @@ public class LogCleaner extends CleanerChore<BaseLogCleanerDelegate>
     this.pendingDelete = new LinkedBlockingQueue<>();
     int size = conf.getInt(OLD_WALS_CLEANER_THREAD_SIZE, DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE);
     if (size <= 0) {
+      size = DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE;
       LOG.warn(
         "The configuration {} has been set to an invalid value {}, "
           + "the default value {} will be used.",
         OLD_WALS_CLEANER_THREAD_SIZE, size, DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE);
-      size = DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE;
     }
     this.oldWALsCleaner = createOldWalsCleaner(size);
     this.cleanerThreadTimeoutMsec = conf.getLong(OLD_WALS_CLEANER_THREAD_TIMEOUT_MSEC,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/LogCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/LogCleaner.java
@@ -78,6 +78,11 @@ public class LogCleaner extends CleanerChore<BaseLogCleanerDelegate>
       pool, params, null);
     this.pendingDelete = new LinkedBlockingQueue<>();
     int size = conf.getInt(OLD_WALS_CLEANER_THREAD_SIZE, DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE);
+    if (size <= 0) {
+      LOG.warn("The size of old WALs cleaner thread is {}, which is invalid, "
+          + "the default value will be used.", size);
+      size = DEFAULT_OLD_WALS_CLEANER_THREAD_SIZE;
+    }
     this.oldWALsCleaner = createOldWalsCleaner(size);
     this.cleanerThreadTimeoutMsec = conf.getLong(OLD_WALS_CLEANER_THREAD_TIMEOUT_MSEC,
       DEFAULT_OLD_WALS_CLEANER_THREAD_TIMEOUT_MSEC);


### PR DESCRIPTION
…k HMaster and produce hard-to-diagnose logs

This Pull Request addresses the issue described in [HBASE-28866](https://issues.apache.org/jira/browse/HBASE-28866): setting hbase.oldwals.cleaner.thread.size to a negative value can break HMaster and produce hard-to-diagnose logs.

Problem: When the configuration property is set to -1, the HBase Master fails to initialize due to an IllegalArgumentException, resulting in confusing logs that mislead users regarding the root cause.

Solution: The attached patch adds a validation check and relevant logging for the hbase.oldwals.cleaner.thread.size during the LogCleaner initialization. This improvement will help users diagnose issues more effectively.

We appreciate your review and feedback!