### PR TITLE
HBASE-28484: Add ability to replicate to a different tableName

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -968,6 +968,9 @@ public final class HConstants {
   public static final String REPLICATION_SINK_SERVICE_CLASSNAME_DEFAULT =
     "org.apache.hadoop.hbase.replication.ReplicationSinkServiceImpl";
   public static final String REPLICATION_BULKLOAD_ENABLE_KEY = "hbase.replication.bulkload.enabled";
+  public static final String REPLICATION_SINK_TRANSLATOR = "hbase.replication.sink.translator";
+  public static final String REPLICATION_SINK_TRANSLATOR_DEFAULT =
+    "org.apache.hadoop.hbase.replication.regionserver.DefaultReplicationSinkTranslator";
   public static final boolean REPLICATION_BULKLOAD_ENABLE_DEFAULT = false;
   /** Replication cluster id of source cluster which uniquely identifies itself with peer cluster */
   public static final String REPLICATION_CLUSTER_ID = "hbase.replication.cluster.id";

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/master/ReplicationSinkTrackerTableCreator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/master/ReplicationSinkTrackerTableCreator.java
@@ -80,7 +80,7 @@ public final class ReplicationSinkTrackerTableCreator {
 
   /*
    * We will create this table only if hbase.regionserver.replication.sink.tracker.enabled is
-   * enabled and table doesn't exists already.
+   * enabled and table doesn't exist already.
    */
   public static void createIfNeededAndNotExists(Configuration conf, MasterServices masterServices)
     throws IOException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/IdentityReplicationSinkTranslator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/IdentityReplicationSinkTranslator.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.replication.regionserver;
+
+import org.apache.hadoop.hbase.ExtendedCell;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Public
+public class IdentityReplicationSinkTranslator implements ReplicationSinkTranslator {
+  @Override
+  public TableName getSinkTableName(TableName tableName) {
+    return tableName;
+  }
+
+  @Override
+  public byte[] getSinkRowKey(TableName tableName, byte[] rowKey) {
+    return rowKey;
+  }
+
+  @Override
+  public byte[] getSinkFamily(TableName tableName, byte[] family) {
+    return family;
+  }
+
+  @Override
+  public byte[] getSinkQualifier(TableName tableName, byte[] family, byte[] qualifier) {
+    return qualifier;
+  }
+
+  @Override
+  public ExtendedCell getSinkExtendedCell(TableName tableName, ExtendedCell cell) {
+    return cell;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSinkTranslator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/regionserver/ReplicationSinkTranslator.java
@@ -1,0 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.replication.regionserver;
+
+import org.apache.hadoop.hbase.ExtendedCell;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Public
+public interface ReplicationSinkTranslator {
+
+  public TableName getSinkTableName(TableName tableName);
+
+  public byte[] getSinkRowKey(TableName tableName, byte[] rowKey);
+
+  public byte[] getSinkFamily(TableName tableName, byte[] family);
+
+  public byte[] getSinkQualifier(TableName tableName, byte[] family, byte[] qualifier);
+
+  public ExtendedCell getSinkExtendedCell(TableName tableName, ExtendedCell cell);
+}


### PR DESCRIPTION
[Design document](https://docs.google.com/document/d/1h6G55j3B4vKxHliw6Wx9tXezNDhod7dY1EiHkhcKFDI/edit?tab=t.0)

[Jira](https://issues.apache.org/jira/browse/HBASE-28484)

Currently, replication can only occur if the source and sink clusters both house tables with the same (tableName, family) pairs. This requirement exists so that the sink cluster knows where to persist the data it receives from the source cluster. In this PR, we loosen the naming constraint and give clients more configuration power over the name of their sink namespaces and tableNames.

cc: @rmdmattingly @hgromer @krconv @ndimiduk @bbeaudreault