### PR TITLE
HBASE-28268 Provide option to skip wal while using TableOutputFormat

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableOutputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableOutputFormat.java
@@ -33,9 +33,9 @@ import org.apache.hadoop.hbase.client.BufferedMutator;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
-import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.OutputFormat;
@@ -190,7 +190,7 @@ public class TableOutputFormat<KEY> extends OutputFormat<KEY, Mutation> implemen
       if (!(value instanceof Put) && !(value instanceof Delete)) {
         throw new IOException("Pass a Delete or a Put");
       }
-      if(!useWriteAheadLogging) {
+      if (!useWriteAheadLogging) {
         value.setDurability(Durability.SKIP_WAL);
       }
       mutator.mutate(value);

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableOutputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableOutputFormat.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Mutation;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Durability;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.apache.hadoop.mapreduce.OutputFormat;
@@ -55,6 +56,15 @@ public class TableOutputFormat<KEY> extends OutputFormat<KEY, Mutation> implemen
 
   /** Job parameter that specifies the output table. */
   public static final String OUTPUT_TABLE = "hbase.mapred.outputtable";
+
+  /** Property value to use write-ahead logging */
+  public static final boolean WAL_ON = true;
+
+  /** Property value to disable write-ahead logging */
+  public static final boolean WAL_OFF = false;
+
+  /** Set this to {@link #WAL_OFF} to turn off write-ahead logging (WAL) */
+  public static final String WAL_PROPERTY = "hbase.mapreduce.tableoutputformat.write.wal";
 
   /**
    * Optional job parameter to specify a peer cluster. Used specifying remote cluster when copying
@@ -139,12 +149,14 @@ public class TableOutputFormat<KEY> extends OutputFormat<KEY, Mutation> implemen
 
     private Connection connection;
     private BufferedMutator mutator;
+    boolean useWriteAheadLogging;
 
     public TableRecordWriter() throws IOException {
       this.connection = createConnection(conf);
       String tableName = conf.get(OUTPUT_TABLE);
       this.mutator = connection.getBufferedMutator(TableName.valueOf(tableName));
       LOG.info("Created table instance for " + tableName);
+      this.useWriteAheadLogging = conf.getBoolean(WAL_PROPERTY, WAL_ON);
     }
 
     /**
@@ -177,6 +189,9 @@ public class TableOutputFormat<KEY> extends OutputFormat<KEY, Mutation> implemen
     public void write(KEY key, Mutation value) throws IOException {
       if (!(value instanceof Put) && !(value instanceof Delete)) {
         throw new IOException("Pass a Delete or a Put");
+      }
+      if(!useWriteAheadLogging) {
+        value.setDurability(Durability.SKIP_WAL);
       }
       mutator.mutate(value);
     }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.mapreduce;
 
+import java.io.IOException;
+import javax.validation.constraints.Null;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
@@ -29,7 +31,6 @@ import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.mapreduce.RecordWriter;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
-
 import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
@@ -38,8 +39,6 @@ import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
-import javax.validation.constraints.Null;
-import java.io.IOException;
 
 /**
  * Simple Tests to check whether the durability of the Mutation is changed or not, for
@@ -64,7 +63,7 @@ public class TestTableOutputFormat {
     util.startMiniCluster();
     util.createTable(TABLE_NAME, columnFamily);
 
-    conf =  new Configuration(util.getConfiguration());
+    conf = new Configuration(util.getConfiguration());
     context = Mockito.mock(TaskAttemptContext.class);
     tableOutputFormat = new TableOutputFormat<>();
     conf.set(TableOutputFormat.OUTPUT_TABLE, "TEST_TABLE");
@@ -82,46 +81,47 @@ public class TestTableOutputFormat {
 
   @Test
   public void testTableOutputFormatWhenWalIsOFFForPut() throws IOException, InterruptedException {
-    //setting up the configuration for the TableOutputFormat, with writing to the WAL off.
+    // setting up the configuration for the TableOutputFormat, with writing to the WAL off.
     conf.setBoolean(TableOutputFormat.WAL_PROPERTY, TableOutputFormat.WAL_OFF);
     tableOutputFormat.setConf(conf);
 
     writer = tableOutputFormat.getRecordWriter(context);
 
-    //creating mutation of the type put
+    // creating mutation of the type put
     Put put = new Put("row1".getBytes());
     put.addColumn(columnFamily, Bytes.toBytes("aa"), Bytes.toBytes("value"));
 
-    //verifying whether durability of mutation is USE_DEFAULT or not, before commiting write.
+    // verifying whether durability of mutation is USE_DEFAULT or not, before commiting write.
     Assert.assertEquals("Durability of the mutation should be USE_DEFAULT", Durability.USE_DEFAULT,
       put.getDurability());
 
     writer.write(null, put);
 
-    //verifying whether durability of mutation got changed to the SKIP_WAL or not.
+    // verifying whether durability of mutation got changed to the SKIP_WAL or not.
     Assert.assertEquals("Durability of the mutation should be SKIP_WAL", Durability.SKIP_WAL,
       put.getDurability());
   }
 
   @Test
-  public void testTableOutputFormatWhenWalIsOFFForDelete() throws IOException, InterruptedException {
-    //setting up the configuration for the TableOutputFormat, with writing to the WAL off.
+  public void testTableOutputFormatWhenWalIsOFFForDelete()
+    throws IOException, InterruptedException {
+    // setting up the configuration for the TableOutputFormat, with writing to the WAL off.
     conf.setBoolean(TableOutputFormat.WAL_PROPERTY, TableOutputFormat.WAL_OFF);
     tableOutputFormat.setConf(conf);
 
     writer = tableOutputFormat.getRecordWriter(context);
 
-    //creating mutation of the type delete
+    // creating mutation of the type delete
     Delete delete = new Delete("row2".getBytes());
     delete.addColumn(columnFamily, Bytes.toBytes("aa"));
 
-    //verifying whether durability of mutation is USE_DEFAULT or not, before commiting write.
+    // verifying whether durability of mutation is USE_DEFAULT or not, before commiting write.
     Assert.assertEquals("Durability of the mutation should be USE_DEFAULT", Durability.USE_DEFAULT,
       delete.getDurability());
 
     writer.write(null, delete);
 
-    //verifying whether durability of mutation got changed from  USE_DEFAULT to the SKIP_WAL or not.
+    // verifying whether durability of mutation got changed from USE_DEFAULT to the SKIP_WAL or not.
     Assert.assertEquals("Durability of the mutation should be SKIP_WAL", Durability.SKIP_WAL,
       delete.getDurability());
   }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.mapreduce;
 
 import org.apache.hadoop.conf.Configuration;
-import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Durability;
@@ -46,7 +46,7 @@ import java.io.IOException;
 @Category(MediumTests.class)
 public class TestTableOutputFormat {
 
-  private static final HBaseTestingUtility util = new HBaseTestingUtility();
+  private static final HBaseTestingUtil util = new HBaseTestingUtil();
   private static final TableName TABLE_NAME = TableName.valueOf("TEST_TABLE");
   private static final byte[] columnFamily = Bytes.toBytes("f");
   private static Configuration conf;

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.mapreduce;
 
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Delete;
@@ -33,6 +34,7 @@ import org.junit.After;
 import org.junit.AfterClass;
 import org.junit.Assert;
 import org.junit.BeforeClass;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.mockito.Mockito;
@@ -45,6 +47,9 @@ import java.io.IOException;
  */
 @Category(MediumTests.class)
 public class TestTableOutputFormat {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestTableOutputFormat.class);
 
   private static final HBaseTestingUtil util = new HBaseTestingUtil();
   private static final TableName TABLE_NAME = TableName.valueOf("TEST_TABLE");

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.mapreduce;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.mapreduce.RecordWriter;
+import org.apache.hadoop.mapreduce.TaskAttemptContext;
+
+import org.junit.After;
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.mockito.Mockito;
+import javax.validation.constraints.Null;
+import java.io.IOException;
+
+/**
+ * Simple Tests to check whether the durability of the Mutation is changed or not, for
+ * {@link TableOutputFormat} if {@link TableOutputFormat#WAL_PROPERTY} is set to false.
+ */
+@Category(MediumTests.class)
+public class TestTableOutputFormat {
+
+  private static final HBaseTestingUtility util = new HBaseTestingUtility();
+  private static final TableName TABLE_NAME = TableName.valueOf("TEST_TABLE");
+  private static final byte[] columnFamily = Bytes.toBytes("f");
+  private static Configuration conf;
+  private static RecordWriter<Null, Mutation> writer;
+  private static TaskAttemptContext context;
+  private static TableOutputFormat<Null> tableOutputFormat;
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    util.startMiniCluster();
+    util.createTable(TABLE_NAME, columnFamily);
+
+    conf =  new Configuration(util.getConfiguration());
+    context = Mockito.mock(TaskAttemptContext.class);
+    tableOutputFormat = new TableOutputFormat<>();
+    conf.set(TableOutputFormat.OUTPUT_TABLE, "TEST_TABLE");
+  }
+
+  @AfterClass
+  public static void tearDown() throws Exception {
+    util.shutdownMiniCluster();
+  }
+
+  @After
+  public void close() throws IOException, InterruptedException {
+    if (writer != null && context != null) writer.close(context);
+  }
+
+  @Test
+  public void testTableOutputFormatWhenWalIsOFFForPut() throws IOException, InterruptedException {
+    //setting up the configuration for the TableOutputFormat, with writing to the WAL off.
+    conf.setBoolean(TableOutputFormat.WAL_PROPERTY, TableOutputFormat.WAL_OFF);
+    tableOutputFormat.setConf(conf);
+
+    writer = tableOutputFormat.getRecordWriter(context);
+
+    //creating mutation of the type put
+    Put put = new Put("row1".getBytes());
+    put.addColumn(columnFamily, Bytes.toBytes("aa"), Bytes.toBytes("value"));
+
+    //verifying whether durability of mutation is USE_DEFAULT or not, before commiting write.
+    Assert.assertEquals("Durability of the mutation should be USE_DEFAULT", Durability.USE_DEFAULT,
+      put.getDurability());
+
+    writer.write(null, put);
+
+    //verifying whether durability of mutation got changed to the SKIP_WAL or not.
+    Assert.assertEquals("Durability of the mutation should be SKIP_WAL", Durability.SKIP_WAL,
+      put.getDurability());
+  }
+
+  @Test
+  public void testTableOutputFormatWhenWalIsOFFForDelete() throws IOException, InterruptedException {
+    //setting up the configuration for the TableOutputFormat, with writing to the WAL off.
+    conf.setBoolean(TableOutputFormat.WAL_PROPERTY, TableOutputFormat.WAL_OFF);
+    tableOutputFormat.setConf(conf);
+
+    writer = tableOutputFormat.getRecordWriter(context);
+
+    //creating mutation of the type delete
+    Delete delete = new Delete("row2".getBytes());
+    delete.addColumn(columnFamily, Bytes.toBytes("aa"));
+
+    //verifying whether durability of mutation is USE_DEFAULT or not, before commiting write.
+    Assert.assertEquals("Durability of the mutation should be USE_DEFAULT", Durability.USE_DEFAULT,
+      delete.getDurability());
+
+    writer.write(null, delete);
+
+    //verifying whether durability of mutation got changed from  USE_DEFAULT to the SKIP_WAL or not.
+    Assert.assertEquals("Durability of the mutation should be SKIP_WAL", Durability.SKIP_WAL,
+      delete.getDurability());
+  }
+}

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableOutputFormat.java
@@ -76,7 +76,9 @@ public class TestTableOutputFormat {
 
   @After
   public void close() throws IOException, InterruptedException {
-    if (writer != null && context != null) writer.close(context);
+    if (writer != null && context != null) {
+      writer.close(context);
+    }
   }
 
   @Test


### PR DESCRIPTION
Jira: HBASE-28268

If we have replication setup between clusters A <-> B, If we use CopyTable job to copy the data from cluster B to cluster A during production issues. It doesn't make sense to write to WALs on A using TableOutputFormat (since the mutations being copied already exist on B). 
So, added config which helps to skip writing to the WALs while using the TableOutputFormat, if we want to skip writing to WAL then Durability of the mutation is set to SKIP_WAL, or else default value will be used.