### PR TITLE
HBASE-28733 Add "2.6 Documentation" to the website

### DIFF
--- a/src/site/site.xml
+++ b/src/site/site.xml
@@ -151,6 +151,12 @@
         <item name="Developer API" href="2.5/devapidocs/index.html" target="_blank" />
         <item name="Developer API (Test)" href="2.5/testdevapidocs/index.html" target="_blank" />
       </item>
+      <item name="2.6 Documentation">
+        <item name="User API" href="2.6/apidocs/index.html" target="_blank" />
+        <item name="User API (Test)" href="2.6/testapidocs/index.html" target="_blank" />
+        <item name="Developer API" href="2.6/devapidocs/index.html" target="_blank" />
+        <item name="Developer API (Test)" href="2.6/testdevapidocs/index.html" target="_blank" />
+      </item>
     </menu>
     <menu name="ASF">
       <item name="Apache Software Foundation" href="http://www.apache.org/foundation/" target="_blank" />


### PR DESCRIPTION
https://github.com/apache/hbase-site/pull/9 will add the 2.6 documentation to the website git repo.

This PR will add the menu items on the homepage.