### PR TITLE
HBASE-28890 RefCnt Leak error when caching index blocks at write time (addendum) for branch-2.5

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
@@ -184,8 +184,8 @@ public class TestHFileBlockIndex {
       .withIncludesMvcc(includesMemstoreTS).withIncludesTags(true).withCompression(compr)
       .withBytesPerCheckSum(HFile.DEFAULT_BYTES_PER_CHECKSUM).build();
     ByteBuffAllocator allocator = ByteBuffAllocator.create(TEST_UTIL.getConfiguration(), true);
-    HFileBlock.Writer hbw = new HFileBlock.Writer(TEST_UTIL.getConfiguration(), null, meta,
-      allocator);
+    HFileBlock.Writer hbw =
+      new HFileBlock.Writer(TEST_UTIL.getConfiguration(), null, meta, allocator);
     FSDataOutputStream outputStream = fs.create(path);
 
     final AtomicInteger counter = new AtomicInteger();


### PR DESCRIPTION


Run spotless:apply