### PR TITLE
HBASE-29068: Report percentFilesLocalPrimaryRegions metric

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSource.java
@@ -314,10 +314,16 @@ public interface MetricsRegionServerSource extends BaseSource, JvmPauseMonitorSo
     "Size of data that has been sent by clients with the write ahead logging turned off.";
   String PERCENT_FILES_LOCAL = "percentFilesLocal";
   String PERCENT_FILES_LOCAL_DESC =
-    "The percent of HFiles that are stored on the local hdfs data node.";
+    "The percent of HFiles that are stored on the local hdfs data node. If not using "
+      + "region replicas, this should equal percentFilesLocalPrimaryRegions";
+  String PERCENT_FILES_LOCAL_PRIMARY_REGIONS = "percentFilesLocalPrimaryRegions";
+  String PERCENT_FILES_LOCAL_PRIMARY_REGIONS_DESC =
+    "The percent of HFiles used by primary regions that are stored on the local hdfs data node. "
+      + "This is the category of locality that you want to reach 100% when using region replicas";
   String PERCENT_FILES_LOCAL_SECONDARY_REGIONS = "percentFilesLocalSecondaryRegions";
   String PERCENT_FILES_LOCAL_SECONDARY_REGIONS_DESC =
-    "The percent of HFiles used by secondary regions that are stored on the local hdfs data node.";
+    "The percent of HFiles used by secondary regions that are stored on the local hdfs data node. "
+      + "This is not likely to reach 100%";
   String SPLIT_QUEUE_LENGTH = "splitQueueLength";
   String SPLIT_QUEUE_LENGTH_DESC = "Length of the queue for splits.";
   String COMPACTION_QUEUE_LENGTH = "compactionQueueLength";

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSourceImpl.java
@@ -557,6 +557,9 @@ public class MetricsRegionServerSourceImpl extends BaseSourceImpl
         rsWrap.getDataInMemoryWithoutWAL())
       .addGauge(Interns.info(PERCENT_FILES_LOCAL, PERCENT_FILES_LOCAL_DESC),
         rsWrap.getPercentFileLocal())
+      .addGauge(
+        Interns.info(PERCENT_FILES_LOCAL_PRIMARY_REGIONS, PERCENT_FILES_LOCAL_PRIMARY_REGIONS_DESC),
+        rsWrap.getPercentFileLocalPrimaryRegions())
       .addGauge(Interns.info(PERCENT_FILES_LOCAL_SECONDARY_REGIONS,
         PERCENT_FILES_LOCAL_SECONDARY_REGIONS_DESC), rsWrap.getPercentFileLocalSecondaryRegions())
       .addGauge(Interns.info(TOTAL_BYTES_READ, TOTAL_BYTES_READ_DESC), rsWrap.getTotalBytesRead())

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerWrapper.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerWrapper.java
@@ -230,6 +230,11 @@ public interface MetricsRegionServerWrapper {
   double getPercentFileLocal();
 
   /**
+   * Get the percent of HFiles' that are local for primary region replicas.
+   */
+  double getPercentFileLocalPrimaryRegions();
+
+  /**
    * Get the percent of HFiles' that are local for secondary region replicas.
    */
   double getPercentFileLocalSecondaryRegions();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerWrapperStub.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerWrapperStub.java
@@ -263,6 +263,11 @@ public class MetricsRegionServerWrapperStub implements MetricsRegionServerWrappe
   }
 
   @Override
+  public double getPercentFileLocalPrimaryRegions() {
+    return 99;
+  }
+
+  @Override
   public double getPercentFileLocalSecondaryRegions() {
     return 99;
   }


### PR DESCRIPTION
If you are running a table with region replicas, the secondary replicas usually cannot achieve 100% locality. Currently a RegionServer reports two locality metrics:
* `percentFilesLocal`
* `percentFilesLocalSecondaryRegions`

Both of these will be less than 100% if region replicas are enabled. The best we can do is get 100% locality for the primary replicas, but there is currently no way to see if we've achieved it.

I propose introducing the new metric `percentFilesLocalPrimaryRegions`, which will close this gap.