### PR TITLE
HBASE-28921 Avoid bundling hbase-webapps folder in default jars

### DIFF
--- a/hbase-rest/pom.xml
+++ b/hbase-rest/pom.xml
@@ -289,6 +289,15 @@
           <skipAssembly>true</skipAssembly>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/hbase-webapps/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <!-- Make a jar and put the sources in the jar -->
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -35,6 +35,8 @@
     <license.bundles.bootstrap>true</license.bundles.bootstrap>
     <license.bundles.jquery>true</license.bundles.jquery>
     <license.bundles.vega>true</license.bundles.vega>
+    <hbase.webapps.dir>target/hbase-webapps</hbase.webapps.dir>
+    <test.classes.webapps.dir>target/test-classes/hbase-webapps</test.classes.webapps.dir>
   </properties>
   <dependencies>
     <dependency>
@@ -439,22 +441,84 @@
       </plugin>
       <plugin>
         <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-resources-plugin</artifactId>
+        <executions>
+          <!-- Copy hbase-webapps from build directory to test classes directory -->
+          <execution>
+            <id>copy-hbase-webapps-to-test</id>
+            <goals>
+              <goal>copy-resources</goal>
+            </goals>
+            <phase>process-test-resources</phase>
+            <configuration>
+              <!-- Output directory for the copied resources -->
+              <outputDirectory>${test.classes.webapps.dir}</outputDirectory>
+              <resources>
+                <resource>
+                  <!-- Directory containing hbase-webapps, which needs to be copied -->
+                  <directory>${hbase.webapps.dir}</directory>
+                  <includes>
+                    <include>**/*</include>
+                  </includes>
+                </resource>
+              </resources>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
         <artifactId>maven-jar-plugin</artifactId>
-        <configuration>
-          <!-- Exclude these 2 packages, because their dependency _binary_ files
-            include the sources, and Maven 2.2 appears to add them to the sources to compile,
-            weird -->
-          <excludes>
-            <exclude>org/apache/jute/**</exclude>
-            <exclude>org/apache/zookeeper/**</exclude>
-            <exclude>**/*.jsp</exclude>
-            <exclude>hbase-site.xml</exclude>
-            <exclude>hdfs-site.xml</exclude>
-            <exclude>log4j.properties</exclude>
-            <exclude>mapred-queues.xml</exclude>
-            <exclude>mapred-site.xml</exclude>
-          </excludes>
-        </configuration>
+        <executions>
+          <!-- Exclude specified file(s) from the default JAR -->
+          <execution>
+            <id>default-jar</id>
+            <goals>
+              <goal>jar</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <excludes>
+                <!-- Exclude these 2 packages, because their dependency _binary_ files
+                include the sources, and Maven 2.2 appears to add them to the sources to compile,
+                weird -->
+                <exclude>org/apache/jute/**</exclude>
+                <exclude>org/apache/zookeeper/**</exclude>
+                <exclude>**/*.jsp</exclude>
+                <exclude>hbase-site.xml</exclude>
+                <exclude>hdfs-site.xml</exclude>
+                <exclude>log4j.properties</exclude>
+                <exclude>mapred-queues.xml</exclude>
+                <exclude>mapred-site.xml</exclude>
+                <!-- NOTE: We have the below exclude only for the default JAR -->
+                <exclude>**/hbase-webapps/**</exclude>
+              </excludes>
+            </configuration>
+          </execution>
+          <!-- Copy of default jar exclusions, minus not removing hbase-webapps-->
+          <execution>
+            <id>test-jar</id>
+            <goals>
+              <goal>test-jar</goal>
+            </goals>
+            <phase>package</phase>
+            <configuration>
+              <classifier>tests</classifier>
+              <excludes>
+                <exclude>org/apache/jute/**</exclude>
+                <exclude>org/apache/zookeeper/**</exclude>
+                <exclude>**/*.jsp</exclude>
+                <exclude>hbase-site.xml</exclude>
+                <exclude>hdfs-site.xml</exclude>
+                <exclude>log4j.properties</exclude>
+                <exclude>mapred-queues.xml</exclude>
+                <exclude>mapred-site.xml</exclude>
+                <!-- We do not want to exclude hbase-webapps from tests. We actually copied it with
+                copy-hbase-webapps-to-test. See HBASE-28921 for details! -->
+              </excludes>
+            </configuration>
+          </execution>
+        </executions>
       </plugin>
       <!-- General ant tasks, bound to different build phases -->
       <plugin>

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -35,8 +35,7 @@
     <license.bundles.bootstrap>true</license.bundles.bootstrap>
     <license.bundles.jquery>true</license.bundles.jquery>
     <license.bundles.vega>true</license.bundles.vega>
-    <hbase.webapps.dir>target/hbase-webapps</hbase.webapps.dir>
-    <test.classes.webapps.dir>target/test-classes/hbase-webapps</test.classes.webapps.dir>
+    <hbase.webapps.dir>hbase-webapps</hbase.webapps.dir>
   </properties>
   <dependencies>
     <dependency>
@@ -440,26 +439,23 @@
         </configuration>
       </plugin>
       <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-resources-plugin</artifactId>
+        <groupId>org.codehaus.mojo</groupId>
+        <artifactId>build-helper-maven-plugin</artifactId>
         <executions>
-          <!-- Copy hbase-webapps from build directory to test classes directory -->
           <execution>
-            <id>copy-hbase-webapps-to-test</id>
+            <id>add-test-source</id>
             <goals>
-              <goal>copy-resources</goal>
+              <goal>add-test-resource</goal>
             </goals>
-            <phase>process-test-resources</phase>
+            <phase>generate-test-sources</phase>
             <configuration>
-              <!-- Output directory for the copied resources -->
-              <outputDirectory>${test.classes.webapps.dir}</outputDirectory>
+              <!-- Add the hbase-webapps directory to the test resources -->
               <resources>
                 <resource>
-                  <!-- Directory containing hbase-webapps, which needs to be copied -->
-                  <directory>${hbase.webapps.dir}</directory>
-                  <includes>
-                    <include>**/*</include>
-                  </includes>
+                  <!-- Directory containing hbase-webapps -->
+                  <directory>target/${hbase.webapps.dir}</directory>
+                  <!-- Target directory under test-classes -->
+                  <targetPath>${hbase.webapps.dir}</targetPath>
                 </resource>
               </resources>
             </configuration>
@@ -513,8 +509,8 @@
                 <exclude>log4j.properties</exclude>
                 <exclude>mapred-queues.xml</exclude>
                 <exclude>mapred-site.xml</exclude>
-                <!-- We do not want to exclude hbase-webapps from tests. We actually copied it with
-                copy-hbase-webapps-to-test. See HBASE-28921 for details! -->
+                <!-- We do not want to exclude hbase-webapps from tests. We actually intentionally
+                add this directory to out test resources. See HBASE-28921 for details! -->
               </excludes>
             </configuration>
           </execution>

--- a/hbase-thrift/pom.xml
+++ b/hbase-thrift/pom.xml
@@ -194,6 +194,15 @@
           <skipAssembly>true</skipAssembly>
         </configuration>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-jar-plugin</artifactId>
+        <configuration>
+          <excludes>
+            <exclude>**/hbase-webapps/**</exclude>
+          </excludes>
+        </configuration>
+      </plugin>
       <!-- General ant tasks, bound to different build phases -->
       <plugin>
         <artifactId>maven-antrun-plugin</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -803,9 +803,9 @@
     <!-- override on command line to have generated LICENSE files include
          diagnostic info for verifying notice requirements -->
     <license.debug.print.included>false</license.debug.print.included>
-    <!-- When a particular module bundles its depenendencies, should be true -->
+    <!-- When a particular module bundles its dependencies, should be true -->
     <license.bundles.dependencies>false</license.bundles.dependencies>
-    <!-- modules that include a the logo in their source tree should set true -->
+    <!-- modules that include a logo in their source tree should set true -->
     <license.bundles.logo>false</license.bundles.logo>
     <!-- modules that include bootstrap in their source tree should set true -->
     <license.bundles.bootstrap>false</license.bundles.bootstrap>

--- a/pom.xml
+++ b/pom.xml
@@ -803,9 +803,9 @@
     <!-- override on command line to have generated LICENSE files include
          diagnostic info for verifying notice requirements -->
     <license.debug.print.included>false</license.debug.print.included>
-    <!-- When a particular module bundles its dependencies, should be true -->
+    <!-- When a particular module bundles its depenendencies, should be true -->
     <license.bundles.dependencies>false</license.bundles.dependencies>
-    <!-- modules that include a logo in their source tree should set true -->
+    <!-- modules that include a the logo in their source tree should set true -->
     <license.bundles.logo>false</license.bundles.logo>
     <!-- modules that include bootstrap in their source tree should set true -->
     <license.bundles.bootstrap>false</license.bundles.bootstrap>


### PR DESCRIPTION
We are bundling all webapp resources in hbase-server, hbase-thrift, hbase-rest and transitively to hbase-shaded-mapreduce jar. This can be an issue, say if any of the Js projects used by hbase are vulnerable, security scan tools like sonatype start flagging the jars too as vulnerable since they contain vulnerable code.

With this JIRA, we want to avoid bundling static webapp resources in our default jars as these are available during runtime via hbase-webapps directory bundled in our assembly.

But, we still need this for our minicluster based tests which expects it to be present in test classpath. Hence, we are copying hbase-webapps to hbase-server tests jar, which contains class SingleProcessHBaseCluster responsible for hbase minicluster creation. This class eventually needs hbase-webapps in classpath during HttpServer initialisation and hence we are copying it to hbase-server tests.