### PR TITLE
HBASE-28931: Poll SSL cert file for changes

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/FileChangeWatcher.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/FileChangeWatcher.java
@@ -199,7 +199,7 @@ public final class FileChangeWatcher {
     @Override
     public void run() {
       try {
-        LOG.info("{} thread started", getName());
+        LOG.debug("{} thread started", getName());
         if (
           !compareAndSetState(FileChangeWatcher.State.STARTING, FileChangeWatcher.State.RUNNING)
         ) {
@@ -216,7 +216,7 @@ public final class FileChangeWatcher {
         LOG.warn("Error in runLoop()", e);
         throw new RuntimeException(e);
       } finally {
-        LOG.info("{} thread finished", getName());
+        LOG.debug("{} thread finished", getName());
         FileChangeWatcher.this.setState(FileChangeWatcher.State.STOPPED);
       }
     }
@@ -245,7 +245,7 @@ public final class FileChangeWatcher {
         try {
           Thread.sleep(pollInterval.toMillis());
         } catch (InterruptedException e) {
-          LOG.info("Interrupted", e);
+          LOG.debug("Interrupted", e);
           Thread.currentThread().interrupt();
           return;
         }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/FileChangeWatcher.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/FileChangeWatcher.java
@@ -18,30 +18,27 @@
 package org.apache.hadoop.hbase.io;
 
 import java.io.IOException;
-import java.nio.file.ClosedWatchServiceException;
-import java.nio.file.FileSystem;
+import java.nio.file.Files;
 import java.nio.file.Path;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
-import java.nio.file.WatchKey;
-import java.nio.file.WatchService;
-import java.util.function.Consumer;
+import java.nio.file.attribute.BasicFileAttributes;
+import java.nio.file.attribute.FileTime;
+import java.time.Duration;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Instances of this class can be used to watch a directory for file changes. When a file is added
- * to, deleted from, or is modified in the given directory, the callback provided by the user will
- * be called from a background thread. Some things to keep in mind:
+ * Instances of this class can be used to watch a file for changes. When a file's modification time
+ * changes, the callback provided by the user will be called from a background thread. Modification
+ * are detected by checking the file's attributes every polling interval. Some things to keep in
+ * mind:
  * <ul>
  * <li>The callback should be thread-safe.</li>
  * <li>Changes that happen around the time the thread is started may be missed.</li>
  * <li>There is a delay between a file changing and the callback firing.</li>
- * <li>The watch is not recursive - changes to subdirectories will not trigger a callback.</li>
  * </ul>
  * <p/>
- * This file has been copied from the Apache ZooKeeper project.
+ * This file was originally copied from the Apache ZooKeeper project, and then modified.
  * @see <a href=
  *      "https://github.com/apache/zookeeper/blob/8148f966947d3ecf3db0b756d93c9ffa88174af9/zookeeper-server/src/main/java/org/apache/zookeeper/common/FileChangeWatcher.java">Base
  *      revision</a>
@@ -49,9 +46,13 @@ import org.slf4j.LoggerFactory;
 @InterfaceAudience.Private
 public final class FileChangeWatcher {
 
+  public interface FileChangeWatcherCallback {
+    void callback(Path path);
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(FileChangeWatcher.class);
 
-  public enum State {
+  enum State {
     NEW, // object created but start() not called yet
     STARTING, // start() called but background thread has not entered main loop
     RUNNING, // background thread is running
@@ -61,29 +62,29 @@ public final class FileChangeWatcher {
 
   private final WatcherThread watcherThread;
   private State state; // protected by synchronized(this)
+  private FileTime lastModifiedTime;
+  private final Object lastModifiedTimeLock;
+  private final Path filePath;
+  private final Duration pollInterval;
 
   /**
-   * Creates a watcher that watches <code>dirPath</code> and invokes <code>callback</code> on
+   * Creates a watcher that watches <code>filePath</code> and invokes <code>callback</code> on
    * changes.
-   * @param dirPath  the directory to watch.
+   * @param filePath the file to watch.
    * @param callback the callback to invoke with events. <code>event.kind()</code> will return the
    *                 type of event, and <code>event.context()</code> will return the filename
    *                 relative to <code>dirPath</code>.
    * @throws IOException if there is an error creating the WatchService.
    */
-  public FileChangeWatcher(Path dirPath, String threadNameSuffix, Consumer<WatchEvent<?>> callback)
-    throws IOException {
-    FileSystem fs = dirPath.getFileSystem();
-    WatchService watchService = fs.newWatchService();
+  public FileChangeWatcher(Path filePath, String threadNameSuffix, Duration pollInterval,
+    FileChangeWatcherCallback callback) throws IOException {
+    this.filePath = filePath;
+    this.pollInterval = pollInterval;
 
-    LOG.debug("Registering with watch service: {}", dirPath);
-
-    dirPath.register(watchService,
-      new WatchEvent.Kind<?>[] { StandardWatchEventKinds.ENTRY_CREATE,
-        StandardWatchEventKinds.ENTRY_DELETE, StandardWatchEventKinds.ENTRY_MODIFY,
-        StandardWatchEventKinds.OVERFLOW });
     state = State.NEW;
-    this.watcherThread = new WatcherThread(threadNameSuffix, watchService, callback);
+    lastModifiedTimeLock = new Object();
+    lastModifiedTime = Files.readAttributes(filePath, BasicFileAttributes.class).lastModifiedTime();
+    this.watcherThread = new WatcherThread(threadNameSuffix, callback);
     this.watcherThread.setDaemon(true);
   }
 
@@ -91,7 +92,7 @@ public final class FileChangeWatcher {
    * Returns the current {@link FileChangeWatcher.State}.
    * @return the current state.
    */
-  public synchronized State getState() {
+  private synchronized State getState() {
     return state;
   }
 
@@ -187,13 +188,10 @@ public final class FileChangeWatcher {
 
     private static final String THREAD_NAME_PREFIX = "FileChangeWatcher-";
 
-    final WatchService watchService;
-    final Consumer<WatchEvent<?>> callback;
+    final FileChangeWatcherCallback callback;
 
-    WatcherThread(String threadNameSuffix, WatchService watchService,
-      Consumer<WatchEvent<?>> callback) {
+    WatcherThread(String threadNameSuffix, FileChangeWatcherCallback callback) {
       super(THREAD_NAME_PREFIX + threadNameSuffix);
-      this.watchService = watchService;
       this.callback = callback;
       setUncaughtExceptionHandler(FileChangeWatcher::handleException);
     }
@@ -216,44 +214,40 @@ public final class FileChangeWatcher {
         runLoop();
       } catch (Exception e) {
         LOG.warn("Error in runLoop()", e);
-        throw e;
+        throw new RuntimeException(e);
       } finally {
-        try {
-          watchService.close();
-        } catch (IOException e) {
-          LOG.warn("Error closing watch service", e);
-        }
         LOG.info("{} thread finished", getName());
         FileChangeWatcher.this.setState(FileChangeWatcher.State.STOPPED);
       }
     }
 
-    private void runLoop() {
+    private void runLoop() throws IOException {
       while (FileChangeWatcher.this.getState() == FileChangeWatcher.State.RUNNING) {
-        WatchKey key;
-        try {
-          key = watchService.take();
-        } catch (InterruptedException | ClosedWatchServiceException e) {
-          LOG.debug("{} was interrupted and is shutting down...", getName());
-          break;
+        BasicFileAttributes attributes = Files.readAttributes(filePath, BasicFileAttributes.class);
+        boolean modified = false;
+        synchronized (lastModifiedTimeLock) {
+          FileTime maybeNewLastModifiedTime = attributes.lastModifiedTime();
+          if (!lastModifiedTime.equals(maybeNewLastModifiedTime)) {
+            modified = true;
+            lastModifiedTime = maybeNewLastModifiedTime;
+          }
         }
-        for (WatchEvent<?> event : key.pollEvents()) {
-          LOG.debug("Got file changed event: {} with context: {}", event.kind(), event.context());
+
+        // avoid calling callback while holding lock
+        if (modified) {
           try {
-            callback.accept(event);
+            callback.callback(filePath);
           } catch (Throwable e) {
             LOG.error("Error from callback", e);
           }
         }
-        boolean isKeyValid = key.reset();
-        if (!isKeyValid) {
-          // This is likely a problem, it means that file reloading is broken, probably because the
-          // directory we are watching was deleted or otherwise became inaccessible (unmounted,
-          // permissions
-          // changed, ???).
-          // For now, we log an error and exit the watcher thread.
-          LOG.error("Watch key no longer valid, maybe the directory is inaccessible?");
-          break;
+
+        try {
+          Thread.sleep(pollInterval.toMillis());
+        } catch (InterruptedException e) {
+          LOG.info("Interrupted", e);
+          Thread.currentThread().interrupt();
+          return;
         }
       }
     }

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/TestFileChangeWatcher.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/TestFileChangeWatcher.java
@@ -27,8 +27,8 @@ import static org.junit.Assert.assertTrue;
 import java.io.File;
 import java.io.IOException;
 import java.nio.charset.StandardCharsets;
-import java.nio.file.StandardWatchEventKinds;
-import java.nio.file.WatchEvent;
+import java.nio.file.Path;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.concurrent.atomic.AtomicInteger;
@@ -50,7 +50,7 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * This file has been copied from the Apache ZooKeeper project.
+ * This file was originally copied from the Apache ZooKeeper project, but has been modified
  * @see <a href=
  *      "https://github.com/apache/zookeeper/blob/391cb4aa6b54e19a028215e1340232a114c23ed3/zookeeper-server/src/test/java/org/apache/zookeeper/common/FileChangeWatcherTest.java">Base
  *      revision</a>
@@ -62,20 +62,17 @@ public class TestFileChangeWatcher {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestFileChangeWatcher.class);
 
-  private static File tempDir;
   private static File tempFile;
 
   private static final Logger LOG = LoggerFactory.getLogger(TestFileChangeWatcher.class);
   private static final HBaseCommonTestingUtil UTIL = new HBaseCommonTestingUtil();
 
   private static final long FS_TIMEOUT = 30000L;
+  private static final Duration POLL_INTERVAL = Duration.ofMillis(100);
 
   @BeforeClass
   public static void createTempFile() throws IOException {
-    tempDir = new File(UTIL.getDataTestDir(TestFileChangeWatcher.class.getSimpleName()).toString())
-      .getCanonicalFile();
-    FileUtils.forceMkdir(tempDir);
-    tempFile = File.createTempFile("zk_test_", "", tempDir);
+    tempFile = File.createTempFile("zk_test_", "");
   }
 
   @AfterClass
@@ -86,7 +83,7 @@ public class TestFileChangeWatcher {
   @Test
   public void testEnableCertFileReloading() throws IOException {
     Configuration myConf = new Configuration();
-    String sharedPath = "/tmp/foo.jks";
+    String sharedPath = File.createTempFile("foo", "foo.jks").getAbsolutePath();
     myConf.set(X509Util.TLS_CONFIG_KEYSTORE_LOCATION, sharedPath);
     myConf.set(X509Util.TLS_CONFIG_TRUSTSTORE_LOCATION, sharedPath);
     AtomicReference<FileChangeWatcher> keystoreWatcher = new AtomicReference<>();
@@ -94,42 +91,60 @@ public class TestFileChangeWatcher {
     X509Util.enableCertFileReloading(myConf, keystoreWatcher, truststoreWatcher, () -> {
     });
     assertNotNull(keystoreWatcher.get());
-    assertThat(keystoreWatcher.get().getWatcherThreadName(), Matchers.endsWith("-foo.jks"));
+    assertThat(keystoreWatcher.get().getWatcherThreadName(), Matchers.endsWith("foo.jks"));
     assertNull(truststoreWatcher.get());
 
     keystoreWatcher.getAndSet(null).stop();
     truststoreWatcher.set(null);
 
-    String truststorePath = "/tmp/bar.jks";
+    String truststorePath = File.createTempFile("bar", "bar.jks").getAbsolutePath();
     myConf.set(X509Util.TLS_CONFIG_TRUSTSTORE_LOCATION, truststorePath);
     X509Util.enableCertFileReloading(myConf, keystoreWatcher, truststoreWatcher, () -> {
     });
 
     assertNotNull(keystoreWatcher.get());
-    assertThat(keystoreWatcher.get().getWatcherThreadName(), Matchers.endsWith("-foo.jks"));
+    assertThat(keystoreWatcher.get().getWatcherThreadName(), Matchers.endsWith("foo.jks"));
     assertNotNull(truststoreWatcher.get());
-    assertThat(truststoreWatcher.get().getWatcherThreadName(), Matchers.endsWith("-bar.jks"));
+    assertThat(truststoreWatcher.get().getWatcherThreadName(), Matchers.endsWith("bar.jks"));
 
     keystoreWatcher.getAndSet(null).stop();
     truststoreWatcher.getAndSet(null).stop();
   }
 
   @Test
+  public void testNoFalseNotifications() throws IOException, InterruptedException {
+    FileChangeWatcher watcher = null;
+    try {
+      final List<Path> notifiedPaths = new ArrayList<>();
+      watcher = new FileChangeWatcher(tempFile.toPath(), "test", POLL_INTERVAL, path -> {
+        LOG.info("Got an update on path {}", path);
+        synchronized (notifiedPaths) {
+          notifiedPaths.add(path);
+          notifiedPaths.notifyAll();
+        }
+      });
+      watcher.start();
+      watcher.waitForState(FileChangeWatcher.State.RUNNING);
+      Thread.sleep(1000L); // TODO hack
+      assertEquals("Should not have been notified", 0, notifiedPaths.size());
+    } finally {
+      if (watcher != null) {
+        watcher.stop();
+        watcher.waitForState(FileChangeWatcher.State.STOPPED);
+      }
+    }
+  }
+
+  @Test
   public void testCallbackWorksOnFileChanges() throws IOException, InterruptedException {
     FileChangeWatcher watcher = null;
     try {
-      final List<WatchEvent<?>> events = new ArrayList<>();
-      watcher = new FileChangeWatcher(tempDir.toPath(), "test", event -> {
-        LOG.info("Got an update: {} {}", event.kind(), event.context());
-        // Filter out the extra ENTRY_CREATE events that are
-        // sometimes seen at the start. Even though we create the watcher
-        // after the file exists, sometimes we still get a create event.
-        if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())) {
-          return;
-        }
-        synchronized (events) {
-          events.add(event);
-          events.notifyAll();
+      final List<Path> notifiedPaths = new ArrayList<>();
+      watcher = new FileChangeWatcher(tempFile.toPath(), "test", POLL_INTERVAL, path -> {
+        LOG.info("Got an update on path {}", path);
+        synchronized (notifiedPaths) {
+          notifiedPaths.add(path);
+          notifiedPaths.notifyAll();
         }
       });
       watcher.start();
@@ -139,14 +154,13 @@ public class TestFileChangeWatcher {
         LOG.info("Modifying file, attempt {}", (i + 1));
         FileUtils.writeStringToFile(tempFile, "Hello world " + i + "\n", StandardCharsets.UTF_8,
           true);
-        synchronized (events) {
-          if (events.size() < i + 1) {
-            events.wait(FS_TIMEOUT);
+        synchronized (notifiedPaths) {
+          if (notifiedPaths.size() < i + 1) {
+            notifiedPaths.wait(FS_TIMEOUT);
           }
-          assertEquals("Wrong number of events", i + 1, events.size());
-          WatchEvent<?> event = events.get(i);
-          assertEquals(StandardWatchEventKinds.ENTRY_MODIFY, event.kind());
-          assertEquals(tempFile.getName(), event.context().toString());
+          assertEquals("Wrong number of notifications", i + 1, notifiedPaths.size());
+          Path path = notifiedPaths.get(i);
+          assertEquals(tempFile.getPath(), path.toString());
         }
       }
     } finally {
@@ -161,18 +175,12 @@ public class TestFileChangeWatcher {
   public void testCallbackWorksOnFileTouched() throws IOException, InterruptedException {
     FileChangeWatcher watcher = null;
     try {
-      final List<WatchEvent<?>> events = new ArrayList<>();
-      watcher = new FileChangeWatcher(tempDir.toPath(), "test", event -> {
-        LOG.info("Got an update: {} {}", event.kind(), event.context());
-        // Filter out the extra ENTRY_CREATE events that are
-        // sometimes seen at the start. Even though we create the watcher
-        // after the file exists, sometimes we still get a create event.
-        if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())) {
-          return;
-        }
-        synchronized (events) {
-          events.add(event);
-          events.notifyAll();
+      final List<Path> notifiedPaths = new ArrayList<>();
+      watcher = new FileChangeWatcher(tempFile.toPath(), "test", POLL_INTERVAL, path -> {
+        LOG.info("Got an update on path {}", path);
+        synchronized (notifiedPaths) {
+          notifiedPaths.add(path);
+          notifiedPaths.notifyAll();
         }
       });
       watcher.start();
@@ -180,87 +188,13 @@ public class TestFileChangeWatcher {
       Thread.sleep(1000L); // TODO hack
       LOG.info("Touching file");
       FileUtils.touch(tempFile);
-      synchronized (events) {
-        if (events.isEmpty()) {
-          events.wait(FS_TIMEOUT);
+      synchronized (notifiedPaths) {
+        if (notifiedPaths.isEmpty()) {
+          notifiedPaths.wait(FS_TIMEOUT);
         }
-        assertFalse(events.isEmpty());
-        WatchEvent<?> event = events.get(0);
-        assertEquals(StandardWatchEventKinds.ENTRY_MODIFY, event.kind());
-        assertEquals(tempFile.getName(), event.context().toString());
-      }
-    } finally {
-      if (watcher != null) {
-        watcher.stop();
-        watcher.waitForState(FileChangeWatcher.State.STOPPED);
-      }
-    }
-  }
-
-  @Test
-  public void testCallbackWorksOnFileAdded() throws IOException, InterruptedException {
-    FileChangeWatcher watcher = null;
-    try {
-      final List<WatchEvent<?>> events = new ArrayList<>();
-      watcher = new FileChangeWatcher(tempDir.toPath(), "test", event -> {
-        LOG.info("Got an update: {} {}", event.kind(), event.context());
-        synchronized (events) {
-          events.add(event);
-          events.notifyAll();
-        }
-      });
-      watcher.start();
-      watcher.waitForState(FileChangeWatcher.State.RUNNING);
-      Thread.sleep(1000L); // TODO hack
-      File tempFile2 = File.createTempFile("zk_test_", "", tempDir);
-      tempFile2.deleteOnExit();
-      synchronized (events) {
-        if (events.isEmpty()) {
-          events.wait(FS_TIMEOUT);
-        }
-        assertFalse(events.isEmpty());
-        WatchEvent<?> event = events.get(0);
-        assertEquals(StandardWatchEventKinds.ENTRY_CREATE, event.kind());
-        assertEquals(tempFile2.getName(), event.context().toString());
-      }
-    } finally {
-      if (watcher != null) {
-        watcher.stop();
-        watcher.waitForState(FileChangeWatcher.State.STOPPED);
-      }
-    }
-  }
-
-  @Test
-  public void testCallbackWorksOnFileDeleted() throws IOException, InterruptedException {
-    FileChangeWatcher watcher = null;
-    try {
-      final List<WatchEvent<?>> events = new ArrayList<>();
-      watcher = new FileChangeWatcher(tempDir.toPath(), "test", event -> {
-        LOG.info("Got an update: {} {}", event.kind(), event.context());
-        // Filter out the extra ENTRY_CREATE events that are
-        // sometimes seen at the start. Even though we create the watcher
-        // after the file exists, sometimes we still get a create event.
-        if (StandardWatchEventKinds.ENTRY_CREATE.equals(event.kind())) {
-          return;
-        }
-        synchronized (events) {
-          events.add(event);
-          events.notifyAll();
-        }
-      });
-      watcher.start();
-      watcher.waitForState(FileChangeWatcher.State.RUNNING);
-      Thread.sleep(1000L); // TODO hack
-      tempFile.delete();
-      synchronized (events) {
-        if (events.isEmpty()) {
-          events.wait(FS_TIMEOUT);
-        }
-        assertFalse(events.isEmpty());
-        WatchEvent<?> event = events.get(0);
-        assertEquals(StandardWatchEventKinds.ENTRY_DELETE, event.kind());
-        assertEquals(tempFile.getName(), event.context().toString());
+        assertFalse(notifiedPaths.isEmpty());
+        Path path = notifiedPaths.get(0);
+        assertEquals(tempFile.getPath(), path.toString());
       }
     } finally {
       if (watcher != null) {
@@ -276,8 +210,8 @@ public class TestFileChangeWatcher {
     FileChangeWatcher watcher = null;
     try {
       final AtomicInteger callCount = new AtomicInteger(0);
-      watcher = new FileChangeWatcher(tempDir.toPath(), "test", event -> {
-        LOG.info("Got an update: {} {}", event.kind(), event.context());
+      watcher = new FileChangeWatcher(tempFile.toPath(), "test", POLL_INTERVAL, path -> {
+        LOG.info("Got an update for path {}", path);
         int oldValue;
         synchronized (callCount) {
           oldValue = callCount.getAndIncrement();


### PR DESCRIPTION
At my company we have an issue with our HBase servers not reloading TLS certificate files after they change on disk. We run our HMasters inside Kubernetes Pods, and define our certificate contents as Kubernetes Secrets. Then, the Secrets are projected into the HMaster containers as files. When the value of a Secret changes, the file changes automatically. However, Kubernetes does some complicated indirection, and does not change the files directly. It swaps a new directory in with new files in it.

HBase sets up a `WatchService` on the directory containing the TLS cert. For example, at my company, the cert is at `/etc/hadoop/conf/ssl/cert/server-chain.pem`. Then, events from that `WatchService` are delivered to a [handler method](https://github.com/apache/hbase/blob/836630422df2776287a860eff9d7104c3eca0582/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java#L530) which contains this check:
```
Path eventFilePath = dirPath.resolve((Path) event.context());
if (filePath.equals(eventFilePath)) {
 shouldResetContext = true;
}
```
Debug logs show why this conditional is never true:
```
2024-10-21T17:48:13,659 [FileChangeWatcher-server-chain.pem] DEBUG org.apache.hadoop.hbase.io.FileChangeWatcher: Got file changed event: ENTRY_CREATE with context: ..2024_10_21_17_48_13.2471317370
2024-10-21T17:48:13,659 [FileChangeWatcher-server-chain.pem] DEBUG org.apache.hadoop.hbase.io.FileChangeWatcher: Got file changed event: ENTRY_CREATE with context: ..2024_10_21_17_48_13.2471317370
2024-10-21T17:48:13,660 [FileChangeWatcher-server-chain.pem] DEBUG org.apache.hadoop.hbase.io.crypto.tls.X509Util: Ignoring watch event and keeping previous default SSL context. Event kind: ENTRY_CREATE with context: ..2024_10_21_17_48_13.2471317370
.... 
```
The watcher events have a variety of files attached to them, but none of them are `server-chain.pem`, so HBase thinks they are not relevant.

I propose that we simply remove the condition inspecting the file name that was changed, and always reload the SSL context if a watcher event fires. This may lead to unnecessary reloads, but that will be harmless.

cc @bbeaudreault 