### PR TITLE
HBASE-29040 Fix description of "sampleRate" of PerformanceEvaluation

### DIFF
--- a/hbase-diagnostics/src/main/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-diagnostics/src/main/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -1205,7 +1205,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       this.opts = options;
       this.status = status;
       this.testName = this.getClass().getSimpleName();
-      everyN = (int) (opts.totalRows / (opts.totalRows * opts.sampleRate));
+      everyN = (int) (1 / opts.sampleRate);
       if (options.isValueZipf()) {
         this.zipf = new RandomDistribution.Zipf(this.rand, 1, options.getValueSize(), 1.2);
       }

--- a/hbase-diagnostics/src/main/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-diagnostics/src/main/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -2707,8 +2707,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       + "Default: depend on oneCon parameter. if oneCon set to true, then connCount=1, "
       + "if not, connCount=thread number");
 
-    System.err.println(" sampleRate      Execute test on a sample of total "
-      + "rows. Only supported by randomRead. Default: 1.0");
+    System.err.println(" sampleRate      Execute test on a sample of total rows. Default: 1.0");
     System.err.println(" period          Report every 'period' rows: "
       + "Default: opts.perClientRunRows / 10 = " + DEFAULT_OPTS.getPerClientRunRows() / 10);
     System.err.println(" cycles          How many times to cycle the test. Defaults: 1.");


### PR DESCRIPTION
The option applies to all tests since HBASE-10788.