### PR TITLE
HBASE-29066 Fix NPE in rits.jsp when regions are not open

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateNode.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateNode.java
@@ -245,6 +245,14 @@ public class RegionStateNode implements Comparable<RegionStateNode> {
     return regionLocation;
   }
 
+  public String getRegionServerName() {
+    ServerName sn = getRegionLocation();
+    if (sn != null) {
+      return sn.getServerName();
+    }
+    return null;
+  }
+
   public State getState() {
     return state;
   }

--- a/hbase-server/src/main/resources/hbase-webapps/master/rits.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/rits.jsp
@@ -97,7 +97,7 @@
                 <td><%= regionStateNode.getRegionInfo().getEncodedName() %></td>
                 <td><%= regionStateNode.getRegionInfo().getTable() %></td>
                 <td><%= regionStateNode.getState() %></td>
-                <td><%= regionStateNode.getRegionLocation().getServerName() %></td>
+                <td><%= regionStateNode.getRegionServerName() %></td>
                 <%
                     TransitRegionStateProcedure procedure = regionStateNode.getProcedure();
 
@@ -134,7 +134,7 @@
             r.put("region", regionStateNode.getRegionInfo().getEncodedName());
             r.put("table", regionStateNode.getRegionInfo().getTable().getNameAsString());
             r.put("state", regionStateNode.getState());
-            r.put("server", regionStateNode.getRegionLocation().getServerName());
+            r.put("server", regionStateNode.getRegionServerName());
 
             TransitRegionStateProcedure procedure = regionStateNode.getProcedure();
             if (procedure != null) {


### PR DESCRIPTION
With the patch, the location of the unassigned regions are shown as "null". I added a method to RegionStateNode for the null-check, but if you prefer to do without it, I can change the expressions in the jsp file instead.

<img width="1725" alt="image" src="https://github.com/user-attachments/assets/1bd4cd7f-68d0-4372-96f6-93f211dc0d39" />
