### PR TITLE
HBASE-28832 Fixed TestInfoServersACL test

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/http/TestInfoServersACL.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/http/TestInfoServersACL.java
@@ -193,7 +193,7 @@ public class TestInfoServersACL {
 
   @Test
   public void testTableActionsAvailableForAdmins() throws Exception {
-    final String expectedAuthorizedContent = "Actions:";
+    final String expectedAuthorizedContent = "Actions";
     UserGroupInformation admin = UserGroupInformation
       .loginUserFromKeytabAndReturnUGI(USER_ADMIN_STR, KEYTAB_FILE.getAbsolutePath());
     admin.doAs(new PrivilegedExceptionAction<Void>() {


### PR DESCRIPTION
There were some changes in the Bootstrap upgrade which caused the test to fail because the test expected certain text to appear on the UI page.
