### PR TITLE
HBASE-28921 Skip bundling hbase-webapps folder in jars

### DIFF
--- a/hbase-rest/pom.xml
+++ b/hbase-rest/pom.xml
@@ -289,6 +289,15 @@
           <skipAssembly>true</skipAssembly>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/hbase-webapps/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -453,6 +453,7 @@
             <exclude>log4j.properties</exclude>
             <exclude>mapred-queues.xml</exclude>
             <exclude>mapred-site.xml</exclude>
+            <exclude>**/hbase-webapps/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/hbase-thrift/pom.xml
+++ b/hbase-thrift/pom.xml
@@ -194,6 +194,15 @@
           <skipAssembly>true</skipAssembly>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/hbase-webapps/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <!-- General ant tasks, bound to different build phases -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
We are bundling all webapp resources in hbase-server, hbase-thrift, hbase-rest and transitively to hbase-shaded-mapreduce jar. This can be an issue, say if any of the Js projects used by hbase are vulnerable, security scan tools like sonatype start flagging the jars too as vulnerable since they contain vulnerable code.

With this JIRA, we want to avoid bundling static webapp resources in our jars.