### PR TITLE
HBASE-28919 Soft drop for destructive table actions

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/DeleteAndRecoverTableAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/DeleteAndRecoverTableAction.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.chaos.actions;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotDisabledException;
+import org.apache.hadoop.hbase.TableNotEnabledException;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.SnapshotDescription;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.hadoop.hbase.util.RetryCounter.RetryConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Action that drops a table and then recovers it from the recovery snapshot, if available. If a
+ * recovery snapshot is not available it will recreate the table instead and log a warning. After
+ * recovering from the found recovery snapshot it will delete the recovery snapshot.
+ */
+public class DeleteAndRecoverTableAction extends Action {
+  private static final Logger LOG = LoggerFactory.getLogger(DeleteAndRecoverTableAction.class);
+  private final TableName tableName;
+  protected Pattern snapshotNamePattern;
+
+  public DeleteAndRecoverTableAction(TableName tableName) {
+    this.tableName = tableName;
+    snapshotNamePattern = Pattern.compile("auto_" + tableName.getNameAsString() + "_[0-9]+");
+  }
+
+  @Override
+  protected Logger getLogger() {
+    return LOG;
+  }
+
+  @Override
+  public void perform() throws Exception {
+    HBaseTestingUtil util = context.getHBaseIntegrationTestingUtility();
+    Admin admin = util.getAdmin();
+    TableDescriptor descriptor = admin.getDescriptor(tableName);
+
+    // Drop and recreate the table
+    admin.disableTable(tableName);
+    try {
+      try {
+        admin.deleteTable(tableName);
+      } finally {
+        // We may need to retry this a few times because of ambient chaos.
+        RetryCounter retryCounter = new RetryCounter(new RetryConfig().setMaxAttempts(10));
+        while (true) {
+          try {
+            if (!admin.tableExists(tableName)) {
+              admin.createTable(descriptor);
+            }
+            break;
+          } catch (IOException e) {
+            if (retryCounter.shouldRetry()) {
+              getLogger().warn("Retrying recreation of " + tableName, e);
+              retryCounter.sleepUntilNextRetry();
+            } else {
+              getLogger().error("Recreate of " + tableName + " failed after too many retries!", e);
+              break;
+            }
+          }
+        }
+      }
+    } finally {
+      if (admin.isTableDisabled(tableName)) {
+        try {
+          admin.enableTable(tableName);
+        } catch (TableNotDisabledException e) {
+          // Ignore
+        }
+      }
+    }
+
+    // Now lets try to recover from that action
+    List<SnapshotDescription> snapshots = admin.listSnapshots(snapshotNamePattern);
+    if (!snapshots.isEmpty()) {
+      // It's possible due to various event sequences under chaos that we have more than one
+      // recovery snapshot for the table even though we are trying to clean up. The most
+      // recent snapshot is almost certainly ours.
+      snapshots.sort(new Comparator<SnapshotDescription>() {
+        @Override
+        public int compare(SnapshotDescription o1, SnapshotDescription o2) {
+          // Reversed order by name, so we get the most recent
+          return o2.getName().compareTo(o1.getName());
+        }
+      });
+      SnapshotDescription snapshot = snapshots.get(0);
+      try {
+        // We might need to retry this because of ambient chaos
+        RetryCounter retryCounter = new RetryCounter(new RetryConfig().setMaxAttempts(10));
+        while (true) {
+          try {
+            restoreTable(context, tableName, snapshot);
+            break;
+          } catch (IOException e) {
+            if (retryCounter.shouldRetry()) {
+              getLogger().warn("Retrying restore of " + tableName + " from " + snapshot.getName()
+                + " after exception", e);
+              retryCounter.sleepUntilNextRetry();
+            } else {
+              throw e;
+            }
+          }
+        }
+      } catch (IOException e) {
+        getLogger().warn("Failed to restore " + tableName + " from " + snapshot.getName(), e);
+      } finally {
+        try {
+          admin.deleteSnapshot(snapshot.getName());
+        } catch (IOException e) {
+          getLogger().warn("Failed to delete recovery snapshot " + snapshot.getName());
+        }
+      }
+    } else {
+      getLogger().warn("No recovery snapshots found for " + tableName);
+    }
+  }
+
+  static void restoreTable(ActionContext context, TableName tableName, SnapshotDescription snapshot)
+    throws IOException {
+    Admin admin = context.getHBaseIntegrationTestingUtility().getAdmin();
+    try {
+      if (admin.isTableEnabled(tableName)) {
+        try {
+          admin.disableTable(tableName);
+        } catch (TableNotEnabledException e) {
+          // Ignore
+        }
+      }
+      admin.restoreSnapshot(snapshot.getName());
+    } finally {
+      if (admin.isTableDisabled(tableName)) {
+        try {
+          admin.enableTable(tableName);
+        } catch (TableNotDisabledException e) {
+          // Ignore
+        }
+      }
+    }
+  }
+
+}

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/RemoveColumnAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/RemoveColumnAction.java
@@ -35,9 +35,9 @@ import org.slf4j.LoggerFactory;
  */
 public class RemoveColumnAction extends Action {
   private static final Logger LOG = LoggerFactory.getLogger(RemoveColumnAction.class);
-  private final TableName tableName;
-  private final Set<String> protectedColumns;
-  private Admin admin;
+  protected final TableName tableName;
+  protected final Set<String> protectedColumns;
+  protected Admin admin;
 
   public RemoveColumnAction(TableName tableName, Set<String> protectedColumns) {
     this.tableName = tableName;

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/RemoveColumnAndRecoverAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/RemoveColumnAndRecoverAction.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.chaos.actions;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Set;
+import java.util.regex.Pattern;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.SnapshotDescription;
+import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.hadoop.hbase.util.RetryCounter.RetryConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Action that removes a column family and then restores the table to the state prior to that action
+ * using a recovery snapshot, if one is available. If a recovery snapshot is not available it will
+ * log a warning and take no further action. After recovering from the found recovery snapshot it
+ * will delete the recovery snapshot.
+ */
+public class RemoveColumnAndRecoverAction extends RemoveColumnAction {
+  private static final Logger LOG = LoggerFactory.getLogger(RemoveColumnAndRecoverAction.class);
+  protected Pattern snapshotNamePattern;
+
+  public RemoveColumnAndRecoverAction(TableName tableName, Set<String> protectedColumns) {
+    super(tableName, protectedColumns);
+    snapshotNamePattern = Pattern.compile("auto_" + tableName.getNameAsString() + "_[0-9]+");
+  }
+
+  @Override
+  protected Logger getLogger() {
+    return LOG;
+  }
+
+  @Override
+  public void perform() throws Exception {
+    // First perform the remove column action
+    super.perform();
+
+    // Now lets try to recover from that action
+    List<SnapshotDescription> snapshots = admin.listSnapshots(snapshotNamePattern);
+    if (!snapshots.isEmpty()) {
+      // It's possible due to various event sequences under chaos that we have more than one
+      // recovery snapshot for the table even though we are trying to clean up. The most
+      // recent snapshot is almost certainly ours.
+      snapshots.sort(new Comparator<SnapshotDescription>() {
+        @Override
+        public int compare(SnapshotDescription o1, SnapshotDescription o2) {
+          // Reversed order by name, so we get the most recent
+          return o2.getName().compareTo(o1.getName());
+        }
+      });
+      SnapshotDescription snapshot = snapshots.get(0);
+      try {
+        // We might need to retry this because of ambient chaos
+        RetryCounter retryCounter = new RetryCounter(new RetryConfig().setMaxAttempts(10));
+        while (true) {
+          try {
+            DeleteAndRecoverTableAction.restoreTable(context, tableName, snapshot);
+            break;
+          } catch (IOException e) {
+            if (retryCounter.shouldRetry()) {
+              getLogger().warn("Retrying restore of " + tableName + " from " + snapshot.getName()
+                + " after exception", e);
+              retryCounter.sleepUntilNextRetry();
+            } else {
+              throw e;
+            }
+          }
+        }
+      } catch (IOException e) {
+        getLogger().warn("Failed to restore " + tableName + " from " + snapshot.getName(), e);
+      } finally {
+        try {
+          admin.deleteSnapshot(snapshot.getName());
+        } catch (IOException e) {
+          getLogger().warn("Failed to delete recovery snapshot " + snapshot.getName());
+        }
+      }
+    } else {
+      getLogger().warn("No recovery snapshots found for " + tableName);
+    }
+  }
+
+}

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/TruncateAndRecoverTableAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/TruncateAndRecoverTableAction.java
@@ -1,0 +1,100 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.chaos.actions;
+
+import java.io.IOException;
+import java.util.Comparator;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.SnapshotDescription;
+import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.hadoop.hbase.util.RetryCounter.RetryConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Action that truncates a table and then recovers it from the recovery snapshot, if available. If a
+ * recovery snapshot is not available it will simply truncate the table and log a warning. After
+ * recovering from the found recovery snapshot it will delete the recovery snapshot.
+ */
+public class TruncateAndRecoverTableAction extends TruncateTableAction {
+  private static final Logger LOG = LoggerFactory.getLogger(TruncateAndRecoverTableAction.class);
+  protected Pattern snapshotNamePattern;
+
+  public TruncateAndRecoverTableAction(TableName tableName) {
+    super(tableName);
+    snapshotNamePattern = Pattern.compile(tableName.getNameAsString() + "_TruncateTable_[0-9]+");
+  }
+
+  @Override
+  protected Logger getLogger() {
+    return LOG;
+  }
+
+  @Override
+  public void perform() throws Exception {
+    // Truncate the table
+    super.perform();
+
+    // Now try to recover from that action
+    List<SnapshotDescription> snapshots = admin.listSnapshots(snapshotNamePattern);
+    if (!snapshots.isEmpty()) {
+      // It's possible due to various event sequences under chaos that we have more than one
+      // recovery snapshot for the table even though we are trying to clean up. The most
+      // recent snapshot is almost certainly ours.
+      snapshots.sort(new Comparator<SnapshotDescription>() {
+        @Override
+        public int compare(SnapshotDescription o1, SnapshotDescription o2) {
+          // Reversed order by name, so we get the most recent
+          return o2.getName().compareTo(o1.getName());
+        }
+      });
+      SnapshotDescription snapshot = snapshots.get(0);
+      try {
+        // We might need to retry this because of ambient chaos
+        RetryCounter retryCounter = new RetryCounter(new RetryConfig().setMaxAttempts(10));
+        while (true) {
+          try {
+            DeleteAndRecoverTableAction.restoreTable(context, tableName, snapshot);
+            break;
+          } catch (IOException e) {
+            if (retryCounter.shouldRetry()) {
+              getLogger().warn("Retrying restore of " + tableName + " from " + snapshot.getName()
+                + " after exception", e);
+              retryCounter.sleepUntilNextRetry();
+            } else {
+              throw e;
+            }
+          }
+        }
+      } catch (IOException e) {
+        getLogger().warn("Failed to restore " + tableName + " from " + snapshot.getName(), e);
+      } finally {
+        try {
+          admin.deleteSnapshot(snapshot.getName());
+        } catch (IOException e) {
+          getLogger().warn("Failed to delete recovery snapshot " + snapshot.getName());
+        }
+      }
+    } else {
+      getLogger().warn("No recovery snapshots found for " + tableName);
+    }
+  }
+
+}

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/TruncateTableAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/TruncateTableAction.java
@@ -29,10 +29,11 @@ import org.slf4j.LoggerFactory;
  */
 public class TruncateTableAction extends Action {
   private static final Logger LOG = LoggerFactory.getLogger(TruncateTableAction.class);
-  private final TableName tableName;
+  protected final TableName tableName;
+  protected Admin admin;
 
-  public TruncateTableAction(String tableName) {
-    this.tableName = TableName.valueOf(tableName);
+  public TruncateTableAction(TableName tableName) {
+    this.tableName = tableName;
   }
 
   @Override
@@ -43,7 +44,7 @@ public class TruncateTableAction extends Action {
   @Override
   public void perform() throws Exception {
     HBaseTestingUtil util = context.getHBaseIntegrationTestingUtility();
-    Admin admin = util.getAdmin();
+    admin = util.getAdmin();
 
     // Don't try the truncate if we're stopping
     if (context.isStopping()) {

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/factories/DestructiveSchemaActionsMonkeyFactory.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/factories/DestructiveSchemaActionsMonkeyFactory.java
@@ -1,0 +1,83 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.chaos.factories;
+
+import org.apache.hadoop.hbase.chaos.actions.Action;
+import org.apache.hadoop.hbase.chaos.actions.AddColumnAction;
+import org.apache.hadoop.hbase.chaos.actions.DeleteAndRecoverTableAction;
+import org.apache.hadoop.hbase.chaos.actions.DumpClusterStatusAction;
+import org.apache.hadoop.hbase.chaos.actions.GracefulRollingRestartRsAction;
+import org.apache.hadoop.hbase.chaos.actions.MergeRandomAdjacentRegionsOfTableAction;
+import org.apache.hadoop.hbase.chaos.actions.MoveRandomRegionOfTableAction;
+import org.apache.hadoop.hbase.chaos.actions.MoveRegionsOfTableAction;
+import org.apache.hadoop.hbase.chaos.actions.RemoveColumnAction;
+import org.apache.hadoop.hbase.chaos.actions.RemoveColumnAndRecoverAction;
+import org.apache.hadoop.hbase.chaos.actions.RestartRandomRsAction;
+import org.apache.hadoop.hbase.chaos.actions.SplitRandomRegionOfTableAction;
+import org.apache.hadoop.hbase.chaos.actions.TruncateAndRecoverTableAction;
+import org.apache.hadoop.hbase.chaos.actions.TruncateTableAction;
+import org.apache.hadoop.hbase.chaos.monkies.ChaosMonkey;
+import org.apache.hadoop.hbase.chaos.monkies.PolicyBasedChaosMonkey;
+import org.apache.hadoop.hbase.chaos.policies.CompositeSequentialPolicy;
+import org.apache.hadoop.hbase.chaos.policies.DoActionsOncePolicy;
+import org.apache.hadoop.hbase.chaos.policies.PeriodicRandomActionPolicy;
+
+public class DestructiveSchemaActionsMonkeyFactory extends MonkeyFactory {
+
+  private long gracefulRollingRestartTSSLeepTime;
+
+  @Override
+  public ChaosMonkey build() {
+    loadProperties();
+
+    // Actions that could prevent snapshotting
+    // These could also get regions stuck if there are issues.
+    Action[] actions1 = new Action[] { new SplitRandomRegionOfTableAction(tableName),
+      new MergeRandomAdjacentRegionsOfTableAction(tableName),
+      new MoveRegionsOfTableAction(MonkeyConstants.DEFAULT_MOVE_REGIONS_SLEEP_TIME, 1600,
+        tableName),
+      new MoveRandomRegionOfTableAction(MonkeyConstants.DEFAULT_MOVE_RANDOM_REGION_SLEEP_TIME,
+        tableName),
+      new RestartRandomRsAction(MonkeyConstants.DEFAULT_RESTART_RANDOM_RS_SLEEP_TIME),
+      new GracefulRollingRestartRsAction(gracefulRollingRestartTSSLeepTime), };
+
+    // Actions that mutate table schema and cause destructive actions
+    // Actions that roll back table state to recovery snapshots
+    Action[] actions2 =
+      new Action[] { new AddColumnAction(tableName), new DeleteAndRecoverTableAction(tableName),
+        new RemoveColumnAndRecoverAction(tableName, columnFamilies),
+        new RemoveColumnAction(tableName, columnFamilies),
+        new TruncateAndRecoverTableAction(tableName), new TruncateTableAction(tableName), };
+
+    // Action to log more info for debugging
+    Action[] actions3 = new Action[] { new DumpClusterStatusAction() };
+
+    return new PolicyBasedChaosMonkey(properties, util,
+      new PeriodicRandomActionPolicy(90 * 1000, actions1),
+      new CompositeSequentialPolicy(new DoActionsOncePolicy(90 * 1000, actions2),
+        new PeriodicRandomActionPolicy(90 * 1000, actions2)),
+      new PeriodicRandomActionPolicy(90 * 1000, actions3));
+  }
+
+  private void loadProperties() {
+    gracefulRollingRestartTSSLeepTime =
+      Long.parseLong(this.properties.getProperty(MonkeyConstants.GRACEFUL_RESTART_RS_SLEEP_TIME,
+        MonkeyConstants.DEFAULT_GRACEFUL_RESTART_RS_SLEEP_TIME + ""));
+  }
+
+}

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
@@ -77,6 +77,7 @@ enum ModifyTableState {
   MODIFY_TABLE_CLOSE_EXCESS_REPLICAS = 8;
   MODIFY_TABLE_ASSIGN_NEW_REPLICAS = 9;
   MODIFY_TABLE_SYNC_ERASURE_CODING_POLICY = 10;
+  MODIFY_TABLE_SNAPSHOT = 11;
 }
 
 message ModifyTableStateData {
@@ -86,6 +87,7 @@ message ModifyTableStateData {
   required bool delete_column_family_in_modify = 4;
   optional bool should_check_descriptor = 5;
   optional bool reopen_regions = 6;
+  optional string snapshot_name = 7;
 }
 
 enum TruncateTableState {
@@ -96,6 +98,7 @@ enum TruncateTableState {
   TRUNCATE_TABLE_ADD_TO_META = 5;
   TRUNCATE_TABLE_ASSIGN_REGIONS = 6;
   TRUNCATE_TABLE_POST_OPERATION = 7;
+  TRUNCATE_TABLE_SNAPSHOT = 8;
 }
 
 message TruncateTableStateData {
@@ -104,6 +107,7 @@ message TruncateTableStateData {
   optional TableName table_name = 3;
   optional TableSchema table_schema = 4;
   repeated RegionInfo region_info = 5;
+  optional string snapshot_name = 6;
 }
 
 enum TruncateRegionState {
@@ -112,6 +116,11 @@ enum TruncateRegionState {
   TRUNCATE_REGION_REMOVE = 3;
   TRUNCATE_REGION_MAKE_ONLINE = 4;
   TRUNCATE_REGION_POST_OPERATION = 5;
+  TRUNCATE_REGION_SNAPSHOT = 6;
+}
+
+message TruncateRegionStateData {
+  optional string snapshot_name = 1;
 }
 
 enum DeleteTableState {
@@ -121,12 +130,14 @@ enum DeleteTableState {
   DELETE_TABLE_UPDATE_DESC_CACHE = 4;
   DELETE_TABLE_UNASSIGN_REGIONS = 5;
   DELETE_TABLE_POST_OPERATION = 6;
+  DELETE_TABLE_SNAPSHOT = 7;
 }
 
 message DeleteTableStateData {
   required UserInformation user_info = 1;
   required TableName table_name = 2;
   repeated RegionInfo region_info = 3;
+  optional string snapshot_name = 4;
 }
 
 enum CreateNamespaceState {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/AbstractSnapshottingStateMachineRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/AbstractSnapshottingStateMachineRegionProcedure.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.procedure2.ProcedureStateSerializer;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos;
+
+@InterfaceAudience.Private
+public abstract class AbstractSnapshottingStateMachineRegionProcedure<TState>
+  extends AbstractSnapshottingStateMachineTableProcedure<TState> {
+  private RegionInfo hri;
+
+  protected AbstractSnapshottingStateMachineRegionProcedure(MasterProcedureEnv env, RegionInfo hri,
+    ProcedurePrepareLatch latch) {
+    super(env, latch);
+    this.hri = hri;
+  }
+
+  protected AbstractSnapshottingStateMachineRegionProcedure() {
+    // Required by the Procedure framework to create the procedure on replay
+    super();
+  }
+
+  /** Returns The RegionInfo of the region we are operating on. */
+  public RegionInfo getRegion() {
+    return this.hri;
+  }
+
+  /**
+   * Used when deserializing. Otherwise, DON'T TOUCH IT!
+   */
+  protected void setRegion(final RegionInfo hri) {
+    this.hri = hri;
+  }
+
+  @Override
+  public TableName getTableName() {
+    return getRegion().getTable();
+  }
+
+  @Override
+  public abstract TableOperationType getTableOperationType();
+
+  @Override
+  public void toStringClassDetails(final StringBuilder sb) {
+    super.toStringClassDetails(sb);
+    sb.append(", region=").append(getRegion().getShortNameToLog());
+  }
+
+  @Override
+  protected boolean holdLock(MasterProcedureEnv env) {
+    return true;
+  }
+
+  @Override
+  protected LockState acquireLock(final MasterProcedureEnv env) {
+    if (env.getProcedureScheduler().waitRegions(this, getTableName(), getRegion())) {
+      return LockState.LOCK_EVENT_WAIT;
+    }
+    return LockState.LOCK_ACQUIRED;
+  }
+
+  @Override
+  protected void releaseLock(final MasterProcedureEnv env) {
+    env.getProcedureScheduler().wakeRegions(this, getTableName(), getRegion());
+  }
+
+  protected void setFailure(Throwable cause) {
+    super.setFailure(getClass().getSimpleName(), cause);
+  }
+
+  @Override
+  protected void serializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    super.serializeStateData(serializer);
+    serializer.serialize(ProtobufUtil.toRegionInfo(getRegion()));
+  }
+
+  @Override
+  protected void deserializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    super.deserializeStateData(serializer);
+    this.hri = ProtobufUtil.toRegionInfo(serializer.deserialize(HBaseProtos.RegionInfo.class));
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/AbstractSnapshottingStateMachineTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/AbstractSnapshottingStateMachineTableProcedure.java
@@ -1,0 +1,306 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.apache.hadoop.hbase.procedure2.ProcedureUtil.DEFAULT_PROCEDURE_RETRY_MAX_SLEEP_TIME_MS;
+import static org.apache.hadoop.hbase.procedure2.ProcedureUtil.DEFAULT_PROCEDURE_RETRY_SLEEP_INTERVAL_MS;
+import static org.apache.hadoop.hbase.procedure2.ProcedureUtil.PROCEDURE_RETRY_MAX_SLEEP_TIME_MS;
+import static org.apache.hadoop.hbase.procedure2.ProcedureUtil.PROCEDURE_RETRY_SLEEP_INTERVAL_MS;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableState;
+import org.apache.hadoop.hbase.master.MasterCoprocessorHost;
+import org.apache.hadoop.hbase.master.MasterServices;
+import org.apache.hadoop.hbase.master.snapshot.DisabledTableSnapshotHandler;
+import org.apache.hadoop.hbase.master.snapshot.EnabledTableSnapshotHandler;
+import org.apache.hadoop.hbase.master.snapshot.SnapshotManager;
+import org.apache.hadoop.hbase.master.snapshot.TakeSnapshotHandler;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
+import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
+import org.apache.hadoop.hbase.snapshot.SnapshotDoesNotExistException;
+import org.apache.hadoop.hbase.snapshot.SnapshotTTLExpiredException;
+import org.apache.hadoop.hbase.snapshot.UnknownSnapshotException;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hbase.util.ReflectionUtils;
+import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.hadoop.hbase.util.RetryCounter.BackoffPolicy;
+import org.apache.hadoop.hbase.util.RetryCounter.RetryConfig;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ProcedureProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos.SnapshotDescription;
+
+@InterfaceAudience.Private
+public abstract class AbstractSnapshottingStateMachineTableProcedure<TState>
+  extends AbstractStateMachineTableProcedure<TState> {
+
+  /** If true, snapshot the table before making a destructive schema change. */
+  public static final String SNAPSHOT_BEFORE_DELETE_ENABLED_KEY =
+    "hbase.snapshot.before.delete.enabled";
+  public static final boolean SNAPSHOT_BEFORE_DELETE_ENABLED_DEFAULT = false;
+
+  /** TTL for snapshots taken before a destructive schema change, in seconds, default 86400. */
+  public static final String SNAPSHOT_BEFORE_DELETE_TTL_KEY = "hbase.snapshot.before.delete.ttl";
+  public static final int SNAPSHOT_BEFORE_DELETE_TTL_DEFAULT = 86400;
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(AbstractSnapshottingStateMachineTableProcedure.class);
+
+  private MasterProcedureEnv env;
+  private boolean isSnapshotEnabled;
+  private long snapshotTtl;
+  private RetryCounter retryCounter;
+  private long retrySleepTime;
+  private long retryMaxAttempts;
+  private String snapshotName;
+  private TakeSnapshotHandler snapshotHandler;
+
+  public AbstractSnapshottingStateMachineTableProcedure() {
+    super();
+  }
+
+  public AbstractSnapshottingStateMachineTableProcedure(MasterProcedureEnv env,
+    ProcedurePrepareLatch latch) {
+    super(env, latch);
+    this.env = env;
+    Configuration conf = env.getMasterConfiguration();
+    snapshotTtl = conf.getLong(SNAPSHOT_BEFORE_DELETE_TTL_KEY, SNAPSHOT_BEFORE_DELETE_TTL_DEFAULT);
+    retrySleepTime =
+      conf.getLong(PROCEDURE_RETRY_SLEEP_INTERVAL_MS, DEFAULT_PROCEDURE_RETRY_SLEEP_INTERVAL_MS);
+    retryMaxAttempts =
+      conf.getLong(PROCEDURE_RETRY_MAX_SLEEP_TIME_MS, DEFAULT_PROCEDURE_RETRY_MAX_SLEEP_TIME_MS)
+        / retrySleepTime;
+    try {
+      env.getMasterServices().getSnapshotManager().checkSnapshotSupport();
+      // If we got past checkSnapshotSupport then we are capable of taking snapshots
+      isSnapshotEnabled =
+        conf.getBoolean(SNAPSHOT_BEFORE_DELETE_ENABLED_KEY, SNAPSHOT_BEFORE_DELETE_ENABLED_DEFAULT);
+    } catch (UnsupportedOperationException e) {
+      isSnapshotEnabled = false;
+    }
+  }
+
+  protected boolean isSnapshotEnabled() {
+    return isSnapshotEnabled;
+  }
+
+  protected String getSnapshotName() {
+    return snapshotName;
+  }
+
+  // Used by tests
+  protected void setSnapshotName(String snapshotName) {
+    this.snapshotName = snapshotName;
+  }
+
+  // Used by tests
+  protected void setSnapshotHandler(Class<? extends TakeSnapshotHandler> clazz,
+    SnapshotDescription snapshot) {
+    this.snapshotHandler = ReflectionUtils.newInstance(clazz, snapshot, env.getMasterServices(),
+      env.getMasterServices().getSnapshotManager());
+  }
+
+  protected void takeSnapshot() throws ProcedureSuspendedException, IOException {
+    if (getTableName() == null) {
+      throw new NullPointerException("Cannot take snapshot because tableName is null");
+    }
+    long now = EnvironmentEdgeManager.currentTime();
+    // Make the snapshot name if one has not been set
+    if (snapshotName == null) {
+      StringBuilder sb = new StringBuilder();
+      sb.append("auto_");
+      sb.append(getTableName());
+      sb.append("_");
+      sb.append(now);
+      snapshotName = sb.toString();
+    }
+    // Make the snapshot description
+    SnapshotDescription snapshot = SnapshotDescription.newBuilder().setName(snapshotName)
+      .setCreationTime(now).setVersion(SnapshotDescriptionUtils.SNAPSHOT_LAYOUT_VERSION)
+      .setTable(getTableName().getNameAsString()).setTtl(snapshotTtl)
+      .setType(SnapshotDescription.Type.FLUSH).build();
+    takeSnapshot(snapshot);
+  }
+
+  // Used by tests
+  protected void takeSnapshot(SnapshotDescription snapshot)
+    throws ProcedureSuspendedException, IOException {
+    SnapshotManager snapshotManager = env.getMasterServices().getSnapshotManager();
+    boolean isDone;
+    try {
+      // isSnapshotDone will return true if the snapshot is completed and ready, false otherwise.
+      // It will also throw an HBaseSnapshotException if the snapshot failed, which is what we
+      // want, so this failure can propagate and fail the procedure execution.
+      isDone = snapshotManager.isSnapshotDone(snapshot);
+      LOG.debug("isSnapshotDone returns {}", isDone);
+    } catch (UnknownSnapshotException e) {
+      // We may not have requested the snapshot yet.
+      LOG.debug("isSnapshotDone throws UnknownSnapshotException, we have not requested it yet");
+      isDone = false;
+    } catch (IOException e) {
+      LOG.debug("isSnapshotDone throws an exception indicating a snapshotting failure", e);
+      throw e; // rethrow
+    }
+    if (!isDone) {
+      // A snapshot may be running on the table. It is either ours or someone else's but either way
+      // we can handle it using the same logic.
+      if (snapshotManager.isTakingSnapshot(getTableName())) {
+        LOG.debug("Snapshot is in progress for table {}", getTableName());
+      } else {
+        // Our snapshot is not in completed state and no snapshot is running on the table. This
+        // means we haven't made the request yet and need to do that now.
+        LOG.info("Taking recovery snapshot {} on {}", snapshotName, getTableName());
+        // We bypass the main entry point for SnapshotManager's take snapshot function in order
+        // to supply a custom snapshot handler that avoids taking an exclusive lock on the table.
+        // We already are holding the exclusive lock so that wouldn't work. So now we must upcall
+        // to any coprocessors registered on the snapshot hook to preserve that semantic. This
+        // should be refactored.
+        // prepareWorkingDirectory prepares the working directory for the snapshot. We must call
+        // this first.
+        snapshotManager.prepareWorkingDirectory(snapshot);
+        // call pre coproc hook
+        TableDescriptor desc = null;
+        MasterCoprocessorHost cpHost = env.getMasterCoprocessorHost();
+        MasterServices masterServices = env.getMasterServices();
+        org.apache.hadoop.hbase.client.SnapshotDescription snapshotPOJO = null;
+        if (cpHost != null) {
+          snapshotPOJO = ProtobufUtil.createSnapshotDesc(snapshot);
+          cpHost.preSnapshot(snapshotPOJO, desc, null);
+        }
+        if (snapshotHandler == null) {
+          TableState state = masterServices.getTableStateManager().getTableState(getTableName());
+          if (state.isEnabled()) {
+            snapshotHandler =
+              new NoLockEnabledTableSnapshotHandler(snapshot, masterServices, snapshotManager);
+          } else {
+            snapshotHandler =
+              new NoLockDisabledTableSnapshotHandler(snapshot, masterServices, snapshotManager);
+          }
+        }
+        snapshotManager.snapshotTable(snapshot, snapshotHandler);
+        // call post coproc hook
+        if (cpHost != null) {
+          cpHost.postSnapshot(snapshotPOJO, desc, null);
+        }
+      }
+      // If we have come back from suspension a retryCounter exists and is in progress.
+      if (retryCounter == null) {
+        // If we are suspending for the first time create the retry counter.
+        RetryConfig retryConfig = new RetryConfig().setMaxAttempts((int) retryMaxAttempts)
+          .setSleepInterval(retrySleepTime).setBackoffPolicy(new BackoffPolicy());
+        retryCounter = new RetryCounter(retryConfig);
+      }
+      // If we cannot wait any longer for the snapshot we need to fail the procedure.
+      if (!retryCounter.shouldRetry()) {
+        String message = "Retries exceeded waiting for recovery snapshot on " + getTableName();
+        LOG.warn(message);
+        retryCounter = null;
+        throw new DoNotRetryIOException(message);
+      }
+      // Suspend the procedure for the time calculated by the retry counter.
+      long backoff = retryCounter.getBackoffTimeAndIncrementAttempts();
+      LOG.debug("Yielding for recovery snapshot {} on {}, suspend {} ms", snapshotName,
+        getTableName(), backoff);
+      throw suspend(Math.toIntExact(backoff), true);
+    } else {
+      // A snapshot with our name is complete.
+      LOG.info("Recovery snapshot {} completed for {} with ttl {} seconds", snapshotName,
+        getTableName(), snapshotTtl);
+      retryCounter = null; // We are finished with the retry counter, clean it up
+    }
+  }
+
+  protected void deleteSnapshot() {
+    // No snapshot to delete if snapshot name is not found in state. This is weird but not a fatal
+    // problem.
+    if (snapshotName == null) {
+      LOG.warn("Cannot delete snapshot because snapshotName is null. This is probably a bug.");
+      return;
+    }
+    SnapshotManager snapshotManager = env.getMasterServices().getSnapshotManager();
+    SnapshotDescription snapshot = SnapshotDescription.newBuilder().setName(snapshotName).build();
+    try {
+      LOG.info("Deleting recovery snapshot {} on {}", snapshotName, getTableName());
+      snapshotManager.deleteSnapshot(snapshot);
+    } catch (SnapshotDoesNotExistException e) {
+      LOG.debug("No recovery snapshot {} on {}, nothing to do", snapshotName, getTableName());
+    } catch (SnapshotTTLExpiredException e) {
+      LOG.debug("Expired recovery snapshot {} on {}, nothing to do", snapshotName, getTableName());
+    } catch (IOException e) {
+      // Some filesystem level failure occurred while deleting the snapshot but we should not fail
+      // the rollback over this. Warn about it. If there is garbage in the fs the operator will
+      // need to clean it up.
+      LOG.warn(
+        "Exception while deleting recovery snapshot " + snapshotName + " on " + getTableName(), e);
+    }
+  }
+
+  @Override
+  protected synchronized boolean setTimeoutFailure(MasterProcedureEnv env) {
+    // We request ourselves suspended by throwing a ProcedureSuspendedException from yield() with a
+    // timeout. When that timeout elapses the procedure framework will call this method. We need to
+    // mark ourselves runnable and insert ourselves at the front of the queue in order to resume.
+    setState(ProcedureProtos.ProcedureState.RUNNABLE);
+    env.getProcedureScheduler().addFront(this);
+    return false;
+  }
+
+  public static class NoLockEnabledTableSnapshotHandler extends EnabledTableSnapshotHandler {
+
+    public NoLockEnabledTableSnapshotHandler(SnapshotDescription snapshot,
+      MasterServices masterServices, SnapshotManager snapshotManager) throws IOException {
+      super(snapshot, masterServices, snapshotManager);
+    }
+
+    @Override
+    public NoLockEnabledTableSnapshotHandler prepare() throws IOException {
+      // We skip acquiring this.tableLock, which is constructed as an exclusive lock on the table,
+      // because we already have an exclusive lock on the table. This works and is safe because any
+      // release() calls on the lock are a no-op if it is never taken.
+      // So the only thing we need to do is load the table descriptor.
+      this.htd = loadTableDescriptor(); // check that .tableinfo is present
+      return this;
+    }
+
+  }
+
+  public static class NoLockDisabledTableSnapshotHandler extends DisabledTableSnapshotHandler {
+
+    public NoLockDisabledTableSnapshotHandler(SnapshotDescription snapshot,
+      MasterServices masterServices, SnapshotManager snapshotManager) throws IOException {
+      super(snapshot, masterServices, snapshotManager);
+    }
+
+    @Override
+    public NoLockDisabledTableSnapshotHandler prepare() throws IOException {
+      // We skip acquiring this.tableLock, which is constructed as an exclusive lock on the table,
+      // because we already have an exclusive lock on the table. This works and is safe because any
+      // release() calls on the lock are a no-op if it is never taken.
+      // So the only thing we need to do is load the table descriptor.
+      this.htd = loadTableDescriptor(); // check that .tableinfo is present
+      return this;
+    }
+  }
+
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/SnapshotManager.java
@@ -653,7 +653,7 @@ public class SnapshotManager extends MasterProcedureManager implements Stoppable
    * @param snapshot the snapshot description
    * @param handler  the snapshot handler
    */
-  private synchronized void snapshotTable(SnapshotDescription snapshot,
+  public synchronized void snapshotTable(SnapshotDescription snapshot,
     final TakeSnapshotHandler handler) throws IOException {
     try {
       handler.prepare();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/snapshot/TakeSnapshotHandler.java
@@ -146,7 +146,7 @@ public abstract class TakeSnapshotHandler extends EventHandler
       conf.getLong(HBASE_RPC_TIMEOUT_KEY, DEFAULT_HBASE_RPC_TIMEOUT));
   }
 
-  private TableDescriptor loadTableDescriptor() throws IOException {
+  protected TableDescriptor loadTableDescriptor() throws IOException {
     TableDescriptor htd = this.master.getTableDescriptors().get(snapshotTable);
     if (htd == null) {
       throw new IOException("TableDescriptor missing for " + snapshotTable);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestDeleteTableProcedureWithSnapshot.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestDeleteTableProcedureWithSnapshot.java
@@ -1,0 +1,313 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotFoundException;
+import org.apache.hadoop.hbase.master.MasterServices;
+import org.apache.hadoop.hbase.master.procedure.AbstractSnapshottingStateMachineTableProcedure.NoLockDisabledTableSnapshotHandler;
+import org.apache.hadoop.hbase.master.snapshot.SnapshotManager;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.snapshot.UnknownSnapshotException;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos.DeleteTableState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos.SnapshotDescription;
+
+@Category({ MasterTests.class, MediumTests.class })
+public class TestDeleteTableProcedureWithSnapshot extends TestSnapshottingTableDDLProcedureBase {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestDeleteTableProcedureWithSnapshot.class);
+
+  @Rule
+  public TestName name = new TestName();
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestDeleteTableProcedureWithSnapshot.class);
+
+  @Test
+  public void testDeleteNotExistentTable() throws Exception {
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    DeleteTableProcedure proc =
+      new DeleteTableProcedure(procExec.getEnvironment(), tableName, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    try {
+      latch.await();
+      fail("TableNotFoundException not thrown");
+    } catch (TableNotFoundException e) {
+      // Expected
+    } catch (IOException e) {
+      LOG.error("Unexpected IOException", e);
+      fail("Unexpected exception");
+    }
+    // We failed in preflight, there should be no recovery snapshot
+    assertSnapshotAbsent(snapshotName);
+  }
+
+  @Test
+  public void testDelete() throws Exception {
+    final String cf1 = "cf1";
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    DeleteTableProcedure proc =
+      new DeleteTableProcedure(procExec.getEnvironment(), tableName, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Delete table procedure requires the table to be disabled
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    // Execute the procedure
+    LOG.info("Submitting DeleteTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // Validate that the table was deleted
+    MasterProcedureTestingUtility.validateTableDeletion(getMaster(), tableName);
+    // There should be a recovery snapshot
+    assertSnapshotExists(snapshotName);
+    // The recovery snapshot should have the correct TTL
+    assertSnapshotHasTtl(snapshotName, ttlForTest);
+  }
+
+  @Test
+  public void testDeleteSnapshotRollback() throws Exception {
+    final String cf1 = "cf1";
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later.
+    // FaultyDeleteTableProcedure faults in DELETE_TABLE_SNAPSHOT, triggering rollback from that
+    // state.
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    DeleteTableProcedure proc =
+      new FaultyDeleteTableProcedure(procExec.getEnvironment(), tableName, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Delete table procedure requires the table to be disabled
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    // Execute the procedure
+    LOG.info("Submitting FaultyDeleteTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    try {
+      latch.await();
+    } catch (IOException e) {
+      // Expected
+    }
+    // We should have aborted and rolled back the DeleteTableProcedure
+    // The table exists and is still disabled
+    MasterProcedureTestingUtility.validateTableIsDisabled(getMaster(), tableName);
+    // It should be possible to enable it
+    LOG.info("Enabling {}", tableName);
+    UTIL.getAdmin().enableTable(tableName);
+    // Rollback should have deleted the snapshot
+    assertSnapshotAbsent(snapshotName);
+  }
+
+  @Test
+  public void testRecoveryAfterDelete() throws Exception {
+    final String cf1 = "cf1";
+    final int rows = 100;
+    // Create the test table
+    final TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Load data
+    insertData(tableName, rows, 1, cf1);
+    assertEquals("Table load failed", rows, countRows(tableName, cf1));
+    // Prepare the procedure and set a snapshot name for testing that we will check for later.
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    DeleteTableProcedure proc =
+      new DeleteTableProcedure(procExec.getEnvironment(), tableName, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Delete table procedure requires the table to be disabled
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    // Execute the procedure
+    LOG.info("Submitting DeleteTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // Validate that the table was deleted
+    MasterProcedureTestingUtility.validateTableDeletion(getMaster(), tableName);
+    // There should be a recovery snapshot
+    assertSnapshotExists(snapshotName);
+    // Restore the table
+    LOG.info("Restoring {} from {}", tableName, snapshotName);
+    UTIL.getAdmin().restoreSnapshot(snapshotName, false);
+    // The data should have been restored
+    assertEquals("Restore from snapshot failed", rows, countRows(tableName, cf1));
+  }
+
+  @Test
+  public void testDeleteWithSlowSnapshot() throws Exception {
+    final String cf1 = "cf1";
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    DeleteTableProcedure proc =
+      new SlowSnapshotDeleteTableProcedure(procExec.getEnvironment(), tableName, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Delete table procedure requires the table to be disabled
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    // Execute the procedure
+    LOG.info("Submitting DeleteTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // Validate that the table was deleted
+    MasterProcedureTestingUtility.validateTableDeletion(getMaster(), tableName);
+    // There should be a recovery snapshot
+    assertSnapshotExists(snapshotName);
+    // The recovery snapshot should have the correct TTL
+    assertSnapshotHasTtl(snapshotName, ttlForTest);
+  }
+
+  /**
+   * A DeleteTableProcedure for testing that will throw an exception at the end of the
+   * DELETE_STATE_SNAPSHOT state processing just after the snapshot is completed, so we can test
+   * rollback from that state.
+   */
+  public static class FaultyDeleteTableProcedure extends DeleteTableProcedure {
+
+    public FaultyDeleteTableProcedure() {
+      super();
+    }
+
+    public FaultyDeleteTableProcedure(MasterProcedureEnv env, TableName tableName,
+      ProcedurePrepareLatch latch) {
+      super(env, tableName, latch);
+    }
+
+    @Override
+    protected Flow executeFromState(final MasterProcedureEnv env, DeleteTableState state)
+      throws InterruptedException, ProcedureSuspendedException {
+      switch (state) {
+        case DELETE_TABLE_SNAPSHOT:
+          SnapshotDescription snapshot =
+            SnapshotDescription.newBuilder().setName(getSnapshotName()).build();
+          boolean isDone;
+          try {
+            isDone = env.getMasterServices().getSnapshotManager().isSnapshotDone(snapshot);
+          } catch (UnknownSnapshotException e) {
+            isDone = false;
+          } catch (IOException e) {
+            // Unexpected IOException
+            LOG.error("Unexpected exception", e);
+            throw new RuntimeException(e);
+          }
+          // Situation normal until we've taken the snapshot
+          if (!isDone) {
+            return super.executeFromState(env, state);
+          } else {
+            throw new RuntimeException("Injected fault");
+          }
+        default:
+          return super.executeFromState(env, state);
+      }
+    }
+  }
+
+  /**
+   * A DeleteTableProcedure that will pause for 10 seconds during snapshot execution, to simulate
+   * the taking of a snapshot that requires some time to complete.
+   */
+  public static class SlowSnapshotDeleteTableProcedure extends DeleteTableProcedure {
+
+    public SlowSnapshotDeleteTableProcedure() {
+      super();
+    }
+
+    public SlowSnapshotDeleteTableProcedure(MasterProcedureEnv env, TableName tableName,
+      ProcedurePrepareLatch latch) {
+      super(env, tableName, latch);
+    }
+
+    @Override
+    protected void takeSnapshot(SnapshotDescription snapshot)
+      throws ProcedureSuspendedException, IOException {
+      // Set our snapshot handler to the test type below that will delay the snapshot for a while.
+      setSnapshotHandler(SlowNoLockDisabledTableSnapshotHandler.class, snapshot);
+      super.takeSnapshot(snapshot);
+    }
+
+  }
+
+  /**
+   * A snapshot handler that will introduce a 10 second delay in process() to simulate the taking of
+   * a snapshot that requires some time to complete.
+   */
+  public static class SlowNoLockDisabledTableSnapshotHandler
+    extends NoLockDisabledTableSnapshotHandler {
+
+    public SlowNoLockDisabledTableSnapshotHandler(SnapshotDescription snapshot,
+      MasterServices masterServices, SnapshotManager snapshotManager) throws IOException {
+      super(snapshot, masterServices, snapshotManager);
+    }
+
+    @Override
+    public void process() {
+      // First, let's sleep 10 seconds. We want to delay the procedure for long enough so it will
+      // go through a few suspend and wakeup cycles.
+      try {
+        Thread.sleep(10 * 1000);
+      } catch (InterruptedException e) {
+        // Restore interrupt status
+        Thread.currentThread().interrupt();
+      }
+      // Then we can let the snapshot handler do its thing
+      super.process();
+    }
+
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestDeleteTableProcedureWithSnapshotDisabled.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestDeleteTableProcedureWithSnapshotDisabled.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.Assert.assertFalse;
+
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category({ MasterTests.class, MediumTests.class })
+public class TestDeleteTableProcedureWithSnapshotDisabled
+  extends TestSnapshottingTableDDLProcedureBase {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestDeleteTableProcedureWithSnapshotDisabled.class);
+
+  @Rule
+  public TestName name = new TestName();
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestDeleteTableProcedureWithSnapshotDisabled.class);
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    UTIL.getConfiguration().setBoolean(
+      AbstractSnapshottingStateMachineTableProcedure.SNAPSHOT_BEFORE_DELETE_ENABLED_KEY, false);
+    TestTableDDLProcedureBase.setupCluster();
+  }
+
+  @Test
+  public void testDeleteWithSnapshotDisabled() throws Exception {
+    assertFalse("SNAPSHOT_BEFORE_DELETE_ENABLED is on", getMaster().getConfiguration().getBoolean(
+      AbstractSnapshottingStateMachineTableProcedure.SNAPSHOT_BEFORE_DELETE_ENABLED_KEY, false));
+    final String cf1 = "cf1";
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Delete table procedure requires the table to be disabled
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    DeleteTableProcedure proc =
+      new DeleteTableProcedure(procExec.getEnvironment(), tableName, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Execute the procedure
+    LOG.info("Submitting DeleteTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // Validate that the table was deleted
+    MasterProcedureTestingUtility.validateTableDeletion(getMaster(), tableName);
+    // Snapshotting is disabled so a recovery snapshot should not exist
+    assertSnapshotAbsent(snapshotName);
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestDisableTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestDisableTableProcedure.java
@@ -104,8 +104,7 @@ public class TestDisableTableProcedure extends TestTableDDLProcedureBase {
     // Disable the table - expect failure from ProcedurePrepareLatch
     try {
       final ProcedurePrepareLatch prepareLatch = new ProcedurePrepareLatch.CompatibilityLatch();
-
-      long procId3 = procExec.submitProcedure(
+      procExec.submitProcedure(
         new DisableTableProcedure(procExec.getEnvironment(), tableName, false, prepareLatch));
       prepareLatch.await();
       Assert.fail("Disable should throw exception through latch.");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedureWithSnapshot.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedureWithSnapshot.java
@@ -1,0 +1,246 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseIOException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.snapshot.UnknownSnapshotException;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos.ModifyTableState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos.SnapshotDescription;
+
+@Category({ MasterTests.class, MediumTests.class })
+public class TestModifyTableProcedureWithSnapshot extends TestSnapshottingTableDDLProcedureBase {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestModifyTableProcedureWithSnapshot.class);
+
+  @Rule
+  public TestName name = new TestName();
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestModifyTableProcedureWithSnapshot.class);
+
+  @Test
+  public void testModifyTableAddCF() throws Exception {
+    final String cf1 = "cf1";
+    final String cf2 = "cf2";
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    List<ColumnFamilyDescriptor> families = new ArrayList<>();
+    families.add(ColumnFamilyDescriptorBuilder.of(cf1));
+    families.add(ColumnFamilyDescriptorBuilder.of(cf2));
+    TableDescriptor newTd =
+      TableDescriptorBuilder.newBuilder(tableName).setColumnFamilies(families).build();
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    ModifyTableProcedure proc = new ModifyTableProcedure(procExec.getEnvironment(), newTd, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Execute the procedure
+    LOG.info("Submitting ModifyTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // Validate that we really did add the CF
+    TableDescriptor currentTd = UTIL.getAdmin().getDescriptor(tableName);
+    assertTrue("cf2 should exist", currentTd.hasColumnFamily(Bytes.toBytes(cf2)));
+    // We did not take a destructive action so there should not be a snapshot
+    assertSnapshotAbsent(snapshotName);
+  }
+
+  @Test
+  public void testModifyTableRemoveCF() throws Exception {
+    final String cf1 = "cf1";
+    final String cf2 = "cf2";
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1, cf2);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    List<ColumnFamilyDescriptor> families = new ArrayList<>();
+    families.add(ColumnFamilyDescriptorBuilder.of(cf1)); // Only cf1, we will drop cf2
+    TableDescriptor newTd =
+      TableDescriptorBuilder.newBuilder(tableName).setColumnFamilies(families).build();
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    ModifyTableProcedure proc = new ModifyTableProcedure(procExec.getEnvironment(), newTd, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Execute the procedure
+    LOG.info("Submitting ModifyTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // Validate that we really did remove the CF
+    TableDescriptor currentTd = UTIL.getAdmin().getDescriptor(tableName);
+    assertFalse("cf2 should not exist", currentTd.hasColumnFamily(Bytes.toBytes(cf2)));
+    // We took a destructive action so there should be a recovery snapshot
+    assertSnapshotExists(snapshotName);
+    // The recovery snapshot should have the correct TTL
+    assertSnapshotHasTtl(snapshotName, ttlForTest);
+  }
+
+  @Test
+  public void testModifyTableRemoveCFSnapshotRollback() throws Exception {
+    final String cf1 = "cf1";
+    final String cf2 = "cf2";
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1, cf2);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later.
+    // FaultyModifyTableProcedure faults in MODIFY_TABLE_SNAPSHOT, triggering rollback from that
+    // state.
+    List<ColumnFamilyDescriptor> families = new ArrayList<>();
+    families.add(ColumnFamilyDescriptorBuilder.of(cf1)); // Only cf1, we will drop cf2
+    TableDescriptor newTd =
+      TableDescriptorBuilder.newBuilder(tableName).setColumnFamilies(families).build();
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    ModifyTableProcedure proc =
+      new FaultyModifyTableProcedure(procExec.getEnvironment(), newTd, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Execute the procedure
+    LOG.info("Submitting FaultyModifyTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    try {
+      latch.await();
+    } catch (Exception e) {
+      // Expected
+    }
+    // We should have aborted and rolled back the ModifyTableProcedure
+    TableDescriptor currentTd = UTIL.getAdmin().getDescriptor(tableName);
+    assertTrue("cf2 should exist", currentTd.hasColumnFamily(Bytes.toBytes(cf2)));
+    // Rollback should have deleted the snapshot
+    assertSnapshotAbsent(snapshotName);
+  }
+
+  @Test
+  public void testRecoveryAfterRemoveCF() throws Exception {
+    final String cf1 = "cf1";
+    final String cf2 = "cf2";
+    final int rows = 100;
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1, cf2);
+    // Load data
+    insertData(tableName, rows, 1, cf1, cf2);
+    assertEquals("Table load failed", rows, countRows(tableName, cf1, cf2));
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    List<ColumnFamilyDescriptor> families = new ArrayList<>();
+    families.add(ColumnFamilyDescriptorBuilder.of(cf1)); // Only cf1, we will drop cf2
+    TableDescriptor newTd =
+      TableDescriptorBuilder.newBuilder(tableName).setColumnFamilies(families).build();
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    ModifyTableProcedure proc = new ModifyTableProcedure(procExec.getEnvironment(), newTd, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Execute the procedure
+    LOG.info("Submitting ModifyTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // Validate that we really did remove the CF
+    TableDescriptor currentTd = UTIL.getAdmin().getDescriptor(tableName);
+    assertFalse("cf2 should not exist", currentTd.hasColumnFamily(Bytes.toBytes(cf2)));
+    // We took a destructive action so there should be a recovery snapshot
+    assertSnapshotExists(snapshotName);
+    // The data in cf2 no longer exists but we should still check cf1
+    assertEquals("Data is also missing from cf1?", rows, countRows(tableName, cf1));
+    // Restore from snapshot
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    LOG.info("Restoring {}", tableName);
+    UTIL.getAdmin().restoreSnapshot(snapshotName, false);
+    // Validate we recovered the data
+    LOG.info("Enabling {}", tableName);
+    UTIL.getAdmin().enableTable(tableName);
+    assertEquals("Restore from snapshot failed", rows, countRows(tableName, cf1));
+  }
+
+  public static class FaultyModifyTableProcedure extends ModifyTableProcedure {
+
+    public FaultyModifyTableProcedure() {
+      super();
+    }
+
+    public FaultyModifyTableProcedure(MasterProcedureEnv env, TableDescriptor descriptor,
+      ProcedurePrepareLatch latch) throws HBaseIOException {
+      super(env, descriptor, latch);
+    }
+
+    @Override
+    protected Flow executeFromState(MasterProcedureEnv env, ModifyTableState state)
+      throws InterruptedException, ProcedureSuspendedException {
+      switch (state) {
+        case MODIFY_TABLE_SNAPSHOT:
+          SnapshotDescription snapshot =
+            SnapshotDescription.newBuilder().setName(getSnapshotName()).build();
+          boolean isDone;
+          try {
+            isDone = env.getMasterServices().getSnapshotManager().isSnapshotDone(snapshot);
+          } catch (UnknownSnapshotException e) {
+            isDone = false;
+          } catch (IOException e) {
+            // Unexpected IOException
+            LOG.error("Unexpected exception", e);
+            throw new RuntimeException(e);
+          }
+          // Situation normal until we've taken the snapshot
+          if (!isDone) {
+            return super.executeFromState(env, state);
+          } else {
+            throw new RuntimeException("Injected fault");
+          }
+        default:
+          return super.executeFromState(env, state);
+      }
+    }
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedureWithSnapshotDisabled.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestModifyTableProcedureWithSnapshotDisabled.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.Assert.assertFalse;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category({ MasterTests.class, MediumTests.class })
+public class TestModifyTableProcedureWithSnapshotDisabled
+  extends TestSnapshottingTableDDLProcedureBase {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestModifyTableProcedureWithSnapshotDisabled.class);
+
+  @Rule
+  public TestName name = new TestName();
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestModifyTableProcedureWithSnapshotDisabled.class);
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    UTIL.getConfiguration().setBoolean(
+      AbstractSnapshottingStateMachineTableProcedure.SNAPSHOT_BEFORE_DELETE_ENABLED_KEY, false);
+    TestTableDDLProcedureBase.setupCluster();
+  }
+
+  @Test
+  public void testModifyTableRemoveCFWithSnapshotDisabled() throws Exception {
+    assertFalse("SNAPSHOT_BEFORE_DELETE_ENABLED is on", getMaster().getConfiguration().getBoolean(
+      AbstractSnapshottingStateMachineTableProcedure.SNAPSHOT_BEFORE_DELETE_ENABLED_KEY, false));
+    final String cf1 = "cf1";
+    final String cf2 = "cf2";
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1, cf2);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    List<ColumnFamilyDescriptor> families = new ArrayList<>();
+    families.add(ColumnFamilyDescriptorBuilder.of(cf1)); // Only cf1, we will drop cf2
+    TableDescriptor newTd =
+      TableDescriptorBuilder.newBuilder(tableName).setColumnFamilies(families).build();
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    ModifyTableProcedure proc = new ModifyTableProcedure(procExec.getEnvironment(), newTd, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Execute the procedure
+    LOG.info("Submitting ModifyTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // Validate that we really did remove the CF
+    TableDescriptor currentTd = UTIL.getAdmin().getDescriptor(tableName);
+    assertFalse("cf2 should not exist", currentTd.hasColumnFamily(Bytes.toBytes(cf2)));
+    // Snapshotting is disabled so a recovery snapshot should not exist
+    assertSnapshotAbsent(snapshotName);
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestSnapshottingTableDDLProcedureBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestSnapshottingTableDDLProcedureBase.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.master.assignment.AssignmentTestingUtil;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.BeforeClass;
+import org.junit.rules.TestName;
+
+public class TestSnapshottingTableDDLProcedureBase extends TestTableDDLProcedureBase {
+
+  protected static final int ttlForTest = 604800; // one week in seconds
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    UTIL.getConfiguration().setBoolean(
+      AbstractSnapshottingStateMachineTableProcedure.SNAPSHOT_BEFORE_DELETE_ENABLED_KEY, true);
+    UTIL.getConfiguration().setInt(
+      AbstractSnapshottingStateMachineTableProcedure.SNAPSHOT_BEFORE_DELETE_TTL_KEY, ttlForTest);
+    TestTableDDLProcedureBase.setupCluster();
+  }
+
+  protected void assertSnapshotAbsent(String snapshotName) throws IOException {
+    boolean found[] = new boolean[] { false };
+    getMaster().getSnapshotManager().getCompletedSnapshots().forEach((desc) -> {
+      if (snapshotName.equals(desc.getName())) {
+        found[0] = true;
+      }
+    });
+    assertFalse("Snapshot " + snapshotName + " should not exist", found[0]);
+  }
+
+  protected void assertSnapshotExists(String snapshotName) throws IOException {
+    boolean found[] = new boolean[] { false };
+    getMaster().getSnapshotManager().getCompletedSnapshots().forEach((desc) -> {
+      if (snapshotName.equals(desc.getName())) {
+        found[0] = true;
+      }
+    });
+    assertTrue("Snapshot " + snapshotName + " should exist", found[0]);
+  }
+
+  protected void assertSnapshotHasTtl(String snapshotName, long ttl) throws IOException {
+    boolean found[] = new boolean[] { false };
+    long foundTtl[] = new long[] { -1 };
+    getMaster().getSnapshotManager().getCompletedSnapshots().forEach((desc) -> {
+      if (snapshotName.equals(desc.getName())) {
+        found[0] = true;
+        foundTtl[0] = desc.getTtl();
+      }
+    });
+    assertTrue("Snapshot " + snapshotName + " should exist", found[0]);
+    assertEquals(
+      "Snapshot " + snapshotName + " has incorrect TTL: want=" + ttl + ", has=" + foundTtl[0], ttl,
+      foundTtl[0]);
+  }
+
+  protected static String makeSnapshotName(TestName name) {
+    return "auto_" + name.getMethodName() + "_" + EnvironmentEdgeManager.currentTime();
+  }
+
+  protected void insertData(TableName tableName, int rows, int startRow, String... cfs)
+    throws IOException {
+    AssignmentTestingUtil.insertData(UTIL, tableName, rows, startRow, cfs);
+  }
+
+  protected int countRows(TableName tableName, String... cfs) throws IOException {
+    Scan scan = new Scan();
+    for (String cf : cfs) {
+      scan.addFamily(Bytes.toBytes(cf));
+    }
+    try (Table t = UTIL.getConnection().getTable(tableName)) {
+      return HBaseTestingUtil.countRows(t, scan);
+    }
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateRegionProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateRegionProcedure.java
@@ -134,9 +134,10 @@ public class TestTruncateRegionProcedure extends TestTableDDLProcedureBase {
       .min((o1, o2) -> Bytes.compareTo(o1.getStartKey(), o2.getStartKey())).get();
 
     // Act - Execute Truncate region procedure
-    long procId =
-      procExec.submitProcedure(new TruncateRegionProcedure(environment, regionToBeTruncated));
-    ProcedureTestingUtility.waitProcedure(procExec, procId);
+    final ProcedurePrepareLatch prepareLatch = new ProcedurePrepareLatch.CompatibilityLatch();
+    procExec
+      .submitProcedure(new TruncateRegionProcedure(environment, regionToBeTruncated, prepareLatch));
+    prepareLatch.await();
     assertEquals(8 - 2, UTIL.countRows(tableName));
 
     int rowsAfterDropRegion = UTIL.countRows(tableName);
@@ -170,10 +171,10 @@ public class TestTruncateRegionProcedure extends TestTableDDLProcedureBase {
       RegionReplicaUtil.getRegionInfoForReplica(regionToBeTruncated, 1);
 
     // Act - Execute Truncate region procedure
-    long procId =
-      procExec.submitProcedure(new TruncateRegionProcedure(environment, replicatedRegionId));
-
-    ProcedureTestingUtility.waitProcedure(procExec, procId);
+    final ProcedurePrepareLatch prepareLatch = new ProcedurePrepareLatch.CompatibilityLatch();
+    long procId = procExec
+      .submitProcedure(new TruncateRegionProcedure(environment, replicatedRegionId, prepareLatch));
+    prepareLatch.await();
     Procedure<MasterProcedureEnv> result = procExec.getResult(procId);
     // Asserts
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateRegionProcedureWithSnapshot.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateRegionProcedureWithSnapshot.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.List;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category({ MasterTests.class, LargeTests.class })
+public class TestTruncateRegionProcedureWithSnapshot extends TestSnapshottingTableDDLProcedureBase {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestTruncateRegionProcedureWithSnapshot.class);
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestTruncateRegionProcedureWithSnapshot.class);
+
+  @Rule
+  public TestName name = new TestName();
+
+  @Test
+  public void testTruncateRegion() throws Exception {
+    final String cf1 = "cf1";
+    final int rows = 100;
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Load data
+    insertData(tableName, rows / 2, 1, cf1);
+    insertData(tableName, rows / 2, 100, cf1);
+    assertEquals("Table load failed", rows, countRows(tableName, cf1));
+    // Split the table
+    LOG.info("Splitting {}", tableName);
+    Admin admin = UTIL.getAdmin();
+    admin.split(tableName, Bytes.toBytes("" + 100));
+    ProcedureTestingUtility.waitNoProcedureRunning(procExec);
+    List<RegionInfo> regions = admin.getRegions(tableName);
+    RegionInfo region = regions.get(0);
+    LOG.info("Submitting TruncateRegionProcedure for {} {}", tableName, region);
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    TruncateRegionProcedure proc =
+      new TruncateRegionProcedure(procExec.getEnvironment(), region, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    procExec.submitProcedure(proc);
+    latch.await();
+    // We should have too few rows now
+    assertNotEquals("Did not truncate the region?", rows, countRows(tableName, cf1));
+    // There should be a recovery snapshot
+    assertSnapshotExists(snapshotName);
+    // The recovery snapshot should have the correct TTL
+    assertSnapshotHasTtl(snapshotName, ttlForTest);
+    // And we should be able to recover
+    LOG.info("Disabling {}", tableName);
+    admin.disableTable(tableName);
+    LOG.info("Restoring {} from {}", tableName, snapshotName);
+    admin.restoreSnapshot(snapshotName, false);
+    LOG.info("Enabling {}", tableName);
+    admin.enableTable(tableName);
+    // The data should have been restored
+    assertEquals("Restore from snapshot failed", rows, countRows(tableName, cf1));
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateTableProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateTableProcedure.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.master.MasterFileSystem;
 import org.apache.hadoop.hbase.procedure2.Procedure;
 import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
 import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
@@ -262,7 +263,8 @@ public class TestTruncateTableProcedure extends TestTableDDLProcedureBase {
 
     @Override
     protected Flow executeFromState(MasterProcedureEnv env,
-      MasterProcedureProtos.TruncateTableState state) throws InterruptedException {
+      MasterProcedureProtos.TruncateTableState state)
+      throws InterruptedException, ProcedureSuspendedException {
 
       if (
         !failOnce

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateTableProcedureWithSnapshot.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateTableProcedureWithSnapshot.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.Assert.assertEquals;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseIOException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.snapshot.UnknownSnapshotException;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos.TruncateTableState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos.SnapshotDescription;
+
+@Category({ MasterTests.class, MediumTests.class })
+public class TestTruncateTableProcedureWithSnapshot extends TestSnapshottingTableDDLProcedureBase {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestTruncateTableProcedureWithSnapshot.class);
+
+  @Rule
+  public TestName name = new TestName();
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestTruncateTableProcedureWithSnapshot.class);
+
+  @Test
+  public void testTruncate() throws Exception {
+    final String cf1 = "cf1";
+    final int rows = 100;
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Load data
+    insertData(tableName, rows, 1, cf1);
+    assertEquals("Table load failed", rows, countRows(tableName, cf1));
+    // Truncate table procedure requires the table to be disabled
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    TruncateTableProcedure proc =
+      new TruncateTableProcedure(procExec.getEnvironment(), tableName, false, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Execute the procedure
+    LOG.info("Submitting TruncateTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // The table should have been truncated
+    assertEquals("Table was not truncated", 0, countRows(tableName, cf1));
+    // There should be a recovery snapshot
+    assertSnapshotExists(snapshotName);
+    // The recovery snapshot should have the correct TTL
+    assertSnapshotHasTtl(snapshotName, ttlForTest);
+  }
+
+  @Test
+  public void testTruncateSnapshotRollback() throws Exception {
+    final String cf1 = "cf1";
+    final int rows = 100;
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Load data
+    insertData(tableName, rows, 1, cf1);
+    assertEquals("Table load failed", rows, countRows(tableName, cf1));
+    // Truncate table procedure requires the table to be disabled
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later.
+    // FaultyTruncateTableProcedure faults in TRUNCATE_TABLE_SNAPSHOT, triggering rollback from
+    // that state.
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    TruncateTableProcedure proc =
+      new FaultyTruncateTableProcedure(procExec.getEnvironment(), tableName, false, latch);
+    String snapshotName = makeSnapshotName(name);
+    // Execute the procedure
+    LOG.info("Submitting FaultyTruncateTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    try {
+      latch.await();
+    } catch (IOException e) {
+      // Expected
+    }
+    // We should have aborted and rolled back the TruncateTableProcedure
+    // The table should not have been truncated
+    UTIL.getAdmin().enableTable(tableName);
+    assertEquals("Table was truncated", rows, countRows(tableName, cf1));
+    // Rollback should have deleted the snapshot
+    assertSnapshotAbsent(snapshotName);
+  }
+
+  @Test
+  public void testRecoveryAfterTruncate() throws Exception {
+    final String cf1 = "cf1";
+    final int rows = 100;
+    // Create the test table
+    final TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Load data
+    insertData(tableName, rows, 1, cf1);
+    assertEquals("Table load failed", rows, countRows(tableName, cf1));
+    // Truncate table procedure requires the table to be disabled
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    // Prepare the procedure and set a snapshot name for testing that we will check for later.
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    TruncateTableProcedure proc =
+      new TruncateTableProcedure(procExec.getEnvironment(), tableName, false, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    // Execute the procedure
+    LOG.info("Submitting TruncateTableProcedure for {}", tableName);
+    ProcedureTestingUtility.submitAndWait(procExec, proc);
+    latch.await();
+    // There should be a recovery snapshot
+    assertSnapshotExists(snapshotName);
+    // The table should have been truncated
+    assertEquals("Table was not truncated", 0, countRows(tableName, cf1));
+    // Restore the table
+    LOG.info("Disabling {}", tableName);
+    UTIL.getAdmin().disableTable(tableName);
+    LOG.info("Restoring snapshot {} for {}", snapshotName, tableName);
+    UTIL.getAdmin().restoreSnapshot(snapshotName, false);
+    LOG.info("Enabling {}", tableName);
+    UTIL.getAdmin().enableTable(tableName);
+    // The data should have been restored
+    assertEquals("Restore from snapshot failed", rows, countRows(tableName, cf1));
+  }
+
+  public static class FaultyTruncateTableProcedure extends TruncateTableProcedure {
+
+    public FaultyTruncateTableProcedure() {
+      super();
+    }
+
+    public FaultyTruncateTableProcedure(MasterProcedureEnv env, TableName tableName,
+      boolean preserveSplits, ProcedurePrepareLatch latch) throws HBaseIOException {
+      super(env, tableName, preserveSplits, latch);
+    }
+
+    @Override
+    protected Flow executeFromState(final MasterProcedureEnv env, TruncateTableState state)
+      throws InterruptedException, ProcedureSuspendedException {
+      switch (state) {
+        case TRUNCATE_TABLE_SNAPSHOT:
+          SnapshotDescription snapshot =
+            SnapshotDescription.newBuilder().setName(getSnapshotName()).build();
+          boolean isDone;
+          try {
+            isDone = env.getMasterServices().getSnapshotManager().isSnapshotDone(snapshot);
+          } catch (UnknownSnapshotException e) {
+            isDone = false;
+          } catch (IOException e) {
+            // Unexpected IOException
+            LOG.error("Unexpected exception", e);
+            throw new RuntimeException(e);
+          }
+          // Situation normal until we've taken the snapshot
+          if (!isDone) {
+            return super.executeFromState(env, state);
+          } else {
+            throw new RuntimeException("Injected fault");
+          }
+        default:
+          return super.executeFromState(env, state);
+      }
+    }
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateTableProcedureWithSnapshotDisabled.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateTableProcedureWithSnapshotDisabled.java
@@ -1,0 +1,96 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.List;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestName;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Category({ MasterTests.class, LargeTests.class })
+public class TestTruncateTableProcedureWithSnapshotDisabled
+  extends TestSnapshottingTableDDLProcedureBase {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestTruncateTableProcedureWithSnapshotDisabled.class);
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestTruncateTableProcedureWithSnapshotDisabled.class);
+
+  @Rule
+  public TestName name = new TestName();
+
+  @BeforeClass
+  public static void setupCluster() throws Exception {
+    UTIL.getConfiguration().setBoolean(
+      AbstractSnapshottingStateMachineTableProcedure.SNAPSHOT_BEFORE_DELETE_ENABLED_KEY, false);
+    TestTableDDLProcedureBase.setupCluster();
+  }
+
+  @Test
+  public void testTruncateRegion() throws Exception {
+    final String cf1 = "cf1";
+    final int rows = 100;
+    // Create the test table
+    TableName tableName = TableName.valueOf(name.getMethodName());
+    ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    LOG.info("Creating {}", tableName);
+    MasterProcedureTestingUtility.createTable(procExec, tableName, null, cf1);
+    // Load data
+    insertData(tableName, rows / 2, 1, cf1);
+    insertData(tableName, rows / 2, 100, cf1);
+    assertEquals("Table load failed", rows, countRows(tableName, cf1));
+    // Split the table
+    LOG.info("Splitting {}", tableName);
+    Admin admin = UTIL.getAdmin();
+    admin.split(tableName, Bytes.toBytes("" + 100));
+    ProcedureTestingUtility.waitNoProcedureRunning(procExec);
+    List<RegionInfo> regions = admin.getRegions(tableName);
+    RegionInfo region = regions.get(0);
+    LOG.info("Submitting TruncateRegionProcedure for {} {}", tableName, region);
+    ProcedurePrepareLatch latch = new ProcedurePrepareLatch.CompatibilityLatch();
+    TruncateRegionProcedure proc =
+      new TruncateRegionProcedure(procExec.getEnvironment(), region, latch);
+    String snapshotName = makeSnapshotName(name);
+    proc.setSnapshotName(snapshotName);
+    procExec.submitProcedure(proc);
+    latch.await();
+    // We should have too few rows now
+    assertNotEquals("Did not truncate the region?", rows, countRows(tableName, cf1));
+    // There should not be a recovery snapshot
+    assertSnapshotAbsent(snapshotName);
+  }
+
+}


### PR DESCRIPTION
Although HFiles are copied to the archive in a destructive schema change, recovery scenarios are not automatic and involve some operator labor to reconstruct the table and re-import the archived data. We can easily prevent the deletion of the HFiles of a deleted table or column family by taking a snapshot of the table immediately prior to any destructive actions. We also set a TTL on the snapshot so housekeeping of unwanted HFiles remains no touch. Because we take a table snapshot all table structure and metadata is also captured and saved so fast recovery is possible, as either a restore from snapshot, or a clone from snapshot to a new table.

Existing site configuration property prerequisites:

* hbase.snapshot.enabled = true ( default is true )

New site configuration properties:

* hbase.snapshot.before.delete.enabled = true ( default is false )
* hbase.snapshot.before.delete.ttl = <integer> , in seconds ( default 86400 (one day) )