### PR TITLE
HBASE-28328 Add an option to count different types of Delete Markers in RowCounter

### DIFF
--- a/hbase-mapreduce/pom.xml
+++ b/hbase-mapreduce/pom.xml
@@ -274,14 +274,6 @@
         <groupId>net.revelc.code</groupId>
         <artifactId>warbucks-maven-plugin</artifactId>
       </plugin>
-      <plugin>
-        <groupId>org.apache.maven.plugins</groupId>
-        <artifactId>maven-compiler-plugin</artifactId>
-        <configuration>
-          <source>8</source>
-          <target>8</target>
-        </configuration>
-      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/hbase-mapreduce/pom.xml
+++ b/hbase-mapreduce/pom.xml
@@ -274,6 +274,14 @@
         <groupId>net.revelc.code</groupId>
         <artifactId>warbucks-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-compiler-plugin</artifactId>
+        <configuration>
+          <source>8</source>
+          <target>8</target>
+        </configuration>
+      </plugin>
     </plugins>
   </build>
   <profiles>

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -21,7 +21,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
-import org.apache.curator.shaded.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;
@@ -449,7 +448,7 @@ public class RowCounter extends AbstractHBaseTool {
     return new RowCounterCommandLineParser();
   }
 
-  @VisibleForTesting
+  // Visible for testing
   public Job getMapReduceJob() {
     return job;
   }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -164,6 +164,7 @@ public class RowCounter extends AbstractHBaseTool {
     Job job = Job.getInstance(conf, conf.get(JOB_NAME_CONF_KEY, NAME + "_" + tableName));
     job.setJarByClass(RowCounter.class);
     Scan scan = new Scan();
+    // raw scan will be needed to account for delete markers when --countDeleteMarkers flag is set
     scan.setRaw(this.countDeleteMarkers);
     scan.setCacheBlocks(false);
     setScanFilter(scan, rowRangeList, this.countDeleteMarkers);
@@ -256,6 +257,7 @@ public class RowCounter extends AbstractHBaseTool {
     job.setJarByClass(RowCounter.class);
     Scan scan = new Scan();
     scan.setCacheBlocks(false);
+    // raw scan will be needed to account for delete markers when --countDeleteMarkers flag is set
     scan.setRaw(countDeleteMarkers);
     setScanFilter(scan, rowRangeList, countDeleteMarkers);
     if (sb.length() > 0) {
@@ -315,8 +317,10 @@ public class RowCounter extends AbstractHBaseTool {
    * Otherwise, method sets filter which is instance of {@link FirstKeyOnlyFilter}. If rowRangeList
    * contains exactly one element, startRow and stopRow are set to the scan.
    */
-  private static void setScanFilter(Scan scan, List<MultiRowRangeFilter.RowRange> rowRangeList, boolean countDeleteMarkers) {
+  private static void setScanFilter(Scan scan, List<MultiRowRangeFilter.RowRange> rowRangeList,
+    boolean countDeleteMarkers) {
     final int size = rowRangeList == null ? 0 : rowRangeList.size();
+    // all cells will be needed if --countDeleteMarkers flag is set, hence, skipping filter
     if (size <= 1 && !countDeleteMarkers) {
       scan.setFilter(new FirstKeyOnlyFilter());
     }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -17,10 +17,10 @@
  */
 package org.apache.hadoop.hbase.mapreduce;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
-import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
@@ -87,15 +87,21 @@ public class RowCounter extends AbstractHBaseTool {
 
     /** Counter enumeration to count the actual rows, cells and delete markers. */
     public static enum Counters {
-      ROWS, CELLS, DELETE, DELETE_COLUMN, DELETE_FAMILY, DELETE_FAMILY_VERSION,
+      ROWS,
+      CELLS,
+      DELETE,
+      DELETE_COLUMN,
+      DELETE_FAMILY,
+      DELETE_FAMILY_VERSION,
       ROWS_WITH_DELETE_MARKER
     }
 
     private boolean countDeleteMarkers;
 
     @Override
-    protected void setup(Mapper<ImmutableBytesWritable, Result, ImmutableBytesWritable,
-      Result>.Context context) throws IOException, InterruptedException {
+    protected void
+      setup(Mapper<ImmutableBytesWritable, Result, ImmutableBytesWritable, Result>.Context context)
+        throws IOException, InterruptedException {
       Configuration conf = context.getConfiguration();
       countDeleteMarkers = conf.getBoolean(OPT_COUNT_DELETE_MARKERS, false);
     }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -461,7 +461,7 @@ public class RowCounter extends AbstractHBaseTool {
   }
 
   // Visible for testing
-  public Job getMapReduceJob() {
+  Job getMapReduceJob() {
     return job;
   }
 

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -109,11 +109,11 @@ public class RowCounter extends AbstractHBaseTool {
     public void map(ImmutableBytesWritable row, Result values, Context context) throws IOException {
       // Count every row containing data, whether it's in qualifiers or values
       context.getCounter(Counters.ROWS).increment(1);
-      context.getCounter(Counters.CELLS).increment(values.size());
-
-      boolean rowContainsDeleteMarker = true;
 
       if (countDeleteMarkers) {
+        context.getCounter(Counters.CELLS).increment(values.size());
+
+        boolean rowContainsDeleteMarker = true;
         for (Cell cell : values.rawCells()) {
           Cell.Type type = cell.getType();
           switch (type) {
@@ -134,10 +134,10 @@ public class RowCounter extends AbstractHBaseTool {
               break;
           }
         }
-      }
 
-      if (rowContainsDeleteMarker) {
-        context.getCounter(Counters.ROWS_WITH_DELETE_MARKER).increment(1);
+        if (rowContainsDeleteMarker) {
+          context.getCounter(Counters.ROWS_WITH_DELETE_MARKER).increment(1);
+        }
       }
     }
   }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -17,11 +17,11 @@
  */
 package org.apache.hadoop.hbase.mapreduce;
 
-import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.commons.lang3.StringUtils;
+import org.apache.curator.shaded.com.google.common.annotations.VisibleForTesting;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HConstants;

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -345,7 +345,8 @@ public class RowCounter extends AbstractHBaseTool {
     Option expectedOption = Option.builder(null).valueSeparator('=').hasArg(true)
       .desc("expected number of rows to be count.").longOpt(OPT_EXPECTED_COUNT).build();
     Option countDeleteMarkersOption = Option.builder(null).hasArg(false)
-      .desc("counts the number of Delete Markers of all types, i.e. (DELETE, DELETE_COLUMN, DELETE_FAMILY, DELETE_FAMILY_VERSION)")
+      .desc("counts the number of Delete Markers of all types, i.e. "
+        + "(DELETE, DELETE_COLUMN, DELETE_FAMILY, DELETE_FAMILY_VERSION)")
       .longOpt(OPT_COUNT_DELETE_MARKERS).build();
     addOption(startTimeOption);
     addOption(endTimeOption);

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -160,7 +160,6 @@ public class RowCounter extends AbstractHBaseTool {
    * @throws IOException When setting up the job fails.
    */
   public Job createSubmittableJob(Configuration conf) throws IOException {
-    conf.setBoolean(OPT_COUNT_DELETE_MARKERS, this.countDeleteMarkers);
     Job job = Job.getInstance(conf, conf.get(JOB_NAME_CONF_KEY, NAME + "_" + tableName));
     job.setJarByClass(RowCounter.class);
     Scan scan = new Scan();
@@ -182,6 +181,7 @@ public class RowCounter extends AbstractHBaseTool {
     if (this.expectedCount >= 0) {
       conf.setLong(EXPECTED_COUNT_KEY, this.expectedCount);
     }
+    conf.setBoolean(OPT_COUNT_DELETE_MARKERS, this.countDeleteMarkers);
 
     scan.setTimeRange(startTime, endTime);
     job.setOutputFormatClass(NullOutputFormat.class);

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -87,7 +87,6 @@ public class RowCounter extends AbstractHBaseTool {
     /** Counter enumeration to count the actual rows, cells and delete markers. */
     public static enum Counters {
       ROWS,
-      CELLS,
       DELETE,
       DELETE_COLUMN,
       DELETE_FAMILY,
@@ -119,8 +118,6 @@ public class RowCounter extends AbstractHBaseTool {
       context.getCounter(Counters.ROWS).increment(1);
 
       if (countDeleteMarkers) {
-        context.getCounter(Counters.CELLS).increment(values.size());
-
         boolean rowContainsDeleteMarker = false;
         for (Cell cell : values.rawCells()) {
           Cell.Type type = cell.getType();
@@ -160,6 +157,7 @@ public class RowCounter extends AbstractHBaseTool {
    * @throws IOException When setting up the job fails.
    */
   public Job createSubmittableJob(Configuration conf) throws IOException {
+    conf.setBoolean(OPT_COUNT_DELETE_MARKERS, this.countDeleteMarkers);
     Job job = Job.getInstance(conf, conf.get(JOB_NAME_CONF_KEY, NAME + "_" + tableName));
     job.setJarByClass(RowCounter.class);
     Scan scan = new Scan();
@@ -181,7 +179,6 @@ public class RowCounter extends AbstractHBaseTool {
     if (this.expectedCount >= 0) {
       conf.setLong(EXPECTED_COUNT_KEY, this.expectedCount);
     }
-    conf.setBoolean(OPT_COUNT_DELETE_MARKERS, this.countDeleteMarkers);
 
     scan.setTimeRange(startTime, endTime);
     job.setOutputFormatClass(NullOutputFormat.class);

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.mapreduce;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import com.google.common.annotations.VisibleForTesting;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Cell;
@@ -76,6 +77,8 @@ public class RowCounter extends AbstractHBaseTool {
   private long expectedCount;
   private boolean countDeleteMarkers;
   private List<String> columns = new ArrayList<>();
+
+  private Job job;
 
   /**
    * Mapper that runs the count.
@@ -398,7 +401,7 @@ public class RowCounter extends AbstractHBaseTool {
 
   @Override
   protected int doWork() throws Exception {
-    Job job = createSubmittableJob(getConf());
+    job = createSubmittableJob(getConf());
     if (job == null) {
       return -1;
     }
@@ -437,6 +440,11 @@ public class RowCounter extends AbstractHBaseTool {
   @Override
   protected CommandLineParser newParser() {
     return new RowCounterCommandLineParser();
+  }
+
+  @VisibleForTesting
+  public Job getMapReduceJob() {
+    return job;
   }
 
 }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RowCounter.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.mapreduce;
 
+import com.google.errorprone.annotations.RestrictedApi;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
@@ -460,7 +461,8 @@ public class RowCounter extends AbstractHBaseTool {
     return new RowCounterCommandLineParser();
   }
 
-  // Visible for testing
+  @RestrictedApi(explanation = "Only visible for testing", link = "",
+      allowedOnPath = ".*/src/test/.*")
   Job getMapReduceJob() {
     return job;
   }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hbase.mapreduce;
 
 import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -532,11 +531,9 @@ public class TestRowCounter {
    * column family and 4 columns. Step 2: Delete a column for row1. Step 3: Delete a column family
    * for row2 and row4. Step 4: Delete all versions of a specific column for row3, row5 and row6.
    * <p>
-   * Case 1: Run row counter without countDeleteMarkers flag Step a: Validate counter values. Step
-   * b: Assert that the countOfDeleteMarker variable is false.
+   * Case 1: Run row counter without countDeleteMarkers flag Step a: Validate counter values.
    * <p>
-   * Case 2: Run row counter with countDeleteMarkers flag Step a: Validate counter values. Step b:
-   * Assert that the countOfDeleteMarker variable is true.
+   * Case 2: Run row counter with countDeleteMarkers flag Step a: Validate counter values.
    */
   @Test
   public void testRowCounterWithCountDeleteMarkersOption() throws Exception {
@@ -595,14 +592,10 @@ public class TestRowCounter {
     // Case 1:
     validateCounterCounts(rowCounterWithoutCountDeleteMarkers.getMapReduceJob().getCounters(), 4, 0,
       0, 0, 0, 0, 0);
-    assertFalse(
-      rowCounterWithoutCountDeleteMarkers.getConf().getBoolean("countDeleteMarkers", true));
 
     // Case 2:
-    validateCounterCounts(rowCounterWithoutCountDeleteMarkers.getMapReduceJob().getCounters(), 6,
-      24, 6, 1, 3, 2, 0);
-    assertTrue(
-      rowCounterWithoutCountDeleteMarkers.getConf().getBoolean("countDeleteMarkers", false));
+    validateCounterCounts(rowCounterWithCountDeleteMarkers.getMapReduceJob().getCounters(), 6,
+      6, 6, 1, 3, 2, 0);
   }
 
   private void validateCounterCounts(Counters counters, long rowCount, long cellCount,

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
@@ -594,21 +594,28 @@ public class TestRowCounter {
       0, 0, 0, 0, 0);
 
     // Case 2:
-    validateCounterCounts(rowCounterWithCountDeleteMarkers.getMapReduceJob().getCounters(), 6,
-      30, 6, 1, 3, 2, 0);
+    validateCounterCounts(rowCounterWithCountDeleteMarkers.getMapReduceJob().getCounters(), 6, 30,
+      6, 1, 3, 2, 0);
   }
 
   private void validateCounterCounts(Counters counters, long rowCount, long cellCount,
     long rowsWithDeleteMarkersCount, long deleteCount, long deleteColumnCount,
     long deleteFamilyCount, long deleteFamilyVersionCount) {
-    
-    long actualRowCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS).getValue();
-    long actualCellCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.CELLS).getValue();
-    long actualRowsWithDeleteMarkersCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS_WITH_DELETE_MARKER).getValue();
-    long actualDeleteCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE).getValue();
-    long actualDeleteColumnCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_COLUMN).getValue();
-    long actualDeleteFamilyCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY).getValue();
-    long actualDeleteFamilyVersionCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY_VERSION).getValue();
+
+    long actualRowCount =
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS).getValue();
+    long actualCellCount =
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.CELLS).getValue();
+    long actualRowsWithDeleteMarkersCount =
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS_WITH_DELETE_MARKER).getValue();
+    long actualDeleteCount =
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE).getValue();
+    long actualDeleteColumnCount =
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_COLUMN).getValue();
+    long actualDeleteFamilyCount =
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY).getValue();
+    long actualDeleteFamilyVersionCount =
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY_VERSION).getValue();
 
     assertEquals(rowCount, actualRowCount);
     assertEquals(cellCount, actualCellCount);

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.mapreduce;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
@@ -29,6 +30,7 @@ import java.util.Arrays;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
@@ -37,6 +39,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.LauncherSecurityManager;
 import org.apache.hadoop.mapreduce.Counter;
+import org.apache.hadoop.mapreduce.Counters;
 import org.apache.hadoop.mapreduce.Job;
 import org.junit.AfterClass;
 import org.junit.BeforeClass;
@@ -522,6 +525,99 @@ public class TestRowCounter {
     } catch (Throwable e) {
       assertTrue(e instanceof AssertionError);
     }
+  }
+
+  /**
+   * Step 1: Add 6 rows(row1, row2, row3, row4, row5 and row6) to a table. Each row contains 1 column family and 4 columns.
+   * Step 2: Delete a column for row1.
+   * Step 3: Delete a column family for row2 and row4.
+   * Step 4: Delete all versions of a specific column for row3, row5 and row6.
+   * <p>
+   * Case 1: Run row counter without countDeleteMarkers flag
+   *  Step a: Validate counter values.
+   *  Step b: Assert that the countOfDeleteMarker variable is false.
+   * <p>
+   * Case 2: Run row counter with countDeleteMarkers flag
+   *  Step a: Validate counter values.
+   *  Step b: Assert that the countOfDeleteMarker variable is true.
+   * @throws Exception
+   */
+  @Test
+  public void testRowCounterWithCountDeleteMarkersOption() throws Exception {
+    // Test Setup
+
+    final TableName tableName = TableName.valueOf(TABLE_NAME + "_" + "withCountDeleteMarkersOption");
+    final byte[][] rowKeys = {
+      Bytes.toBytes("row1"), Bytes.toBytes("row2"),
+      Bytes.toBytes("row3"), Bytes.toBytes("row4"),
+      Bytes.toBytes("row5"), Bytes.toBytes("row6")
+    };
+    final byte[] columnFamily = Bytes.toBytes("cf");
+    final byte[][] columns = {
+      Bytes.toBytes("A"), Bytes.toBytes("B"),
+      Bytes.toBytes("C"), Bytes.toBytes("D")
+    };
+    final byte[] value = Bytes.toBytes("a");
+
+    try (Table table = TEST_UTIL.createTable(tableName, columnFamily)) {
+      // Step 1: Insert rows with columns
+      for (byte[] rowKey : rowKeys) {
+        Put put = new Put(rowKey);
+        for (byte[] col : columns) {
+          put.addColumn(columnFamily, col, value);
+        }
+        table.put(put);
+      }
+      TEST_UTIL.getAdmin().flush(tableName);
+
+      // Steps 2, 3, and 4: Delete columns, families, and all versions of columns
+      Delete deleteA = new Delete(rowKeys[0]).addColumn(columnFamily, columns[0]);
+      Delete deleteB = new Delete(rowKeys[1]).addFamily(columnFamily);
+      Delete deleteC = new Delete(rowKeys[2]).addColumns(columnFamily, columns[0]);
+      Delete deleteD = new Delete(rowKeys[3]).addFamily(columnFamily);
+      Delete deleteE = new Delete(rowKeys[4]).addColumns(columnFamily, columns[0]);
+      Delete deleteF = new Delete(rowKeys[5]).addColumns(columnFamily, columns[0]);
+
+      table.delete(deleteA);
+      table.delete(deleteB);
+      table.delete(deleteC);
+      table.delete(deleteD);
+      table.delete(deleteE);
+      table.delete(deleteF);
+      TEST_UTIL.getAdmin().flush(tableName);
+    }
+
+    RowCounter rowCounterWithoutCountDeleteMarkers = new RowCounter();
+    RowCounter rowCounterWithCountDeleteMarkers = new RowCounter();
+    rowCounterWithoutCountDeleteMarkers.setConf(TEST_UTIL.getConfiguration());
+    rowCounterWithCountDeleteMarkers.setConf(TEST_UTIL.getConfiguration());
+
+    // Invocation
+
+    rowCounterWithoutCountDeleteMarkers.run(new String[]{tableName.getNameAsString()});
+    rowCounterWithCountDeleteMarkers.run(new String[]{ tableName.getNameAsString(), "--countDeleteMarkers"});
+
+    // Validation
+
+    // Case 1:
+    validateCounterCounts(rowCounterWithoutCountDeleteMarkers.getMapReduceJob().getCounters(), 4, 0, 0, 0, 0, 0, 0);
+    assertFalse(rowCounterWithoutCountDeleteMarkers.getConf().getBoolean("countDeleteMarkers", true));
+
+    // Case 2:
+    validateCounterCounts(rowCounterWithoutCountDeleteMarkers.getMapReduceJob().getCounters(), 6, 24, 6, 1, 3, 2, 0);
+    assertTrue(rowCounterWithoutCountDeleteMarkers.getConf().getBoolean("countDeleteMarkers", false));
+  }
+
+  private void validateCounterCounts(Counters counters, long rowCount, long cellCount,
+    long rowsWithDeleteMarkersCount, long deleteCount, long deleteColumnCount,
+    long deleteFamilyCount, long deleteFamilyVersionCount) {
+    assertEquals(rowCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS).getValue());
+    assertEquals(cellCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.CELLS).getValue());
+    assertEquals(rowsWithDeleteMarkersCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS_WITH_DELETE_MARKER).getValue());
+    assertEquals(deleteCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE).getValue());
+    assertEquals(deleteColumnCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_COLUMN).getValue());
+    assertEquals(deleteFamilyCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY).getValue());
+    assertEquals(deleteFamilyVersionCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY_VERSION).getValue());
   }
 
   private void assertUsageContent(String usage) {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
@@ -528,35 +528,27 @@ public class TestRowCounter {
   }
 
   /**
-   * Step 1: Add 6 rows(row1, row2, row3, row4, row5 and row6) to a table. Each row contains 1 column family and 4 columns.
-   * Step 2: Delete a column for row1.
-   * Step 3: Delete a column family for row2 and row4.
-   * Step 4: Delete all versions of a specific column for row3, row5 and row6.
+   * Step 1: Add 6 rows(row1, row2, row3, row4, row5 and row6) to a table. Each row contains 1
+   * column family and 4 columns. Step 2: Delete a column for row1. Step 3: Delete a column family
+   * for row2 and row4. Step 4: Delete all versions of a specific column for row3, row5 and row6.
    * <p>
-   * Case 1: Run row counter without countDeleteMarkers flag
-   *  Step a: Validate counter values.
-   *  Step b: Assert that the countOfDeleteMarker variable is false.
+   * Case 1: Run row counter without countDeleteMarkers flag Step a: Validate counter values. Step
+   * b: Assert that the countOfDeleteMarker variable is false.
    * <p>
-   * Case 2: Run row counter with countDeleteMarkers flag
-   *  Step a: Validate counter values.
-   *  Step b: Assert that the countOfDeleteMarker variable is true.
-   * @throws Exception
+   * Case 2: Run row counter with countDeleteMarkers flag Step a: Validate counter values. Step b:
+   * Assert that the countOfDeleteMarker variable is true.
    */
   @Test
   public void testRowCounterWithCountDeleteMarkersOption() throws Exception {
     // Test Setup
 
-    final TableName tableName = TableName.valueOf(TABLE_NAME + "_" + "withCountDeleteMarkersOption");
-    final byte[][] rowKeys = {
-      Bytes.toBytes("row1"), Bytes.toBytes("row2"),
-      Bytes.toBytes("row3"), Bytes.toBytes("row4"),
-      Bytes.toBytes("row5"), Bytes.toBytes("row6")
-    };
+    final TableName tableName =
+      TableName.valueOf(TABLE_NAME + "_" + "withCountDeleteMarkersOption");
+    final byte[][] rowKeys = { Bytes.toBytes("row1"), Bytes.toBytes("row2"), Bytes.toBytes("row3"),
+      Bytes.toBytes("row4"), Bytes.toBytes("row5"), Bytes.toBytes("row6") };
     final byte[] columnFamily = Bytes.toBytes("cf");
-    final byte[][] columns = {
-      Bytes.toBytes("A"), Bytes.toBytes("B"),
-      Bytes.toBytes("C"), Bytes.toBytes("D")
-    };
+    final byte[][] columns =
+      { Bytes.toBytes("A"), Bytes.toBytes("B"), Bytes.toBytes("C"), Bytes.toBytes("D") };
     final byte[] value = Bytes.toBytes("a");
 
     try (Table table = TEST_UTIL.createTable(tableName, columnFamily)) {
@@ -594,30 +586,42 @@ public class TestRowCounter {
 
     // Invocation
 
-    rowCounterWithoutCountDeleteMarkers.run(new String[]{tableName.getNameAsString()});
-    rowCounterWithCountDeleteMarkers.run(new String[]{ tableName.getNameAsString(), "--countDeleteMarkers"});
+    rowCounterWithoutCountDeleteMarkers.run(new String[] { tableName.getNameAsString() });
+    rowCounterWithCountDeleteMarkers
+      .run(new String[] { tableName.getNameAsString(), "--countDeleteMarkers" });
 
     // Validation
 
     // Case 1:
-    validateCounterCounts(rowCounterWithoutCountDeleteMarkers.getMapReduceJob().getCounters(), 4, 0, 0, 0, 0, 0, 0);
-    assertFalse(rowCounterWithoutCountDeleteMarkers.getConf().getBoolean("countDeleteMarkers", true));
+    validateCounterCounts(rowCounterWithoutCountDeleteMarkers.getMapReduceJob().getCounters(), 4, 0,
+      0, 0, 0, 0, 0);
+    assertFalse(
+      rowCounterWithoutCountDeleteMarkers.getConf().getBoolean("countDeleteMarkers", true));
 
     // Case 2:
-    validateCounterCounts(rowCounterWithoutCountDeleteMarkers.getMapReduceJob().getCounters(), 6, 24, 6, 1, 3, 2, 0);
-    assertTrue(rowCounterWithoutCountDeleteMarkers.getConf().getBoolean("countDeleteMarkers", false));
+    validateCounterCounts(rowCounterWithoutCountDeleteMarkers.getMapReduceJob().getCounters(), 6,
+      24, 6, 1, 3, 2, 0);
+    assertTrue(
+      rowCounterWithoutCountDeleteMarkers.getConf().getBoolean("countDeleteMarkers", false));
   }
 
   private void validateCounterCounts(Counters counters, long rowCount, long cellCount,
     long rowsWithDeleteMarkersCount, long deleteCount, long deleteColumnCount,
     long deleteFamilyCount, long deleteFamilyVersionCount) {
-    assertEquals(rowCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS).getValue());
-    assertEquals(cellCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.CELLS).getValue());
-    assertEquals(rowsWithDeleteMarkersCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS_WITH_DELETE_MARKER).getValue());
-    assertEquals(deleteCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE).getValue());
-    assertEquals(deleteColumnCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_COLUMN).getValue());
-    assertEquals(deleteFamilyCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY).getValue());
-    assertEquals(deleteFamilyVersionCount, counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY_VERSION).getValue());
+    assertEquals(rowCount,
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS).getValue());
+    assertEquals(cellCount,
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.CELLS).getValue());
+    assertEquals(rowsWithDeleteMarkersCount, counters
+      .findCounter(RowCounter.RowCounterMapper.Counters.ROWS_WITH_DELETE_MARKER).getValue());
+    assertEquals(deleteCount,
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE).getValue());
+    assertEquals(deleteColumnCount,
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_COLUMN).getValue());
+    assertEquals(deleteFamilyCount,
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY).getValue());
+    assertEquals(deleteFamilyVersionCount,
+      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY_VERSION).getValue());
   }
 
   private void assertUsageContent(String usage) {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestRowCounter.java
@@ -595,26 +595,28 @@ public class TestRowCounter {
 
     // Case 2:
     validateCounterCounts(rowCounterWithCountDeleteMarkers.getMapReduceJob().getCounters(), 6,
-      6, 6, 1, 3, 2, 0);
+      30, 6, 1, 3, 2, 0);
   }
 
   private void validateCounterCounts(Counters counters, long rowCount, long cellCount,
     long rowsWithDeleteMarkersCount, long deleteCount, long deleteColumnCount,
     long deleteFamilyCount, long deleteFamilyVersionCount) {
-    assertEquals(rowCount,
-      counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS).getValue());
-    assertEquals(cellCount,
-      counters.findCounter(RowCounter.RowCounterMapper.Counters.CELLS).getValue());
-    assertEquals(rowsWithDeleteMarkersCount, counters
-      .findCounter(RowCounter.RowCounterMapper.Counters.ROWS_WITH_DELETE_MARKER).getValue());
-    assertEquals(deleteCount,
-      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE).getValue());
-    assertEquals(deleteColumnCount,
-      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_COLUMN).getValue());
-    assertEquals(deleteFamilyCount,
-      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY).getValue());
-    assertEquals(deleteFamilyVersionCount,
-      counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY_VERSION).getValue());
+    
+    long actualRowCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS).getValue();
+    long actualCellCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.CELLS).getValue();
+    long actualRowsWithDeleteMarkersCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.ROWS_WITH_DELETE_MARKER).getValue();
+    long actualDeleteCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE).getValue();
+    long actualDeleteColumnCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_COLUMN).getValue();
+    long actualDeleteFamilyCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY).getValue();
+    long actualDeleteFamilyVersionCount = counters.findCounter(RowCounter.RowCounterMapper.Counters.DELETE_FAMILY_VERSION).getValue();
+
+    assertEquals(rowCount, actualRowCount);
+    assertEquals(cellCount, actualCellCount);
+    assertEquals(rowsWithDeleteMarkersCount, actualRowsWithDeleteMarkersCount);
+    assertEquals(deleteCount, actualDeleteCount);
+    assertEquals(deleteColumnCount, actualDeleteColumnCount);
+    assertEquals(deleteFamilyCount, actualDeleteFamilyCount);
+    assertEquals(deleteFamilyVersionCount, actualDeleteFamilyVersionCount);
   }
 
   private void assertUsageContent(String usage) {


### PR DESCRIPTION
A flag is introduced, which, when enabled, allows RowCounter to count the various types of Delete Markers - DELETE_COLUMN, DELETE_FAMILY, DELETE_FAMILY_VERSION. It will also calculate the number of rows having a delete marker.

To enable this the scan object was modified -> if flag is set, raw scan is performed without FirstKeyOnlyFilter.

Note: Commits are cherry-picked from https://github.com/apache/hbase/pull/6435