### PR TITLE
HBASE-28951 rename the wal before retrying the wal-split with another worker

### DIFF
--- a/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
@@ -723,6 +723,7 @@ enum SplitWALState{
   ACQUIRE_SPLIT_WAL_WORKER = 1;
   DISPATCH_WAL_TO_WORKER = 2;
   RELEASE_SPLIT_WORKER = 3;
+  RETRY_ON_DIFFERENT_WORKER = 4;
 }
 
 message ClaimReplicationQueuesStateData {

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
@@ -709,7 +709,6 @@ message SplitWALData{
   required string wal_path = 1;
   required ServerName crashed_server=2;
   optional ServerName worker = 3;
-  optional uint32 workerChangeCount =4;
 }
 
 message SplitWALRemoteData{

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
@@ -709,6 +709,7 @@ message SplitWALData{
   required string wal_path = 1;
   required ServerName crashed_server=2;
   optional ServerName worker = 3;
+  optional uint32 workerChangeCount =4;
 }
 
 message SplitWALRemoteData{

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
@@ -186,7 +186,7 @@ public class SplitWALManager {
     splitWorkerAssigner.addUsedWorker(worker);
   }
 
-  public String renameWALForRetry(String walPath, Integer workerChangeCount) throws IOException {
+  public String renameWALForRetry(String walPath) throws IOException {
     String originalWALPath;
     // If the WAL split is retried with another worker, ".retrying-xxx" is appended to the walPath.
     // In the case where a SplitWalProcedure is bypassed or rolled back after being retried with
@@ -194,8 +194,10 @@ public class SplitWALManager {
     // SplitWalProcedure (by different SCP) will be created, which will have a workerChangeCount of
     // 0 but will still have ".retrying-xxx" appended to the walPath. This is why we cannot use the
     // condition workerChangeCount != 0.
+    int workerChangeCount = 0;
     if (walPath.substring(walPath.length() - RETRYING_EXT.length() - 3).startsWith(RETRYING_EXT)) {
       originalWALPath = walPath.substring(0, walPath.length() - RETRYING_EXT.length() - 3);
+      workerChangeCount = Integer.parseInt(walPath.substring(walPath.length() - 3));
     } else {
       originalWALPath = walPath;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hbase.HConstants.DEFAULT_HBASE_SPLIT_WAL_MAX_SPL
 import static org.apache.hadoop.hbase.HConstants.HBASE_SPLIT_WAL_MAX_SPLITTER;
 import static org.apache.hadoop.hbase.master.MasterWalManager.META_FILTER;
 import static org.apache.hadoop.hbase.master.MasterWalManager.NON_META_FILTER;
+import static org.apache.hadoop.hbase.wal.AbstractFSWALProvider.RETRYING_EXT;
 
 import java.io.IOException;
 import java.util.Arrays;
@@ -183,5 +184,14 @@ public class SplitWALManager {
    */
   public void addUsedSplitWALWorker(ServerName worker) {
     splitWorkerAssigner.addUsedWorker(worker);
+  }
+
+  public String renameWALForRetry(String walPath) throws IOException {
+    Path walCurrentPath = new Path(rootDir, walPath);
+    Path walNewPath = walPath.endsWith(RETRYING_EXT)
+      ? new Path(rootDir, walPath.substring(0, walPath.length() - RETRYING_EXT.length()))
+      : walCurrentPath.suffix(RETRYING_EXT);
+    fs.rename(walCurrentPath, walNewPath);
+    return walNewPath.toString();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
@@ -188,7 +188,9 @@ public class SplitWALManager {
   /**
    * Rename the WAL file at the specified walPath to retry with another worker. Returns true if the
    * file is successfully renamed, or if it has already been renamed in previous try. Returns false
-   * if neither of the files exists. It throws an IOException if got any error while renaming.
+   * if neither of the files exists. It throws an IOException if got any error while renaming. This
+   * method is only called in case of failure on one worker so in case of no failure flow is same as
+   * old one.
    */
   public boolean ifExistRenameWALForRetry(String walPath, String postRenameWalPath)
     throws IOException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/SplitWALManager.java
@@ -188,10 +188,16 @@ public class SplitWALManager {
 
   public String renameWALForRetry(String walPath, Integer workerChangeCount) throws IOException {
     String originalWALPath;
-    if (workerChangeCount == 0) {
-      originalWALPath = walPath;
-    } else {
+    // If the WAL split is retried with another worker, ".retrying-xxx" is appended to the walPath.
+    // In the case where a SplitWalProcedure is bypassed or rolled back after being retried with
+    // another worker, the walPath will still have ".retrying-xxx" appended. During recovery, a new
+    // SplitWalProcedure (by different SCP) will be created, which will have a workerChangeCount of
+    // 0 but will still have ".retrying-xxx" appended to the walPath. This is why we cannot use the
+    // condition workerChangeCount != 0.
+    if (walPath.substring(walPath.length() - RETRYING_EXT.length() - 3).startsWith(RETRYING_EXT)) {
       originalWALPath = walPath.substring(0, walPath.length() - RETRYING_EXT.length() - 3);
+    } else {
+      originalWALPath = walPath;
     }
     String walNewName =
       originalWALPath + RETRYING_EXT + String.format("%03d", (workerChangeCount + 1) % 1000);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SplitWALProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SplitWALProcedure.java
@@ -51,7 +51,7 @@ public class SplitWALProcedure
   private ServerName worker;
   private ServerName crashedServer;
   private RetryCounter retryCounter;
-  private Integer workerChangeCount = 0;
+  private int workerChangeCount = 0;
 
   public SplitWALProcedure() {
   }
@@ -181,10 +181,6 @@ public class SplitWALProcedure
 
   public ServerName getWorker() {
     return worker;
-  }
-
-  public Integer getWorkerChangeCount() {
-    return workerChangeCount;
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
@@ -237,6 +237,8 @@ public abstract class AbstractFSWALProvider<T extends AbstractFSWAL<?>>
   /** File Extension used while splitting an WAL into regions (HBASE-2312) */
   public static final String SPLITTING_EXT = "-splitting";
 
+  public static final String RETRYING_EXT = ".retrying";
+
   /**
    * Pattern used to validate a WAL file name see {@link #validateWALFilename(String)} for
    * description.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
@@ -237,6 +237,7 @@ public abstract class AbstractFSWALProvider<T extends AbstractFSWAL<?>>
   /** File Extension used while splitting an WAL into regions (HBASE-2312) */
   public static final String SPLITTING_EXT = "-splitting";
 
+  // Extension for the WAL where the split failed on one worker and is being retried on another.
   public static final String RETRYING_EXT = ".retrying";
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/AbstractFSWALProvider.java
@@ -234,10 +234,14 @@ public abstract class AbstractFSWALProvider<T extends AbstractFSWAL<?>>
   static final String DEFAULT_PROVIDER_ID = "default";
 
   // Implementation details that currently leak in tests or elsewhere follow
-  /** File Extension used while splitting an WAL into regions (HBASE-2312) */
+  /**
+   * File Extension used while splitting an WAL into regions (HBASE-2312) This is used with the
+   * directory name/path
+   */
   public static final String SPLITTING_EXT = "-splitting";
 
   // Extension for the WAL where the split failed on one worker and is being retried on another.
+  // this is used with the WAL file itself
   public static final String RETRYING_EXT = ".retrying";
 
   /**


### PR DESCRIPTION
Added an workerchange counter so that each time we can have a new name, that is needed in case the supposed dead RS starts to process the WAL after some time. I checked that wal name pattern, that we use for validating the wal is `(.+)\.(\d+)(\.[0-9A-Za-z]+)? `. This change is fitting there.