### PR TITLE
HBASE-28924 Create the start time right before creating the reader to calculate elapsedTime in testPrefetchWithDelay

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
@@ -359,8 +359,8 @@ public class TestPrefetch {
     HFileContext context = new HFileContextBuilder().withCompression(Compression.Algorithm.GZ)
       .withBlockSize(DATA_BLOCK_SIZE).build();
     Path storeFile = writeStoreFile("TestPrefetchWithDelay", context);
-    HFile.Reader reader = HFile.createReader(fs, storeFile, cacheConf, true, conf);
     long startTime = System.currentTimeMillis();
+    HFile.Reader reader = HFile.createReader(fs, storeFile, cacheConf, true, conf);
 
     // Wait for 20 seconds, no thread should start prefetch
     Thread.sleep(20000);


### PR DESCRIPTION
This test currently fails intermittently in master branch, as startime is post reader creation 
Elapsed time is sometimes  25074ms and sometimes 24994ms (but delay is 25000ms) since starttime was calculated after reader creation