### PR TITLE
HBASE-29028 Backport missing UI patches to branch-2.5

### DIFF
--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTDumpServlet.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTDumpServlet.java
@@ -1,0 +1,80 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.rest;
+
+import java.io.IOException;
+import java.io.OutputStream;
+import java.io.PrintStream;
+import java.io.PrintWriter;
+import java.util.Date;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.http.HttpServer;
+import org.apache.hadoop.hbase.monitoring.StateDumpServlet;
+import org.apache.hadoop.hbase.util.LogMonitoring;
+import org.apache.hadoop.hbase.util.Threads;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class RESTDumpServlet extends StateDumpServlet {
+  private static final long serialVersionUID = 1L;
+  private static final String LINE = "===========================================================";
+
+  @Override
+  public void doGet(HttpServletRequest request, HttpServletResponse response) throws IOException {
+    if (!HttpServer.isInstrumentationAccessAllowed(getServletContext(), request, response)) {
+      return;
+    }
+
+    RESTServer restServer = (RESTServer) getServletContext().getAttribute(RESTServer.REST_SERVER);
+    assert restServer != null : "No REST Server in context!";
+
+    response.setContentType("text/plain");
+    OutputStream os = response.getOutputStream();
+    try (PrintWriter out = new PrintWriter(os)) {
+
+      out.println("REST Server status for " + restServer.getServerName() + " as of " + new Date());
+
+      out.println("\n\nVersion Info:");
+      out.println(LINE);
+      dumpVersionInfo(out);
+
+      out.println("\n\nStacks:");
+      out.println(LINE);
+      out.flush();
+      PrintStream ps = new PrintStream(response.getOutputStream(), false, "UTF-8");
+      Threads.printThreadInfo(ps, "");
+      ps.flush();
+
+      out.println("\n\nREST Server configuration:");
+      out.println(LINE);
+      Configuration conf = restServer.conf;
+      out.flush();
+      conf.writeXml(os);
+      os.flush();
+
+      out.println("\n\nLogs");
+      out.println(LINE);
+      long tailKb = getTailKbParam(request);
+      LogMonitoring.dumpTailOfLogs(out, tailKb);
+
+      out.flush();
+    }
+  }
+}

--- a/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
+++ b/hbase-rest/src/main/java/org/apache/hadoop/hbase/rest/RESTServer.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.rest;
 import static org.apache.hadoop.hbase.http.HttpServerUtil.PATH_SPEC_ANY;
 
 import java.lang.management.ManagementFactory;
+import java.net.UnknownHostException;
 import java.util.ArrayList;
 import java.util.EnumSet;
 import java.util.List;
@@ -31,6 +32,7 @@ import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.http.HttpServerUtil;
 import org.apache.hadoop.hbase.http.InfoServer;
 import org.apache.hadoop.hbase.log.HBaseMarkers;
@@ -83,6 +85,7 @@ import org.apache.hbase.thirdparty.org.glassfish.jersey.servlet.ServletContainer
 @InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.TOOLS)
 public class RESTServer implements Constants {
   static Logger LOG = LoggerFactory.getLogger("RESTServer");
+  public static final String REST_SERVER = "rest";
 
   static final String REST_CSRF_ENABLED_KEY = "hbase.rest.csrf.enabled";
   static final boolean REST_CSRF_ENABLED_DEFAULT = false;
@@ -110,6 +113,7 @@ public class RESTServer implements Constants {
   private final UserProvider userProvider;
   private Server server;
   private InfoServer infoServer;
+  private ServerName serverName;
 
   public RESTServer(Configuration conf) {
     RESTServer.conf = conf;
@@ -143,8 +147,7 @@ public class RESTServer implements Constants {
     loginServerPrincipal(UserProvider userProvider, Configuration conf) throws Exception {
     Class<? extends ServletContainer> containerClass = ServletContainer.class;
     if (userProvider.isHadoopSecurityEnabled() && userProvider.isHBaseSecurityEnabled()) {
-      String machineName = Strings.domainNamePointerToHostName(DNS.getDefaultHost(
-        conf.get(REST_DNS_INTERFACE, "default"), conf.get(REST_DNS_NAMESERVER, "default")));
+      String machineName = getHostName(conf);
       String keytabFilename = conf.get(REST_KEYTAB_FILE);
       Preconditions.checkArgument(keytabFilename != null && !keytabFilename.isEmpty(),
         REST_KEYTAB_FILE + " should be set if security is enabled");
@@ -385,14 +388,24 @@ public class RESTServer implements Constants {
     // Put up info server.
     int port = conf.getInt("hbase.rest.info.port", 8085);
     if (port >= 0) {
-      conf.setLong("startcode", EnvironmentEdgeManager.currentTime());
-      String a = conf.get("hbase.rest.info.bindAddress", "0.0.0.0");
-      this.infoServer = new InfoServer("rest", a, port, false, conf);
+      final long startCode = EnvironmentEdgeManager.currentTime();
+      conf.setLong("startcode", startCode);
+      this.serverName = ServerName.valueOf(getHostName(conf), servicePort, startCode);
+
+      String addr = conf.get("hbase.rest.info.bindAddress", "0.0.0.0");
+      this.infoServer = new InfoServer(REST_SERVER, addr, port, false, conf);
+      this.infoServer.addPrivilegedServlet("dump", "/dump", RESTDumpServlet.class);
+      this.infoServer.setAttribute(REST_SERVER, this);
       this.infoServer.setAttribute("hbase.conf", conf);
       this.infoServer.start();
     }
     // start server
     server.start();
+  }
+
+  private static String getHostName(Configuration conf) throws UnknownHostException {
+    return Strings.domainNamePointerToHostName(DNS.getDefaultHost(
+      conf.get(REST_DNS_INTERFACE, "default"), conf.get(REST_DNS_NAMESERVER, "default")));
   }
 
   public synchronized void join() throws Exception {
@@ -402,7 +415,19 @@ public class RESTServer implements Constants {
     server.join();
   }
 
+  private void stopInfoServer() {
+    if (this.infoServer != null) {
+      LOG.info("Stop info server");
+      try {
+        this.infoServer.stop();
+      } catch (Exception e) {
+        LOG.error("Failed to stop infoServer", e);
+      }
+    }
+  }
+
   public synchronized void stop() throws Exception {
+    stopInfoServer();
     if (server == null) {
       throw new IllegalStateException("Server is not running");
     }
@@ -424,6 +449,10 @@ public class RESTServer implements Constants {
       throw new IllegalStateException("InfoServer is not running");
     }
     return infoServer.getPort();
+  }
+
+  public ServerName getServerName() {
+    return serverName;
   }
 
   public Configuration getConf() {

--- a/hbase-rest/src/main/resources/hbase-webapps/rest/footer.jsp
+++ b/hbase-rest/src/main/resources/hbase-webapps/rest/footer.jsp
@@ -1,0 +1,32 @@
+<%--
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+--%>
+
+    <script src="/static/js/jquery.min.js" type="text/javascript"></script>
+    <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="/static/js/tab.js" type="text/javascript"></script>
+    <script type="text/javascript">
+      $(document).ready(function() {
+        $('div.navbar li.active').removeClass('active');
+        $('a[href="' + location.pathname + '"]').closest('li').addClass('active');
+      });
+    </script>
+</body>
+</html>
+

--- a/hbase-rest/src/main/resources/hbase-webapps/rest/header.jsp
+++ b/hbase-rest/src/main/resources/hbase-webapps/rest/header.jsp
@@ -1,0 +1,74 @@
+<%--
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+--%>
+<%@ page contentType="text/html;charset=UTF-8"
+         import="org.apache.hadoop.hbase.HBaseConfiguration"%>
+
+<!DOCTYPE html>
+<?xml version="1.0" encoding="UTF-8" ?>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title><%= request.getParameter("pageTitle")%></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="">
+
+  <link href="/static/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/static/css/bootstrap-theme.min.css" rel="stylesheet">
+  <link href="/static/css/hbase.css" rel="stylesheet">
+</head>
+
+<body>
+<div class="navbar  navbar-fixed-top navbar-default">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="/rest.jsp"><img src="/static/hbase_logo_small.png" alt="HBase Logo"/></a>
+    </div>
+    <div class="collapse navbar-collapse">
+      <ul class="nav navbar-nav">
+        <li class="active"><a href="/rest.jsp">Home</a></li>
+        <li><a href="/logs/">Local logs</a></li>
+        <li><a href="/processRest.jsp">Process Metrics</a></li>
+        <li><a href="/logLevel">Log Level</a></li>
+        <li><a href="/dump">Debug Dump</a></li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Metrics <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+            <li><a target="_blank" href="/jmx">JMX</a></li>
+            <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+            <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+            <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+          </ul>
+        </li>
+        <li><a href="/prof">Profiler</a></li>
+        <% if (HBaseConfiguration.isShowConfInServlet()) { %>
+        <li><a href="/conf">HBase Configuration</a></li>
+        <% } %>
+      </ul>
+    </div><!--/.nav-collapse -->
+  </div>
+</div>
+

--- a/hbase-rest/src/main/resources/hbase-webapps/rest/header.jsp
+++ b/hbase-rest/src/main/resources/hbase-webapps/rest/header.jsp
@@ -59,8 +59,6 @@
           <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
             <li><a target="_blank" href="/jmx">JMX</a></li>
             <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
-            <li><a target="_blank" href="/prometheus">Prometheus</a></li>
-            <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
           </ul>
         </li>
         <li><a href="/prof">Profiler</a></li>

--- a/hbase-rest/src/main/resources/hbase-webapps/rest/processRest.jsp
+++ b/hbase-rest/src/main/resources/hbase-webapps/rest/processRest.jsp
@@ -1,0 +1,184 @@
+<%--
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+--%>
+<%@ page contentType="text/html;charset=UTF-8"
+  import="java.util.Date"
+  import="java.util.List"
+  import="javax.management.ObjectName"
+  import="java.lang.management.ManagementFactory"
+  import="java.lang.management.MemoryPoolMXBean"
+  import="java.lang.management.RuntimeMXBean"
+  import="java.lang.management.GarbageCollectorMXBean"
+  import="org.apache.hadoop.hbase.util.JSONMetricUtil"
+  import="org.apache.hadoop.hbase.procedure2.util.StringUtils"
+  import="org.apache.hadoop.util.StringUtils.TraditionalBinaryPrefix"
+%>
+
+<%
+RuntimeMXBean runtimeBean = ManagementFactory.getRuntimeMXBean();
+ObjectName jvmMetrics = new ObjectName("Hadoop:service=HBase,name=JvmMetrics");
+
+// There is always two of GC collectors
+List<GarbageCollectorMXBean> gcBeans = JSONMetricUtil.getGcCollectorBeans();
+GarbageCollectorMXBean collector1 = null;
+GarbageCollectorMXBean collector2 = null;
+try {
+collector1 = gcBeans.get(0);
+collector2 = gcBeans.get(1);
+} catch(IndexOutOfBoundsException e) {}
+List<MemoryPoolMXBean> mPools = JSONMetricUtil.getMemoryPools();
+pageContext.setAttribute("pageTitle", "Process info for PID: " + JSONMetricUtil.getProcessPID());
+%>
+
+<jsp:include page="header.jsp">
+  <jsp:param name="pageTitle" value="${pageTitle}"/>
+</jsp:include>
+
+<div class="container-fluid content">
+  <div class="row">
+      <div class="page-header">
+          <h1><%= JSONMetricUtil.getCommmand().split(" ")[0] %></h1>
+      </div>
+  </div>
+  <table class="table table-striped" width="90%" >
+    <tr>
+        <th>Started</th>
+        <th>Uptime</th>
+        <th>PID</th>
+        <th>Owner</th>
+    </tr>
+    <tr>
+      <tr>
+        <td><%= new Date(runtimeBean.getStartTime()) %></td>
+        <td><%= StringUtils.humanTimeDiff(runtimeBean.getUptime()) %></td>
+        <td><%= JSONMetricUtil.getProcessPID() %></td>
+        <td><%= runtimeBean.getSystemProperties().get("user.name") %></td>
+      </tr>
+  </table>
+</div>
+<div class="container-fluid content">
+  <div class="row">
+    <div class="page-header">
+    <h2>Threads</h2>
+    </div>
+    </div>
+  <table class="table table-striped" width="90%" >
+    <tr>
+        <th>ThreadsNew</th>
+        <th>ThreadsRunable</th>
+        <th>ThreadsBlocked</th>
+        <th>ThreadsWaiting</th>
+        <th>ThreadsTimeWaiting</th>
+        <th>ThreadsTerminated</th>
+    </tr>
+     <tr>
+        <td><%= JSONMetricUtil.getValueFromMBean(jvmMetrics, "ThreadsNew")  %></td>
+        <td><%= JSONMetricUtil.getValueFromMBean(jvmMetrics, "ThreadsRunnable")%></td>
+        <td><%= JSONMetricUtil.getValueFromMBean(jvmMetrics, "ThreadsBlocked")%></td>
+        <td><%= JSONMetricUtil.getValueFromMBean(jvmMetrics, "ThreadsWaiting")%></td>
+        <td><%= JSONMetricUtil.getValueFromMBean(jvmMetrics, "ThreadsTimedWaiting")%></td>
+        <td><%= JSONMetricUtil.getValueFromMBean(jvmMetrics, "ThreadsTerminated")%></td>
+     </tr>
+  </table>
+</div>
+<div class="container-fluid content">
+  <div class="row">
+    <div class="page-header">
+    <h2>GC Collectors</h2>
+    </div>
+    </div>
+    <% if (gcBeans.size() == 2) { %>
+<div class="tabbable">
+  <ul class="nav nav-pills">
+    <li class="active">
+      <a href="#tab_gc1" data-toggle="tab"><%=collector1.getName() %></a>
+    </li>
+    <li class="">
+      <a href="#tab_gc2" data-toggle="tab"><%=collector2.getName() %></a>
+     </li>
+  </ul>
+    <div class="tab-content" style="padding-bottom: 9px; border-bottom: 1px solid #ddd;">
+      <div class="tab-pane active" id="tab_gc1">
+          <table class="table table-striped">
+            <tr>
+              <th>Collection Count</th>
+              <th>Collection Time</th>
+              <th>Last duration</th>
+            </tr>
+            <tr>
+              <td> <%= collector1.getCollectionCount() %></td>
+              <td> <%= StringUtils.humanTimeDiff(collector1.getCollectionTime()) %> </td>
+              <td> <%= StringUtils.humanTimeDiff(JSONMetricUtil.getLastGcDuration(
+                collector1.getObjectName())) %></td>
+            </tr>
+          </table>
+      </div>
+      <div class="tab-pane" id="tab_gc2">
+        <table class="table table-striped">
+          <tr>
+            <th>Collection Count</th>
+            <th>Collection Time</th>
+             <th>Last duration</th>
+          </tr>
+          <tr>
+            <td> <%= collector2.getCollectionCount()  %></td>
+            <td> <%= StringUtils.humanTimeDiff(collector2.getCollectionTime()) %> </td>
+            <td> <%= StringUtils.humanTimeDiff(JSONMetricUtil.getLastGcDuration(
+              collector2.getObjectName())) %></td>
+          </tr>
+          </table>
+      </div>
+      </div>
+  </div>
+  <%} else { %>
+  <p> Can not display GC Collector stats.</p>
+  <%} %>
+  Total GC Collection time: <%= StringUtils.humanTimeDiff(collector1.getCollectionTime() +
+    collector2.getCollectionTime())%>
+</div>
+<% for(MemoryPoolMXBean mp:mPools) {
+if(mp.getName().contains("Cache")) continue;%>
+<div class="container-fluid content">
+  <div class="row">
+      <div class="page-header">
+          <h2><%= mp.getName() %></h2>
+      </div>
+  </div>
+  <table class="table table-striped" width="90%" >
+    <tr>
+        <th>Commited</th>
+        <th>Init</th>
+        <th>Max</th>
+        <th>Used</th>
+        <th>Utilization [%]</th>
+    </tr>
+    <tr>
+      <tr>
+        <td><%= TraditionalBinaryPrefix.long2String(mp.getUsage().getCommitted(), "B", 1) %></td>
+        <td><%= TraditionalBinaryPrefix.long2String(mp.getUsage().getInit(), "B", 1) %></td>
+        <td><%= TraditionalBinaryPrefix.long2String(mp.getUsage().getMax(), "B", 1) %></td>
+        <td><%= TraditionalBinaryPrefix.long2String(mp.getUsage().getUsed(), "B", 1) %></td>
+        <td><%= JSONMetricUtil.calcPercentage(mp.getUsage().getUsed(),
+          mp.getUsage().getCommitted()) %></td>
+      </tr>
+  </table>
+</div>
+<% } %>
+
+<jsp:include page="footer.jsp" />

--- a/hbase-rest/src/main/resources/hbase-webapps/rest/rest.jsp
+++ b/hbase-rest/src/main/resources/hbase-webapps/rest/rest.jsp
@@ -18,70 +18,29 @@
  */
 --%>
 <%@ page contentType="text/html;charset=UTF-8"
-  import="org.apache.hadoop.conf.Configuration"
-  import="org.apache.hadoop.hbase.HBaseConfiguration"
-  import="org.apache.hadoop.hbase.rest.model.VersionModel"
-  import="org.apache.hadoop.hbase.util.VersionInfo"
-  import="java.util.Date"%>
+         import="org.apache.hadoop.conf.Configuration"
+         import="org.apache.hadoop.hbase.rest.RESTServer"
+         import="org.apache.hadoop.hbase.rest.model.VersionModel"
+         import="org.apache.hadoop.hbase.util.VersionInfo"
+         import="java.util.Date"%>
+
 <%
-Configuration conf = (Configuration)getServletContext().getAttribute("hbase.conf");
-long startcode = conf.getLong("startcode", System.currentTimeMillis());
-String listenPort = conf.get("hbase.rest.port", "8080");
+  Configuration conf = (Configuration) getServletContext().getAttribute("hbase.conf");
+  long startcode = conf.getLong("startcode", System.currentTimeMillis());
+
+  final RESTServer restServer = (RESTServer) getServletContext().getAttribute(RESTServer.REST_SERVER);
+  final String hostName = restServer.getServerName().getHostname();
+  pageContext.setAttribute("pageTitle", "HBase REST Server" + hostName);
 %>
-<!DOCTYPE html>
-<?xml version="1.0" encoding="UTF-8" ?>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>HBase REST Server: <%= listenPort %></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="">
 
-    <link href="/static/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/static/css/bootstrap-theme.min.css" rel="stylesheet">
-    <link href="/static/css/hbase.css" rel="stylesheet">
-  </head>
-
-  <body>
-  <div class="navbar  navbar-fixed-top navbar-default">
-      <div class="container-fluid">
-          <div class="navbar-header">
-              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-              </button>
-              <a class="navbar-brand" href="/rest.jsp"><img src="/static/hbase_logo_small.png" alt="HBase Logo"/></a>
-          </div>
-          <div class="collapse navbar-collapse">
-              <ul class="nav navbar-nav">
-                  <li class="active"><a href="/rest.jsp">Home</a></li>
-                  <li><a href="/logs/">Local logs</a></li>
-                  <li><a href="/logLevel">Log Level</a></li>
-                  <li class="nav-item dropdown">
-                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                      Metrics <span class="caret"></span>
-                    </a>
-                    <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                      <li><a target="_blank" href="/jmx">JMX</a></li>
-                      <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
-                      <li><a target="_blank" href="/prometheus">Prometheus</a></li>
-                      <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
-                    </ul>
-                  </li>
-                  <li><a href="/prof">Profiler</a></li>
-                  <% if (HBaseConfiguration.isShowConfInServlet()) { %>
-                  <li><a href="/conf">HBase Configuration</a></li>
-                  <% } %>
-              </ul>
-          </div><!--/.nav-collapse -->
-      </div>
-  </div>
+<jsp:include page="header.jsp">
+  <jsp:param name="pageTitle" value="${pageTitle}"/>
+</jsp:include>
 
 <div class="container-fluid content">
     <div class="row inner_header">
         <div class="page-header">
-            <h1>RESTServer <small><%= listenPort %></small></h1>
+            <h1>RESTServer <small><%= hostName %></small></h1>
         </div>
     </div>
     <div class="row">
@@ -124,9 +83,6 @@ String listenPort = conf.get("hbase.rest.port", "8080");
     </section>
     </div>
 </div>
-<script src="/static/js/jquery.min.js" type="text/javascript"></script>
-<script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="/static/js/tab.js" type="text/javascript"></script>
-</body>
-</html>
+
+<jsp:include page="footer.jsp" />
 

--- a/hbase-rest/src/main/resources/hbase-webapps/rest/rest.jsp
+++ b/hbase-rest/src/main/resources/hbase-webapps/rest/rest.jsp
@@ -58,7 +58,17 @@ String listenPort = conf.get("hbase.rest.port", "8080");
                   <li class="active"><a href="/rest.jsp">Home</a></li>
                   <li><a href="/logs/">Local logs</a></li>
                   <li><a href="/logLevel">Log Level</a></li>
-                  <li><a href="/jmx">Metrics Dump</a></li>
+                  <li class="nav-item dropdown">
+                    <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                      Metrics <span class="caret"></span>
+                    </a>
+                    <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                      <li><a target="_blank" href="/jmx">JMX</a></li>
+                      <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                      <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                      <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+                    </ul>
+                  </li>
                   <li><a href="/prof">Profiler</a></li>
                   <% if (HBaseConfiguration.isShowConfInServlet()) { %>
                   <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
@@ -169,8 +169,6 @@ AssignmentManager assignmentManager = master.getAssignmentManager();
                   <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                     <li><a target="_blank" href="/jmx">JMX</a></li>
                     <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
-                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
-                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
                   </ul>
                 </li>
                 <li><a href="/prof">Profiler</a></li>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
@@ -162,7 +162,17 @@ AssignmentManager assignmentManager = master.getAssignmentManager();
                 <li><a href="/logs/">Local Logs</a></li>
                 <li><a href="/logLevel">Log Level</a></li>
                 <li><a href="/dump">Debug Dump</a></li>
-                <li><a href="/jmx">Metrics Dump</a></li>
+                <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Metrics <span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                    <li><a target="_blank" href="/jmx">JMX</a></li>
+                    <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+                  </ul>
+                </li>
                 <li><a href="/prof">Profiler</a></li>
                 <%if HBaseConfiguration.isShowConfInServlet()%>
                 <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
@@ -299,7 +299,12 @@ $(document).ready(function()
             type: "numeric"
         });
 
-        $("#baseStatsTable").tablesorter();
+        $("#baseStatsTable").tablesorter({
+            headers: {
+                1: {empty: 'emptyMin'},
+                2: {empty: 'emptyMax'}
+            }
+        });
         $("#requestStatsTable").tablesorter({
             headers: {
                 1: {sorter: 'separator'},

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
@@ -121,8 +121,6 @@ org.apache.hadoop.hbase.zookeeper.MasterAddressTracker;
                   <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                     <li><a target="_blank" href="/jmx">JMX</a></li>
                     <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
-                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
-                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
                   </ul>
                 </li>
                 <li><a href="/prof">Profiler</a></li>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
@@ -114,7 +114,17 @@ org.apache.hadoop.hbase.zookeeper.MasterAddressTracker;
                 <li><a href="/rsOperationDetails.jsp">Operation Details</a></li>
                 <li><a href="/logLevel">Log Level</a></li>
                 <li><a href="/dump">Debug Dump</a></li>
-                <li><a href="/jmx">Metrics Dump</a></li>
+                <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Metrics <span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                    <li><a target="_blank" href="/jmx">JMX</a></li>
+                    <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+                  </ul>
+                </li>
                 <li><a href="/prof">Profiler</a></li>
                 <%if HBaseConfiguration.isShowConfInServlet()%>
                 <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-server/src/main/resources/hbase-webapps/master/header.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/header.jsp
@@ -76,8 +76,6 @@
               <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                 <li><a target="_blank" href="/jmx">JMX</a></li>
                 <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
-                <li><a target="_blank" href="/prometheus">Prometheus</a></li>
-                <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
               </ul>
             </li>
             <li><a href="/prof">Profiler</a></li>

--- a/hbase-server/src/main/resources/hbase-webapps/master/header.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/header.jsp
@@ -69,7 +69,17 @@
             <li><a href="/logs/">Local Logs</a></li>
             <li><a href="/logLevel">Log Level</a></li>
             <li><a href="/dump">Debug Dump</a></li>
-            <li><a href="/jmx">Metrics Dump</a></li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Metrics <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <li><a target="_blank" href="/jmx">JMX</a></li>
+                <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+              </ul>
+            </li>
             <li><a href="/prof">Profiler</a></li>
             <% if (HBaseConfiguration.isShowConfInServlet()) { %>
             <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -317,6 +317,7 @@
             <th>Region Server</th>
             <th>ReadRequests</th>
             <th>WriteRequests</th>
+            <th>Uncompressed StoreFileSize</th>
             <th>StorefileSize</th>
             <th>Num.Storefiles</th>
             <th>MemSize</th>
@@ -340,6 +341,7 @@
               String hostAndPort = "";
               String readReq = "N/A";
               String writeReq = "N/A";
+              String fileSizeUncompressed = ZEROMB;
               String fileSize = ZEROMB;
               String fileCount = "N/A";
               String memSize = ZEROMB;
@@ -357,6 +359,10 @@
                     if (rSize > 0) {
                       fileSize = StringUtils.byteDesc((long) rSize);
                     }
+                    double rSizeUncompressed = load.getUncompressedStoreFileSize().get(Size.Unit.BYTE);
+                    if (rSizeUncompressed > 0) {
+                    fileSizeUncompressed = StringUtils.byteDesc((long) rSizeUncompressed);
+                    }
                     fileCount = String.format("%,1d", load.getStoreFileCount());
                     double mSize = load.getMemStoreSize().get(Size.Unit.BYTE);
                     if (mSize > 0) {
@@ -371,6 +377,7 @@
             <td><a href="http://<%= hostAndPort %>/rs-status"><%= StringEscapeUtils.escapeHtml4(hostAndPort) %></a></td>
             <td><%= readReq%></td>
             <td><%= writeReq%></td>
+            <td><%= fileSizeUncompressed%></td>
             <td><%= fileSize%></td>
             <td><%= fileCount%></td>
             <td><%= memSize%></td>
@@ -833,6 +840,7 @@
 <%
   long totalReadReq = 0;
   long totalWriteReq = 0;
+  long totalSizeUncompressed = 0;
   long totalSize = 0;
   long totalStoreFileCount = 0;
   long totalMemSize = 0;
@@ -843,6 +851,7 @@
   long totalBlocksLocalWithSsdWeight = 0;
   String totalCompactionProgress = "";
   String totalMemSizeStr = ZEROMB;
+  String totalSizeUncompressedStr = ZEROMB;
   String totalSizeStr = ZEROMB;
   String totalLocality = "";
   String totalLocalityForSsd = "";
@@ -865,6 +874,7 @@
         if (regionMetrics != null) {
           totalReadReq += regionMetrics.getReadRequestCount();
           totalWriteReq += regionMetrics.getWriteRequestCount();
+          totalSizeUncompressed += regionMetrics.getUncompressedStoreFileSize().get(Size.Unit.MEGABYTE);
           totalSize += regionMetrics.getStoreFileSize().get(Size.Unit.MEGABYTE);
           totalStoreFileCount += regionMetrics.getStoreFileCount();
           totalMemSize += regionMetrics.getMemStoreSize().get(Size.Unit.MEGABYTE);
@@ -889,6 +899,9 @@
   }
   if (totalSize > 0) {
     totalSizeStr = StringUtils.byteDesc(totalSize*1024l*1024);
+  }
+  if (totalSizeUncompressed > 0){
+    totalSizeUncompressedStr = StringUtils.byteDesc(totalSizeUncompressed*1024l*1024);
   }
   if (totalMemSize > 0) {
     totalMemSizeStr = StringUtils.byteDesc(totalMemSize*1024l*1024);
@@ -920,6 +933,7 @@
             <th>Region Server</th>
             <th>ReadRequests<br>(<%= String.format("%,1d", totalReadReq)%>)</th>
             <th>WriteRequests<br>(<%= String.format("%,1d", totalWriteReq)%>)</th>
+            <th>Uncompressed StoreFileSize<br>(<%= totalSizeUncompressedStr %>)</th>
             <th>StorefileSize<br>(<%= totalSizeStr %>)</th>
             <th>Num.Storefiles<br>(<%= String.format("%,1d", totalStoreFileCount)%>)</th>
             <th>MemSize<br>(<%= totalMemSizeStr %>)</th>
@@ -944,6 +958,7 @@
             RegionMetrics load = hriEntry.getValue();
             String readReq = "N/A";
             String writeReq = "N/A";
+            String regionSizeUncompressed = ZEROMB;
             String regionSize = ZEROMB;
             String fileCount = "N/A";
             String memSize = ZEROMB;
@@ -951,6 +966,10 @@
             if (load != null) {
               readReq = String.format("%,1d", load.getReadRequestCount());
               writeReq = String.format("%,1d", load.getWriteRequestCount());
+              double rSizeUncompressed = load.getUncompressedStoreFileSize().get(Size.Unit.BYTE);
+              if (rSizeUncompressed > 0) {
+                regionSizeUncompressed = StringUtils.byteDesc((long)rSizeUncompressed);
+              }
               double rSize = load.getStoreFileSize().get(Size.Unit.BYTE);
               if (rSize > 0) {
                 regionSize = StringUtils.byteDesc((long)rSize);
@@ -987,6 +1006,7 @@
           <%= buildRegionDeployedServerTag(regionInfo, master, regionsToServer) %>
           <td><%= readReq%></td>
           <td><%= writeReq%></td>
+          <td><%= regionSizeUncompressed%></td>
           <td><%= regionSize%></td>
           <td><%= fileCount%></td>
           <td><%= memSize%></td>

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -93,7 +93,7 @@
    * its region server.
    * @return an anchor tag if one can be built, {@code null} otherwise.
    */
-  private static String buildRegionServerLink(final ServerName serverName, final int rsInfoPort,
+  private static String buildRegionLink(final ServerName serverName, final int rsInfoPort,
     final RegionInfo regionInfo, final RegionState.State regionState) {
     if (serverName == null || regionInfo == null) { return null; }
 
@@ -107,6 +107,45 @@
       + "?name=" + regionInfo.getEncodedName();
     return "<a href=\"" + URI + "\">" + serverName.getServerName() + "</a>";
   }
+
+  /**
+   * Render an <td> tag contents server name which the given region deploys.
+   * Links to the server rs-status page.
+   * <td class="undeployed-region">not deployed</td> instead if can not find the deploy message.
+   * @return an <td> tag contents server name links to server rs-status page.
+   */
+  private static String buildRegionDeployedServerTag(RegionInfo regionInfo, HMaster master,
+    Map<RegionInfo, ServerName> regionsToServer) {
+    ServerName serverName = regionsToServer.get(regionInfo);
+
+    if (serverName == null) {
+      return "<td class=\"undeployed-region\">not deployed</td>";
+    }
+
+    String hostName = serverName.getHostname();
+    String hostNameEncoded = URLEncoder.encode(hostName);
+    // This port might be wrong if RS actually ended up using something else.
+    int serverInfoPort = master.getRegionServerInfoPort(serverName);
+    String urlRegionServer = "//" + hostNameEncoded + ":" + serverInfoPort + "/rs-status";
+
+    return "<td><a href=\"" + urlRegionServer + "\">" + StringEscapeUtils.escapeHtml4(hostName)
+      + ":" + serverInfoPort + "</a></td>";
+  }
+
+  /**
+   * @return an <p> tag guide user to see all region messages.
+   */
+  private static String moreRegionsToRender(int numRegionsRendered, int numRegions, String fqtn) {
+    if (numRegions > numRegionsRendered) {
+      String allRegionsUrl = "?name=" + URLEncoder.encode(fqtn) + "&numRegions=all";
+
+      return "This table has <b>" + numRegions
+        + "</b> regions in total, in order to improve the page load time, only <b>"
+        + numRegionsRendered + "</b> regions are displayed here, <a href=\""
+        + allRegionsUrl + "\">click here</a> to see all regions.</p>";
+    }
+    return "";
+  }
 %>
 <%
   final String ZEROMB = "0 MB";
@@ -114,8 +153,7 @@
   Configuration conf = master.getConfiguration();
   String fqtn = request.getParameter("name");
   final String escaped_fqtn = StringEscapeUtils.escapeHtml4(fqtn);
-  Table table;
-  boolean withReplica = false;
+  Table table = master.getConnection().getTable(TableName.valueOf(fqtn));
   boolean showFragmentation = conf.getBoolean("hbase.master.ui.fragmentation.enabled", false);
   boolean readOnly = !InfoServer.canUserModifyUI(request, getServletContext(), conf);
   int numMetaReplicas =
@@ -166,31 +204,50 @@
   <jsp:param name="pageTitle" value="${pageTitle}"/>
 </jsp:include>
 
-<%
-  if (fqtn != null && master.isInitialized()) {
-    try {
-      table = master.getConnection().getTable(TableName.valueOf(fqtn));
-      if (table.getTableDescriptor().getRegionReplication() > 1) {
-        withReplica = true;
-      }
-      if ( !readOnly && action != null ) {
-%>
-<div class="container-fluid content">
-  <div class="row inner_header">
-    <div class="page-header">
-      <h1>Table action request accepted</h1>
+<% // handle the case for fqtn is null or master is not initialized with error message + redirect
+  if (fqtn == null || ! master.isInitialized()) { %>
+    <div class="container-fluid content">
+      <div class="row inner_header">
+        <div class="page-header">
+          <h1>Table not ready</h1>
+        </div>
+      </div>
+      <p><hr><p>
+      <jsp:include page="redirect.jsp" />
     </div>
-  </div>
-  <p><hr><p>
-    <%
-    if (action.equals("split")) {
+<%  return;
+  } %>
+
+<% // unknow table
+  if (! admin.tableExists(TableName.valueOf(fqtn)).get()) { %>
+    <div class="container-fluid content">
+      <div class="row inner_header">
+        <div class="page-header">
+          <h1>Table not found</h1>
+        </div>
+      </div>
+      <p><hr><p>
+      <jsp:include page="redirect.jsp" />
+    </div>
+<%  return;
+  } %>
+
+<% // table split/compact/merge actions
+  if ( !readOnly && action != null ) { %>
+    <div class="container-fluid content">
+      <div class="row inner_header">
+        <div class="page-header">
+          <h1>Table action request accepted</h1>
+        </div>
+      </div>
+      <p><hr><p>
+<%  if (action.equals("split")) {
       if (key != null && key.length() > 0) {
         admin.split(TableName.valueOf(fqtn), Bytes.toBytes(key));
       } else {
         admin.split(TableName.valueOf(fqtn));
       }
-
-    %> Split request accepted. <%
+%>    Split request accepted. <%
     } else if (action.equals("compact")) {
       if (key != null && key.length() > 0) {
         List<RegionInfo> regions = admin.getRegions(TableName.valueOf(fqtn)).get();
@@ -204,239 +261,222 @@
       } else {
         admin.compact(TableName.valueOf(fqtn));
       }
-    %> Compact request accepted. <%
+%>    Compact request accepted. <%
     } else if (action.equals("merge")) {
-        if (left != null && left.length() > 0 && right != null && right.length() > 0) {
-            admin.mergeRegions(Bytes.toBytesBinary(left), Bytes.toBytesBinary(right), false);
-        }
-        %> Merge request accepted. <%
-    }
-%>
-  <jsp:include page="redirect.jsp" />
-</div>
-<%
-} else {
-%>
+      if (left != null && left.length() > 0 && right != null && right.length() > 0) {
+        admin.mergeRegions(Bytes.toBytesBinary(left), Bytes.toBytesBinary(right), false);
+      }
+%>    Merge request accepted. <%
+    } %>
+    <jsp:include page="redirect.jsp" />
+    </div>
+<%  return;
+  } %>
+
 <div class="container-fluid content">
-  <div class="row inner_header">
-    <div class="page-header">
-      <h1>Table <small><%= escaped_fqtn %></small></h1>
+<div class="row inner_header">
+  <div class="page-header">
+    <h1>Table <small><%= escaped_fqtn %></small></h1>
+  </div>
+</div>
+
+<div class="row">
+<% //Meta table.
+  if(fqtn.equals(TableName.META_TABLE_NAME.getNameAsString())) { %>
+<h2>Table Regions</h2>
+<div class="tabbable">
+  <ul class="nav nav-pills">
+    <li class="active"><a href="#metaTab_baseStats" data-toggle="tab">Base Stats</a></li>
+    <li class=""><a href="#metaTab_localityStats" data-toggle="tab">Localities</a></li>
+    <li class=""><a href="#metaTab_compactStats" data-toggle="tab">Compactions</a></li>
+  </ul>
+
+  <div class="tab-content" style="padding-bottom: 9px; border-bottom: 1px solid #ddd;">
+    <div class="tab-pane active" id="metaTab_baseStats">
+      <table id="metaTableBaseStatsTable" class="tablesorter table table-striped">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Region Server</th>
+            <th>ReadRequests</th>
+            <th>WriteRequests</th>
+            <th>StorefileSize</th>
+            <th>Num.Storefiles</th>
+            <th>MemSize</th>
+            <th>Start Key</th>
+            <th>End Key</th>
+            <th>ReplicaID</th>
+          </tr>
+        </thead>
+        <tbody>
+        <%
+          // NOTE: Presumes meta with one or more replicas
+          for (int j = 0; j < numMetaReplicas; j++) {
+            RegionInfo meta = RegionReplicaUtil.getRegionInfoForReplica(
+                    RegionInfoBuilder.FIRST_META_REGIONINFO, j);
+            //If a metaLocation is null, All of its info would be empty here to be displayed.
+            RegionStateNode rsn = master.getAssignmentManager().getRegionStates()
+              .getRegionStateNode(meta);
+            ServerName metaLocation = rsn != null ? rsn.getRegionLocation() : null;
+            for (int i = 0; i < 1; i++) {
+              //If metaLocation is null, default value below would be displayed in UI.
+              String hostAndPort = "";
+              String readReq = "N/A";
+              String writeReq = "N/A";
+              String fileSize = ZEROMB;
+              String fileCount = "N/A";
+              String memSize = ZEROMB;
+              if (metaLocation != null) {
+                ServerMetrics sl = master.getServerManager().getLoad(metaLocation);
+                // The host name portion should be safe, but I don't know how we handle IDNs so err on the side of failing safely.
+                hostAndPort = URLEncoder.encode(metaLocation.getHostname()) + ":" + master.getRegionServerInfoPort(metaLocation);
+                if (sl != null) {
+                  Map<byte[], RegionMetrics> map = sl.getRegionMetrics();
+                  if (map.containsKey(meta.getRegionName())) {
+                    RegionMetrics load = map.get(meta.getRegionName());
+                    readReq = String.format("%,1d", load.getReadRequestCount());
+                    writeReq = String.format("%,1d", load.getWriteRequestCount());
+                    double rSize = load.getStoreFileSize().get(Size.Unit.BYTE);
+                    if (rSize > 0) {
+                      fileSize = StringUtils.byteDesc((long) rSize);
+                    }
+                    fileCount = String.format("%,1d", load.getStoreFileCount());
+                    double mSize = load.getMemStoreSize().get(Size.Unit.BYTE);
+                    if (mSize > 0) {
+                      memSize = StringUtils.byteDesc((long)mSize);
+                    }
+                  }
+                }
+              }
+            %>
+          <tr>
+            <td><%= escapeXml(meta.getRegionNameAsString()) %></td>
+            <td><a href="http://<%= hostAndPort %>/rs-status"><%= StringEscapeUtils.escapeHtml4(hostAndPort) %></a></td>
+            <td><%= readReq%></td>
+            <td><%= writeReq%></td>
+            <td><%= fileSize%></td>
+            <td><%= fileCount%></td>
+            <td><%= memSize%></td>
+            <td><%= escapeXml(Bytes.toString(meta.getStartKey())) %></td>
+            <td><%= escapeXml(Bytes.toString(meta.getEndKey())) %></td>
+            <td><%= meta.getReplicaId() %></td>
+          </tr>
+        <%  } %>
+        <%} %>
+        </tbody>
+      </table>
+    </div>
+    <div class="tab-pane" id="metaTab_localityStats">
+       <table id="metaTableLocalityStatsTable" class="tablesorter table table-striped">
+         <thead>
+           <tr>
+             <th>Name</th>
+             <th>Region Server</th>
+             <th>Locality</th>
+             <th>LocalityForSsd</th>
+           </tr>
+         </thead>
+         <tbody>
+         <%
+           // NOTE: Presumes meta with one or more replicas
+           for (int j = 0; j < numMetaReplicas; j++) {
+             RegionInfo meta = RegionReplicaUtil.getRegionInfoForReplica(
+                                     RegionInfoBuilder.FIRST_META_REGIONINFO, j);
+             //If a metaLocation is null, All of its info would be empty here to be displayed.
+             RegionStateNode rsn = master.getAssignmentManager().getRegionStates()
+               .getRegionStateNode(meta);
+             ServerName metaLocation = rsn != null ? rsn.getRegionLocation() : null;
+             for (int i = 0; i < 1; i++) {
+               //If metaLocation is null, default value below would be displayed in UI.
+               String hostAndPort = "";
+               float locality = 0.0f;
+               float localityForSsd = 0.0f;
+               if (metaLocation != null) {
+                 ServerMetrics sl = master.getServerManager().getLoad(metaLocation);
+                 hostAndPort = URLEncoder.encode(metaLocation.getHostname()) + ":" + master.getRegionServerInfoPort(metaLocation);
+                 if (sl != null) {
+                   Map<byte[], RegionMetrics> map = sl.getRegionMetrics();
+                   if (map.containsKey(meta.getRegionName())) {
+                     RegionMetrics load = map.get(meta.getRegionName());
+                     locality = load.getDataLocality();
+                     localityForSsd = load.getDataLocalityForSsd();
+                   }
+                 }
+               }
+             %>
+           <tr>
+             <td><%= escapeXml(meta.getRegionNameAsString()) %></td>
+             <td><a href="http://<%= hostAndPort %>/rs-status"><%= StringEscapeUtils.escapeHtml4(hostAndPort) %></a></td>
+             <td><%= locality%></td>
+             <td><%= localityForSsd%></td>
+           </tr>
+         <%  } %>
+         <%} %>
+         </tbody>
+       </table>
+     </div>
+    <div class="tab-pane" id="metaTab_compactStats">
+      <table id="metaTableCompactStatsTable" class="tablesorter table table-striped">
+        <thead>
+          <tr>
+            <th>Name</th>
+            <th>Region Server</th>
+            <th>Num. Compacting Cells</th>
+            <th>Num. Compacted Cells</th>
+            <th>Remaining Cells</th>
+            <th>Compaction Progress</th>
+          </tr>
+        </thead>
+        <tbody>
+        <%
+          // NOTE: Presumes meta with one or more replicas
+          for (int j = 0; j < numMetaReplicas; j++) {
+            RegionInfo meta = RegionReplicaUtil.getRegionInfoForReplica(
+                        RegionInfoBuilder.FIRST_META_REGIONINFO, j);
+            //If a metaLocation is null, All of its info would be empty here to be displayed.
+            RegionStateNode rsn = master.getAssignmentManager().getRegionStates()
+              .getRegionStateNode(meta);
+            ServerName metaLocation = rsn != null ? rsn.getRegionLocation() : null;
+            for (int i = 0; i < 1; i++) {
+              //If metaLocation is null, default value below would be displayed in UI.
+              String hostAndPort = "";
+              long compactingCells = 0;
+              long compactedCells = 0;
+              String compactionProgress = "";
+              if (metaLocation != null) {
+                ServerMetrics sl = master.getServerManager().getLoad(metaLocation);
+                hostAndPort = URLEncoder.encode(metaLocation.getHostname()) + ":" + master.getRegionServerInfoPort(metaLocation);
+                if (sl != null) {
+                  Map<byte[], RegionMetrics> map = sl.getRegionMetrics();
+                  if (map.containsKey(meta.getRegionName())) {
+                    RegionMetrics load = map.get(meta.getRegionName());
+                    compactingCells = load.getCompactingCellCount();
+                    compactedCells = load.getCompactedCellCount();
+                    if (compactingCells > 0) {
+                      compactionProgress = String.format("%.2f", 100 * ((float)
+                              compactedCells / compactingCells)) + "%";
+                    }
+                  }
+                }
+              }
+        %>
+          <tr>
+            <td><%= escapeXml(meta.getRegionNameAsString()) %></td>
+            <td><a href="http://<%= hostAndPort %>/rs-status"><%= StringEscapeUtils.escapeHtml4(hostAndPort) %></a></td>
+            <td><%= String.format("%,1d", compactingCells)%></td>
+            <td><%= String.format("%,1d", compactedCells)%></td>
+            <td><%= String.format("%,1d", compactingCells - compactedCells)%></td>
+            <td><%= compactionProgress%></td>
+          </tr>
+        <%  } %>
+        <%} %>
+        </tbody>
+      </table>
     </div>
   </div>
-  <div class="row">
-    <%
-      if(fqtn.equals(TableName.META_TABLE_NAME.getNameAsString())) {
-    %>
-    <h2>Table Regions</h2>
-    <div class="tabbable">
-      <ul class="nav nav-pills">
-        <li class="active">
-          <a href="#metaTab_baseStats" data-toggle="tab">Base Stats</a>
-        </li>
-        <li class="">
-          <a href="#metaTab_localityStats" data-toggle="tab">Localities</a>
-        </li>
-        <li class="">
-          <a href="#metaTab_compactStats" data-toggle="tab">Compactions</a>
-        </li>
-      </ul>
-      <div class="tab-content" style="padding-bottom: 9px; border-bottom: 1px solid #ddd;">
-        <div class="tab-pane active" id="metaTab_baseStats">
-          <table id="tableRegionTable" class="tablesorter table table-striped">
-            <thead>
-            <tr>
-              <th>Name</th>
-              <th>Region Server</th>
-              <th>ReadRequests</th>
-              <th>WriteRequests</th>
-              <th>StorefileSize</th>
-              <th>Num.Storefiles</th>
-              <th>MemSize</th>
-              <th>Start Key</th>
-              <th>End Key</th>
-              <%
-                if (withReplica) {
-              %>
-              <th>ReplicaID</th>
-              <%
-                }
-              %>
-            </tr>
-            </thead>
-            <tbody>
-            <%
-              // NOTE: Presumes meta with one or more replicas
-              for (int j = 0; j < numMetaReplicas; j++) {
-                RegionInfo meta = RegionReplicaUtil.getRegionInfoForReplica(
-                        RegionInfoBuilder.FIRST_META_REGIONINFO, j);
-                //If a metaLocation is null, All of its info would be empty here to be displayed.
-                RegionStateNode rsn = master.getAssignmentManager().getRegionStates()
-                  .getRegionStateNode(meta);
-                ServerName metaLocation = rsn != null ? rsn.getRegionLocation() : null;
-                for (int i = 0; i < 1; i++) {
-                  //If metaLocation is null, default value below would be displayed in UI.
-                  String hostAndPort = "";
-                  String readReq = "N/A";
-                  String writeReq = "N/A";
-                  String fileSize = ZEROMB;
-                  String fileCount = "N/A";
-                  String memSize = ZEROMB;
-                  if (metaLocation != null) {
-                    ServerMetrics sl = master.getServerManager().getLoad(metaLocation);
-                    // The host name portion should be safe, but I don't know how we handle IDNs so err on the side of failing safely.
-                    hostAndPort = URLEncoder.encode(metaLocation.getHostname()) + ":" + master.getRegionServerInfoPort(metaLocation);
-                    if (sl != null) {
-                      Map<byte[], RegionMetrics> map = sl.getRegionMetrics();
-                      if (map.containsKey(meta.getRegionName())) {
-                        RegionMetrics load = map.get(meta.getRegionName());
-                        readReq = String.format("%,1d", load.getReadRequestCount());
-                        writeReq = String.format("%,1d", load.getWriteRequestCount());
-                        double rSize = load.getStoreFileSize().get(Size.Unit.BYTE);
-                        if (rSize > 0) {
-                          fileSize = StringUtils.byteDesc((long) rSize);
-                        }
-                        fileCount = String.format("%,1d", load.getStoreFileCount());
-                        double mSize = load.getMemStoreSize().get(Size.Unit.BYTE);
-                        if (mSize > 0) {
-                          memSize = StringUtils.byteDesc((long)mSize);
-                        }
-                      }
-                    }
-                  }
-            %>
-            <tr>
-              <td><%= escapeXml(meta.getRegionNameAsString()) %></td>
-              <td><a href="http://<%= hostAndPort %>/rs-status"><%= StringEscapeUtils.escapeHtml4(hostAndPort) %></a></td>
-              <td><%= readReq%></td>
-              <td><%= writeReq%></td>
-              <td><%= fileSize%></td>
-              <td><%= fileCount%></td>
-              <td><%= memSize%></td>
-              <td><%= escapeXml(Bytes.toString(meta.getStartKey())) %></td>
-              <td><%= escapeXml(Bytes.toString(meta.getEndKey())) %></td>
-              <%
-                if (withReplica) {
-              %>
-              <td><%= meta.getReplicaId() %></td>
-              <%
-                }
-              %>
-            </tr>
-            <%  } %>
-            <%} %>
-            </tbody>
-          </table>
-        </div>
-        <div class="tab-pane" id="metaTab_localityStats">
-           <table id="tableRegionTable" class="tablesorter table table-striped">
-             <thead>
-               <tr>
-                 <th>Name</th>
-                 <th>Region Server</th>
-                 <th>Locality</th>
-                 <th>LocalityForSsd</th>
-               </tr>
-             </thead>
-             <tbody>
-             <%
-               // NOTE: Presumes meta with one or more replicas
-               for (int j = 0; j < numMetaReplicas; j++) {
-                 RegionInfo meta = RegionReplicaUtil.getRegionInfoForReplica(
-                                         RegionInfoBuilder.FIRST_META_REGIONINFO, j);
-                 //If a metaLocation is null, All of its info would be empty here to be displayed.
-                 RegionStateNode rsn = master.getAssignmentManager().getRegionStates()
-                   .getRegionStateNode(meta);
-                 ServerName metaLocation = rsn != null ? rsn.getRegionLocation() : null;
-                 for (int i = 0; i < 1; i++) {
-                   //If metaLocation is null, default value below would be displayed in UI.
-                   String hostAndPort = "";
-                   float locality = 0.0f;
-                   float localityForSsd = 0.0f;
-                   if (metaLocation != null) {
-                     ServerMetrics sl = master.getServerManager().getLoad(metaLocation);
-                     hostAndPort = URLEncoder.encode(metaLocation.getHostname()) + ":" + master.getRegionServerInfoPort(metaLocation);
-                     if (sl != null) {
-                       Map<byte[], RegionMetrics> map = sl.getRegionMetrics();
-                       if (map.containsKey(meta.getRegionName())) {
-                         RegionMetrics load = map.get(meta.getRegionName());
-                         locality = load.getDataLocality();
-                         localityForSsd = load.getDataLocalityForSsd();
-                       }
-                     }
-                   }
-                 %>
-               <tr>
-                 <td><%= escapeXml(meta.getRegionNameAsString()) %></td>
-                 <td><a href="http://<%= hostAndPort %>/rs-status"><%= StringEscapeUtils.escapeHtml4(hostAndPort) %></a></td>
-                 <td><%= locality%></td>
-                 <td><%= localityForSsd%></td>
-               </tr>
-             <%  } %>
-             <%} %>
-             </tbody>
-           </table>
-         </div>
-        <div class="tab-pane" id="metaTab_compactStats">
-          <table id="metaTableCompactStatsTable" class="tablesorter table table-striped">
-            <thead>
-            <tr>
-              <th>Name</th>
-              <th>Region Server</th>
-              <th>Num. Compacting Cells</th>
-              <th>Num. Compacted Cells</th>
-              <th>Remaining Cells</th>
-              <th>Compaction Progress</th>
-            </tr>
-            </thead>
-            <tbody>
-            <%
-              // NOTE: Presumes meta with one or more replicas
-              for (int j = 0; j < numMetaReplicas; j++) {
-                RegionInfo meta = RegionReplicaUtil.getRegionInfoForReplica(
-                        RegionInfoBuilder.FIRST_META_REGIONINFO, j);
-                //If a metaLocation is null, All of its info would be empty here to be displayed.
-                RegionStateNode rsn = master.getAssignmentManager().getRegionStates()
-                  .getRegionStateNode(meta);
-                ServerName metaLocation = rsn != null ? rsn.getRegionLocation() : null;
-                for (int i = 0; i < 1; i++) {
-                  //If metaLocation is null, default value below would be displayed in UI.
-                  String hostAndPort = "";
-                  long compactingCells = 0;
-                  long compactedCells = 0;
-                  String compactionProgress = "";
-                  if (metaLocation != null) {
-                    ServerMetrics sl = master.getServerManager().getLoad(metaLocation);
-                    hostAndPort = URLEncoder.encode(metaLocation.getHostname()) + ":" + master.getRegionServerInfoPort(metaLocation);
-                    if (sl != null) {
-                      Map<byte[], RegionMetrics> map = sl.getRegionMetrics();
-                      if (map.containsKey(meta.getRegionName())) {
-                        RegionMetrics load = map.get(meta.getRegionName());
-                        compactingCells = load.getCompactingCellCount();
-                        compactedCells = load.getCompactedCellCount();
-                        if (compactingCells > 0) {
-                          compactionProgress = String.format("%.2f", 100 * ((float)
-                                  compactedCells / compactingCells)) + "%";
-                        }
-                      }
-                    }
-                  }
-            %>
-            <tr>
-              <td><%= escapeXml(meta.getRegionNameAsString()) %></td>
-              <td><a href="http://<%= hostAndPort %>/rs-status"><%= StringEscapeUtils.escapeHtml4(hostAndPort) %></a></td>
-              <td><%= String.format("%,1d", compactingCells)%></td>
-              <td><%= String.format("%,1d", compactedCells)%></td>
-              <td><%= String.format("%,1d", compactingCells - compactedCells)%></td>
-              <td><%= compactionProgress%></td>
-            </tr>
-            <%  } %>
-            <%} %>
-            </tbody>
-          </table>
-        </div>
-      </div>
-    </div>
-    <h2 id="meta-entries">Meta Entries</h2>
+</div>
+
+<h2 id="meta-entries">Meta Entries</h2>
 <%
   if (!metaBrowser.getErrorMessages().isEmpty()) {
     for (final String errorMessage : metaBrowser.getErrorMessages()) {
@@ -504,6 +544,7 @@
       final RegionInfo regionInfo = regionReplicaInfo.getRegionInfo();
       final ServerName serverName = regionReplicaInfo.getServerName();
       final RegionState.State regionState = regionReplicaInfo.getRegionState();
+      final int rsPort = master.getRegionServerInfoPort(serverName);
 
       final long seqNum = regionReplicaInfo.getSeqNum();
 
@@ -521,21 +562,21 @@
         splitRegions.entrySet().stream()
           .map(entry -> String.format(regionSpanFormat, entry.getKey(), entry.getValue().getRegionNameAsString()))
           .collect(Collectors.joining("<br/>"));
-%>
-        <tr>
-          <td title="<%= regionInfoColumnName %>"><%= regionNameDisplay %></td>
-          <td title="startKey"><%= startKeyDisplay %></td>
-          <td title="endKey"><%= endKeyDisplay %></td>
-          <td title="replicaId"><%= replicaIdDisplay %></td>
-          <td title="regionState"><%= regionStateDisplay %></td>
-          <td title="<%= serverColumnName + "," + startCodeColumnName %>"><%= serverName != null ? buildRegionServerLink(serverName, master.getRegionServerInfoPort(serverName), regionInfo, regionState) : "" %></td>
-          <td title="<%= seqNumColumnName %>"><%= seqNum %></td>
-          <td title="<%= serverNameColumnName %>"><%= targetServerName %></td>
-          <td><%= mergeRegionNames %></td>
-          <td><%= splitName %></td>
-        </tr>
-<%
-    }
+  %>
+    <tr>
+      <td title="<%= regionInfoColumnName %>"><%= regionNameDisplay %></td>
+      <td title="startKey"><%= startKeyDisplay %></td>
+      <td title="endKey"><%= endKeyDisplay %></td>
+      <td title="replicaId"><%= replicaIdDisplay %></td>
+      <td title="regionState"><%= regionStateDisplay %></td>
+      <td title="<%= serverColumnName + "," + startCodeColumnName %>"><%= buildRegionLink(serverName, rsPort, regionInfo, regionState) %></td>
+      <td title="<%= seqNumColumnName %>"><%= seqNum %></td>
+      <td title="<%= serverNameColumnName %>"><%= targetServerName %></td>
+      <td><%= mergeRegionNames %></td>
+      <td><%= splitName %></td>
+    </tr>
+  <%
+      }
 
     metaScanHasMore = results.hasMoreResults();
   }
@@ -588,555 +629,478 @@
 <%
   }
 %>
-            </select>
-            <button type="submit" class="btn btn-primary" style="display:inline; width:auto">
-              Filter Results
-            </button>
-          </div>
-        </form>
+        </select>
+        <button type="submit" class="btn btn-primary" style="display:inline; width:auto">
+          Filter Results
+        </button>
       </div>
-    </div>
-    <%} else {
-      RegionStates states = master.getAssignmentManager().getRegionStates();
-      Map<RegionState.State, List<RegionInfo>> regionStates = states.getRegionByStateOfTable(table.getName());
-      Map<String, RegionState.State> stateMap = new HashMap<>();
-      for (RegionState.State regionState : regionStates.keySet()) {
-        for (RegionInfo regionInfo : regionStates.get(regionState)) {
-          stateMap.put(regionInfo.getEncodedName(), regionState);
-        }
+    </form>
+  </div>
+</div>
+<%} else {
+  //Common tables
+  RegionStates states = master.getAssignmentManager().getRegionStates();
+  Map<RegionState.State, List<RegionInfo>> regionStates = states.getRegionByStateOfTable(table.getName());
+  Map<String, RegionState.State> stateMap = new HashMap<>();
+  for (RegionState.State regionState : regionStates.keySet()) {
+    for (RegionInfo regionInfo : regionStates.get(regionState)) {
+        stateMap.put(regionInfo.getEncodedName(), regionState);
+    }
+  }
+  RegionLocator r = master.getConnection().getRegionLocator(table.getName());
+
+  try {
+%>
+<h2>Table Attributes</h2>
+<table class="table table-striped">
+  <tr>
+      <th>Attribute Name</th>
+      <th>Value</th>
+      <th>Description</th>
+  </tr>
+  <tr>
+      <td>Enabled</td>
+      <td><%= master.getTableStateManager().isTableState(table.getName(), TableState.State.ENABLED) %></td>
+      <td>Is the table enabled</td>
+  </tr>
+  <tr>
+      <td>Compaction</td>
+      <td>
+<%
+  if (master.getTableStateManager().isTableState(table.getName(), TableState.State.ENABLED)) {
+    CompactionState compactionState = master.getCompactionState(table.getName());
+    %><%= compactionState==null?"UNKNOWN":compactionState %><%
+  } else {
+  %><%= CompactionState.NONE %><%
+  }
+%>
+      </td>
+      <td>Is the table compacting</td>
+  </tr>
+<%  if (showFragmentation) { %>
+  <tr>
+      <td>Fragmentation</td>
+      <td><%= frags.get(fqtn) != null ? frags.get(fqtn).intValue() + "%" : "n/a" %></td>
+      <td>How fragmented is the table. After a major compaction it is 0%.</td>
+  </tr>
+<%  } %>
+<%
+  if (quotasEnabled) {
+    TableName tn = TableName.valueOf(fqtn);
+    SpaceQuotaSnapshot masterSnapshot = null;
+    Quotas quota = QuotaTableUtil.getTableQuota(master.getConnection(), tn);
+    if (quota == null || !quota.hasSpace()) {
+      quota = QuotaTableUtil.getNamespaceQuota(master.getConnection(), tn.getNamespaceAsString());
+      if (quota != null) {
+        masterSnapshot = master.getQuotaObserverChore().getNamespaceQuotaSnapshots()
+                .get(tn.getNamespaceAsString());
       }
-      RegionLocator r = master.getConnection().getRegionLocator(table.getName());
-      try { %>
-    <h2>Table Attributes</h2>
-    <table class="table table-striped">
-      <tr>
-        <th>Attribute Name</th>
-        <th>Value</th>
-        <th>Description</th>
-      </tr>
-      <tr>
-        <td>Enabled</td>
-        <td><%= master.getTableStateManager().isTableState(table.getName(), TableState.State.ENABLED) %></td>
-        <td>Is the table enabled</td>
-      </tr>
-      <tr>
-        <td>Compaction</td>
-        <td>
-          <%
-            if (master.getTableStateManager().isTableState(table.getName(), TableState.State.ENABLED)) {
-              CompactionState compactionState = master.getCompactionState(table.getName());
-              %><%= compactionState==null?"UNKNOWN":compactionState %><%
-            } else {
-            %><%= CompactionState.NONE %><%
-            }
-            %>
-        </td>
-        <td>Is the table compacting</td>
-      </tr>
-      <%  if (showFragmentation) { %>
-      <tr>
-        <td>Fragmentation</td>
-        <td><%= frags.get(fqtn) != null ? frags.get(fqtn).intValue() + "%" : "n/a" %></td>
-        <td>How fragmented is the table. After a major compaction it is 0%.</td>
-      </tr>
-      <%  } %>
-      <%
-        if (quotasEnabled) {
-          TableName tn = TableName.valueOf(fqtn);
-          SpaceQuotaSnapshot masterSnapshot = null;
-          Quotas quota = QuotaTableUtil.getTableQuota(master.getConnection(), tn);
-          if (quota == null || !quota.hasSpace()) {
-            quota = QuotaTableUtil.getNamespaceQuota(master.getConnection(), tn.getNamespaceAsString());
-            if (quota != null) {
-              masterSnapshot = master.getQuotaObserverChore().getNamespaceQuotaSnapshots()
-                      .get(tn.getNamespaceAsString());
-            }
-          } else {
-            masterSnapshot = master.getQuotaObserverChore().getTableQuotaSnapshots().get(tn);
-          }
-          if (quota != null && quota.hasSpace()) {
-            SpaceQuota spaceQuota = quota.getSpace();
-      %>
-      <tr>
-        <td>Space Quota</td>
-        <td>
-          <table>
-            <tr>
-              <th>Property</th>
-              <th>Value</th>
-            </tr>
-            <tr>
-              <td>Limit</td>
-              <td><%= StringUtils.byteDesc(spaceQuota.getSoftLimit()) %></td>
-            </tr>
-            <tr>
-              <td>Policy</td>
-              <td><%= spaceQuota.getViolationPolicy() %></td>
-            </tr>
-            <%
-              if (masterSnapshot != null) {
-            %>
-            <tr>
-              <td>Usage</td>
-              <td><%= StringUtils.byteDesc(masterSnapshot.getUsage()) %></td>
-            </tr>
-            <tr>
-              <td>State</td>
-              <td><%= masterSnapshot.getQuotaStatus().isInViolation() ? "In Violation" : "In Observance" %></td>
-            </tr>
-            <%
-              }
-            %>
-          </table>
-        </td>
-        <td>Information about a Space Quota on this table, if set.</td>
-      </tr>
-      <%
-        }
-        if (quota != null && quota.hasThrottle()) {
-          List<ThrottleSettings> throttles = QuotaSettingsFactory.fromTableThrottles(table.getName(), quota.getThrottle());
-          if (throttles.size() > 0) {
-      %>
-      <tr>
-        <td>Throttle Quota</td>
-        <td>
-          <table>
-            <tr>
-              <th>Limit</th>
-              <th>Type</th>
-              <th>TimeUnit</th>
-              <th>Scope</th>
-            </tr>
-            <%
-              for (ThrottleSettings throttle : throttles) {
-            %>
-            <tr>
-              <td><%= throttle.getSoftLimit() %></td>
-              <td><%= throttle.getThrottleType() %></td>
-              <td><%= throttle.getTimeUnit() %></td>
-              <td><%= throttle.getQuotaScope() %></td>
-            </tr>
-            <%
-              }
-            %>
-          </table>
-        </td>
-        <td>Information about a Throttle Quota on this table, if set.</td>
-      </tr>
-      <%
-            }
-          }
-        }
-      %>
-    </table>
-    <h2>Table Schema</h2>
-    <table class="table table-striped">
-    <%
-      ColumnFamilyDescriptor[] families = table.getDescriptor().getColumnFamilies();
-      Set<Bytes> familyKeySet = new HashSet<>();
+    } else {
+      masterSnapshot = master.getQuotaObserverChore().getTableQuotaSnapshots().get(tn);
+    }
+    if (quota != null && quota.hasSpace()) {
+      SpaceQuota spaceQuota = quota.getSpace();
+%>
+  <tr>
+    <td>Space Quota</td>
+    <td>
+      <table>
+        <tr>
+          <th>Property</th>
+          <th>Value</th>
+        </tr>
+        <tr>
+          <td>Limit</td>
+          <td><%= StringUtils.byteDesc(spaceQuota.getSoftLimit()) %></td>
+        </tr>
+        <tr>
+          <td>Policy</td>
+          <td><%= spaceQuota.getViolationPolicy() %></td>
+        </tr>
+<%
+      if (masterSnapshot != null) {
+%>
+        <tr>
+          <td>Usage</td>
+          <td><%= StringUtils.byteDesc(masterSnapshot.getUsage()) %></td>
+        </tr>
+        <tr>
+          <td>State</td>
+          <td><%= masterSnapshot.getQuotaStatus().isInViolation() ? "In Violation" : "In Observance" %></td>
+        </tr>
+<%
+      }
+%>
+      </table>
+    </td>
+    <td>Information about a Space Quota on this table, if set.</td>
+  </tr>
+<%
+    }
+  if (quota != null && quota.hasThrottle()) {
+    List<ThrottleSettings> throttles = QuotaSettingsFactory.fromTableThrottles(table.getName(), quota.getThrottle());
+    if (throttles.size() > 0) {
+%>
+  <tr>
+    <td>Throttle Quota</td>
+    <td>
+      <table>
+        <tr>
+          <th>Limit</th>
+          <th>Type</th>
+          <th>TimeUnit</th>
+          <th>Scope</th>
+        </tr>
+<%
+    for (ThrottleSettings throttle : throttles) {
+%>
+        <tr>
+          <td><%= throttle.getSoftLimit() %></td>
+          <td><%= throttle.getThrottleType() %></td>
+          <td><%= throttle.getTimeUnit() %></td>
+          <td><%= throttle.getQuotaScope() %></td>
+        </tr>
+<%
+    }
+%>
+      </table>
+    </td>
+    <td>Information about a Throttle Quota on this table, if set.</td>
+  </tr>
+<%
+    }
+   }
+ }
+%>
+</table>
+<h2>Table Schema</h2>
+<table class="table table-striped">
+<%
+  ColumnFamilyDescriptor[] families = table.getDescriptor().getColumnFamilies();
+  Set<Bytes> familyKeySet = new HashSet<>();
+  for (ColumnFamilyDescriptor family: families) {
+    familyKeySet.addAll(family.getValues().keySet());
+  }
+%>
+  <tr>
+      <th>Property \ Column Family Name</th>
+  <%
       for (ColumnFamilyDescriptor family: families) {
-        familyKeySet.addAll(family.getValues().keySet());
-      }
+  %>
+  <th>
+    <%= StringEscapeUtils.escapeHtml4(family.getNameAsString()) %>
+      </th>
+      <% } %>
+    </tr>
+    <%
+    for (Bytes familyKey: familyKeySet) {
     %>
       <tr>
-        <th>Property \ Column Family Name</th>
+        <td>
+          <%= StringEscapeUtils.escapeHtml4(familyKey.toString()) %>
+        </td>
         <%
         for (ColumnFamilyDescriptor family: families) {
-        %>
-        <th>
-          <%= StringEscapeUtils.escapeHtml4(family.getNameAsString()) %>
-        </th>
-        <% } %>
-      </tr>
-        <%
-        for (Bytes familyKey: familyKeySet) {
-        %>
-          <tr>
-            <td>
-              <%= StringEscapeUtils.escapeHtml4(familyKey.toString()) %>
-            </td>
-            <%
-            for (ColumnFamilyDescriptor family: families) {
-              String familyValue = "-";
-              if(family.getValues().containsKey(familyKey)){
-                familyValue = family.getValues().get(familyKey).toString();
-              }
-            %>
-            <td>
-              <%= StringEscapeUtils.escapeHtml4(familyValue) %>
-            </td>
-            <% } %>
-          </tr>
-        <% } %>
-    </table>
-    <%
-      long totalReadReq = 0;
-      long totalWriteReq = 0;
-      long totalSize = 0;
-      long totalStoreFileCount = 0;
-      long totalMemSize = 0;
-      long totalCompactingCells = 0;
-      long totalCompactedCells = 0;
-      long totalBlocksTotalWeight = 0;
-      long totalBlocksLocalWeight = 0;
-      long totalBlocksLocalWithSsdWeight = 0;
-      String totalCompactionProgress = "";
-      String totalMemSizeStr = ZEROMB;
-      String totalSizeStr = ZEROMB;
-      String totalLocality = "";
-      String totalLocalityForSsd = "";
-      String urlRegionServer = null;
-      Map<ServerName, Integer> regDistribution = new TreeMap<>();
-      Map<ServerName, Integer> primaryRegDistribution = new TreeMap<>();
-      List<HRegionLocation> regions = r.getAllRegionLocations();
-      Map<RegionInfo, RegionMetrics> regionsToLoad = new LinkedHashMap<>();
-      Map<RegionInfo, ServerName> regionsToServer = new LinkedHashMap<>();
-      for (HRegionLocation hriEntry : regions) {
-        RegionInfo regionInfo = hriEntry.getRegionInfo();
-        ServerName addr = hriEntry.getServerName();
-        regionsToServer.put(regionInfo, addr);
-
-        if (addr != null) {
-          ServerMetrics sl = master.getServerManager().getLoad(addr);
-          if (sl != null) {
-            RegionMetrics regionMetrics = sl.getRegionMetrics().get(regionInfo.getRegionName());
-            regionsToLoad.put(regionInfo, regionMetrics);
-            if (regionMetrics != null) {
-              totalReadReq += regionMetrics.getReadRequestCount();
-              totalWriteReq += regionMetrics.getWriteRequestCount();
-              totalSize += regionMetrics.getStoreFileSize().get(Size.Unit.MEGABYTE);
-              totalStoreFileCount += regionMetrics.getStoreFileCount();
-              totalMemSize += regionMetrics.getMemStoreSize().get(Size.Unit.MEGABYTE);
-              totalStoreFileSizeMB += regionMetrics.getStoreFileSize().get(Size.Unit.MEGABYTE);
-              totalCompactingCells += regionMetrics.getCompactingCellCount();
-              totalCompactedCells += regionMetrics.getCompactedCellCount();
-              totalBlocksTotalWeight += regionMetrics.getBlocksTotalWeight();
-              totalBlocksLocalWeight += regionMetrics.getBlocksLocalWeight();
-              totalBlocksLocalWithSsdWeight += regionMetrics.getBlocksLocalWithSsdWeight();
-            } else {
-              RegionMetrics load0 = getEmptyRegionMetrics(regionInfo);
-              regionsToLoad.put(regionInfo, load0);
+          String familyValue = "-";
+          if(family.getValues().containsKey(familyKey)){
+              familyValue = family.getValues().get(familyKey).toString();
             }
-          } else{
-            RegionMetrics load0 = getEmptyRegionMetrics(regionInfo);
-            regionsToLoad.put(regionInfo, load0);
-          }
+          %>
+    <td>
+      <%= StringEscapeUtils.escapeHtml4(familyValue) %>
+    </td>
+    <% } %>
+  </tr>
+  <% } %>
+</table>
+<%
+  long totalReadReq = 0;
+  long totalWriteReq = 0;
+  long totalSize = 0;
+  long totalStoreFileCount = 0;
+  long totalMemSize = 0;
+  long totalCompactingCells = 0;
+  long totalCompactedCells = 0;
+  long totalBlocksTotalWeight = 0;
+  long totalBlocksLocalWeight = 0;
+  long totalBlocksLocalWithSsdWeight = 0;
+  String totalCompactionProgress = "";
+  String totalMemSizeStr = ZEROMB;
+  String totalSizeStr = ZEROMB;
+  String totalLocality = "";
+  String totalLocalityForSsd = "";
+  String urlRegionServer = null;
+  Map<ServerName, Integer> regDistribution = new TreeMap<>();
+  Map<ServerName, Integer> primaryRegDistribution = new TreeMap<>();
+  List<HRegionLocation> regions = r.getAllRegionLocations();
+  Map<RegionInfo, RegionMetrics> regionsToLoad = new LinkedHashMap<>();
+  Map<RegionInfo, ServerName> regionsToServer = new LinkedHashMap<>();
+  for (HRegionLocation hriEntry : regions) {
+    RegionInfo regionInfo = hriEntry.getRegionInfo();
+    ServerName addr = hriEntry.getServerName();
+    regionsToServer.put(regionInfo, addr);
+
+    if (addr != null) {
+      ServerMetrics sl = master.getServerManager().getLoad(addr);
+      if (sl != null) {
+        RegionMetrics regionMetrics = sl.getRegionMetrics().get(regionInfo.getRegionName());
+        regionsToLoad.put(regionInfo, regionMetrics);
+        if (regionMetrics != null) {
+          totalReadReq += regionMetrics.getReadRequestCount();
+          totalWriteReq += regionMetrics.getWriteRequestCount();
+          totalSize += regionMetrics.getStoreFileSize().get(Size.Unit.MEGABYTE);
+          totalStoreFileCount += regionMetrics.getStoreFileCount();
+          totalMemSize += regionMetrics.getMemStoreSize().get(Size.Unit.MEGABYTE);
+          totalStoreFileSizeMB += regionMetrics.getStoreFileSize().get(Size.Unit.MEGABYTE);
+          totalCompactingCells += regionMetrics.getCompactingCellCount();
+          totalCompactedCells += regionMetrics.getCompactedCellCount();
+          totalBlocksTotalWeight += regionMetrics.getBlocksTotalWeight();
+          totalBlocksLocalWeight += regionMetrics.getBlocksLocalWeight();
+          totalBlocksLocalWithSsdWeight += regionMetrics.getBlocksLocalWithSsdWeight();
         } else {
           RegionMetrics load0 = getEmptyRegionMetrics(regionInfo);
           regionsToLoad.put(regionInfo, load0);
         }
+      } else{
+        RegionMetrics load0 = getEmptyRegionMetrics(regionInfo);
+        regionsToLoad.put(regionInfo, load0);
       }
-      if (totalSize > 0) {
-        totalSizeStr = StringUtils.byteDesc(totalSize*1024l*1024);
-      }
-      if (totalMemSize > 0) {
-        totalMemSizeStr = StringUtils.byteDesc(totalMemSize*1024l*1024);
-      }
-      if (totalCompactingCells > 0) {
-        totalCompactionProgress = String.format("%.2f", 100 *
-                ((float) totalCompactedCells / totalCompactingCells)) + "%";
-      }
-      if (totalBlocksTotalWeight > 0) {
-        totalLocality = String.format("%.1f",
-          ((float) totalBlocksLocalWeight / totalBlocksTotalWeight));
-        totalLocalityForSsd = String.format("%.1f",
-          ((float) totalBlocksLocalWithSsdWeight / totalBlocksTotalWeight));
-      }
-      if(regions != null && regions.size() > 0) { %>
-    <h2>Table Regions</h2>
-    <div class="tabbable">
-      <ul class="nav nav-pills">
-        <li class="active">
-          <a href="#tab_baseStats" data-toggle="tab">Base Stats</a>
-        </li>
-        <li class="">
-          <a href="#tab_localityStats" data-toggle="tab">Localities</a>
-        </li>
-        <li class="">
-          <a href="#tab_compactStats" data-toggle="tab">Compactions</a>
-        </li>
-      </ul>
-      <div class="tab-content" style="padding-bottom: 9px; border-bottom: 1px solid #ddd;">
-        <div class="tab-pane active" id="tab_baseStats">
-          <table id="regionServerDetailsTable" class="tablesorter table table-striped">
-            <thead>
-            <tr>
-              <th>Name(<%= String.format("%,1d", regions.size())%>)</th>
-              <th>Region Server</th>
-              <th>ReadRequests<br>(<%= String.format("%,1d", totalReadReq)%>)</th>
-              <th>WriteRequests<br>(<%= String.format("%,1d", totalWriteReq)%>)</th>
-              <th>StorefileSize<br>(<%= totalSizeStr %>)</th>
-              <th>Num.Storefiles<br>(<%= String.format("%,1d", totalStoreFileCount)%>)</th>
-              <th>MemSize<br>(<%= totalMemSizeStr %>)</th>
-              <th>Start Key</th>
-              <th>End Key</th>
-              <th>Region State</th>
-              <%
-                if (withReplica) {
-              %>
-              <th>ReplicaID</th>
-              <%
-                }
-              %>
-            </tr>
-            </thead>
-            <tbody>
-            <%
-              List<Map.Entry<RegionInfo, RegionMetrics>> entryList = new ArrayList<>(regionsToLoad.entrySet());
-              numRegions = regions.size();
-              int numRegionsRendered = 0;
-              // render all regions
-              if (numRegionsToRender < 0) {
-                numRegionsToRender = numRegions;
-              }
-              for (Map.Entry<RegionInfo, RegionMetrics> hriEntry : entryList) {
-                RegionInfo regionInfo = hriEntry.getKey();
-                ServerName addr = regionsToServer.get(regionInfo);
-                RegionMetrics load = hriEntry.getValue();
-                String readReq = "N/A";
-                String writeReq = "N/A";
-                String regionSize = ZEROMB;
-                String fileCount = "N/A";
-                String memSize = ZEROMB;
-                String state = "N/A";
-                if (load != null) {
-                  readReq = String.format("%,1d", load.getReadRequestCount());
-                  writeReq = String.format("%,1d", load.getWriteRequestCount());
-                  double rSize = load.getStoreFileSize().get(Size.Unit.BYTE);
-                  if (rSize > 0) {
-                    regionSize = StringUtils.byteDesc((long)rSize);
-                  }
-                  fileCount = String.format("%,1d", load.getStoreFileCount());
-                  double mSize = load.getMemStoreSize().get(Size.Unit.BYTE);
-                  if (mSize > 0) {
-                    memSize = StringUtils.byteDesc((long)mSize);
-                  }
-                }
-                if (stateMap.containsKey(regionInfo.getEncodedName())) {
-                  state = stateMap.get(regionInfo.getEncodedName()).toString();
-                }
-                if (addr != null) {
-                  ServerMetrics sl = master.getServerManager().getLoad(addr);
-                  // This port might be wrong if RS actually ended up using something else.
-                  urlRegionServer =
-                          "//" + URLEncoder.encode(addr.getHostname()) + ":" + master.getRegionServerInfoPort(addr) + "/rs-status";
-                  if(sl != null) {
-                    Integer i = regDistribution.get(addr);
-                    if (null == i) i = Integer.valueOf(0);
-                    regDistribution.put(addr, i + 1);
-                    if (withReplica && RegionReplicaUtil.isDefaultReplica(regionInfo.getReplicaId())) {
-                      i = primaryRegDistribution.get(addr);
-                      if (null == i) i = Integer.valueOf(0);
-                      primaryRegDistribution.put(addr, i+1);
-                    }
-                  }
-                }
-                if (numRegionsRendered < numRegionsToRender) {
-                  numRegionsRendered++;
-            %>
-            <tr>
-              <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getRegionName())) %></td>
-              <%
-                if (urlRegionServer != null) {
-              %>
-              <td>
-                <a href="<%= urlRegionServer %>"><%= addr == null? "-": StringEscapeUtils.escapeHtml4(addr.getHostname().toString()) + ":" + master.getRegionServerInfoPort(addr) %></a>
-              </td>
-              <%
-              } else {
-              %>
-              <td class="undeployed-region">not deployed</td>
-              <%
-                }
-              %>
-              <td><%= readReq%></td>
-              <td><%= writeReq%></td>
-              <td><%= regionSize%></td>
-              <td><%= fileCount%></td>
-              <td><%= memSize%></td>
-              <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getStartKey()))%></td>
-              <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getEndKey()))%></td>
-              <td><%= state%></td>
-              <%
-                if (withReplica) {
-              %>
-              <td><%= regionInfo.getReplicaId() %></td>
-              <%
-                }
-              %>
-            </tr>
-            <% } %>
-            <% } %>
-            </tbody>
-          </table>
-          <% if (numRegions > numRegionsRendered) {
-            String allRegionsUrl = "?name=" + URLEncoder.encode(fqtn,"UTF-8") + "&numRegions=all";
-          %>
-          <p>This table has <b><%= numRegions %></b> regions in total, in order to improve the page load time,
-            only <b><%= numRegionsRendered %></b> regions are displayed here, <a href="<%= allRegionsUrl %>">click
-              here</a> to see all regions.</p>
-          <% } %>
-        </div>
-        <div class="tab-pane" id="tab_localityStats">
-          <table id="regionServerDetailsTable" class="tablesorter table table-striped">
-            <thead>
-              <tr>
-                <th>Name(<%= String.format("%,1d", regions.size())%>)</th>
-                <th>Region Server</th>
-                <th>Locality<br>(<%= totalLocality %>)</th>
-                <th>LocalityForSsd<br>(<%= totalLocalityForSsd %>)</th>
-              </tr>
-            </thead>
-            <tbody>
-            <%
-              numRegionsRendered = 0;
-              for (Map.Entry<RegionInfo, RegionMetrics> hriEntry : entryList) {
-                RegionInfo regionInfo = hriEntry.getKey();
-                ServerName addr = regionsToServer.get(regionInfo);
-                RegionMetrics load = hriEntry.getValue();
-                float locality = 0.0f;
-                float localityForSsd = 0.0f;
-                String state = "N/A";
-                if (load != null) {
-                  locality = load.getDataLocality();
-                  localityForSsd = load.getDataLocalityForSsd();
-                }
-                if (addr != null) {
-                  // This port might be wrong if RS actually ended up using something else.
-                  urlRegionServer =
-                    "//" + URLEncoder.encode(addr.getHostname()) + ":" + master.getRegionServerInfoPort(addr) + "/rs-status";
-                }
-                if (numRegionsRendered < numRegionsToRender) {
-                  numRegionsRendered++;
-            %>
-            <tr>
-              <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getRegionName())) %></td>
-              <%
-              if (urlRegionServer != null) {
-              %>
-              <td>
-                 <a href="<%= urlRegionServer %>"><%= addr == null? "-": StringEscapeUtils.escapeHtml4(addr.getHostname().toString()) + ":" + master.getRegionServerInfoPort(addr) %></a>
-              </td>
-              <%
-              } else {
-              %>
-              <td class="undeployed-region">not deployed</td>
-              <%
-              }
-              %>
-              <td><%= locality%></td>
-              <td><%= localityForSsd%></td>
-            </tr>
-            <% } %>
-            <% } %>
-            </tbody>
-          </table>
-        </div>
-        <div class="tab-pane" id="tab_compactStats">
-          <table id="tableCompactStatsTable" class="tablesorter table table-striped">
-            <thead>
-            <tr>
-              <th>Name(<%= String.format("%,1d", regions.size())%>)</th>
-              <th>Region Server</th>
-              <th>Num. Compacting Cells<br>(<%= String.format("%,1d", totalCompactingCells)%>)</th>
-              <th>Num. Compacted Cells<br>(<%= String.format("%,1d", totalCompactedCells)%>)</th>
-              <th>Remaining Cells<br>(<%= String.format("%,1d", totalCompactingCells-totalCompactedCells)%>)</th>
-              <th>Compaction Progress<br>(<%= totalCompactionProgress %>)</th>
-            </tr>
-            </thead>
-            <tbody>
-            <%
-              numRegionsRendered = 0;
-              for (Map.Entry<RegionInfo, RegionMetrics> hriEntry : entryList) {
-                RegionInfo regionInfo = hriEntry.getKey();
-                ServerName addr = regionsToServer.get(regionInfo);
-                RegionMetrics load = hriEntry.getValue();
-                long compactingCells = 0;
-                long compactedCells = 0;
-                String compactionProgress = "";
-                if (load != null) {
-                  compactingCells = load.getCompactingCellCount();
-                  compactedCells = load.getCompactedCellCount();
-                  if (compactingCells > 0) {
-                    compactionProgress = String.format("%.2f", 100 * ((float)
-                            compactedCells / compactingCells)) + "%";
-                  }
-                }
-                if (addr != null) {
-                  // This port might be wrong if RS actually ended up using something else.
-                  urlRegionServer =
-                          "//" + URLEncoder.encode(addr.getHostname()) + ":" + master.getRegionServerInfoPort(addr) + "/rs-status";
-                }
-                if (numRegionsRendered < numRegionsToRender) {
-                  numRegionsRendered++;
-            %>
-            <tr>
-              <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getRegionName())) %></td>
-              <%
-                if (urlRegionServer != null) {
-              %>
-              <td>
-                <a href="<%= urlRegionServer %>"><%= addr == null? "-": StringEscapeUtils.escapeHtml4(addr.getHostname().toString()) + ":" + master.getRegionServerInfoPort(addr) %></a>
-              </td>
-              <%
-              } else {
-              %>
-              <td class="undeployed-region">not deployed</td>
-              <%
-                }
-              %>
-              <td><%= String.format("%,1d", compactingCells)%></td>
-              <td><%= String.format("%,1d", compactedCells)%></td>
-              <td><%= String.format("%,1d", compactingCells - compactedCells)%></td>
-              <td><%= compactionProgress%></td>
-            </tr>
-            <% } %>
-            <% } %>
-            </tbody>
-          </table>
-          <% if (numRegions > numRegionsRendered) {
-            String allRegionsUrl = "?name=" + URLEncoder.encode(fqtn,"UTF-8") + "&numRegions=all";
-          %>
-          <p>This table has <b><%= numRegions %></b> regions in total, in order to improve the page load time,
-            only <b><%= numRegionsRendered %></b> regions are displayed here, <a href="<%= allRegionsUrl %>">click
-              here</a> to see all regions.</p>
-          <% } %>
-        </div>
-      </div>
-    </div>
-    <h2>Regions by Region Server</h2>
-    <%
-      if (withReplica) {
-    %>
-    <table id="regionServerTable" class="tablesorter table table-striped"><thead><tr><th>Region Server</th><th>Region Count</th><th>Primary Region Count</th></tr></thead>
-        <%
-} else {
-%>
-      <table id="regionServerTable" class="tablesorter table table-striped"><thead><tr><th>Region Server</th><th>Region Count</th></tr></thead>
+    } else {
+      RegionMetrics load0 = getEmptyRegionMetrics(regionInfo);
+      regionsToLoad.put(regionInfo, load0);
+    }
+  }
+  if (totalSize > 0) {
+    totalSizeStr = StringUtils.byteDesc(totalSize*1024l*1024);
+  }
+  if (totalMemSize > 0) {
+    totalMemSizeStr = StringUtils.byteDesc(totalMemSize*1024l*1024);
+  }
+  if (totalCompactingCells > 0) {
+    totalCompactionProgress = String.format("%.2f", 100 *
+            ((float) totalCompactedCells / totalCompactingCells)) + "%";
+  }
+  if (totalBlocksTotalWeight > 0) {
+    totalLocality = String.format("%.1f",
+      ((float) totalBlocksLocalWeight / totalBlocksTotalWeight));
+    totalLocalityForSsd = String.format("%.1f",
+      ((float) totalBlocksLocalWithSsdWeight / totalBlocksTotalWeight));
+  }
+  if(regions != null && regions.size() > 0) { %>
+<h2>Table Regions</h2>
+<div class="tabbable">
+  <ul class="nav nav-pills">
+    <li class="active"><a href="#tab_baseStats" data-toggle="tab">Base Stats</a></li>
+    <li class=""><a href="#tab_localityStats" data-toggle="tab">Localities</a></li>
+    <li class=""><a href="#tab_compactStats" data-toggle="tab">Compactions</a></li>
+  </ul>
+  <div class="tab-content" style="padding-bottom: 9px; border-bottom: 1px solid #ddd;">
+    <div class="tab-pane active" id="tab_baseStats">
+      <table id="tableBaseStatsTable" class="tablesorter table table-striped">
+        <thead>
+          <tr>
+            <th>Name(<%= String.format("%,1d", regions.size())%>)</th>
+            <th>Region Server</th>
+            <th>ReadRequests<br>(<%= String.format("%,1d", totalReadReq)%>)</th>
+            <th>WriteRequests<br>(<%= String.format("%,1d", totalWriteReq)%>)</th>
+            <th>StorefileSize<br>(<%= totalSizeStr %>)</th>
+            <th>Num.Storefiles<br>(<%= String.format("%,1d", totalStoreFileCount)%>)</th>
+            <th>MemSize<br>(<%= totalMemSizeStr %>)</th>
+            <th>Start Key</th>
+            <th>End Key</th>
+            <th>Region State</th>
+            <th>ReplicaID</th>
+          </tr>
+        </thead>
         <tbody>
         <%
+          List<Map.Entry<RegionInfo, RegionMetrics>> entryList = new ArrayList<>(regionsToLoad.entrySet());
+          numRegions = regions.size();
+          int numRegionsRendered = 0;
+          // render all regions
+          if (numRegionsToRender < 0) {
+            numRegionsToRender = numRegions;
           }
-        %>
-        <%
-          for (Map.Entry<ServerName, Integer> rdEntry : regDistribution.entrySet()) {
-            ServerName addr = rdEntry.getKey();
-            String url = "//" + URLEncoder.encode(addr.getHostname()) + ":" + master.getRegionServerInfoPort(addr) + "/rs-status";
+          for (Map.Entry<RegionInfo, RegionMetrics> hriEntry : entryList) {
+            RegionInfo regionInfo = hriEntry.getKey();
+            ServerName addr = regionsToServer.get(regionInfo);
+            RegionMetrics load = hriEntry.getValue();
+            String readReq = "N/A";
+            String writeReq = "N/A";
+            String regionSize = ZEROMB;
+            String fileCount = "N/A";
+            String memSize = ZEROMB;
+            String state = "N/A";
+            if (load != null) {
+              readReq = String.format("%,1d", load.getReadRequestCount());
+              writeReq = String.format("%,1d", load.getWriteRequestCount());
+              double rSize = load.getStoreFileSize().get(Size.Unit.BYTE);
+              if (rSize > 0) {
+                regionSize = StringUtils.byteDesc((long)rSize);
+              }
+              fileCount = String.format("%,1d", load.getStoreFileCount());
+              double mSize = load.getMemStoreSize().get(Size.Unit.BYTE);
+              if (mSize > 0) {
+                memSize = StringUtils.byteDesc((long)mSize);
+              }
+            }
+
+            if (stateMap.containsKey(regionInfo.getEncodedName())) {
+              state = stateMap.get(regionInfo.getEncodedName()).toString();
+            }
+
+            if (addr != null) {
+              ServerMetrics sl = master.getServerManager().getLoad(addr);
+              if(sl != null) {
+                Integer i = regDistribution.get(addr);
+                if (null == i) i = Integer.valueOf(0);
+                regDistribution.put(addr, i + 1);
+                if (RegionReplicaUtil.isDefaultReplica(regionInfo.getReplicaId())) {
+                  i = primaryRegDistribution.get(addr);
+                  if (null == i) i = Integer.valueOf(0);
+                  primaryRegDistribution.put(addr, i+1);
+                }
+              }
+            }
+            if (numRegionsRendered < numRegionsToRender) {
+              numRegionsRendered++;
         %>
         <tr>
-          <td><a href="<%= url %>"><%= StringEscapeUtils.escapeHtml4(addr.getHostname().toString()) + ":" + master.getRegionServerInfoPort(addr) %></a></td>
-          <td><%= rdEntry.getValue()%></td>
-          <%
-            if (withReplica) {
-          %>
-          <td><%= primaryRegDistribution.get(addr)%></td>
-          <%
-            }
-          %>
+          <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getRegionName())) %></td>
+          <%= buildRegionDeployedServerTag(regionInfo, master, regionsToServer) %>
+          <td><%= readReq%></td>
+          <td><%= writeReq%></td>
+          <td><%= regionSize%></td>
+          <td><%= fileCount%></td>
+          <td><%= memSize%></td>
+          <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getStartKey()))%></td>
+          <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getEndKey()))%></td>
+          <td><%= state%></td>
+          <td><%= regionInfo.getReplicaId() %></td>
         </tr>
+        <% } %>
         <% } %>
         </tbody>
       </table>
-        <% }
+      <%= moreRegionsToRender(numRegionsRendered, numRegions, fqtn) %>
+    </div>
+    <div class="tab-pane" id="tab_localityStats">
+      <table id="tableLocalityStatsTable" class="tablesorter table table-striped">
+        <thead>
+          <tr>
+            <th>Name(<%= String.format("%,1d", regions.size())%>)</th>
+            <th>Region Server</th>
+            <th>Locality<br>(<%= totalLocality %>)</th>
+            <th>LocalityForSsd<br>(<%= totalLocalityForSsd %>)</th>
+          </tr>
+        </thead>
+        <tbody>
+        <%
+          numRegionsRendered = 0;
+          for (Map.Entry<RegionInfo, RegionMetrics> hriEntry : entryList) {
+            RegionInfo regionInfo = hriEntry.getKey();
+            ServerName addr = regionsToServer.get(regionInfo);
+            RegionMetrics load = hriEntry.getValue();
+            float locality = 0.0f;
+            float localityForSsd = 0.0f;
+            String state = "N/A";
+            if (load != null) {
+              locality = load.getDataLocality();
+              localityForSsd = load.getDataLocalityForSsd();
+            }
+
+            if (numRegionsRendered < numRegionsToRender) {
+              numRegionsRendered++;
+        %>
+        <tr>
+          <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getRegionName())) %></td>
+          <%= buildRegionDeployedServerTag(regionInfo, master, regionsToServer) %>
+          <td><%= locality%></td>
+          <td><%= localityForSsd%></td>
+        </tr>
+        <% } %>
+        <% } %>
+        </tbody>
+      </table>
+      <%= moreRegionsToRender(numRegionsRendered, numRegions, fqtn) %>
+    </div>
+    <div class="tab-pane" id="tab_compactStats">
+      <table id="tableCompactStatsTable" class="tablesorter table table-striped">
+        <thead>
+          <tr>
+            <th>Name(<%= String.format("%,1d", regions.size())%>)</th>
+            <th>Region Server</th>
+            <th>Num. Compacting Cells<br>(<%= String.format("%,1d", totalCompactingCells)%>)</th>
+            <th>Num. Compacted Cells<br>(<%= String.format("%,1d", totalCompactedCells)%>)</th>
+            <th>Remaining Cells<br>(<%= String.format("%,1d", totalCompactingCells-totalCompactedCells)%>)</th>
+            <th>Compaction Progress<br>(<%= totalCompactionProgress %>)</th>
+          </tr>
+        </thead>
+        <tbody>
+        <%
+          numRegionsRendered = 0;
+          for (Map.Entry<RegionInfo, RegionMetrics> hriEntry : entryList) {
+            RegionInfo regionInfo = hriEntry.getKey();
+            ServerName addr = regionsToServer.get(regionInfo);
+            RegionMetrics load = hriEntry.getValue();
+            long compactingCells = 0;
+            long compactedCells = 0;
+            String compactionProgress = "";
+            if (load != null) {
+              compactingCells = load.getCompactingCellCount();
+              compactedCells = load.getCompactedCellCount();
+              if (compactingCells > 0) {
+                compactionProgress = String.format("%.2f", 100 * ((float)
+                        compactedCells / compactingCells)) + "%";
+              }
+            }
+
+            if (numRegionsRendered < numRegionsToRender) {
+              numRegionsRendered++;
+        %>
+        <tr>
+          <td><%= escapeXml(Bytes.toStringBinary(regionInfo.getRegionName())) %></td>
+          <%= buildRegionDeployedServerTag(regionInfo, master, regionsToServer) %>
+          <td><%= String.format("%,1d", compactingCells)%></td>
+          <td><%= String.format("%,1d", compactedCells)%></td>
+          <td><%= String.format("%,1d", compactingCells - compactedCells)%></td>
+          <td><%= compactionProgress%></td>
+        </tr>
+        <% } %>
+        <% } %>
+        </tbody>
+      </table>
+      <%= moreRegionsToRender(numRegionsRendered, numRegions, fqtn) %>
+    </div>
+  </div>
+</div>
+
+<h2>Regions by Region Server</h2>
+<table id="regionServerTable" class="tablesorter table table-striped">
+  <thead>
+    <tr>
+      <th>Region Server</th><th>Region Count</th><th>Primary Region Count</th>
+    </tr>
+  </thead>
+
+  <tbody>
+  <%
+    for (Map.Entry<ServerName, Integer> rdEntry : regDistribution.entrySet()) {
+      ServerName addr = rdEntry.getKey();
+      String url = "//" + URLEncoder.encode(addr.getHostname()) + ":"
+        + master.getRegionServerInfoPort(addr) + "/rs-status";
+  %>
+      <tr>
+        <td><a href="<%= url %>"><%= StringEscapeUtils.escapeHtml4(addr.getHostname().toString())
+          + ":" + master.getRegionServerInfoPort(addr) %></a></td>
+        <td><%= rdEntry.getValue()%></td>
+        <td><%= primaryRegDistribution.get(addr) == null ? 0 : primaryRegDistribution.get(addr)%></td>
+      </tr>
+  <% } %>
+  </tbody>
+</table>
+
+<% }
 } catch(Exception ex) { %>
   Unknown Issue with Regions
   <div onclick="document.getElementById('closeStackTrace').style.display='block';document.getElementById('openStackTrace').style.display='none';">
@@ -1246,41 +1210,6 @@
         <% } %>
   </div>
 </div>
-<% }
-} catch(TableNotFoundException e) { %>
-<div class="container-fluid content">
-  <div class="row inner_header">
-    <div class="page-header">
-      <h1>Table not found</h1>
-    </div>
-  </div>
-  <p><hr><p>
-  <p>Go <a href="javascript:history.back()">Back</a>
-</div> <%
-} catch(IllegalArgumentException e) { %>
-<div class="container-fluid content">
-  <div class="row inner_header">
-    <div class="page-header">
-      <h1>Table qualifier must not be empty</h1>
-    </div>
-  </div>
-  <p><hr><p>
-  <p>Go <a href="javascript:history.back()">Back</a>
-</div> <%
-  }
-}
-else { // handle the case for fqtn is null or master is not initialized with error message + redirect
-%>
-<div class="container-fluid content">
-  <div class="row inner_header">
-    <div class="page-header">
-      <h1>Table not ready</h1>
-    </div>
-  </div>
-  <p><hr><p>
-  <jsp:include page="redirect.jsp" />
-</div>
-<% } %>
 
 <jsp:include page="footer.jsp" />
 <script src="/static/js/jquery.min.js" type="text/javascript"></script>
@@ -1288,78 +1217,90 @@ else { // handle the case for fqtn is null or master is not initialized with err
 <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
 
 <script>
-    $(document).ready(function()
+$(document).ready(function()
+    {
+        $.tablesorter.addParser(
         {
-            $.tablesorter.addParser(
-                {
-                    id: 'filesize',
-                    is: function(s) {
-                        return s.match(new RegExp( /([\.0-9]+)\ (B|KB|MB|GB|TB)/ ));
-                    },
-                    format: function(s) {
-                        var suf = s.match(new RegExp( /(B|KB|MB|GB|TB)$/ ))[1];
-                        var num = parseFloat(s.match( new RegExp( /([\.0-9]+)\ (B|KB|MB|GB|TB)/ ))[0]);
-                        switch(suf) {
-                            case 'B':
-                                return num;
-                            case 'KB':
-                                return num * 1024;
-                            case 'MB':
-                                return num * 1024 * 1024;
-                            case 'GB':
-                                return num * 1024 * 1024 * 1024;
-                            case 'TB':
-                                return num * 1024 * 1024 * 1024 * 1024;
-                        }
-                    },
-                    type: 'numeric'
-                });
-            $.tablesorter.addParser(
-                {
-                    id: "separator",
-                    is: function (s) {
-                        return /^[0-9]?[0-9,]*$/.test(s);
-                    }, format: function (s) {
-                        return $.tablesorter.formatFloat( s.replace(/,/g,'') );
-                    }, type: "numeric"
-                });
-            $("#regionServerTable").tablesorter({
-                headers: {
-                    1: {sorter: 'separator'}
+            id: 'filesize',
+            is: function(s) {
+                return s.match(new RegExp( /([\.0-9]+)\ (B|KB|MB|GB|TB)/ ));
+            },
+            format: function(s) {
+                var suf = s.match(new RegExp( /(B|KB|MB|GB|TB)$/ ))[1];
+                var num = parseFloat(s.match( new RegExp( /([\.0-9]+)\ (B|KB|MB|GB|TB)/ ))[0]);
+                switch(suf) {
+                    case 'B':
+                        return num;
+                    case 'KB':
+                        return num * 1024;
+                    case 'MB':
+                        return num * 1024 * 1024;
+                    case 'GB':
+                        return num * 1024 * 1024 * 1024;
+                    case 'TB':
+                        return num * 1024 * 1024 * 1024 * 1024;
                 }
-            });
-            $("#regionServerDetailsTable").tablesorter({
-                headers: {
-                    2: {sorter: 'separator'},
-                    3: {sorter: 'separator'},
-                    4: {sorter: 'filesize'},
-                    5: {sorter: 'separator'},
-                    6: {sorter: 'filesize'}
-                }
-            });
-            $("#tableRegionTable").tablesorter({
-                headers: {
-                    2: {sorter: 'separator'},
-                    3: {sorter: 'separator'},
-                    4: {sorter: 'filesize'},
-                    5: {sorter: 'separator'},
-                    6: {sorter: 'filesize'}
-                }
-            });
-            $("#tableCompactStatsTable").tablesorter({
-                headers: {
-                    2: {sorter: 'separator'},
-                    3: {sorter: 'separator'},
-                    4: {sorter: 'separator'}
-                }
-            });
-            $("#metaTableCompactStatsTable").tablesorter({
-                headers: {
-                    2: {sorter: 'separator'},
-                    3: {sorter: 'separator'},
-                    4: {sorter: 'separator'}
-                }
-            });
-        }
-    );
+            },
+            type: 'numeric'
+        });
+        $.tablesorter.addParser(
+        {
+            id: "separator",
+            is: function (s) {
+                return /^[0-9]?[0-9,]*$/.test(s);
+            }, format: function (s) {
+                return $.tablesorter.formatFloat( s.replace(/,/g,'') );
+            }, type: "numeric"
+        });
+        $("#regionServerTable").tablesorter({
+            headers: {
+                1: {sorter: 'separator'}
+            }
+        });
+        $("#tableBaseStatsTable").tablesorter({
+            headers: {
+                2: {sorter: 'separator'},
+                3: {sorter: 'separator'},
+                4: {sorter: 'filesize'},
+                5: {sorter: 'separator'},
+                6: {sorter: 'filesize'}
+            }
+        });
+        $("#metaTableBaseStatsTable").tablesorter({
+            headers: {
+                2: {sorter: 'separator'},
+                3: {sorter: 'separator'},
+                4: {sorter: 'filesize'},
+                5: {sorter: 'separator'},
+                6: {sorter: 'filesize'}
+            }
+        });
+        $("#tableLocalityStatsTable").tablesorter({
+            headers: {
+                2: {sorter: 'separator'},
+                3: {sorter: 'separator'}
+            }
+        });
+        $("#metaTableLocalityStatsTable").tablesorter({
+            headers: {
+                2: {sorter: 'separator'},
+                3: {sorter: 'separator'}
+            }
+        });
+        $("#tableCompactStatsTable").tablesorter({
+            headers: {
+                2: {sorter: 'separator'},
+                3: {sorter: 'separator'},
+                4: {sorter: 'separator'}
+            }
+        });
+        $("#metaTableCompactStatsTable").tablesorter({
+            headers: {
+                2: {sorter: 'separator'},
+                3: {sorter: 'separator'},
+                4: {sorter: 'separator'}
+            }
+        });
+    }
+);
 </script>

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -1249,8 +1249,8 @@ Actions:
     <input style="font-size: 12pt; width: 10em" type="submit" value="Merge" class="btn" />
   </td>
   <td style="text-align: center;">
-    <input type="text" name="left" size="40" placeholder="Region Key (required)" />
-    <input type="text" name="right" size="40" placeholder="Region Key (required)" />
+    <input type="text" name="left" size="40" required="required" placeholder="Region Key (required)" />
+    <input type="text" name="right" size="40" required="required" placeholder="Region Key (required)" />
   </td>
   <td>
     This action will merge two regions of the table, Merge requests for

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -1263,7 +1263,9 @@ $(document).ready(function()
                 3: {sorter: 'separator'},
                 4: {sorter: 'filesize'},
                 5: {sorter: 'separator'},
-                6: {sorter: 'filesize'}
+                6: {sorter: 'filesize'},
+                7: {empty: 'emptyMin'},
+                8: {empty: 'emptyMax'}
             }
         });
         $("#metaTableBaseStatsTable").tablesorter({
@@ -1272,7 +1274,9 @@ $(document).ready(function()
                 3: {sorter: 'separator'},
                 4: {sorter: 'filesize'},
                 5: {sorter: 'separator'},
-                6: {sorter: 'filesize'}
+                6: {sorter: 'filesize'},
+                7: {empty: 'emptyMin'},
+                8: {empty: 'emptyMax'}
             }
         });
         $("#tableLocalityStatsTable").tablesorter({

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -232,7 +232,7 @@
 <%  return;
   } %>
 
-<% // table split/compact/merge actions
+<% // table split/major compact/compact/merge actions
   if ( !readOnly && action != null ) { %>
     <div class="container-fluid content">
       <div class="row inner_header">
@@ -248,6 +248,20 @@
         admin.split(TableName.valueOf(fqtn));
       }
 %>    Split request accepted. <%
+    } else if (action.equals("major compact")) {
+      if (key != null && key.length() > 0) {
+        List<RegionInfo> regions = admin.getRegions(TableName.valueOf(fqtn)).get();
+        byte[] row = Bytes.toBytes(key);
+
+        for (RegionInfo region : regions) {
+          if (region.containsRow(row)) {
+            admin.majorCompactRegion(region.getRegionName());
+          }
+        }
+      } else {
+        admin.majorCompact(TableName.valueOf(fqtn));
+      }
+%>    major Compact request accepted. <%
     } else if (action.equals("compact")) {
       if (key != null && key.length() > 0) {
         List<RegionInfo> regions = admin.getRegions(TableName.valueOf(fqtn)).get();
@@ -1146,69 +1160,86 @@
         </tr>
       </table>
 
-        <% if (!readOnly) { %>
-      <p><hr/></p>
-      Actions:
-      <p>
-      <center>
-        <table class="table" style="border: 0;" width="95%" >
-          <tr>
-            <form method="get">
-              <input type="hidden" name="action" value="compact" />
-              <input type="hidden" name="name" value="<%= escaped_fqtn %>" />
-              <td class="centered">
-                <input style="font-size: 12pt; width: 10em" type="submit" value="Compact" class="btn" />
-              </td>
-              <td style="text-align: center;">
-                <input type="text" name="key" size="40" placeholder="Row Key (optional)" />
-              </td>
-              <td>
-                This action will force a compaction of all regions of the table, or,
-                if a key is supplied, only the region containing the
-                given key.
-              </td>
-            </form>
-          </tr>
-          <tr>
-            <form method="get">
-              <input type="hidden" name="action" value="split" />
-              <input type="hidden" name="name" value="<%= escaped_fqtn %>" />
-              <td class="centered">
-                <input style="font-size: 12pt; width: 10em" type="submit" value="Split" class="btn" />
-              </td>
-              <td style="text-align: center;">
-                <input type="text" name="key" size="40" placeholder="Row Key (optional)" />
-              </td>
-              <td>
-                This action will force a split of all eligible
-                regions of the table, or, if a key is supplied, only the region containing the
-                given key. An eligible region is one that does not contain any references to
-                other regions. Split requests for noneligible regions will be ignored.
-              </td>
-            </form>
-          </tr>
-          <tr>
-            <form method="get">
-              <input type="hidden" name="action" value="merge" />
-              <input type="hidden" name="name" value="<%= escaped_fqtn %>" />
-              <td class="centered">
-                <input style="font-size: 12pt; width: 10em" type="submit" value="Merge" class="btn" />
-              </td>
-              <td style="text-align: center;">
-                <input type="text" name="left" size="40" placeholder="Region Key (required)" />
-                <input type="text" name="right" size="40" placeholder="Region Key (required)" />
-              </td>
-              <td>
-                This action will merge two regions of the table, Merge requests for
-                noneligible regions will be ignored.
-              </td>
-            </form>
-          </tr>
-        </table>
-      </center>
-      </p>
-        <% } %>
-  </div>
+<% if (!readOnly) { %>
+<p><hr/></p>
+Actions:
+<p>
+<center>
+<table class="table" style="border: 0;" width="95%" >
+<tr>
+  <form method="get">
+  <input type="hidden" name="action" value="major compact" />
+  <input type="hidden" name="name" value="<%= escaped_fqtn %>" />
+  <td class="centered">
+    <input style="font-size: 12pt; width: 10em" type="submit" value="Major Compact" class="btn" />
+  </td>
+  <td style="text-align: center;">
+    <input type="text" name="key" size="40" placeholder="Row Key (optional)" />
+  </td>
+  <td>
+    This action will force a major compaction of all regions of the table, or,
+    if a key is supplied, only the region major containing the
+    given key.
+  </td>
+  </form>
+</tr>
+<tr>
+  <form method="get">
+  <input type="hidden" name="action" value="compact" />
+  <input type="hidden" name="name" value="<%= escaped_fqtn %>" />
+  <td class="centered">
+    <input style="font-size: 12pt; width: 10em" type="submit" value="Compact" class="btn" />
+  </td>
+  <td style="text-align: center;">
+    <input type="text" name="key" size="40" placeholder="Row Key (optional)" />
+  </td>
+  <td>
+    This action will force a compaction of all regions of the table, or,
+    if a key is supplied, only the region containing the
+    given key.
+  </td>
+  </form>
+</tr>
+<tr>
+  <form method="get">
+  <input type="hidden" name="action" value="split" />
+  <input type="hidden" name="name" value="<%= escaped_fqtn %>" />
+  <td class="centered">
+    <input style="font-size: 12pt; width: 10em" type="submit" value="Split" class="btn" />
+  </td>
+  <td style="text-align: center;">
+    <input type="text" name="key" size="40" placeholder="Row Key (optional)" />
+  </td>
+  <td>
+      This action will force a split of all eligible
+      regions of the table, or, if a key is supplied, only the region containing the
+      given key. An eligible region is one that does not contain any references to
+      other regions. Split requests for noneligible regions will be ignored.
+  </td>
+  </form>
+</tr>
+<tr>
+  <form method="get">
+  <input type="hidden" name="action" value="merge" />
+  <input type="hidden" name="name" value="<%= escaped_fqtn %>" />
+  <td class="centered">
+    <input style="font-size: 12pt; width: 10em" type="submit" value="Merge" class="btn" />
+  </td>
+  <td style="text-align: center;">
+    <input type="text" name="left" size="40" placeholder="Region Key (required)" />
+    <input type="text" name="right" size="40" placeholder="Region Key (required)" />
+  </td>
+  <td>
+    This action will merge two regions of the table, Merge requests for
+    noneligible regions will be ignored.
+  </td>
+  </form>
+</tr>
+</table>
+</center>
+</p>
+<% } %>
+</div>
 </div>
 
 <jsp:include page="footer.jsp" />

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -147,11 +147,32 @@
     return "";
   }
 %>
+
+<jsp:include page="header.jsp">
+  <jsp:param name="pageTitle" value="${pageTitle}"/>
+</jsp:include>
+
 <%
   final String ZEROMB = "0 MB";
   HMaster master = (HMaster)getServletContext().getAttribute(HMaster.MASTER);
   Configuration conf = master.getConfiguration();
   String fqtn = request.getParameter("name");
+  // handle the case for fqtn is null or master is not initialized with error message + redirect
+  if (fqtn == null || !master.isInitialized()) {
+%>
+    <div class="container-fluid content">
+      <div class="row inner_header">
+        <div class="page-header">
+          <h1>Table not ready</h1>
+        </div>
+      </div>
+      <p><hr><p>
+      <jsp:include page="redirect.jsp" />
+    </div>
+<%  return;
+  } %>
+
+<%
   final String escaped_fqtn = StringEscapeUtils.escapeHtml4(fqtn);
   Table table = master.getConnection().getTable(TableName.valueOf(fqtn));
   boolean showFragmentation = conf.getBoolean("hbase.master.ui.fragmentation.enabled", false);
@@ -199,24 +220,6 @@
     .build();
   final MetaBrowser metaBrowser = new MetaBrowser(connection, request);
 %>
-
-<jsp:include page="header.jsp">
-  <jsp:param name="pageTitle" value="${pageTitle}"/>
-</jsp:include>
-
-<% // handle the case for fqtn is null or master is not initialized with error message + redirect
-  if (fqtn == null || ! master.isInitialized()) { %>
-    <div class="container-fluid content">
-      <div class="row inner_header">
-        <div class="page-header">
-          <h1>Table not ready</h1>
-        </div>
-      </div>
-      <p><hr><p>
-      <jsp:include page="redirect.jsp" />
-    </div>
-<%  return;
-  } %>
 
 <% // unknow table
   if (! admin.tableExists(TableName.valueOf(fqtn)).get()) { %>

--- a/hbase-server/src/main/resources/hbase-webapps/regionserver/header.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/regionserver/header.jsp
@@ -63,8 +63,6 @@
               <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
                 <li><a target="_blank" href="/jmx">JMX</a></li>
                 <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
-                <li><a target="_blank" href="/prometheus">Prometheus</a></li>
-                <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
               </ul>
             </li>
             <li><a href="/prof">Profiler</a></li>

--- a/hbase-server/src/main/resources/hbase-webapps/regionserver/header.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/regionserver/header.jsp
@@ -56,7 +56,17 @@
             <li><a href="/rsOperationDetails.jsp">Operation Details</a></li>
             <li><a href="/logLevel">Log Level</a></li>
             <li><a href="/dump">Debug Dump</a></li>
-            <li><a href="/jmx">Metrics Dump</a></li>
+            <li class="nav-item dropdown">
+              <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                Metrics <span class="caret"></span>
+              </a>
+              <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                <li><a target="_blank" href="/jmx">JMX</a></li>
+                <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+              </ul>
+            </li>
             <li><a href="/prof">Profiler</a></li>
             <% if (HBaseConfiguration.isShowConfInServlet()) { %>
             <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-thrift/src/main/resources/hbase-webapps/thrift/footer.jsp
+++ b/hbase-thrift/src/main/resources/hbase-webapps/thrift/footer.jsp
@@ -1,0 +1,30 @@
+<%--
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+--%>
+    <script src="/static/js/jquery.min.js" type="text/javascript"></script>
+    <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="/static/js/tab.js" type="text/javascript"></script>
+    <script type="text/javascript">
+      $(document).ready(function() {
+        $('li.active').removeClass('active');
+        $('a[href="' + location.pathname + '"]').closest('li').addClass('active');
+      });
+    </script>
+  </body>
+</html>

--- a/hbase-thrift/src/main/resources/hbase-webapps/thrift/header.jsp
+++ b/hbase-thrift/src/main/resources/hbase-webapps/thrift/header.jsp
@@ -1,0 +1,74 @@
+<%--
+/**
+* Licensed to the Apache Software Foundation (ASF) under one
+* or more contributor license agreements.  See the NOTICE file
+* distributed with this work for additional information
+* regarding copyright ownership.  The ASF licenses this file
+* to you under the Apache License, Version 2.0 (the
+* "License"); you may not use this file except in compliance
+* with the License.  You may obtain a copy of the License at
+*
+*     http://www.apache.org/licenses/LICENSE-2.0
+*
+* Unless required by applicable law or agreed to in writing, software
+* distributed under the License is distributed on an "AS IS" BASIS,
+* WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+* See the License for the specific language governing permissions and
+* limitations under the License.
+*/
+--%>
+<%@ page contentType="text/html;charset=UTF-8"
+         import="org.apache.hadoop.hbase.HBaseConfiguration"%>
+
+<!DOCTYPE html>
+<?xml version="1.0" encoding="UTF-8" ?>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title><%= request.getParameter("pageTitle")%></title>
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <meta name="description" content="">
+
+  <link href="/static/css/bootstrap.min.css" rel="stylesheet">
+  <link href="/static/css/bootstrap-theme.min.css" rel="stylesheet">
+  <link href="/static/css/hbase.css" rel="stylesheet">
+</head>
+
+<body>
+<div class="navbar  navbar-fixed-top navbar-default">
+  <div class="container-fluid">
+    <div class="navbar-header">
+      <button type="button"
+              class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+        <span class="icon-bar"></span>
+      </button>
+      <a class="navbar-brand" href="/thrift.jsp">
+        <img src="/static/hbase_logo_small.png" alt="HBase Logo"/>
+      </a>
+    </div>
+    <div class="collapse navbar-collapse">
+      <ul class="nav navbar-nav">
+        <li class="active"><a href="/thrift.jsp">Home</a></li>
+        <li><a href="/logs/">Local logs</a></li>
+        <li><a href="/logLevel">Log Level</a></li>
+        <li class="nav-item dropdown">
+          <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+            Metrics <span class="caret"></span>
+          </a>
+          <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+            <li><a target="_blank" href="/jmx">JMX</a></li>
+            <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+            <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+            <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+          </ul>
+        </li>
+        <li><a href="/prof">Profiler</a></li>
+        <% if (HBaseConfiguration.isShowConfInServlet()) { %>
+        <li><a href="/conf">HBase Configuration</a></li>
+        <% } %>
+      </ul>
+    </div><!--/.nav-collapse -->
+  </div>
+</div>

--- a/hbase-thrift/src/main/resources/hbase-webapps/thrift/header.jsp
+++ b/hbase-thrift/src/main/resources/hbase-webapps/thrift/header.jsp
@@ -60,8 +60,6 @@
           <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
             <li><a target="_blank" href="/jmx">JMX</a></li>
             <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
-            <li><a target="_blank" href="/prometheus">Prometheus</a></li>
-            <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
           </ul>
         </li>
         <li><a href="/prof">Profiler</a></li>

--- a/hbase-thrift/src/main/resources/hbase-webapps/thrift/thrift.jsp
+++ b/hbase-thrift/src/main/resources/hbase-webapps/thrift/thrift.jsp
@@ -19,7 +19,6 @@
 --%>
 <%@ page contentType="text/html;charset=UTF-8"
   import="org.apache.hadoop.conf.Configuration"
-  import="org.apache.hadoop.hbase.HBaseConfiguration"
   import="org.apache.hadoop.hbase.util.VersionInfo"
   import="java.util.Date"
 %>
@@ -27,72 +26,25 @@
 <%@ page import="org.apache.hadoop.hbase.util.JvmVersion" %>
 
 <%
-Configuration conf = (Configuration)getServletContext().getAttribute("hbase.conf");
-String serverType = (String)getServletContext().getAttribute("hbase.thrift.server.type");
-long startcode = conf.getLong("startcode", System.currentTimeMillis());
-String listenPort = conf.get("hbase.regionserver.thrift.port", "9090");
-ImplType implType = ImplType.getServerImpl(conf);
+  Configuration conf = (Configuration)getServletContext().getAttribute("hbase.conf");
+  String serverType = (String)getServletContext().getAttribute("hbase.thrift.server.type");
+  long startcode = conf.getLong("startcode", System.currentTimeMillis());
+  String listenPort = conf.get("hbase.regionserver.thrift.port", "9090");
+  ImplType implType = ImplType.getServerImpl(conf);
 
-String transport =
-  (implType.isAlwaysFramed() ||
-    conf.getBoolean("hbase.regionserver.thrift.framed", false)) ? "Framed" : "Standard";
-String protocol =
-  conf.getBoolean("hbase.regionserver.thrift.compact", false) ? "Compact" : "Binary";
-String qop = conf.get("hbase.thrift.security.qop", "None");
+  String transport =
+    (implType.isAlwaysFramed() ||
+      conf.getBoolean("hbase.regionserver.thrift.framed", false)) ? "Framed" : "Standard";
+  String protocol =
+    conf.getBoolean("hbase.regionserver.thrift.compact", false) ? "Compact" : "Binary";
+  String qop = conf.get("hbase.thrift.security.qop", "None");
 
+  pageContext.setAttribute("pageTitle", "HBase Thrift Server: " + listenPort);
 %>
-<!DOCTYPE html>
-<?xml version="1.0" encoding="UTF-8" ?>
-<html lang="en">
-  <head>
-    <meta charset="utf-8">
-    <title>HBase Thrift Server: <%= listenPort %></title>
-    <meta name="viewport" content="width=device-width, initial-scale=1.0">
-    <meta name="description" content="">
 
-    <link href="/static/css/bootstrap.min.css" rel="stylesheet">
-    <link href="/static/css/bootstrap-theme.min.css" rel="stylesheet">
-    <link href="/static/css/hbase.css" rel="stylesheet">
-  </head>
-
-  <body>
-  <div class="navbar  navbar-fixed-top navbar-default">
-      <div class="container-fluid">
-          <div class="navbar-header">
-              <button type="button"
-                      class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-                  <span class="icon-bar"></span>
-              </button>
-              <a class="navbar-brand" href="/thrift.jsp">
-                <img src="/static/hbase_logo_small.png" alt="HBase Logo"/>
-              </a>
-          </div>
-          <div class="collapse navbar-collapse">
-              <ul class="nav navbar-nav">
-                <li class="active"><a href="/">Home</a></li>
-                <li><a href="/logs/">Local logs</a></li>
-                <li><a href="/logLevel">Log Level</a></li>
-                <li class="nav-item dropdown">
-                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
-                    Metrics <span class="caret"></span>
-                  </a>
-                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
-                    <li><a target="_blank" href="/jmx">JMX</a></li>
-                    <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
-                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
-                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
-                  </ul>
-                </li>
-                <li><a href="/prof">Profiler</a></li>
-                <% if (HBaseConfiguration.isShowConfInServlet()) { %>
-                <li><a href="/conf">HBase Configuration</a></li>
-                <% } %>
-            </ul>
-          </div><!--/.nav-collapse -->
-      </div>
-  </div>
+<jsp:include page="header.jsp">
+  <jsp:param name="pageTitle" value="${pageTitle}"/>
+</jsp:include>
 
 <div class="container-fluid content">
     <div class="row inner_header">
@@ -165,8 +117,5 @@ String qop = conf.get("hbase.thrift.security.qop", "None");
         </section>
     </div>
 </div>
-<script src="/static/js/jquery.min.js" type="text/javascript"></script>
-<script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
-<script src="/static/js/tab.js" type="text/javascript"></script>
-</body>
-</html>
+
+<jsp:include page="footer.jsp" />

--- a/hbase-thrift/src/main/resources/hbase-webapps/thrift/thrift.jsp
+++ b/hbase-thrift/src/main/resources/hbase-webapps/thrift/thrift.jsp
@@ -66,7 +66,17 @@ String compact = conf.get("hbase.regionserver.thrift.compact", "false");
                 <li class="active"><a href="/">Home</a></li>
                 <li><a href="/logs/">Local logs</a></li>
                 <li><a href="/logLevel">Log Level</a></li>
-                <li><a href="/jmx">Metrics Dump</a></li>
+                <li class="nav-item dropdown">
+                  <a class="nav-link dropdown-toggle" href="#" id="navbarDropdownMenuLink" data-toggle="dropdown" aria-haspopup="true" aria-expanded="false">
+                    Metrics <span class="caret"></span>
+                  </a>
+                  <ul class="dropdown-menu" aria-labelledby="navbarDropdownMenuLink">
+                    <li><a target="_blank" href="/jmx">JMX</a></li>
+                    <li><a target="_blank" href="/jmx?description=true">JMX with description</a></li>
+                    <li><a target="_blank" href="/prometheus">Prometheus</a></li>
+                    <li><a target="_blank" href="/prometheus?description=true">Prometheus with description</a></li>
+                  </ul>
+                </li>
                 <li><a href="/prof">Profiler</a></li>
                 <% if (HBaseConfiguration.isShowConfInServlet()) { %>
                 <li><a href="/conf">HBase Configuration</a></li>

--- a/hbase-thrift/src/main/resources/hbase-webapps/thrift/thrift.jsp
+++ b/hbase-thrift/src/main/resources/hbase-webapps/thrift/thrift.jsp
@@ -32,9 +32,14 @@ String serverType = (String)getServletContext().getAttribute("hbase.thrift.serve
 long startcode = conf.getLong("startcode", System.currentTimeMillis());
 String listenPort = conf.get("hbase.regionserver.thrift.port", "9090");
 ImplType implType = ImplType.getServerImpl(conf);
-String framed = implType.isAlwaysFramed()
-    ? "true" : conf.get("hbase.regionserver.thrift.framed", "false");
-String compact = conf.get("hbase.regionserver.thrift.compact", "false");
+
+String transport =
+  (implType.isAlwaysFramed() ||
+    conf.getBoolean("hbase.regionserver.thrift.framed", false)) ? "Framed" : "Standard";
+String protocol =
+  conf.getBoolean("hbase.regionserver.thrift.compact", false) ? "Compact" : "Binary";
+String qop = conf.get("hbase.thrift.security.qop", "None");
+
 %>
 <!DOCTYPE html>
 <?xml version="1.0" encoding="UTF-8" ?>
@@ -54,12 +59,15 @@ String compact = conf.get("hbase.regionserver.thrift.compact", "false");
   <div class="navbar  navbar-fixed-top navbar-default">
       <div class="container-fluid">
           <div class="navbar-header">
-              <button type="button" class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
+              <button type="button"
+                      class="navbar-toggle" data-toggle="collapse" data-target=".navbar-collapse">
                   <span class="icon-bar"></span>
                   <span class="icon-bar"></span>
                   <span class="icon-bar"></span>
               </button>
-              <a class="navbar-brand" href="/thrift.jsp"><img src="/static/hbase_logo_small.png" alt="HBase Logo"/></a>
+              <a class="navbar-brand" href="/thrift.jsp">
+                <img src="/static/hbase_logo_small.png" alt="HBase Logo"/>
+              </a>
           </div>
           <div class="collapse navbar-collapse">
               <ul class="nav navbar-nav">
@@ -128,26 +136,32 @@ String compact = conf.get("hbase.regionserver.thrift.compact", "false");
             <td>Thrift RPC engine implementation type chosen by this Thrift server</td>
         </tr>
         <tr>
-            <td>Compact Protocol</td>
-            <td><%= compact %></td>
-            <td>Thrift RPC engine uses compact protocol</td>
+            <td>Protocol</td>
+            <td><%= protocol %></td>
+            <td>Thrift RPC engine protocol type</td>
         </tr>
         <tr>
-            <td>Framed Transport</td>
-            <td><%= framed %></td>
-            <td>Thrift RPC engine uses framed transport</td>
+            <td>Transport</td>
+            <td><%= transport %></td>
+            <td>Thrift RPC engine transport type</td>
         </tr>
         <tr>
             <td>Thrift Server Type</td>
             <td><%= serverType %></td>
             <td>The type of this Thrift server</td>
         </tr>
+      <tr>
+        <td>Quality of Protection</td>
+        <td><%= qop %></td>
+        <td>QOP Settings for SASL</td>
+      </tr>
     </table>
     </section>
     </div>
     <div class="row">
         <section>
-            <a href="http://hbase.apache.org/book.html#_thrift">Apache HBase Reference Guide chapter on Thrift</a>
+            <a href="http://hbase.apache.org/book.html#_thrift">
+              Apache HBase Reference Guide chapter on Thrift</a>
         </section>
     </div>
 </div>


### PR DESCRIPTION
Cherry-picked the following patches which were missing on branch-2.5 branch. Most of these applied as a clean cherry-pick (without conflicts). Unfortunately there were some which had conflicts and I manually resolved them.
Each commit message contains from which commit it was cherry-picked from.

- HBASE-27406 Make /prometheus endpoint accessible from HBase UI (#4833)
- HBASE-27814 Add support for dump and process metrics servlet in REST InfoServer (#5215)
- HBASE-18382 add transport type info into Thrift UI (#880)
- HBASE-20693 Refactor thrift jsp's and extract header and footer (#5732)
- HBASE-24624 Optimize table.jsp code (#1963) - :warning: This did not apply cleanly - had to resolve conflicts manually
- HBASE-25402 Sorting order by start key or end key is not considering empty start key/end key (#2955)
- HBASE-27309 Add major compact table or region operation on master web table page (#4793)
- HBASE-28778 NPE may occur when opening master-status or table.jsp or procedure.jsp while Master is initializing (#6152)
- HBASE-28305 Add "Uncompressed StoreFileSize" column to the table.jsp (#5620)
- HBASE-20452 Master UI: Table merge button should validate required fields before submit


Is it OK to have multiple patches in one PR like this or would you prefer having a separate PR for each commit?