### PR TITLE
HBASE-28934: Avoid waits within HFilePreadReader constructors for cache initialisation.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -651,6 +651,7 @@ public class BucketCache implements BlockCache, HeapSize {
   public Cacheable getBlock(BlockCacheKey key, boolean caching, boolean repeat,
     boolean updateCacheMetrics) {
     if (!isCacheEnabled()) {
+      cacheStats.miss(caching, key.isPrimary(), key.getBlockType());
       return null;
     }
     RAMQueueEntry re = ramCache.get(key);


### PR DESCRIPTION
The current implementation is such that the HFilePreadReader constructor waits for the cache initialisation to decide whether or not, to create a prefetcher for an HFile.

However, as the HFilePreadReader constructor waits for the bucket cache initialisation, it blocks the region from bein opened. Any calls to read from the region fail until the cache is initialised.

This prevents the region from being usable, which otherwise, can read from the data store (cloud storage) to serve the client requests.

This change prevents the waits with the HFilePreadReader constructor and instead, move this wait to the prefetch thread, which waits until the cache is initialised to decide whether or, not to prefetch the file. Any requests to the regions will be served from the main data store instead of cache.

Also, the missed cache access during the cache initialisation should be accounted for the cache misses.

Change-Id: I952c592a1020874ad874f1909f776d8652375a1b