### PR TITLE
HBASE-29000 SLF4j logging backend incorrectly picked up from Hadoop w…

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -869,9 +869,10 @@ fi
 
 HEAP_SETTINGS="$JAVA_HEAP_MAX $JAVA_OFFHEAP_MAX"
 # by now if we're running a command it means we need logging
+# prepend the logging jars to make sure they are before the ones coming from HADOOP_CLASSPATH
 for f in ${HBASE_HOME}/lib/client-facing-thirdparty/log4j*.jar; do
   if [ -f "${f}" ]; then
-    CLASSPATH="${CLASSPATH}:${f}"
+    CLASSPATH="${f}:${CLASSPATH}"
   fi
 done
 


### PR DESCRIPTION
…hen external Hadoop is specified (#6495)

Signed-off-by: Nihal Jain <nihaljain@apache.org>
Signed-off-by: Duo Zhang <zhangduo@apache.org>
(cherry picked from commit 76586721fa8bd2d1d4caae6c74b45b29f0b45c54)