### PR TITLE
[ADDENDUM] HBASE-28947 Backport "HBASE-27598 Upgrade mockito to 4.x" …

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -2730,7 +2730,7 @@
                 <additionalDependency>
                   <groupId>org.mockito</groupId>
                   <artifactId>mockito-core</artifactId>
-                  <version>${mockito-core.version}</version>
+                  <version>${mockito.version}</version>
                 </additionalDependency>
                 <additionalDependency>
                   <groupId>org.hamcrest</groupId>
@@ -2781,7 +2781,7 @@
                 <additionalDependency>
                   <groupId>org.mockito</groupId>
                   <artifactId>mockito-core</artifactId>
-                  <version>${mockito-core.version}</version>
+                  <version>${mockito.version}</version>
                 </additionalDependency>
                 <additionalDependency>
                   <groupId>org.hamcrest</groupId>
@@ -2840,7 +2840,7 @@
                 <additionalDependency>
                   <groupId>org.mockito</groupId>
                   <artifactId>mockito-core</artifactId>
-                  <version>${mockito-core.version}</version>
+                  <version>${mockito.version}</version>
                 </additionalDependency>
                 <additionalDependency>
                   <groupId>org.hamcrest</groupId>
@@ -2898,7 +2898,7 @@
                 <additionalDependency>
                   <groupId>org.mockito</groupId>
                   <artifactId>mockito-core</artifactId>
-                  <version>${mockito-core.version}</version>
+                  <version>${mockito.version}</version>
                 </additionalDependency>
                 <additionalDependency>
                   <groupId>org.hamcrest</groupId>


### PR DESCRIPTION
…to branch-2.5
- Remove references to mockito-core.version in pom to fix site build
- Backports https://github.com/apache/hbase/commit/55b4bbc05785cc652b4425b9ac45f673b28597b4