### PR TITLE
HBASE-28968 Bump jruby to 9.4.9.0 to fix rexml CVE (#6560)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -841,7 +841,7 @@
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
     <tomcat.jasper.version>9.0.93</tomcat.jasper.version>
-    <jruby.version>9.4.8.0</jruby.version>
+    <jruby.version>9.4.9.0</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
     <opentelemetry.version>1.15.0</opentelemetry.version>


### PR DESCRIPTION
* Backports https://github.com/apache/hbase/pull/6560