### PR TITLE
HBASE-28900: Avoid resetting the bucket cache during recovery from persistence.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -854,7 +854,7 @@ public class BucketCache implements BlockCache, HeapSize {
    *   it is {@link ByteBuffAllocator#putbackBuffer}.
    * </pre>
    */
-  private Recycler createRecycler(final BucketEntry bucketEntry) {
+  public Recycler createRecycler(final BucketEntry bucketEntry) {
     return () -> {
       freeBucketEntry(bucketEntry);
       return;


### PR DESCRIPTION
When an inconsistency is detected during the recovery of bucket cache from persistence, we tend to throw away the complete cache and try to rebuild the cache. Thsi inconsistency can occur when the region server is abruptly terminated.

This can be avoided by skipping the inconsistent backing map entry and continuing with the cache recovery. The inconsistent backing map entry will be discarded during the subsequent bucket cache validation.

Change-Id: I41237bda2189cbd73e22e4eadf4d53d16a3733f6