### PR TITLE
HBASE-29013 Make PerformanceEvaluation support larger data sets (branch-2)

### DIFF
--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -1141,17 +1141,9 @@ public class PerformanceEvaluation extends Configured implements Tool {
    * A test. Subclass to particularize what happens per row.
    */
   static abstract class TestBase {
-    // Below is make it so when Tests are all running in the one
-    // jvm, that they each have a differently seeded Random.
-    private static final Random randomSeed = new Random(EnvironmentEdgeManager.currentTime());
-
-    private static long nextRandomSeed() {
-      return randomSeed.nextLong();
-    }
-
     private final long everyN;
 
-    protected final Random rand = new Random(nextRandomSeed());
+    protected final Random rand = ThreadLocalRandom.current();
     protected final Configuration conf;
     protected final TestOptions opts;
 

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -1792,10 +1792,9 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
     @Override
     boolean testRow(final long i, final long startTime) throws IOException {
-      Scan scan =
-        new Scan().withStartRow(getRandomRow(opts.totalRows)).setCaching(opts.caching)
-          .setCacheBlocks(opts.cacheBlocks).setAsyncPrefetch(opts.asyncPrefetch)
-          .setReadType(opts.scanReadType).setScanMetricsEnabled(true);
+      Scan scan = new Scan().withStartRow(getRandomRow(opts.totalRows)).setCaching(opts.caching)
+        .setCacheBlocks(opts.cacheBlocks).setAsyncPrefetch(opts.asyncPrefetch)
+        .setReadType(opts.scanReadType).setScanMetricsEnabled(true);
       FilterList list = new FilterList();
       for (int family = 0; family < opts.families; family++) {
         byte[] familyName = Bytes.toBytes(FAMILY_NAME_BASE + family);
@@ -2038,8 +2037,8 @@ public class PerformanceEvaluation extends Configured implements Tool {
       if (opts.randomSleep > 0) {
         Thread.sleep(rd.nextInt(opts.randomSleep));
       }
-      HRegionLocation hRegionLocation =
-        regionLocator.getRegionLocation(getSplitKey(ThreadLocalRandom.current().nextLong(opts.perClientRunRows)), true);
+      HRegionLocation hRegionLocation = regionLocator.getRegionLocation(
+        getSplitKey(ThreadLocalRandom.current().nextLong(opts.perClientRunRows)), true);
       LOG.debug("get location for region: " + hRegionLocation);
       return true;
     }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -441,9 +441,9 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
     int numSplitPoints = opts.presplitRegions - 1;
     byte[][] splits = new byte[numSplitPoints][];
-    int jump = opts.totalRows / opts.presplitRegions;
+    long jump = opts.totalRows / opts.presplitRegions;
     for (int i = 0; i < numSplitPoints; i++) {
-      int rowkey = jump * (1 + i);
+      long rowkey = jump * (1 + i);
       splits[i] = format(rowkey);
     }
     return splits;
@@ -620,7 +620,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     // Make input random.
     Map<Integer, String> m = new TreeMap<>();
     Hash h = MurmurHash.getInstance();
-    int perClientRows = (opts.totalRows / opts.numClientThreads);
+    long perClientRows = (opts.totalRows / opts.numClientThreads);
     try {
       for (int j = 0; j < opts.numClientThreads; j++) {
         TestOptions next = new TestOptions(opts);
@@ -679,11 +679,11 @@ public class PerformanceEvaluation extends Configured implements Tool {
     String cmdName = null;
     boolean nomapred = false;
     boolean filterAll = false;
-    int startRow = 0;
+    long startRow = 0;
     float size = 1.0f;
-    int perClientRunRows = DEFAULT_ROWS_PER_GB;
+    long perClientRunRows = DEFAULT_ROWS_PER_GB;
     int numClientThreads = 1;
-    int totalRows = DEFAULT_ROWS_PER_GB;
+    long totalRows = DEFAULT_ROWS_PER_GB;
     int measureAfter = 0;
     float sampleRate = 1.0f;
     /**
@@ -715,7 +715,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     boolean valueRandom = false;
     boolean valueZipf = false;
     int valueSize = DEFAULT_VALUE_LENGTH;
-    int period = (this.perClientRunRows / 10) == 0 ? perClientRunRows : perClientRunRows / 10;
+    long period = (this.perClientRunRows / 10) == 0 ? perClientRunRows : perClientRunRows / 10;
     int cycles = 1;
     int columns = 1;
     int families = 1;
@@ -872,7 +872,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       this.filterAll = filterAll;
     }
 
-    public void setStartRow(int startRow) {
+    public void setStartRow(long startRow) {
       this.startRow = startRow;
     }
 
@@ -888,7 +888,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       this.numClientThreads = numClientThreads;
     }
 
-    public void setTotalRows(int totalRows) {
+    public void setTotalRows(long totalRows) {
       this.totalRows = totalRows;
     }
 
@@ -1000,7 +1000,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       return filterAll;
     }
 
-    public int getStartRow() {
+    public long getStartRow() {
       return startRow;
     }
 
@@ -1008,7 +1008,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       return size;
     }
 
-    public int getPerClientRunRows() {
+    public long getPerClientRunRows() {
       return perClientRunRows;
     }
 
@@ -1016,7 +1016,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       return numClientThreads;
     }
 
-    public int getTotalRows() {
+    public long getTotalRows() {
       return totalRows;
     }
 
@@ -1092,7 +1092,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       return valueSize;
     }
 
-    public int getPeriod() {
+    public long getPeriod() {
       return period;
     }
 
@@ -1149,7 +1149,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       return randomSeed.nextLong();
     }
 
-    private final int everyN;
+    private final long everyN;
 
     protected final Random rand = new Random(nextRandomSeed());
     protected final Configuration conf;
@@ -1180,7 +1180,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       this.opts = options;
       this.status = status;
       this.testName = this.getClass().getSimpleName();
-      everyN = (int) (opts.totalRows / (opts.totalRows * opts.sampleRate));
+      everyN = (long) (opts.totalRows / (opts.totalRows * opts.sampleRate));
       if (options.isValueZipf()) {
         this.zipf = new RandomDistribution.Zipf(this.rand, 1, options.getValueSize(), 1.2);
       }
@@ -1261,7 +1261,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       }
     }
 
-    String generateStatus(final int sr, final int i, final int lr) {
+    String generateStatus(final long sr, final long i, final long lr) {
       return "row [start=" + sr + ", current=" + i + ", last=" + lr + "], latency ["
         + getShortLatencyReport() + "]"
         + (!isRandomValueSize() ? "" : ", value size [" + getShortValueSizeReport() + "]");
@@ -1271,7 +1271,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       return opts.valueRandom;
     }
 
-    protected int getReportingPeriod() {
+    protected long getReportingPeriod() {
       return opts.period;
     }
 
@@ -1374,11 +1374,11 @@ public class PerformanceEvaluation extends Configured implements Tool {
       return (System.nanoTime() - startTime) / 1000000;
     }
 
-    int getStartRow() {
+    long getStartRow() {
       return opts.startRow;
     }
 
-    int getLastRow() {
+    long getLastRow() {
       return getStartRow() + opts.perClientRunRows;
     }
 
@@ -1386,12 +1386,12 @@ public class PerformanceEvaluation extends Configured implements Tool {
      * Provides an extension point for tests that don't want a per row invocation.
      */
     void testTimed() throws IOException, InterruptedException {
-      int startRow = getStartRow();
-      int lastRow = getLastRow();
+      long startRow = getStartRow();
+      long lastRow = getLastRow();
       // Report on completion of 1/10th of total.
       for (int ii = 0; ii < opts.cycles; ii++) {
         if (opts.cycles > 1) LOG.info("Cycle=" + ii + " of " + opts.cycles);
-        for (int i = startRow; i < lastRow; i++) {
+        for (long i = startRow; i < lastRow; i++) {
           if (i % everyN != 0) continue;
           long startTime = System.nanoTime();
           boolean requestSent = false;
@@ -1437,7 +1437,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
      * @return true if the row was sent to server and need to record metrics. False if not, multiGet
      *         and multiPut e.g., the rows are sent to server only if enough gets/puts are gathered.
      */
-    abstract boolean testRow(final int i, final long startTime)
+    abstract boolean testRow(final long i, final long startTime)
       throws IOException, InterruptedException;
   }
 
@@ -1485,7 +1485,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
     MetaTest(Connection con, TestOptions options, Status status) {
       super(con, options, status);
-      keyLength = Integer.toString(opts.perClientRunRows).length();
+      keyLength = Long.toString(opts.perClientRunRows).length();
     }
 
     @Override
@@ -1496,7 +1496,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     /*
      * Generates Lexicographically ascending strings
      */
-    protected byte[] getSplitKey(final int i) {
+    protected byte[] getSplitKey(final long i) {
       return Bytes.toBytes(String.format("%0" + keyLength + "d", i));
     }
 
@@ -1533,7 +1533,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException, InterruptedException {
+    boolean testRow(final long i, final long startTime) throws IOException, InterruptedException {
       if (opts.randomSleep > 0) {
         Thread.sleep(ThreadLocalRandom.current().nextInt(opts.randomSleep));
       }
@@ -1590,8 +1590,8 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    protected int getReportingPeriod() {
-      int period = opts.perClientRunRows / 10;
+    protected long getReportingPeriod() {
+      long period = opts.perClientRunRows / 10;
       return period == 0 ? opts.perClientRunRows : period;
     }
 
@@ -1612,7 +1612,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    protected byte[] generateRow(final int i) {
+    protected byte[] generateRow(final long i) {
       return getRandomRow(this.rand, opts.totalRows);
     }
   }
@@ -1641,7 +1641,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       if (this.testScanner == null) {
         Scan scan = new Scan().withStartRow(format(opts.startRow)).setCaching(opts.caching)
           .setCacheBlocks(opts.cacheBlocks).setAsyncPrefetch(opts.asyncPrefetch)
@@ -1674,7 +1674,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException, InterruptedException {
+    boolean testRow(final long i, final long startTime) throws IOException, InterruptedException {
       Get get = new Get(format(i));
       for (int family = 0; family < opts.families; family++) {
         byte[] familyName = Bytes.toBytes(FAMILY_NAME_BASE + family);
@@ -1710,13 +1710,13 @@ public class PerformanceEvaluation extends Configured implements Tool {
       }
     }
 
-    protected byte[] generateRow(final int i) {
+    protected byte[] generateRow(final long i) {
       return format(i);
     }
 
     @Override
     @SuppressWarnings("ReturnValueIgnored")
-    boolean testRow(final int i, final long startTime) throws IOException, InterruptedException {
+    boolean testRow(final long i, final long startTime) throws IOException, InterruptedException {
       byte[] row = generateRow(i);
       Put put = new Put(row);
       for (int family = 0; family < opts.families; family++) {
@@ -1791,7 +1791,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       Scan scan =
         new Scan().withStartRow(getRandomRow(this.rand, opts.totalRows)).setCaching(opts.caching)
           .setCacheBlocks(opts.cacheBlocks).setAsyncPrefetch(opts.asyncPrefetch)
@@ -1826,8 +1826,8 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    protected int getReportingPeriod() {
-      int period = opts.perClientRunRows / 100;
+    protected long getReportingPeriod() {
+      long period = opts.perClientRunRows / 100;
       return period == 0 ? opts.perClientRunRows : period;
     }
 
@@ -1839,7 +1839,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       Pair<byte[], byte[]> startAndStopRow = getStartAndStopRow();
       Scan scan = new Scan().withStartRow(startAndStopRow.getFirst())
         .withStopRow(startAndStopRow.getSecond()).setCaching(opts.caching)
@@ -1881,15 +1881,15 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
     protected abstract Pair<byte[], byte[]> getStartAndStopRow();
 
-    protected Pair<byte[], byte[]> generateStartAndStopRows(int maxRange) {
-      int start = this.rand.nextInt(Integer.MAX_VALUE) % opts.totalRows;
-      int stop = start + maxRange;
+    protected Pair<byte[], byte[]> generateStartAndStopRows(long maxRange) {
+      long start = this.rand.nextLong(Long.MAX_VALUE) % opts.totalRows;
+      long stop = start + maxRange;
       return new Pair<>(format(start), format(stop));
     }
 
     @Override
-    protected int getReportingPeriod() {
-      int period = opts.perClientRunRows / 100;
+    protected long getReportingPeriod() {
+      long period = opts.perClientRunRows / 100;
       return period == 0 ? opts.perClientRunRows : period;
     }
   }
@@ -1952,7 +1952,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException, InterruptedException {
+    boolean testRow(final long i, final long startTime) throws IOException, InterruptedException {
       if (opts.randomSleep > 0) {
         Thread.sleep(ThreadLocalRandom.current().nextInt(opts.randomSleep));
       }
@@ -2000,8 +2000,8 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    protected int getReportingPeriod() {
-      int period = opts.perClientRunRows / 10;
+    protected long getReportingPeriod() {
+      long period = opts.perClientRunRows / 10;
       return period == 0 ? opts.perClientRunRows : period;
     }
 
@@ -2034,19 +2034,19 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException, InterruptedException {
+    boolean testRow(final long i, final long startTime) throws IOException, InterruptedException {
       if (opts.randomSleep > 0) {
         Thread.sleep(rd.nextInt(opts.randomSleep));
       }
       HRegionLocation hRegionLocation =
-        regionLocator.getRegionLocation(getSplitKey(rd.nextInt(opts.perClientRunRows)), true);
+        regionLocator.getRegionLocation(getSplitKey(rd.nextLong(opts.perClientRunRows)), true);
       LOG.debug("get location for region: " + hRegionLocation);
       return true;
     }
 
     @Override
-    protected int getReportingPeriod() {
-      int period = opts.perClientRunRows / 10;
+    protected long getReportingPeriod() {
+      long period = opts.perClientRunRows / 10;
       return period == 0 ? opts.perClientRunRows : period;
     }
 
@@ -2062,7 +2062,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    protected byte[] generateRow(final int i) {
+    protected byte[] generateRow(final long i) {
       return getRandomRow(this.rand, opts.totalRows);
     }
 
@@ -2074,7 +2074,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    protected byte[] generateRow(final int i) {
+    protected byte[] generateRow(final long i) {
       return getRandomRow(this.rand, opts.totalRows);
     }
 
@@ -2096,7 +2096,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       if (this.testScanner == null) {
         Scan scan = new Scan().withStartRow(format(opts.startRow)).setCaching(opts.caching)
           .setCacheBlocks(opts.cacheBlocks).setAsyncPrefetch(opts.asyncPrefetch)
@@ -2139,7 +2139,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       if (this.testScanner == null) {
         Scan scan = new Scan().setCaching(opts.caching).setCacheBlocks(opts.cacheBlocks)
           .setAsyncPrefetch(opts.asyncPrefetch).setReadType(opts.scanReadType)
@@ -2187,12 +2187,12 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    int getStartRow() {
+    long getStartRow() {
       return 0;
     }
 
     @Override
-    int getLastRow() {
+    long getLastRow() {
       return opts.perClientRunRows;
     }
   }
@@ -2203,7 +2203,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       Increment increment = new Increment(format(i));
       // unlike checkAndXXX tests, which make most sense to do on a single value,
       // if multiple families are specified for an increment test we assume it is
@@ -2223,7 +2223,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       byte[] bytes = format(i);
       Append append = new Append(bytes);
       // unlike checkAndXXX tests, which make most sense to do on a single value,
@@ -2244,7 +2244,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       final byte[] bytes = format(i);
       // checkAndXXX tests operate on only a single value
       // Put a known value so when we go to check it, it is there.
@@ -2265,7 +2265,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       final byte[] bytes = format(i);
       // checkAndXXX tests operate on only a single value
       // Put a known value so when we go to check it, it is there.
@@ -2284,7 +2284,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       final byte[] bytes = format(i);
       // checkAndXXX tests operate on only a single value
       // Put a known value so when we go to check it, it is there.
@@ -2308,7 +2308,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       try {
         RegionInfo regionInfo = connection.getRegionLocator(table.getName())
           .getRegionLocation(getSplitKey(i), false).getRegion();
@@ -2333,7 +2333,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       Get get = new Get(format(i));
       for (int family = 0; family < opts.families; family++) {
         byte[] familyName = Bytes.toBytes(FAMILY_NAME_BASE + family);
@@ -2365,12 +2365,12 @@ public class PerformanceEvaluation extends Configured implements Tool {
       }
     }
 
-    protected byte[] generateRow(final int i) {
+    protected byte[] generateRow(final long i) {
       return format(i);
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       byte[] row = generateRow(i);
       Put put = new Put(row);
       for (int family = 0; family < opts.families; family++) {
@@ -2421,12 +2421,12 @@ public class PerformanceEvaluation extends Configured implements Tool {
       super(con, options, status);
     }
 
-    protected byte[] generateRow(final int i) {
+    protected byte[] generateRow(final long i) {
       return format(i);
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       byte[] row = generateRow(i);
       Delete delete = new Delete(row);
       for (int family = 0; family < opts.families; family++) {
@@ -2453,7 +2453,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(final int i, final long startTime) throws IOException {
+    boolean testRow(final long i, final long startTime) throws IOException {
       List<RegionInfo> regionInfos = new ArrayList<RegionInfo>();
       RegionInfo regionInfo = (RegionInfoBuilder.newBuilder(TableName.valueOf(TABLE_NAME))
         .setStartKey(getSplitKey(i)).setEndKey(getSplitKey(i + 1)).build());
@@ -2480,7 +2480,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     }
 
     @Override
-    boolean testRow(int i, final long startTime) throws IOException {
+    boolean testRow(long i, final long startTime) throws IOException {
       byte[] value = generateData(this.rand, getValueLength(this.rand));
       Scan scan = constructScan(value);
       ResultScanner scanner = null;
@@ -2528,7 +2528,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
    * @param timeMs Time taken in milliseconds.
    * @return String value with label, ie '123.76 MB/s'
    */
-  private static String calculateMbps(int rows, long timeMs, final int valueSize, int families,
+  private static String calculateMbps(long rows, long timeMs, final int valueSize, int families,
     int columns) {
     BigDecimal rowSize = BigDecimal.valueOf(ROW_LENGTH
       + ((valueSize + (FAMILY_NAME_BASE.length() + 1) + COLUMN_ZERO.length) * columns) * families);
@@ -2542,9 +2542,9 @@ public class PerformanceEvaluation extends Configured implements Tool {
    * @return Returns zero-prefixed ROW_LENGTH-byte wide decimal version of passed number (Does
    * absolute in case number is negative).
    */
-  public static byte[] format(final int number) {
+  public static byte[] format(final long number) {
     byte[] b = new byte[ROW_LENGTH];
-    int d = Math.abs(number);
+    long d = Math.abs(number);
     for (int i = b.length - 1; i >= 0; i--) {
       b[i] = (byte) ((d % 10) + '0');
       d /= 10;
@@ -2579,12 +2579,12 @@ public class PerformanceEvaluation extends Configured implements Tool {
     return b;
   }
 
-  static byte[] getRandomRow(final Random random, final int totalRows) {
+  static byte[] getRandomRow(final Random random, final long totalRows) {
     return format(generateRandomRow(random, totalRows));
   }
 
-  static int generateRandomRow(final Random random, final int totalRows) {
-    return random.nextInt(Integer.MAX_VALUE) % totalRows;
+  static long generateRandomRow(final Random random, final long totalRows) {
+    return random.nextLong(Long.MAX_VALUE) % totalRows;
   }
 
   static RunResult runOneClient(final Class<? extends TestBase> cmd, Configuration conf,
@@ -2619,7 +2619,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
     status.setStatus("Finished " + cmd + " in " + totalElapsedTime + "ms at offset " + opts.startRow
       + " for " + opts.perClientRunRows + " rows" + " ("
-      + calculateMbps((int) (opts.perClientRunRows * opts.sampleRate), totalElapsedTime,
+      + calculateMbps((long) (opts.perClientRunRows * opts.sampleRate), totalElapsedTime,
         getAverageValueLength(opts), opts.families, opts.columns)
       + ")");
 
@@ -2814,7 +2814,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
       final String rows = "--rows=";
       if (cmd.startsWith(rows)) {
-        opts.perClientRunRows = Integer.parseInt(cmd.substring(rows.length()));
+        opts.perClientRunRows = Long.parseLong(cmd.substring(rows.length()));
         continue;
       }
 
@@ -2838,7 +2838,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
       final String startRow = "--startRow=";
       if (cmd.startsWith(startRow)) {
-        opts.startRow = Integer.parseInt(cmd.substring(startRow.length()));
+        opts.startRow = Long.parseLong(cmd.substring(startRow.length()));
         continue;
       }
 
@@ -3136,10 +3136,10 @@ public class PerformanceEvaluation extends Configured implements Tool {
         && (opts.getCmdName().equals(RANDOM_READ) || opts.getCmdName().equals(RANDOM_SEEK_SCAN)))
         && opts.size != DEFAULT_OPTS.size && opts.perClientRunRows != DEFAULT_OPTS.perClientRunRows
     ) {
-      opts.totalRows = (int) opts.size * rowsPerGB;
+      opts.totalRows = (long) (opts.size * rowsPerGB);
     } else if (opts.size != DEFAULT_OPTS.size) {
       // total size in GB specified
-      opts.totalRows = (int) opts.size * rowsPerGB;
+      opts.totalRows = (long) (opts.size * rowsPerGB);
       opts.perClientRunRows = opts.totalRows / opts.numClientThreads;
     } else {
       opts.totalRows = opts.perClientRunRows * opts.numClientThreads;

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -1537,7 +1537,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       if (opts.randomSleep > 0) {
         Thread.sleep(ThreadLocalRandom.current().nextInt(opts.randomSleep));
       }
-      Get get = new Get(getRandomRow(this.rand, opts.totalRows));
+      Get get = new Get(getRandomRow(opts.totalRows));
       for (int family = 0; family < opts.families; family++) {
         byte[] familyName = Bytes.toBytes(FAMILY_NAME_BASE + family);
         if (opts.addColumns) {
@@ -1613,7 +1613,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
     @Override
     protected byte[] generateRow(final long i) {
-      return getRandomRow(this.rand, opts.totalRows);
+      return getRandomRow(opts.totalRows);
     }
   }
 
@@ -1793,7 +1793,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     @Override
     boolean testRow(final long i, final long startTime) throws IOException {
       Scan scan =
-        new Scan().withStartRow(getRandomRow(this.rand, opts.totalRows)).setCaching(opts.caching)
+        new Scan().withStartRow(getRandomRow(opts.totalRows)).setCaching(opts.caching)
           .setCacheBlocks(opts.cacheBlocks).setAsyncPrefetch(opts.asyncPrefetch)
           .setReadType(opts.scanReadType).setScanMetricsEnabled(true);
       FilterList list = new FilterList();
@@ -1882,7 +1882,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
     protected abstract Pair<byte[], byte[]> getStartAndStopRow();
 
     protected Pair<byte[], byte[]> generateStartAndStopRows(long maxRange) {
-      long start = this.rand.nextLong(Long.MAX_VALUE) % opts.totalRows;
+      long start = ThreadLocalRandom.current().nextLong(Long.MAX_VALUE) % opts.totalRows;
       long stop = start + maxRange;
       return new Pair<>(format(start), format(stop));
     }
@@ -1956,7 +1956,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
       if (opts.randomSleep > 0) {
         Thread.sleep(ThreadLocalRandom.current().nextInt(opts.randomSleep));
       }
-      Get get = new Get(getRandomRow(this.rand, opts.totalRows));
+      Get get = new Get(getRandomRow(opts.totalRows));
       for (int family = 0; family < opts.families; family++) {
         byte[] familyName = Bytes.toBytes(FAMILY_NAME_BASE + family);
         if (opts.addColumns) {
@@ -2039,7 +2039,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
         Thread.sleep(rd.nextInt(opts.randomSleep));
       }
       HRegionLocation hRegionLocation =
-        regionLocator.getRegionLocation(getSplitKey(rd.nextLong(opts.perClientRunRows)), true);
+        regionLocator.getRegionLocation(getSplitKey(ThreadLocalRandom.current().nextLong(opts.perClientRunRows)), true);
       LOG.debug("get location for region: " + hRegionLocation);
       return true;
     }
@@ -2063,7 +2063,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
     @Override
     protected byte[] generateRow(final long i) {
-      return getRandomRow(this.rand, opts.totalRows);
+      return getRandomRow(opts.totalRows);
     }
 
   }
@@ -2075,7 +2075,7 @@ public class PerformanceEvaluation extends Configured implements Tool {
 
     @Override
     protected byte[] generateRow(final long i) {
-      return getRandomRow(this.rand, opts.totalRows);
+      return getRandomRow(opts.totalRows);
     }
 
   }
@@ -2579,12 +2579,12 @@ public class PerformanceEvaluation extends Configured implements Tool {
     return b;
   }
 
-  static byte[] getRandomRow(final Random random, final long totalRows) {
-    return format(generateRandomRow(random, totalRows));
+  static byte[] getRandomRow(final long totalRows) {
+    return format(generateRandomRow(totalRows));
   }
 
-  static long generateRandomRow(final Random random, final long totalRows) {
-    return random.nextLong(Long.MAX_VALUE) % totalRows;
+  static long generateRandomRow(final long totalRows) {
+    return ThreadLocalRandom.current().nextLong(Long.MAX_VALUE) % totalRows;
   }
 
   static RunResult runOneClient(final Class<? extends TestBase> cmd, Configuration conf,

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
@@ -39,8 +39,6 @@ import java.util.LinkedList;
 import java.util.NoSuchElementException;
 import java.util.Properties;
 import java.util.Queue;
-import java.util.Random;
-import java.util.concurrent.ThreadLocalRandom;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
@@ -181,7 +181,7 @@ public class TestPerformanceEvaluation {
     ctor.setAccessible(true);
     Histogram histogram = (Histogram) ctor.newInstance(new UniformReservoir(1024 * 500));
     for (int i = 0; i < 100; i++) {
-      histogram.update(rrt.getValueLength(null));
+      histogram.update(rrt.getValueLength());
     }
     Snapshot snapshot = histogram.getSnapshot();
     double stddev = snapshot.getStdDev();

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
@@ -160,9 +160,8 @@ public class TestPerformanceEvaluation {
     assertEquals(1000, opts.getPerClientRunRows());
     // assuming we will get one before this loop expires
     boolean foundValue = false;
-    Random rand = ThreadLocalRandom.current();
     for (int i = 0; i < 10000000; i++) {
-      long randomRow = PerformanceEvaluation.generateRandomRow(rand, opts.totalRows);
+      long randomRow = PerformanceEvaluation.generateRandomRow(opts.totalRows);
       if (randomRow > 1000) {
         foundValue = true;
         break;

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/TestPerformanceEvaluation.java
@@ -122,7 +122,7 @@ public class TestPerformanceEvaluation {
   public void testSizeCalculation() {
     TestOptions opts = new PerformanceEvaluation.TestOptions();
     opts = PerformanceEvaluation.calculateRowsAndSize(opts);
-    int rows = opts.getPerClientRunRows();
+    long rows = opts.getPerClientRunRows();
     // Default row count
     final int defaultPerClientRunRows = 1024 * 1024;
     assertEquals(defaultPerClientRunRows, rows);
@@ -144,7 +144,7 @@ public class TestPerformanceEvaluation {
   public void testRandomReadCalculation() {
     TestOptions opts = new PerformanceEvaluation.TestOptions();
     opts = PerformanceEvaluation.calculateRowsAndSize(opts);
-    int rows = opts.getPerClientRunRows();
+    long rows = opts.getPerClientRunRows();
     // Default row count
     final int defaultPerClientRunRows = 1024 * 1024;
     assertEquals(defaultPerClientRunRows, rows);
@@ -162,7 +162,7 @@ public class TestPerformanceEvaluation {
     boolean foundValue = false;
     Random rand = ThreadLocalRandom.current();
     for (int i = 0; i < 10000000; i++) {
-      int randomRow = PerformanceEvaluation.generateRandomRow(rand, opts.totalRows);
+      long randomRow = PerformanceEvaluation.generateRandomRow(rand, opts.totalRows);
       if (randomRow > 1000) {
         foundValue = true;
         break;
@@ -400,7 +400,7 @@ public class TestPerformanceEvaluation {
     }
 
     @Override
-    boolean testRow(int i, long startTime) throws IOException, InterruptedException {
+    boolean testRow(long i, long startTime) throws IOException, InterruptedException {
       return false;
     }
   }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestCellBasedHFileOutputFormat2.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestCellBasedHFileOutputFormat2.java
@@ -506,23 +506,19 @@ public class TestCellBasedHFileOutputFormat2 {
   }
 
   private byte[][] generateRandomStartKeys(int numKeys) {
-    Random random = new Random();
     byte[][] ret = new byte[numKeys][];
     // first region start key is always empty
     ret[0] = HConstants.EMPTY_BYTE_ARRAY;
     for (int i = 1; i < numKeys; i++) {
-      ret[i] =
-        PerformanceEvaluation.generateData(random, PerformanceEvaluation.DEFAULT_VALUE_LENGTH);
+      ret[i] = PerformanceEvaluation.generateData(PerformanceEvaluation.DEFAULT_VALUE_LENGTH);
     }
     return ret;
   }
 
   private byte[][] generateRandomSplitKeys(int numKeys) {
-    Random random = new Random();
     byte[][] ret = new byte[numKeys][];
     for (int i = 0; i < numKeys; i++) {
-      ret[i] =
-        PerformanceEvaluation.generateData(random, PerformanceEvaluation.DEFAULT_VALUE_LENGTH);
+      ret[i] = PerformanceEvaluation.generateData(PerformanceEvaluation.DEFAULT_VALUE_LENGTH);
     }
     return ret;
   }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
@@ -34,14 +34,12 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.Random;
 import java.util.Set;
 import java.util.UUID;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.ThreadLocalRandom;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
@@ -543,23 +541,19 @@ public class TestHFileOutputFormat2 {
   }
 
   private byte[][] generateRandomStartKeys(int numKeys) {
-    Random random = ThreadLocalRandom.current();
     byte[][] ret = new byte[numKeys][];
     // first region start key is always empty
     ret[0] = HConstants.EMPTY_BYTE_ARRAY;
     for (int i = 1; i < numKeys; i++) {
-      ret[i] =
-        PerformanceEvaluation.generateData(random, PerformanceEvaluation.DEFAULT_VALUE_LENGTH);
+      ret[i] = PerformanceEvaluation.generateData(PerformanceEvaluation.DEFAULT_VALUE_LENGTH);
     }
     return ret;
   }
 
   private byte[][] generateRandomSplitKeys(int numKeys) {
-    Random random = ThreadLocalRandom.current();
     byte[][] ret = new byte[numKeys][];
     for (int i = 0; i < numKeys; i++) {
-      ret[i] =
-        PerformanceEvaluation.generateData(random, PerformanceEvaluation.DEFAULT_VALUE_LENGTH);
+      ret[i] = PerformanceEvaluation.generateData(PerformanceEvaluation.DEFAULT_VALUE_LENGTH);
     }
     return ret;
   }


### PR DESCRIPTION
Cherry-picked 6ebd48e477 and replaced `Random#nextLong(bound)` which is not available on JDK 8 with `ThreadLocalRandom#nextLong(bound)` (e140ae762d).

Not being able to provide a seed doesn't matter in this context, so this should be good enough.