### PR TITLE
HBASE-28488 Use encoded name in region span attributes

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocator.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocator.java
@@ -125,13 +125,13 @@ class AsyncRegionLocator {
       return Collections.emptyList();
     }
     return Arrays.stream(locs.getRegionLocations()).filter(Objects::nonNull)
-      .map(HRegionLocation::getRegion).map(RegionInfo::getRegionNameAsString)
+      .map(HRegionLocation::getRegion).map(RegionInfo::getEncodedName)
       .collect(Collectors.toList());
   }
 
   private static List<String> getRegionNames(HRegionLocation location) {
     return Optional.ofNullable(location).map(HRegionLocation::getRegion)
-      .map(RegionInfo::getRegionNameAsString).map(Collections::singletonList)
+      .map(RegionInfo::getEncodedName).map(Collections::singletonList)
       .orElseGet(Collections::emptyList);
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -7003,7 +7003,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
 
   Span createRegionSpan(String name) {
     return TraceUtil.createSpan(name).setAttribute(REGION_NAMES_KEY,
-      Collections.singletonList(getRegionInfo().getRegionNameAsString()));
+      Collections.singletonList(getRegionInfo().getEncodedName()));
   }
 
   // will be override in tests

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegionTracing.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegionTracing.java
@@ -117,7 +117,7 @@ public class TestHRegionTracing {
       }
       List<String> regionNames = span.getAttributes().get(HBaseSemanticAttributes.REGION_NAMES_KEY);
       return regionNames != null && regionNames.size() == 1
-        && regionNames.get(0).equals(region.getRegionInfo().getRegionNameAsString());
+        && regionNames.get(0).equals(region.getRegionInfo().getEncodedName());
     }));
   }
 


### PR DESCRIPTION
On our busy clusters, the alloc profile shows that createRegionSpan() is responsible for 15-20% of all the allocations. These allocations comes from getRegionNameAsString().

getRegionNameAsString() takes the region name and encode invisible characters in their hex representation. This requires the use of a StringBuilder and thus generate new strings every time.

This becomes really expensive on a cluster with high number of requests. It seems better to just take the encoded region name (the md5 part) and use that in trace attributes, because:
- it's fixed in size (the full region name can be much longer depending on the rowkey size),
- it's enough information to link a trace to a region,
- it doesn't require any new allocation.