### PR TITLE
HBASE-28973 Enable HBase RegionServers and Masters to support IPv6 IP addresses as server identity when USEIP is enabled

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/ServerName.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/ServerName.java
@@ -71,6 +71,9 @@ public class ServerName implements Comparable<ServerName>, Serializable {
   static final byte[] VERSION_BYTES = Bytes.toBytes(VERSION);
   private static final String COLON_ENCODED_VALUE = "%3a";
 
+  // IPV6 address separated by COLON(:)
+  public static final String COLON = ":";
+
   /**
    * What to use if no startcode supplied.
    */
@@ -356,13 +359,14 @@ public class ServerName implements Comparable<ServerName>, Serializable {
    * Checks if the provided server address is formatted as an IPv6 address. This method uses Java's
    * InetAddress to parse the input and confirms if the address is an instance of Inet6Address for
    * robust validation instead of relying on string splitting.
-   * @param serverAddress The address string to validate (can be a hostname or IP)
+   * @param serverAddress The address string to validate
    * @return true if the address is a valid IPv6 address; false otherwise.
    */
   public static boolean isIpv6ServerName(String serverAddress) {
     try {
       InetAddress address = InetAddress.getByName(serverAddress);
-      return address instanceof Inet6Address;
+      return address instanceof Inet6Address && !address.getHostName().equals(serverAddress)
+        && serverAddress.contains(COLON);
     } catch (UnknownHostException e) {
       return false; // Not a valid IP, let the logic fall through
     }

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TestServerNameIPv6.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TestServerNameIPv6.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.charset.StandardCharsets;
+import org.apache.hadoop.hbase.testclassification.MiscTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category({ MiscTests.class, SmallTests.class })
+public class TestServerNameIPv6 {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestServerNameIPv6.class);
+
+  @Test
+  public void testIpv6FullForm() {
+    assertTrue(ServerName.isIpv6ServerName("2001:0db8:85a3:0000:0000:8a2e:0370:7334"));
+  }
+
+  @Test
+  public void testIpv6CompressedForm() {
+    assertTrue(ServerName.isIpv6ServerName("2001:db8:85a3::8a2e:370:7334"));
+    assertTrue(ServerName.isIpv6ServerName("::1"));
+  }
+
+  @Test
+  public void testIpv6WithBrackets() {
+    // Brackets are often used in URIs
+    assertTrue(ServerName.isIpv6ServerName("[::1]"));
+  }
+
+  @Test
+  public void testIpv4Address() {
+    assertFalse(ServerName.isIpv6ServerName("192.168.1.1"));
+  }
+
+  @Test
+  public void testHostname() {
+    assertFalse(ServerName.isIpv6ServerName("example.com"));
+  }
+
+  @Test
+  public void testEncodedIpv6() {
+    // If you are supporting encoded values (such as %3A), add related coverage.
+    String encoded = java.net.URLEncoder.encode("::1", StandardCharsets.UTF_8);
+    assertFalse(ServerName.isIpv6ServerName(encoded));
+  }
+
+  @Test
+  public void testInvalidAddress() {
+    assertFalse(ServerName.isIpv6ServerName("notAValidAddress"));
+  }
+
+  @Test
+  public void testParseEncodedIPv6ServerName() {
+    String encodedIPv6 = "2001%3a0db8%3a85a3%3a0%3a0%3a8a2e%3a370%3a7334";
+    String serverNameString = encodedIPv6 + ",16020,12345";
+
+    ServerName sn = ServerName.parseServerName(serverNameString);
+    assertEquals("2001:0db8:85a3:0:0:8a2e:370:7334", sn.getHostname());
+    assertEquals(16020, sn.getPort());
+  }
+
+  @Test
+  public void testEncodeIPv6ForServerName() {
+    ServerName sn = ServerName.valueOf("2001:0db8:85a3::8a2e:370:7334", 16020, 12345L);
+    // hypothetical method to encode for paths
+    String encoded = ServerName.getEncodedServerName(sn.getServerName()).getServerName();
+    assertFalse(encoded.contains(":"));
+    assertTrue(encoded.contains("%3a")); // percent encoded colons
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -1525,13 +1525,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
   }
 
   /**
-   * Normalizes an IPv6 address string by removing leading and trailing square brackets if present,
-   * returning the canonical IPv6 address form.
-   * <p>
-   * This method is intended to convert IPv6 addresses from URI or config contexts, where brackets
-   * may be used, into a format accepted by standard Java networking APIs.
-   * <p>
-   * Examples:
+   * Removes leading and trailing square brackets from an IPv6 address string, if present. Examples:
    *
    * <pre>
    *   normalizeIPv6Address("[2001:db8::1]") returns "2001:db8::1"

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -1430,15 +1430,26 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
               && InetAddresses.isInetAddress(getActiveMaster().get().getHostname())
           ) {
             expectedHostName = rpcServices.getSocketAddress().getAddress().getHostAddress();
+            if (ServerName.isIpv6ServerName(expectedHostName)) {
+              expectedHostName = normalizeIPv6Address(expectedHostName);
+            }
           }
-          boolean isHostnameConsist = StringUtils.isBlank(useThisHostnameInstead)
+
+          String customHostName = useThisHostnameInstead;
+          // Need to normalize for IPv6 address leading and trailing square brackets if present,
+          // because HMaster point of view RegionServer is recognised IP address without brackets.
+          if (
+            !StringUtils.isBlank(useThisHostnameInstead)
+              && ServerName.isIpv6ServerName(customHostName)
+          ) {
+            customHostName = normalizeIPv6Address(useThisHostnameInstead);
+          }
+          boolean isHostnameConsist = StringUtils.isBlank(customHostName)
             ? hostnameFromMasterPOV.equals(expectedHostName)
-            : hostnameFromMasterPOV.equals(useThisHostnameInstead);
+            : hostnameFromMasterPOV.equals(customHostName);
           if (!isHostnameConsist) {
             String msg = "Master passed us a different hostname to use; was="
-              + (StringUtils.isBlank(useThisHostnameInstead)
-                ? expectedHostName
-                : this.useThisHostnameInstead)
+              + (StringUtils.isBlank(customHostName) ? expectedHostName : customHostName)
               + ", but now=" + hostnameFromMasterPOV;
             LOG.error(msg);
             throw new IOException(msg);
@@ -1511,6 +1522,32 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     } finally {
       sleeper.skipSleepCycle();
     }
+  }
+
+  /**
+   * Normalizes an IPv6 address string by removing leading and trailing square brackets if present,
+   * returning the canonical IPv6 address form.
+   * <p>
+   * This method is intended to convert IPv6 addresses from URI or config contexts, where brackets
+   * may be used, into a format accepted by standard Java networking APIs.
+   * <p>
+   * Examples:
+   *
+   * <pre>
+   *   normalizeIPv6Address("[2001:db8::1]") returns "2001:db8::1"
+   *   normalizeIPv6Address("2001:db8::1")  returns "2001:db8::1"
+   *   normalizeIPv6Address("[::1]")        returns "::1"
+   * </pre>
+   *
+   * @param address the input IPv6 address, possibly with square brackets
+   * @return the normalized IPv6 address string without brackets
+   */
+  private String normalizeIPv6Address(String address) {
+    // Remove leading and trailing brackets if present
+    if (address.startsWith("[") && address.endsWith("]")) {
+      return address.substring(1, address.length() - 1);
+    }
+    return address;
   }
 
   private void startHeapMemoryManager() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
@@ -307,9 +307,13 @@ public abstract class AbstractFSWALProvider<T extends AbstractFSWAL<?>>
    * @return the relative WAL directory name, e.g. <code>.logs/1.example.org,60030,12345</code> if
    *         <code>serverName</code> passed is <code>1.example.org,60030,12345</code>
    */
-  public static String getWALDirectoryName(final String serverName) {
+  public static String getWALDirectoryName(String serverName) {
+    // If ServerName is IPV6 address, then need to encode server address
+    if (ServerName.isIpv6ServerName(serverName, ServerName.COLON)) {
+      serverName = ServerName.getEncodedServerName(serverName).getServerName();
+    }
     StringBuilder dirName = new StringBuilder(HConstants.HREGION_LOGDIR_NAME);
-    dirName.append("/");
+    dirName.append(Path.SEPARATOR);
     dirName.append(serverName);
     return dirName.toString();
   }
@@ -321,9 +325,13 @@ public abstract class AbstractFSWALProvider<T extends AbstractFSWAL<?>>
    * @param serverName Server name formatted as described in {@link ServerName}
    * @return the relative WAL directory name
    */
-  public static String getWALArchiveDirectoryName(Configuration conf, final String serverName) {
+  public static String getWALArchiveDirectoryName(Configuration conf, String serverName) {
     StringBuilder dirName = new StringBuilder(HConstants.HREGION_OLDLOGDIR_NAME);
     if (conf.getBoolean(SEPARATE_OLDLOGDIR, DEFAULT_SEPARATE_OLDLOGDIR)) {
+      // If ServerName is IPV6 address, then need to encode server address
+      if (ServerName.isIpv6ServerName(serverName, ServerName.COLON)) {
+        serverName = ServerName.getEncodedServerName(serverName).getServerName();
+      }
       dirName.append(Path.SEPARATOR);
       dirName.append(serverName);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
@@ -308,13 +308,9 @@ public abstract class AbstractFSWALProvider<T extends AbstractFSWAL<?>>
    *         <code>serverName</code> passed is <code>1.example.org,60030,12345</code>
    */
   public static String getWALDirectoryName(String serverName) {
-    // If ServerName is IPV6 address, then need to encode server address
-    if (ServerName.isIpv6ServerName(serverName, ServerName.COLON)) {
-      serverName = ServerName.getEncodedServerName(serverName).getServerName();
-    }
     StringBuilder dirName = new StringBuilder(HConstants.HREGION_LOGDIR_NAME);
     dirName.append(Path.SEPARATOR);
-    dirName.append(serverName);
+    dirName.append(getServerName(serverName));
     return dirName.toString();
   }
 
@@ -328,14 +324,20 @@ public abstract class AbstractFSWALProvider<T extends AbstractFSWAL<?>>
   public static String getWALArchiveDirectoryName(Configuration conf, String serverName) {
     StringBuilder dirName = new StringBuilder(HConstants.HREGION_OLDLOGDIR_NAME);
     if (conf.getBoolean(SEPARATE_OLDLOGDIR, DEFAULT_SEPARATE_OLDLOGDIR)) {
-      // If ServerName is IPV6 address, then need to encode server address
-      if (ServerName.isIpv6ServerName(serverName, ServerName.COLON)) {
-        serverName = ServerName.getEncodedServerName(serverName).getServerName();
-      }
       dirName.append(Path.SEPARATOR);
-      dirName.append(serverName);
+      dirName.append(getServerName(serverName));
     }
     return dirName.toString();
+  }
+
+  private static String getServerName(String serverName) {
+    String address =
+      ServerName.isFullServerName(serverName) ? ServerName.valueOf(serverName).getHostname() : null;
+    // If ServerName is IPV6 address, then need to encode server address
+    if (address != null && ServerName.isIpv6ServerName(address)) {
+      serverName = ServerName.getEncodedServerName(serverName).getServerName();
+    }
+    return serverName;
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/AbstractTestFSWAL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/AbstractTestFSWAL.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.regionserver.wal;
 import static org.hamcrest.CoreMatchers.containsString;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
@@ -693,6 +694,22 @@ public abstract class AbstractTestFSWAL {
       region.close();
       wal.close();
     }
+  }
+
+  @Test
+  public void testEncodeDecodeIPv6InWalPath() throws Exception {
+    String ipv6Address = "2001:0db8:85a3:0000:0000:8a2e:0370:7334";
+    ServerName serverName = ServerName.valueOf(ipv6Address, 16020, 12345L);
+
+    // Assume method encodeServerName(ServerName) encodes IPv6 address properly for WAL path
+    String encoded = AbstractFSWALProvider.getWALDirectoryName(serverName.getServerName());
+    assertFalse("Encoded WAL path should not contain raw colon", encoded.contains(":"));
+
+    // Assume method decodeServerName(String) reverses the encoding
+    ServerName decoded = ServerName.parseServerName(encoded);
+    assertEquals("Decoded ServerName hostname should match original", ipv6Address,
+      decoded.getHostname().split(Path.SEPARATOR)[1]);
+    assertEquals("Decoded ServerName port should match", 16020, decoded.getPort());
   }
 
   public static final class FlushSpecificStoresPolicy extends FlushPolicy {


### PR DESCRIPTION
Using IPV6 address failed to create the WAL path.

IPV6 address contains ":", eg: [0:0:0:0:0:0:0:1]

WAL path creation will fail, because FS will not support to create path with ":".

so for use IP is true and the env is ipv6

Encode for wal path creation with IPV6 address
Decode the IPV6 address, if RS servernames are prepared from the WAL path.