### PR TITLE
HBASE-28963 Updating Quota Factors is too expensive

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.quotas;
 import static org.apache.hadoop.hbase.util.ConcurrentMapUtils.computeIfAbsent;
 
 import java.io.IOException;
+import java.time.Duration;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -28,6 +29,7 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentMap;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ClusterMetrics;
 import org.apache.hadoop.hbase.ClusterMetrics.Option;
@@ -48,6 +50,10 @@ import org.apache.yetus.audience.InterfaceStability;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hbase.thirdparty.com.google.common.cache.CacheBuilder;
+import org.apache.hbase.thirdparty.com.google.common.cache.CacheLoader;
+import org.apache.hbase.thirdparty.com.google.common.cache.LoadingCache;
+
 /**
  * Cache that keeps track of the quota settings for the users and tables that are interacting with
  * it. To avoid blocking the operations if the requested quota is not in cache an "empty quota" will
@@ -61,6 +67,10 @@ public class QuotaCache implements Stoppable {
   private static final Logger LOG = LoggerFactory.getLogger(QuotaCache.class);
 
   public static final String REFRESH_CONF_KEY = "hbase.quota.refresh.period";
+  public static final String TABLE_REGION_STATES_CACHE_TTL_MS =
+    "hbase.quota.cache.ttl.region.states.ms";
+  public static final String REGION_SERVERS_SIZE_CACHE_TTL_MS =
+    "hbase.quota.cache.ttl.servers.size.ms";
 
   // defines the request attribute key which, when provided, will override the request's username
   // from the perspective of user quotas
@@ -102,7 +112,7 @@ public class QuotaCache implements Stoppable {
     // TODO: This will be replaced once we have the notification bus ready.
     Configuration conf = rsServices.getConfiguration();
     int period = conf.getInt(REFRESH_CONF_KEY, REFRESH_DEFAULT_PERIOD);
-    refreshChore = new QuotaRefresherChore(period, this);
+    refreshChore = new QuotaRefresherChore(conf, period, this);
     rsServices.getChoreService().scheduleChore(refreshChore);
   }
 
@@ -140,8 +150,7 @@ public class QuotaCache implements Stoppable {
    */
   public UserQuotaState getUserQuotaState(final UserGroupInformation ugi) {
     return computeIfAbsent(userQuotaCache, getQuotaUserName(ugi),
-      () -> QuotaUtil.buildDefaultUserQuotaState(rsServices.getConfiguration(), 0L),
-      this::triggerCacheRefresh);
+      () -> QuotaUtil.buildDefaultUserQuotaState(rsServices.getConfiguration(), 0L));
   }
 
   /**
@@ -202,7 +211,7 @@ public class QuotaCache implements Stoppable {
    * returned and the quota request will be enqueued for the next cache refresh.
    */
   private <K> QuotaState getQuotaState(final ConcurrentMap<K, QuotaState> quotasMap, final K key) {
-    return computeIfAbsent(quotasMap, key, QuotaState::new, this::triggerCacheRefresh);
+    return computeIfAbsent(quotasMap, key, QuotaState::new);
   }
 
   void triggerCacheRefresh() {
@@ -233,8 +242,33 @@ public class QuotaCache implements Stoppable {
   private class QuotaRefresherChore extends ScheduledChore {
     private long lastUpdate = 0;
 
-    public QuotaRefresherChore(final int period, final Stoppable stoppable) {
+    // Querying cluster metrics so often, per-RegionServer, limits horizontal scalability.
+    // So we cache the results to reduce that load.
+    private final RefreshableExpiringValueCache<ClusterMetrics> tableRegionStatesClusterMetrics;
+    private final RefreshableExpiringValueCache<Integer> regionServersSize;
+
+    public QuotaRefresherChore(Configuration conf, final int period, final Stoppable stoppable) {
       super("QuotaRefresherChore", stoppable, period);
+
+      Duration tableRegionStatesCacheTtl =
+        Duration.ofMillis(conf.getLong(TABLE_REGION_STATES_CACHE_TTL_MS, period));
+      this.tableRegionStatesClusterMetrics =
+        new RefreshableExpiringValueCache<>("tableRegionStatesClusterMetrics",
+          tableRegionStatesCacheTtl, () -> rsServices.getConnection().getAdmin()
+            .getClusterMetrics(EnumSet.of(Option.SERVERS_NAME, Option.TABLE_TO_REGIONS_COUNT)));
+
+      Duration regionServersSizeCacheTtl =
+        Duration.ofMillis(conf.getLong(REGION_SERVERS_SIZE_CACHE_TTL_MS, period));
+      regionServersSize =
+        new RefreshableExpiringValueCache<>("regionServersSize", regionServersSizeCacheTtl,
+          () -> rsServices.getConnection().getAdmin().getRegionServers().size());
+    }
+
+    @Override
+    public synchronized boolean triggerNow() {
+      tableRegionStatesClusterMetrics.invalidate();
+      regionServersSize.invalidate();
+      return super.triggerNow();
     }
 
     @Override
@@ -395,21 +429,40 @@ public class QuotaCache implements Stoppable {
      * over table quota, use [1 / TotalTableRegionNum * MachineTableRegionNum] as machine factor.
      */
     private void updateQuotaFactors() {
-      // Update machine quota factor
-      ClusterMetrics clusterMetrics;
-      try {
-        clusterMetrics = rsServices.getConnection().getAdmin()
-          .getClusterMetrics(EnumSet.of(Option.SERVERS_NAME, Option.TABLE_TO_REGIONS_COUNT));
-      } catch (IOException e) {
-        LOG.warn("Failed to get cluster metrics needed for updating quotas", e);
+      boolean hasTableQuotas = !tableQuotaCache.entrySet().isEmpty()
+        || userQuotaCache.values().stream().anyMatch(UserQuotaState::hasTableLimiters);
+      if (hasTableQuotas) {
+        updateTableMachineQuotaFactors();
+      } else {
+        updateOnlyMachineQuotaFactors();
+      }
+    }
+
+    /**
+     * This method is cheaper than {@link #updateTableMachineQuotaFactors()} and should be used if
+     * we don't have any table quotas in the cache.
+     */
+    private void updateOnlyMachineQuotaFactors() {
+      Optional<Integer> rsSize = regionServersSize.get();
+      if (rsSize.isPresent()) {
+        updateMachineQuotaFactors(rsSize.get());
+      } else {
+        regionServersSize.refresh();
+      }
+    }
+
+    /**
+     * This will call {@link #updateMachineQuotaFactors(int)}, and then update the table machine
+     * factors as well. This relies on a more expensive query for ClusterMetrics.
+     */
+    private void updateTableMachineQuotaFactors() {
+      Optional<ClusterMetrics> clusterMetricsMaybe = tableRegionStatesClusterMetrics.get();
+      if (!clusterMetricsMaybe.isPresent()) {
+        tableRegionStatesClusterMetrics.refresh();
         return;
       }
-
-      int rsSize = clusterMetrics.getServersName().size();
-      if (rsSize != 0) {
-        // TODO if use rs group, the cluster limit should be shared by the rs group
-        machineQuotaFactor = 1.0 / rsSize;
-      }
+      ClusterMetrics clusterMetrics = clusterMetricsMaybe.get();
+      updateMachineQuotaFactors(clusterMetrics.getServersName().size());
 
       Map<TableName, RegionStatesCount> tableRegionStatesCount =
         clusterMetrics.getTableRegionStatesCount();
@@ -436,6 +489,53 @@ public class QuotaCache implements Stoppable {
         }
       }
     }
+
+    private void updateMachineQuotaFactors(int rsSize) {
+      if (rsSize != 0) {
+        // TODO if use rs group, the cluster limit should be shared by the rs group
+        machineQuotaFactor = 1.0 / rsSize;
+      }
+    }
+  }
+
+  static class RefreshableExpiringValueCache<T> {
+    private final String name;
+    private final LoadingCache<String, Optional<T>> cache;
+
+    RefreshableExpiringValueCache(String name, Duration refreshPeriod,
+      ThrowingSupplier<T> supplier) {
+      this.name = name;
+      this.cache =
+        CacheBuilder.newBuilder().expireAfterWrite(refreshPeriod.toMillis(), TimeUnit.MILLISECONDS)
+          .build(new CacheLoader<>() {
+            @Override
+            public Optional<T> load(String key) {
+              try {
+                return Optional.of(supplier.get());
+              } catch (Exception e) {
+                LOG.warn("Failed to refresh cache {}", name, e);
+                return Optional.empty();
+              }
+            }
+          });
+    }
+
+    Optional<T> get() {
+      return cache.getUnchecked(name);
+    }
+
+    void refresh() {
+      cache.refresh(name);
+    }
+
+    void invalidate() {
+      cache.invalidate(name);
+    }
+  }
+
+  @FunctionalInterface
+  static interface ThrowingSupplier<T> {
+    T get() throws Exception;
   }
 
   static interface Fetcher<Key, Value> {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/UserQuotaState.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/UserQuotaState.java
@@ -117,6 +117,10 @@ public class UserQuotaState extends QuotaState {
     namespaceLimiters = setLimiter(namespaceLimiters, namespace, quotas);
   }
 
+  public boolean hasTableLimiters() {
+    return tableLimiters != null && !tableLimiters.isEmpty();
+  }
+
   private <K> Map<K, QuotaLimiter> setLimiter(Map<K, QuotaLimiter> limiters, final K key,
     final Quotas quotas) {
     if (limiters == null) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaCache.java
@@ -40,7 +40,7 @@ public class TestQuotaCache {
     HBaseClassTestRule.forClass(TestQuotaCache.class);
 
   private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
-  private static final int REFRESH_TIME = 30_000;
+  private static final int REFRESH_TIME_MS = 1000;
 
   @After
   public void tearDown() throws Exception {
@@ -52,7 +52,7 @@ public class TestQuotaCache {
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
     TEST_UTIL.getConfiguration().setBoolean(QuotaUtil.QUOTA_CONF_KEY, true);
-    TEST_UTIL.getConfiguration().setInt(QuotaCache.REFRESH_CONF_KEY, REFRESH_TIME);
+    TEST_UTIL.getConfiguration().setInt(QuotaCache.REFRESH_CONF_KEY, REFRESH_TIME_MS);
     TEST_UTIL.getConfiguration().setInt(QuotaUtil.QUOTA_DEFAULT_USER_MACHINE_READ_NUM, 1000);
 
     TEST_UTIL.startMiniCluster(1);


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-28963

My company is running Quotas across a few hundred clusters of varied size. One cluster has hundreds of servers, tens of thousands of regions, and tens of thousands of unique users — for all of whom we build default user quotas to manage resource usage OOTB. 

We noticed that the HMaster was quite busy for this cluster, and after some investigation we realized that RegionServers were hammering the HMaster's ClusterMetrics endpoint to facilitate the refreshing of table machine quota factors. We were also hotspotting the RegionServer hosting the quotas system table.

<img width="1324" alt="" src="https://issues.apache.org/jira/secure/attachment/13072664/13072664_image-2024-11-06-12-06-44-317.png">

```
2024-11-05T21:22:21,024 [regionserver:60020.Chore.1 {}] INFO org.apache.hadoop.hbase.client.HBaseAdmin: getClusterMetrics call stack:
java.base/java.lang.Thread.getStackTrace(Thread.java:2450)
org.apache.hadoop.hbase.client.HBaseAdmin.getClusterMetrics(HBaseAdmin.java:2307)
org.apache.hadoop.hbase.quotas.QuotaCache$QuotaRefresherChore.updateQuotaFactors(QuotaCache.java:402)
org.apache.hadoop.hbase.quotas.QuotaCache$QuotaRefresherChore.chore(QuotaCache.java:267)
org.apache.hadoop.hbase.ScheduledChore.run(ScheduledChore.java:161)
java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:572)
java.base/java.util.concurrent.FutureTask.runAndReset(FutureTask.java:358)
java.base/java.util.concurrent.ScheduledThreadPoolExecutor$ScheduledFutureTask.run(ScheduledThreadPoolExecutor.java:305)
org.apache.hadoop.hbase.JitterScheduledThreadPoolExecutorImpl$JitteredRunnableScheduledFuture.run(JitterScheduledThreadPoolExecutorImpl.java:107)
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1144)
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:642)
java.base/java.lang.Thread.run(Thread.java:1583)
```

After some digging here, we realized there were three meaningful changes that we could make to the quota refresh process to really increase its scalability as RegionServer count, region count, and distinct user count grow.
1. **Each quota cache miss should not trigger a full refresh**. With tens of thousands of distinct users on our cluster, and a routine eviction rate of [5*refreshPeriod](https://github.com/apache/hbase/blob/64a62b4d8e7f11db24ef0225d3f53f10341b349d/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java#L386), this caused a constant refreshing of quotas on every RegionServer. This is the most meaningful change because our RegionServers were truly continuously refreshing the quotas cache
2. **We should only query for every region state if table scoped quotas exist**. This expensive ClusterMetrics call is only necessary if table scoped quotas exist, so we should be a little more thoughtful about when we execute it.
3. **ClusterMetrics should be cached**. As is, each quota refresh would trigger an expensive ClusterMetrics request that would require the HMaster iterating over a map of every region state. We only need this to determine the number of open regions per table — a number that doesn't change significantly in a moment's notice. We should cache this, and the cheaper ClusterMetrics alternative that optimization `#2` introduced. The cache TTL defaults to the defined quota refresh period, but can be customized.

## Testing

I've updated some tests to jive with the expectation that quotas will only refresh on the normally scheduled refresh period. Otherwise, I think our quotas test suite provides pretty good coverage to ensure that nothing is broken by this changeset.

I've also deployed this on a test cluster, and here is how refresh rates change in a given 30s timeperiod pre- and post-restart.

#### Pre-Restart
```
2024-11-08T12:30:02,555 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 5 ms.
2024-11-08T12:30:06,508 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 12 ms.
2024-11-08T12:30:10,437 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 5 ms.
2024-11-08T12:30:13,619 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 4 ms.
2024-11-08T12:30:13,805 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 4 ms.
2024-11-08T12:30:14,308 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 5 ms.
2024-11-08T12:30:14,335 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 4 ms.
2024-11-08T12:30:14,769 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 5 ms.
2024-11-08T12:30:16,781 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 4 ms.
2024-11-08T12:30:17,994 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 6 ms.
2024-11-08T12:30:18,745 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 4 ms.
2024-11-08T12:30:21,214 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 5 ms.
2024-11-08T12:30:24,034 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 29 ms.
2024-11-08T12:30:26,600 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 9 ms.
2024-11-08T12:30:30,976 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 36 ms.
```

#### Post-Restart
```
2024-11-08T12:35:56,886 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 45 ms.
2024-11-08T12:36:27,240 [regionserver.Chore.1 {}] DEBUG org.apache.hadoop.hbase.ScheduledChore: QuotaRefresherChore execution time: 89 ms.
```

On said test cluster I've also confirmed that throttling continues to work as intended. I've also validated that I can enact new manually defined throttles inline with refresh periods, and that I can remove a throttle to return to the default behavior.

cc @ndimiduk @hgromer 