### PR TITLE
HBASE-28898. Use reflection to access recoverLease(), setSafeMode() APIs.

### DIFF
--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
@@ -46,8 +46,8 @@ public final class RecoverLeaseFSUtils {
     try {
       leaseRecoverableClazz = Class.forName("org.apache.hadoop.fs.LeaseRecoverable");
     } catch (ClassNotFoundException e) {
-      LOG.debug("LeaseRecoverable interface not in the classpath, " +
-        "this means Hadoop 3.3.5 or below.");
+      LOG.debug(
+        "LeaseRecoverable interface not in the classpath, this means Hadoop 3.3.5 or below.");
     }
   }
 
@@ -192,8 +192,8 @@ public final class RecoverLeaseFSUtils {
    * Try to recover the lease.
    * @return True if dfs#recoverLease came by true.
    */
-  private static boolean recoverLease(final Object dfs, final int nbAttempt,
-    final Path p, final long startWaiting) throws FileNotFoundException {
+  private static boolean recoverLease(final Object dfs, final int nbAttempt, final Path p,
+    final long startWaiting) throws FileNotFoundException {
     boolean recovered = false;
     try {
       recovered = (Boolean) dfs.getClass().getMethod("recoverLease", new Class[] { Path.class })
@@ -226,8 +226,7 @@ public final class RecoverLeaseFSUtils {
    * Call HDFS-4525 isFileClosed if it is available.
    * @return True if file is closed.
    */
-  private static boolean isFileClosed(final Object dfs, final Method m,
-    final Path p) {
+  private static boolean isFileClosed(final Object dfs, final Method m, final Path p) {
     try {
       return (Boolean) m.invoke(dfs, p);
     } catch (SecurityException e) {

--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
@@ -44,7 +44,7 @@ public final class RecoverLeaseFSUtils {
   private static Method recoverLeaseMethod = null;
   public static final String LEASE_RECOVERABLE_CLASS_NAME = "org.apache.hadoop.fs.LeaseRecoverable";
   static {
-    LOG.debug("RecoverLeaseFSUtils loaded");
+    LOG.debug("Initialize RecoverLeaseFSUtils");
     initializeRecoverLeaseMethod(LEASE_RECOVERABLE_CLASS_NAME);
   }
 
@@ -63,11 +63,13 @@ public final class RecoverLeaseFSUtils {
       try {
         recoverLeaseMethod = DistributedFileSystem.class.getMethod("recoverLease", Path.class);
       } catch (NoSuchMethodException ex) {
-        LOG.error("Cannot find recoverLease method in DistributedFileSystem class. Abort.", ex);
+        LOG.error("Cannot find recoverLease method in DistributedFileSystem class. "
+          + "It should never happen. Abort.", ex);
         throw new RuntimeException(ex);
       }
     } catch (NoSuchMethodException e) {
-      LOG.error("Cannot find recoverLease method in LeaseRecoverable class. Abort.", e);
+      LOG.error("Cannot find recoverLease method in LeaseRecoverable class. "
+        + "It should never happen. Abort.", e);
       throw new RuntimeException(e);
     }
   }

--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
@@ -17,12 +17,12 @@
  */
 package org.apache.hadoop.hbase.util;
 
+import com.google.errorprone.annotations.RestrictedApi;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import com.google.errorprone.annotations.RestrictedApi;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.FilterFileSystem;
@@ -50,7 +50,7 @@ public final class RecoverLeaseFSUtils {
   }
 
   @RestrictedApi(explanation = "Should only be called in tests", link = "",
-    allowedOnPath = ".*/src/test/.*")
+      allowedOnPath = ".*/src/test/.*")
   static void initializeRecoverLeaseMethod(String className) {
     try {
       leaseRecoverableClazz = Class.forName(className);

--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
@@ -49,8 +49,10 @@ public final class RecoverLeaseFSUtils {
     initializeRecoverLeaseMethod(LEASE_RECOVERABLE_CLASS_NAME);
   }
 
-  @RestrictedApi(explanation = "Should only be called in tests", link = "",
-      allowedOnPath = ".*/src/test/.*")
+  /**
+   * Initialize reflection classes and methods. If LeaseRecoverable class is not found,
+   * look for DistributedFilSystem#recoverLease method.
+   */
   static void initializeRecoverLeaseMethod(String className) {
     try {
       leaseRecoverableClazz = Class.forName(className);
@@ -99,7 +101,7 @@ public final class RecoverLeaseFSUtils {
     }
     // return true if the file system implements LeaseRecoverable interface.
     if (leaseRecoverableClazz != null) {
-      return (leaseRecoverableClazz.isAssignableFrom(fs.getClass()));
+      return leaseRecoverableClazz.isAssignableFrom(fs.getClass());
     }
     // return false if the file system is not HDFS and does not implement LeaseRecoverable.
     return false;

--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.util;
 
-import com.google.errorprone.annotations.RestrictedApi;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InterruptedIOException;
@@ -50,8 +49,8 @@ public final class RecoverLeaseFSUtils {
   }
 
   /**
-   * Initialize reflection classes and methods. If LeaseRecoverable class is not found,
-   * look for DistributedFilSystem#recoverLease method.
+   * Initialize reflection classes and methods. If LeaseRecoverable class is not found, look for
+   * DistributedFilSystem#recoverLease method.
    */
   static void initializeRecoverLeaseMethod(String className) {
     try {

--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
@@ -63,9 +63,11 @@ public final class RecoverLeaseFSUtils {
       try {
         recoverLeaseMethod = DistributedFileSystem.class.getMethod("recoverLease", Path.class);
       } catch (NoSuchMethodException ex) {
+        LOG.error("Cannot find recoverLease method in DistributedFileSystem class. Abort.", ex);
         throw new RuntimeException(ex);
       }
     } catch (NoSuchMethodException e) {
+      LOG.error("Cannot find recoverLease method in LeaseRecoverable class. Abort.", e);
       throw new RuntimeException(e);
     }
   }
@@ -228,6 +230,7 @@ public final class RecoverLeaseFSUtils {
       }
       LOG.warn(getLogMessageDetail(nbAttempt, p, startWaiting), e);
     } catch (IllegalAccessException e) {
+      LOG.error("Failed to call recoverLease on {}. Abort.", dfs, e);
       throw new RuntimeException(e);
     }
     return recovered;

--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
@@ -46,7 +46,8 @@ public final class RecoverLeaseFSUtils {
     try {
       leaseRecoverableClazz = Class.forName("org.apache.hadoop.fs.LeaseRecoverable");
     } catch (ClassNotFoundException e) {
-      LOG.debug("LeaseRecoverable interface not in the classpath, this means Hadoop 3.3.5 or below.");
+      LOG.debug("LeaseRecoverable interface not in the classpath, " +
+        "this means Hadoop 3.3.5 or below.");
     }
   }
 

--- a/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/main/java/org/apache/hadoop/hbase/util/RecoverLeaseFSUtils.java
@@ -78,7 +78,7 @@ public final class RecoverLeaseFSUtils {
   }
 
   /**
-   * Recover the lease from HDFS or LeaseRecoverable fs, retrying multiple times.
+   * Recover the lease from Hadoop file system, retrying multiple times.
    */
   public static void recoverFileLease(FileSystem fs, Path p, Configuration conf,
     CancelableProgressable reporter) throws IOException {

--- a/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/util/TestRecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/util/TestRecoverLeaseFSUtils.java
@@ -25,28 +25,19 @@ import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
-import java.lang.reflect.Method;
-import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.fs.FSDataInputStream;
-import org.apache.hadoop.fs.FSDataOutputStream;
-import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
-import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseCommonTestingUtil;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
-import org.apache.hadoop.util.Progressable;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
-import org.mockito.Mockito;
 
 /**
  * Test our recoverLease loop against mocked up filesystem.
@@ -90,14 +81,17 @@ public class TestRecoverLeaseFSUtils {
 
   private interface FakeLeaseRecoverable {
     boolean recoverLease(Path p) throws IOException;
+
     boolean isFileClosed(Path p) throws IOException;
   }
 
-  private static abstract class RecoverableFileSystem extends FileSystem implements FakeLeaseRecoverable {
+  private static abstract class RecoverableFileSystem extends FileSystem
+    implements FakeLeaseRecoverable {
     @Override
     public boolean recoverLease(Path p) throws IOException {
       return true;
     }
+
     @Override
     public boolean isFileClosed(Path p) throws IOException {
       return true;
@@ -105,9 +99,7 @@ public class TestRecoverLeaseFSUtils {
   }
 
   /**
-   *
    * Test that we can use reflection to access LeaseRecoverable methods.
-   * @throws IOException
    */
   @Test
   public void testLeaseRecoverable() throws IOException {

--- a/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/util/TestRecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/util/TestRecoverLeaseFSUtils.java
@@ -80,8 +80,10 @@ public class TestRecoverLeaseFSUtils {
   }
 
   private interface FakeLeaseRecoverable {
+    @SuppressWarnings("unused")
     boolean recoverLease(Path p) throws IOException;
 
+    @SuppressWarnings("unused")
     boolean isFileClosed(Path p) throws IOException;
   }
 

--- a/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/util/TestRecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/util/TestRecoverLeaseFSUtils.java
@@ -17,10 +17,12 @@
  */
 package org.apache.hadoop.hbase.util;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseCommonTestingUtil;
@@ -90,6 +92,12 @@ public class TestRecoverLeaseFSUtils {
     RecoverLeaseFSUtils.recoverFileLease(dfs, FILE, HTU.getConfiguration(), reporter);
     Mockito.verify(dfs, Mockito.times(2)).recoverLease(FILE);
     Mockito.verify(dfs, Mockito.times(1)).isFileClosed(FILE);
+  }
+
+  @Test
+  public void testIsLeaseRecoverable() {
+    assertTrue(RecoverLeaseFSUtils.isLeaseRecoverable(new DistributedFileSystem()));
+    assertFalse(RecoverLeaseFSUtils.isLeaseRecoverable(new LocalFileSystem()));
   }
 
   /**

--- a/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/util/TestRecoverLeaseFSUtils.java
+++ b/hbase-asyncfs/src/test/java/org/apache/hadoop/hbase/util/TestRecoverLeaseFSUtils.java
@@ -17,18 +17,32 @@
  */
 package org.apache.hadoop.hbase.util;
 
+import static org.apache.hadoop.hbase.util.RecoverLeaseFSUtils.LEASE_RECOVERABLE_CLASS_NAME;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
+import java.io.FileNotFoundException;
 import java.io.IOException;
+import java.lang.reflect.Method;
+import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.permission.FsPermission;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseCommonTestingUtil;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hdfs.DistributedFileSystem;
+import org.apache.hadoop.util.Progressable;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -60,18 +74,55 @@ public class TestRecoverLeaseFSUtils {
   public void testRecoverLease() throws IOException {
     long startTime = EnvironmentEdgeManager.currentTime();
     HTU.getConfiguration().setInt("hbase.lease.recovery.dfs.timeout", 1000);
-    CancelableProgressable reporter = Mockito.mock(CancelableProgressable.class);
-    Mockito.when(reporter.progress()).thenReturn(true);
-    DistributedFileSystem dfs = Mockito.mock(DistributedFileSystem.class);
+    CancelableProgressable reporter = mock(CancelableProgressable.class);
+    when(reporter.progress()).thenReturn(true);
+    DistributedFileSystem dfs = mock(DistributedFileSystem.class);
     // Fail four times and pass on the fifth.
-    Mockito.when(dfs.recoverLease(FILE)).thenReturn(false).thenReturn(false).thenReturn(false)
+    when(dfs.recoverLease(FILE)).thenReturn(false).thenReturn(false).thenReturn(false)
       .thenReturn(false).thenReturn(true);
     RecoverLeaseFSUtils.recoverFileLease(dfs, FILE, HTU.getConfiguration(), reporter);
-    Mockito.verify(dfs, Mockito.times(5)).recoverLease(FILE);
+    verify(dfs, times(5)).recoverLease(FILE);
     // Make sure we waited at least hbase.lease.recovery.dfs.timeout * 3 (the first two
     // invocations will happen pretty fast... the we fall into the longer wait loop).
     assertTrue((EnvironmentEdgeManager.currentTime() - startTime)
         > (3 * HTU.getConfiguration().getInt("hbase.lease.recovery.dfs.timeout", 61000)));
+  }
+
+  private interface FakeLeaseRecoverable {
+    boolean recoverLease(Path p) throws IOException;
+    boolean isFileClosed(Path p) throws IOException;
+  }
+
+  private static abstract class RecoverableFileSystem extends FileSystem implements FakeLeaseRecoverable {
+    @Override
+    public boolean recoverLease(Path p) throws IOException {
+      return true;
+    }
+    @Override
+    public boolean isFileClosed(Path p) throws IOException {
+      return true;
+    }
+  }
+
+  /**
+   *
+   * Test that we can use reflection to access LeaseRecoverable methods.
+   * @throws IOException
+   */
+  @Test
+  public void testLeaseRecoverable() throws IOException {
+    try {
+      // set LeaseRecoverable to FakeLeaseRecoverable for testing
+      RecoverLeaseFSUtils.initializeRecoverLeaseMethod(FakeLeaseRecoverable.class.getName());
+      RecoverableFileSystem mockFS = mock(RecoverableFileSystem.class);
+      when(mockFS.recoverLease(FILE)).thenReturn(true);
+      RecoverLeaseFSUtils.recoverFileLease(mockFS, FILE, HTU.getConfiguration());
+      verify(mockFS, times(1)).recoverLease(FILE);
+
+      assertTrue(RecoverLeaseFSUtils.isLeaseRecoverable(mock(RecoverableFileSystem.class)));
+    } finally {
+      RecoverLeaseFSUtils.initializeRecoverLeaseMethod(LEASE_RECOVERABLE_CLASS_NAME);
+    }
   }
 
   /**
@@ -81,17 +132,17 @@ public class TestRecoverLeaseFSUtils {
   public void testIsFileClosed() throws IOException {
     // Make this time long so it is plain we broke out because of the isFileClosed invocation.
     HTU.getConfiguration().setInt("hbase.lease.recovery.dfs.timeout", 100000);
-    CancelableProgressable reporter = Mockito.mock(CancelableProgressable.class);
-    Mockito.when(reporter.progress()).thenReturn(true);
-    IsFileClosedDistributedFileSystem dfs = Mockito.mock(IsFileClosedDistributedFileSystem.class);
+    CancelableProgressable reporter = mock(CancelableProgressable.class);
+    when(reporter.progress()).thenReturn(true);
+    IsFileClosedDistributedFileSystem dfs = mock(IsFileClosedDistributedFileSystem.class);
     // Now make it so we fail the first two times -- the two fast invocations, then we fall into
     // the long loop during which we will call isFileClosed.... the next invocation should
     // therefore return true if we are to break the loop.
-    Mockito.when(dfs.recoverLease(FILE)).thenReturn(false).thenReturn(false).thenReturn(true);
-    Mockito.when(dfs.isFileClosed(FILE)).thenReturn(true);
+    when(dfs.recoverLease(FILE)).thenReturn(false).thenReturn(false).thenReturn(true);
+    when(dfs.isFileClosed(FILE)).thenReturn(true);
     RecoverLeaseFSUtils.recoverFileLease(dfs, FILE, HTU.getConfiguration(), reporter);
-    Mockito.verify(dfs, Mockito.times(2)).recoverLease(FILE);
-    Mockito.verify(dfs, Mockito.times(1)).isFileClosed(FILE);
+    verify(dfs, times(2)).recoverLease(FILE);
+    verify(dfs, times(1)).isFileClosed(FILE);
   }
 
   @Test

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -113,6 +113,21 @@ public final class FSUtils {
   // currently only used in testing. TODO refactor into a test class
   public static final boolean WINDOWS = System.getProperty("os.name").startsWith("Windows");
 
+  private static Class<?> safeModeClazz = null;
+  private static Class<?> safeModeActionClazz = null;
+  private static Object safeModeGet = null;
+  {
+    try {
+      safeModeClazz = Class.forName("org.apache.hadoop.fs.SafeMode");
+      safeModeActionClazz = Class.forName("org.apache.hadoop.fs.SafeModeAction");
+      safeModeGet = safeModeClazz.getField("SAFEMODE_GET").get(null);
+    } catch (ClassNotFoundException | NoSuchFieldException e) {
+      LOG.debug("SafeMode interface not in the classpath, this means Hadoop 3.3.5 or below.");
+    } catch (IllegalAccessException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   private FSUtils() {
   }
 
@@ -247,8 +262,18 @@ public final class FSUtils {
    * @param dfs A DistributedFileSystem object representing the underlying HDFS.
    * @return whether we're in safe mode
    */
-  private static boolean isInSafeMode(DistributedFileSystem dfs) throws IOException {
-    return dfs.setSafeMode(SAFEMODE_GET, true);
+  private static boolean isInSafeMode(FileSystem dfs) throws IOException {
+    if (isDistributedFileSystem(dfs)) {
+      return ((DistributedFileSystem)dfs).setSafeMode(SAFEMODE_GET, true);
+    } else {
+      try {
+        Object ret = dfs.getClass().getMethod("setSafeMode", new Class[] { safeModeActionClazz, Boolean.class })
+          .invoke(dfs, safeModeGet, true);
+        return (Boolean) ret;
+      } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+        throw new RuntimeException(e);
+      }
+    }
   }
 
   /**
@@ -257,9 +282,8 @@ public final class FSUtils {
   public static void checkDfsSafeMode(final Configuration conf) throws IOException {
     boolean isInSafeMode = false;
     FileSystem fs = FileSystem.get(conf);
-    if (fs instanceof DistributedFileSystem) {
-      DistributedFileSystem dfs = (DistributedFileSystem) fs;
-      isInSafeMode = isInSafeMode(dfs);
+    if (supportSafeMode(fs)) {
+      isInSafeMode = isInSafeMode(fs);
     }
     if (isInSafeMode) {
       throw new IOException("File system is in safemode, it can't be written now");
@@ -644,10 +668,9 @@ public final class FSUtils {
    */
   public static void waitOnSafeMode(final Configuration conf, final long wait) throws IOException {
     FileSystem fs = FileSystem.get(conf);
-    if (!(fs instanceof DistributedFileSystem)) return;
-    DistributedFileSystem dfs = (DistributedFileSystem) fs;
+    if (!supportSafeMode(fs)) return;
     // Make sure dfs is not in safe mode
-    while (isInSafeMode(dfs)) {
+    while (isInSafeMode(fs)) {
       LOG.info("Waiting for dfs to exit safe mode...");
       try {
         Thread.sleep(wait);
@@ -656,6 +679,19 @@ public final class FSUtils {
         throw (InterruptedIOException) new InterruptedIOException().initCause(e);
       }
     }
+  }
+
+  public static boolean supportSafeMode(FileSystem fs) {
+    // return true if HDFS.
+    if (fs instanceof DistributedFileSystem) {
+      return true;
+    }
+    // return true if the file system implements SafeMode interface.
+    if (safeModeClazz != null) {
+      return (safeModeClazz.isAssignableFrom(fs.getClass()));
+    }
+    // return false if the file system is not HDFS and does not implement SafeMode interface.
+    return false;
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -264,7 +264,7 @@ public final class FSUtils {
    */
   private static boolean isInSafeMode(FileSystem dfs) throws IOException {
     if (isDistributedFileSystem(dfs)) {
-      return ((DistributedFileSystem)dfs).setSafeMode(SAFEMODE_GET, true);
+      return ((DistributedFileSystem) dfs).setSafeMode(SAFEMODE_GET, true);
     } else {
       try {
         Object ret = dfs.getClass()

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -124,6 +124,8 @@ public final class FSUtils {
     } catch (ClassNotFoundException | NoSuchFieldException e) {
       LOG.debug("SafeMode interface not in the classpath, this means Hadoop 3.3.5 or below.");
     } catch (IllegalAccessException e) {
+      LOG.error("SafeModeAction.SAFEMODE_GET is not accessible. " +
+        "Unexpected Hadoop version or messy classpath?", e);
       throw new RuntimeException(e);
     }
   }
@@ -272,6 +274,7 @@ public final class FSUtils {
           .invoke(dfs, safeModeGet, true);
         return (Boolean) ret;
       } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
+        LOG.error("The file system does not support setSafeMode(). Abort.", e);
         throw new RuntimeException(e);
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -124,8 +124,8 @@ public final class FSUtils {
     } catch (ClassNotFoundException | NoSuchFieldException e) {
       LOG.debug("SafeMode interface not in the classpath, this means Hadoop 3.3.5 or below.");
     } catch (IllegalAccessException e) {
-      LOG.error("SafeModeAction.SAFEMODE_GET is not accessible. " +
-        "Unexpected Hadoop version or messy classpath?", e);
+      LOG.error("SafeModeAction.SAFEMODE_GET is not accessible. "
+        + "Unexpected Hadoop version or messy classpath?", e);
       throw new RuntimeException(e);
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -267,7 +267,8 @@ public final class FSUtils {
       return ((DistributedFileSystem)dfs).setSafeMode(SAFEMODE_GET, true);
     } else {
       try {
-        Object ret = dfs.getClass().getMethod("setSafeMode", new Class[] { safeModeActionClazz, Boolean.class })
+        Object ret = dfs.getClass()
+          .getMethod("setSafeMode", new Class[] { safeModeActionClazz, Boolean.class })
           .invoke(dfs, safeModeGet, true);
         return (Boolean) ret;
       } catch (InvocationTargetException | IllegalAccessException | NoSuchMethodException e) {
@@ -668,7 +669,9 @@ public final class FSUtils {
    */
   public static void waitOnSafeMode(final Configuration conf, final long wait) throws IOException {
     FileSystem fs = FileSystem.get(conf);
-    if (!supportSafeMode(fs)) return;
+    if (!supportSafeMode(fs)) {
+      return;
+    }
     // Make sure dfs is not in safe mode
     while (isInSafeMode(fs)) {
       LOG.info("Waiting for dfs to exit safe mode...");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestFSUtils.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestFSUtils.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.LocalFileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.StreamCapabilities;
 import org.apache.hadoop.fs.permission.FsPermission;
@@ -46,6 +47,7 @@ import org.apache.hadoop.hbase.HDFSBlocksDistribution;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.exceptions.DeserializationException;
 import org.apache.hadoop.hbase.fs.HFileSystem;
+import org.apache.hadoop.hbase.regionserver.TestHStore;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hdfs.DFSConfigKeys;
@@ -92,11 +94,21 @@ public class TestFSUtils {
     try {
       cluster = htu.startMiniDFSCluster(1);
       assertTrue(CommonFSUtils.isHDFS(conf));
+      assertTrue(FSUtils.supportSafeMode(cluster.getFileSystem()));
+      FSUtils.checkDfsSafeMode(conf);
     } finally {
       if (cluster != null) {
         cluster.shutdown();
       }
     }
+  }
+
+  @Test
+  public void testLocalFileSystemSafeMode() throws Exception {
+    conf.setClass("fs.file.impl", LocalFileSystem.class, FileSystem.class);
+    assertFalse(CommonFSUtils.isHDFS(conf));
+    assertFalse(FSUtils.supportSafeMode(FileSystem.get(conf)));
+    FSUtils.checkDfsSafeMode(conf);
   }
 
   private void WriteDataToHDFS(FileSystem fs, Path file, int dataSize) throws Exception {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestFSUtils.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestFSUtils.java
@@ -47,7 +47,6 @@ import org.apache.hadoop.hbase.HDFSBlocksDistribution;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.exceptions.DeserializationException;
 import org.apache.hadoop.hbase.fs.HFileSystem;
-import org.apache.hadoop.hbase.regionserver.TestHStore;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hdfs.DFSConfigKeys;


### PR DESCRIPTION
* use reflection to access these Hadoop APIs.
* added more UT coverage. Tested a few UTs with Hadoop 3.3.5.

TODO:
* Test with Hadoop 3.3.6, 3.4.0.
* Test with Ozone 2.0.0-SNAPSHOT.