### PR TITLE
HBASE-29055 Remove the useless parameter from RootProcedureState

### DIFF
--- a/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/ProcedureExecutor.java
+++ b/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/ProcedureExecutor.java
@@ -1454,7 +1454,7 @@ public class ProcedureExecutor<TEnvironment> {
     }
     do {
       // Try to acquire the execution
-      if (!procStack.acquire(proc)) {
+      if (!procStack.acquire()) {
         if (procStack.setRollback()) {
           // we have the 'rollback-lock' we can start rollingback
           switch (executeRollback(rootProcId, procStack)) {
@@ -1513,7 +1513,7 @@ public class ProcedureExecutor<TEnvironment> {
         default:
           throw new UnsupportedOperationException();
       }
-      procStack.release(proc);
+      procStack.release();
 
       if (proc.isSuccess()) {
         // update metrics on finishing the procedure

--- a/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/RootProcedureState.java
+++ b/hbase-procedure/src/main/java/org/apache/hadoop/hbase/procedure2/RootProcedureState.java
@@ -135,7 +135,7 @@ class RootProcedureState<TEnvironment> {
   /**
    * Called by the ProcedureExecutor to mark the procedure step as running.
    */
-  protected synchronized boolean acquire(Procedure<TEnvironment> proc) {
+  protected synchronized boolean acquire() {
     if (state != State.RUNNING) {
       return false;
     }
@@ -147,7 +147,7 @@ class RootProcedureState<TEnvironment> {
   /**
    * Called by the ProcedureExecutor to mark the procedure step as finished.
    */
-  protected synchronized void release(Procedure<TEnvironment> proc) {
+  protected synchronized void release() {
     running--;
   }
 


### PR DESCRIPTION
Details see: [HBASE-29055](https://issues.apache.org/jira/browse/HBASE-29055)