### PR TITLE
Revert "HBASE-28921 Skip bundling hbase-webapps folder in jars"

### DIFF
--- a/hbase-rest/pom.xml
+++ b/hbase-rest/pom.xml
@@ -289,15 +289,6 @@
           <skipAssembly>true</skipAssembly>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>**/hbase-webapps/**</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -453,7 +453,6 @@
             <exclude>log4j.properties</exclude>
             <exclude>mapred-queues.xml</exclude>
             <exclude>mapred-site.xml</exclude>
-            <exclude>**/hbase-webapps/**</exclude>
           </excludes>
         </configuration>
       </plugin>

--- a/hbase-thrift/pom.xml
+++ b/hbase-thrift/pom.xml
@@ -194,15 +194,6 @@
           <skipAssembly>true</skipAssembly>
         </configuration>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <excludes>
-            <exclude>**/hbase-webapps/**</exclude>
-          </excludes>
-        </configuration>
-      </plugin>
       <!-- General ant tasks, bound to different build phases -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>


### PR DESCRIPTION
Reverts apache/hbase#6368

I see some test failures during debugging some other code. Apparently we use hbase-webapps folder to create an instance hbase local cluster for tests and the folder needs to be present in classpath. I am seeing following since we have removed hbase-webapps from hbase-server jar and hence tests  in other modules can't find it in classpath now:
```
Caused by: java.io.FileNotFoundException: hbase-webapps/master not found in CLASSPATH
        at org.apache.hadoop.hbase.http.HttpServer.getWebAppsPath(HttpServer.java:1086)
        at org.apache.hadoop.hbase.http.HttpServer.getWebAppsPath(HttpServer.java:1073)
        at org.apache.hadoop.hbase.http.HttpServer.<init>(HttpServer.java:589)
        at org.apache.hadoop.hbase.http.HttpServer$Builder.build(HttpServer.java:431)
        at org.apache.hadoop.hbase.http.InfoServer.<init>(InfoServer.java:92)
        at org.apache.hadoop.hbase.HBaseServerBase.putUpWebUI(HBaseServerBase.java:345)
        at org.apache.hadoop.hbase.HBaseServerBase.<init>(HBaseServerBase.java:307)
        at org.apache.hadoop.hbase.master.HMaster.<init>(HMaster.java:511)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
        at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
        at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
        at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:500)
        at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:481)
        at org.apache.hadoop.hbase.util.JVMClusterUtil.createMasterThread(JVMClusterUtil.java:124)
        ... 40 more
```

Fix is to include hbase-webapps in classpath for each impacted module's test resources. Reverting this for now to unblock any new PRs which may get impacted due to this change. Will raise another PR to handle the above case along with current change.
