### PR TITLE
HBASE-29021 When StoreFileTracker is FILE, unable to recognize StoreFileListFile after upgrade from 2.5 to 2.6

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFile.java
@@ -84,9 +84,7 @@ class StoreFileListFile {
 
   static final char TRACK_FILE_SEPARATOR = '.';
 
-  static final Pattern TRACK_FILE_PATTERN = Pattern.compile("^f(1|2)\\.\\d+$");
-
-  static final Pattern TRACK_FILE_OLD_PATTERN = Pattern.compile("^f(1|2)$");
+  static final Pattern TRACK_FILE_PATTERN = Pattern.compile("^f(1|2)(\\.\\d+)?$");
 
   // 16 MB, which is big enough for a tracker file
   private static final int MAX_FILE_SIZE = 16 * 1024 * 1024;
@@ -176,18 +174,14 @@ class StoreFileListFile {
         LOG.warn("Found invalid track file {}, which is not a file", file);
         continue;
       }
-      if (TRACK_FILE_OLD_PATTERN.matcher(file.getName()).matches()) {
-        Path newFile = new Path(trackFileDir,
-          file.getName() + TRACK_FILE_SEPARATOR + System.currentTimeMillis());
-        LOG.info("Found invalid track file {}, Rename to {}", file, newFile);
-        fs.rename(file, newFile);
-        file = newFile;
-      } else if (!TRACK_FILE_PATTERN.matcher(file.getName()).matches()) {
+      if (!TRACK_FILE_PATTERN.matcher(file.getName()).matches()) {
         LOG.warn("Found invalid track file {}, skip", file);
         continue;
       }
       List<String> parts = Splitter.on(TRACK_FILE_SEPARATOR).splitToList(file.getName());
-      map.computeIfAbsent(Long.parseLong(parts.get(1)), k -> new ArrayList<>()).add(file);
+      // For compatibility, set the timestamp to 0 if it is missing in the file name.
+      long timestamp = parts.size() > 1 ? Long.parseLong(parts.get(1)) : 0L;
+      map.computeIfAbsent(timestamp, k -> new ArrayList<>()).add(file);
     }
     return map;
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFile.java
@@ -177,10 +177,11 @@ class StoreFileListFile {
         continue;
       }
       if (TRACK_FILE_OLD_PATTERN.matcher(file.getName()).matches()) {
-        Path newPath = new Path(trackFileDir, file.getName() + TRACK_FILE_SEPARATOR + System.currentTimeMillis());
-        LOG.info("Found invalid track file {}, Rename track file to {}", file, newPath);
-        fs.rename(file, newPath);
-        file = newPath;
+        Path newFile = new Path(trackFileDir,
+          file.getName() + TRACK_FILE_SEPARATOR + System.currentTimeMillis());
+        LOG.info("Found invalid track file {}, Rename to {}", file, newFile);
+        fs.rename(file, newFile);
+        file = newFile;
       } else if (!TRACK_FILE_PATTERN.matcher(file.getName()).matches()) {
         LOG.warn("Found invalid track file {}, skip", file);
         continue;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFile.java
@@ -86,6 +86,8 @@ class StoreFileListFile {
 
   static final Pattern TRACK_FILE_PATTERN = Pattern.compile("^f(1|2)\\.\\d+$");
 
+  static final Pattern TRACK_FILE_OLD_PATTERN = Pattern.compile("^f(1|2)$");
+
   // 16 MB, which is big enough for a tracker file
   private static final int MAX_FILE_SIZE = 16 * 1024 * 1024;
 
@@ -174,7 +176,12 @@ class StoreFileListFile {
         LOG.warn("Found invalid track file {}, which is not a file", file);
         continue;
       }
-      if (!TRACK_FILE_PATTERN.matcher(file.getName()).matches()) {
+      if (TRACK_FILE_OLD_PATTERN.matcher(file.getName()).matches()) {
+        Path newPath = new Path(trackFileDir, file.getName() + TRACK_FILE_SEPARATOR + System.currentTimeMillis());
+        LOG.info("Found invalid track file {}, Rename track file to {}", file, newPath);
+        fs.rename(file, newPath);
+        file = newPath;
+      } else if (!TRACK_FILE_PATTERN.matcher(file.getName()).matches()) {
         LOG.warn("Found invalid track file {}, skip", file);
         continue;
       }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileListFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileListFile.java
@@ -239,4 +239,22 @@ public class TestStoreFileListFile {
     assertEquals("Higher store file list version detected, expected " + StoreFileListFile.VERSION
       + ", got " + (StoreFileListFile.VERSION + 1), error.getMessage());
   }
+
+  @Test
+  public void testLoadOldPatternTrackFiles() throws IOException {
+    FileSystem fs = FileSystem.get(UTIL.getConfiguration());
+    StoreFileList storeFileList =
+      StoreFileList.newBuilder().setTimestamp(EnvironmentEdgeManager.currentTime()).build();
+    Path trackFileDir = new Path(testDir, StoreFileListFile.TRACK_FILE_DIR);
+    StoreFileListFile.write(fs,
+      new Path(trackFileDir, StoreFileListFile.TRACK_FILE_PREFIX), storeFileList);
+
+    FileStatus trackerFileStatus = getOnlyTrackerFile(fs);
+    assertTrue(StoreFileListFile.TRACK_FILE_OLD_PATTERN.matcher(trackerFileStatus.getPath().getName()).matches());
+
+    storeFileListFile.load(true);
+
+    trackerFileStatus = getOnlyTrackerFile(fs);
+    assertTrue(StoreFileListFile.TRACK_FILE_PATTERN.matcher(trackerFileStatus.getPath().getName()).matches());
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileListFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileListFile.java
@@ -244,19 +244,16 @@ public class TestStoreFileListFile {
   public void testLoadOldPatternTrackFiles() throws IOException {
     FileSystem fs = FileSystem.get(UTIL.getConfiguration());
     StoreFileList storeFileList =
-      StoreFileList.newBuilder().setTimestamp(EnvironmentEdgeManager.currentTime()).build();
+      StoreFileList.newBuilder().setTimestamp(EnvironmentEdgeManager.currentTime())
+        .addStoreFile(StoreFileEntry.newBuilder().setName("hehe").setSize(10).build()).build();
     Path trackFileDir = new Path(testDir, StoreFileListFile.TRACK_FILE_DIR);
     StoreFileListFile.write(fs, new Path(trackFileDir, StoreFileListFile.TRACK_FILE_PREFIX),
       storeFileList);
 
     FileStatus trackerFileStatus = getOnlyTrackerFile(fs);
-    assertTrue(StoreFileListFile.TRACK_FILE_OLD_PATTERN
-      .matcher(trackerFileStatus.getPath().getName()).matches());
+    assertEquals(StoreFileListFile.TRACK_FILE_PREFIX, trackerFileStatus.getPath().getName());
 
-    storeFileListFile.load(true);
-
-    trackerFileStatus = getOnlyTrackerFile(fs);
-    assertTrue(StoreFileListFile.TRACK_FILE_PATTERN.matcher(trackerFileStatus.getPath().getName())
-      .matches());
+    StoreFileList list = storeFileListFile.load(true);
+    assertEquals(1, list.getStoreFileCount());
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileListFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileListFile.java
@@ -246,15 +246,17 @@ public class TestStoreFileListFile {
     StoreFileList storeFileList =
       StoreFileList.newBuilder().setTimestamp(EnvironmentEdgeManager.currentTime()).build();
     Path trackFileDir = new Path(testDir, StoreFileListFile.TRACK_FILE_DIR);
-    StoreFileListFile.write(fs,
-      new Path(trackFileDir, StoreFileListFile.TRACK_FILE_PREFIX), storeFileList);
+    StoreFileListFile.write(fs, new Path(trackFileDir, StoreFileListFile.TRACK_FILE_PREFIX),
+      storeFileList);
 
     FileStatus trackerFileStatus = getOnlyTrackerFile(fs);
-    assertTrue(StoreFileListFile.TRACK_FILE_OLD_PATTERN.matcher(trackerFileStatus.getPath().getName()).matches());
+    assertTrue(StoreFileListFile.TRACK_FILE_OLD_PATTERN
+      .matcher(trackerFileStatus.getPath().getName()).matches());
 
     storeFileListFile.load(true);
 
     trackerFileStatus = getOnlyTrackerFile(fs);
-    assertTrue(StoreFileListFile.TRACK_FILE_PATTERN.matcher(trackerFileStatus.getPath().getName()).matches());
+    assertTrue(StoreFileListFile.TRACK_FILE_PATTERN.matcher(trackerFileStatus.getPath().getName())
+      .matches());
   }
 }


### PR DESCRIPTION
When using FileBasedStoreFileTracker, there is an issue where StoreFileListFile is not recognized after upgrading from HBase 2.5 to 2.6. 
In HBase 2.5, the names of StoreFileListFiles are f1 or f2, but starting from 2.6, a timestamp is added to the filenames, as introduced in [HBASE-29021](https://issues.apache.org/jira/browse/HBASE-29021). 
However, this change was not backported to 2.5. 
To resolve this issue, a patch was applied to add the timestamp when it is missing in the StoreFileListFile name.