### PR TITLE
HBASE-29084: Track table level metrics on HBase client side

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionConfiguration.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionConfiguration.java
@@ -19,6 +19,8 @@ package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.HConstants.DEFAULT_HBASE_CLIENT_PAUSE;
 import static org.apache.hadoop.hbase.HConstants.HBASE_CLIENT_PAUSE;
+import static org.apache.hadoop.hbase.HConstants.HBASE_CLIENT_TABLE_METRICS_ENABLE;
+import static org.apache.hadoop.hbase.HConstants.DEFAULT_HBASE_CLIENT_TABLE_METRICS_ENABLE;
 
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HConstants;
@@ -106,6 +108,7 @@ public class ConnectionConfiguration {
   private final long pauseMs;
   private final long pauseMsForServerOverloaded;
   private final boolean useScannerTimeoutForNextCalls;
+  private final boolean tableMetricsEnabled;
 
   /**
    * Constructor
@@ -182,6 +185,8 @@ public class ConnectionConfiguration {
 
     this.pauseMs = pauseMs;
     this.pauseMsForServerOverloaded = pauseMsForServerOverloaded;
+    this.tableMetricsEnabled = conf.getBoolean(HBASE_CLIENT_TABLE_METRICS_ENABLE,
+      DEFAULT_HBASE_CLIENT_TABLE_METRICS_ENABLE);
   }
 
   /**
@@ -213,6 +218,7 @@ public class ConnectionConfiguration {
     this.pauseMsForServerOverloaded = DEFAULT_HBASE_CLIENT_PAUSE;
     this.useScannerTimeoutForNextCalls =
       HBASE_CLIENT_USE_SCANNER_TIMEOUT_PERIOD_FOR_NEXT_CALLS_DEFAULT;
+    this.tableMetricsEnabled = DEFAULT_HBASE_CLIENT_TABLE_METRICS_ENABLE;
   }
 
   public int getReadRpcTimeout() {
@@ -302,4 +308,9 @@ public class ConnectionConfiguration {
   public long getPauseMillisForServerOverloaded() {
     return pauseMsForServerOverloaded;
   }
+
+  public boolean isTableMetricsEnabled() {
+    return tableMetricsEnabled;
+  }
+
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/DelegateTableRunnableWithMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/DelegateTableRunnableWithMetrics.java
@@ -1,0 +1,51 @@
+package org.apache.hadoop.hbase.client;
+
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.client.metrics.TableMetrics;
+import org.apache.hadoop.hbase.client.metrics.TableThreadMetricsHolder;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class DelegateTableRunnableWithMetrics implements Runnable {
+
+  private long submissionTime;
+  private Runnable delegate;
+
+  private TableThreadMetricsHolder tableThreadMetricsHolder;
+
+  public DelegateTableRunnableWithMetrics(Runnable delegate) {
+    this.delegate = delegate;
+    this.tableThreadMetricsHolder = new TableThreadMetricsHolder();
+    this.submissionTime = EnvironmentEdgeManager.currentTime();
+  }
+
+  @Override public void run() {
+    long executionStartTime = EnvironmentEdgeManager.currentTime();
+    try {
+      delegate.run();
+    } catch (Exception e) {
+      tableThreadMetricsHolder.setHasTaskFailed(true);
+      throw e;
+    }
+    finally {
+      long executionEndTime = EnvironmentEdgeManager.currentTime();
+      tableThreadMetricsHolder.setTaskExecutionTime(executionEndTime - executionStartTime);
+      tableThreadMetricsHolder.setQueueWaitTime(executionStartTime - submissionTime);
+    }
+  }
+
+  public TableThreadMetricsHolder getTableThreadMetricsHolder() {
+    return tableThreadMetricsHolder;
+  }
+
+  public static Runnable wrapInDelegateTableRunnableWithMetrics(Runnable runnable, TableMetrics tableMetrics) {
+    if (tableMetrics.equals(TableMetrics.EMPTY_TABLE_METRICS)) {
+      return runnable;
+    }
+    DelegateTableRunnableWithMetrics runnableWrapper = new DelegateTableRunnableWithMetrics(runnable);
+    tableMetrics.addThreadMetricsHolder(runnableWrapper.getTableThreadMetricsHolder());
+    return runnableWrapper;
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/DelegateTableRunnableWithMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/DelegateTableRunnableWithMetrics.java
@@ -1,12 +1,32 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hbase.client;
 
-import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.client.metrics.TableMetrics;
 import org.apache.hadoop.hbase.client.metrics.TableThreadMetricsHolder;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 
 import org.apache.yetus.audience.InterfaceAudience;
 
+/**
+ * Wraps a runnable to record metrics about execution of the runnable. The metrics are
+ * recorded within {@link TableThreadMetricsHolder}.
+ */
 @InterfaceAudience.Private
 public class DelegateTableRunnableWithMetrics implements Runnable {
 
@@ -40,8 +60,17 @@ public class DelegateTableRunnableWithMetrics implements Runnable {
     return tableThreadMetricsHolder;
   }
 
+  /**
+   * Wraps the runnable within {@link DelegateTableRunnableWithMetrics} and registers
+   * {@link TableThreadMetricsHolder}, created as part of wrapping runnable, in
+   * {@link TableMetrics}.
+   * @param runnable Runnable to wrap.
+   * @param tableMetrics Table level metrics.
+   * @return Wrapped runnable if table level metrics are enabled, otherwise the original runnable.
+   */
   public static Runnable wrapInDelegateTableRunnableWithMetrics(Runnable runnable, TableMetrics tableMetrics) {
     if (tableMetrics.equals(TableMetrics.EMPTY_TABLE_METRICS)) {
+      // Table level metrics are not enabled.
       return runnable;
     }
     DelegateTableRunnableWithMetrics runnableWrapper = new DelegateTableRunnableWithMetrics(runnable);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Table.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Table.java
@@ -34,6 +34,7 @@ import org.apache.hadoop.hbase.CompareOperator;
 import org.apache.hadoop.hbase.HTableDescriptor;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.coprocessor.Batch;
+import org.apache.hadoop.hbase.client.metrics.TableMetrics;
 import org.apache.hadoop.hbase.filter.CompareFilter;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.io.TimeRange;
@@ -1009,5 +1010,23 @@ public interface Table extends Closeable {
    */
   default Map<String, byte[]> getRequestAttributes() {
     throw new NotImplementedException("Add an implementation!");
+  }
+
+  /**
+   * Get the table level metrics.
+   * @return table level metrics.
+
+   */
+  default TableMetrics getTableMetrics() {
+    throw new NotImplementedException("Add an implementation!");
+  }
+
+  /**
+   * Check if the table supports table level metrics. Override this method to return true if the
+   * table supports table level metrics.
+   * @return true if the table supports table level metrics.
+   */
+  default boolean hasTableMetrics() {
+    return false;
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/TableMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/TableMetrics.java
@@ -1,12 +1,36 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hbase.client.metrics;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.Iterator;
 import java.util.List;
 
 import org.apache.yetus.audience.InterfaceAudience;
 
+/**
+ * Container for metrics related to a table. This class is thread-safe.
+ *
+ * One instance of {@link TableMetrics} is created for each instance of
+ * {@link org.apache.hadoop.hbase.client.Table}. If instance of
+ * {@link org.apache.hadoop.hbase.client.Table} is shared across multiple application threads
+ * then {@link TableMetrics} will be collection of metrics recorded for all the application threads.
+ */
 @InterfaceAudience.Public
 public class TableMetrics {
 
@@ -40,6 +64,19 @@ public class TableMetrics {
     threadMetricsHolders.add(threadMetricsHolder);
   }
 
+  /**
+   * Returns list of metric holders. The list is synchronized but make sure to
+   * synchronize on returned list object while iterating the list.
+   * <pre>
+   *   synchronized (list) {
+   *       Iterator i = list.iterator(); // Must be in synchronized block
+   *       while (i.hasNext())
+   *           foo(i.next());
+   *   }
+   * </pre>
+   * Failure to follow this advice may result in non-deterministic behavior.
+   * @return list of metric holders
+   */
   public List<TableThreadMetricsHolder> getThreadMetricsHolders() {
     return threadMetricsHolders;
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/TableMetrics.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/TableMetrics.java
@@ -1,0 +1,94 @@
+package org.apache.hadoop.hbase.client.metrics;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Public
+public class TableMetrics {
+
+  private long queueWaitTime = 0;
+  private long taskExecutionTime = 0;
+  private int taskCount = 0;
+  private int failedTaskCount = 0;
+
+
+  public static final TableMetrics EMPTY_TABLE_METRICS = new TableMetrics() {
+    @Override
+    public List<TableThreadMetricsHolder> getThreadMetricsHolders() {
+      return Collections.emptyList();
+    }
+
+    @Override
+    public void addThreadMetricsHolder(TableThreadMetricsHolder threadMetricsHolder) {}
+  };
+
+  private final List<TableThreadMetricsHolder> threadMetricsHolders;
+
+  public TableMetrics() {
+    threadMetricsHolders = Collections.synchronizedList(new ArrayList<>());
+  }
+
+  public TableMetrics(int capacity) {
+    threadMetricsHolders = Collections.synchronizedList(new ArrayList<>(capacity));
+  }
+
+  public void addThreadMetricsHolder(TableThreadMetricsHolder threadMetricsHolder) {
+    threadMetricsHolders.add(threadMetricsHolder);
+  }
+
+  public List<TableThreadMetricsHolder> getThreadMetricsHolders() {
+    return threadMetricsHolders;
+  }
+
+  public void resetMetrics() {
+    synchronized (threadMetricsHolders) {
+      threadMetricsHolders.clear();
+      queueWaitTime = 0;
+      taskExecutionTime = 0;
+      taskCount = 0;
+      failedTaskCount = 0;
+    }
+  }
+
+  public void combineMetrics() {
+    long queueWaitTime = 0;
+    long taskExecutionTime = 0;
+    int taskCount = 0;
+    int failedTaskCount = 0;
+    synchronized (threadMetricsHolders) {
+      for (TableThreadMetricsHolder threadMetricsHolder : threadMetricsHolders) {
+        queueWaitTime += threadMetricsHolder.getQueueWaitTime();
+        taskExecutionTime += threadMetricsHolder.getTaskExecutionTime();
+        taskCount++;
+        if (threadMetricsHolder.hasTaskFailed()) {
+          failedTaskCount++;
+        }
+      }
+      this.queueWaitTime = queueWaitTime;
+      this.taskExecutionTime = taskExecutionTime;
+      this.taskCount = taskCount;
+      this.failedTaskCount = failedTaskCount;
+    }
+  }
+
+  public long getQueueWaitTime() {
+    return queueWaitTime;
+  }
+
+  public long getTaskExecutionTime() {
+    return taskExecutionTime;
+  }
+
+  public int getTaskCount() {
+    return taskCount;
+  }
+
+  public int getFailedTaskCount() {
+    return failedTaskCount;
+  }
+
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/TableThreadMetricsHolder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/TableThreadMetricsHolder.java
@@ -1,0 +1,35 @@
+package org.apache.hadoop.hbase.client.metrics;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class TableThreadMetricsHolder {
+  private long queueWaitTime;
+  private long taskExecutionTime;
+  private boolean hasTaskFailed = false;
+
+  public long getQueueWaitTime() {
+    return queueWaitTime;
+  }
+
+  public long getTaskExecutionTime() {
+    return taskExecutionTime;
+  }
+
+  public void setQueueWaitTime(long queueWaitTime) {
+    this.queueWaitTime = queueWaitTime;
+  }
+
+  public void setTaskExecutionTime(long taskExecutionTime) {
+    this.taskExecutionTime = taskExecutionTime;
+  }
+
+  public boolean hasTaskFailed() {
+    return hasTaskFailed;
+  }
+
+  public void setHasTaskFailed(boolean hasTaskFailed) {
+    this.hasTaskFailed = hasTaskFailed;
+  }
+
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/TableThreadMetricsHolder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/metrics/TableThreadMetricsHolder.java
@@ -1,8 +1,28 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.hadoop.hbase.client.metrics;
 
 import org.apache.yetus.audience.InterfaceAudience;
 
-@InterfaceAudience.Private
+/**
+ * Container for metrics about a runnable.
+ */
+@InterfaceAudience.Public
 public class TableThreadMetricsHolder {
   private long queueWaitTime;
   private long taskExecutionTime;

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1728,8 +1728,15 @@ public final class HConstants {
    */
   public final static boolean REJECT_DECOMMISSIONED_HOSTS_DEFAULT = false;
 
+  /**
+   * The config to enable tracking table level metrics. Currently, metrics from only
+   * HTable#batch() API are collected.
+   */
   public static final String HBASE_CLIENT_TABLE_METRICS_ENABLE = "hbase.client.table.metrics.enable";
 
+  /**
+   * Default value of {@link #DEFAULT_HBASE_CLIENT_TABLE_METRICS_ENABLE}
+   */
   public static final boolean DEFAULT_HBASE_CLIENT_TABLE_METRICS_ENABLE = false;
 
   private HConstants() {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1728,6 +1728,10 @@ public final class HConstants {
    */
   public final static boolean REJECT_DECOMMISSIONED_HOSTS_DEFAULT = false;
 
+  public static final String HBASE_CLIENT_TABLE_METRICS_ENABLE = "hbase.client.table.metrics.enable";
+
+  public static final boolean DEFAULT_HBASE_CLIENT_TABLE_METRICS_ENABLE = false;
+
   private HConstants() {
     // Can't be instantiated with this ctor.
   }

--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -2072,7 +2072,7 @@ possible configurations would overwhelm and obscure the important.
     <value>false</value>
     <description>
       If true, collect Table level metrics in HBase Client. Currently, metrics from only
-      HTable#batch() API is collected.
+      HTable#batch() API are collected.
     </description>
   </property>
 </configuration>

--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -2067,4 +2067,12 @@ possible configurations would overwhelm and obscure the important.
       hitting the namenode, if the DFSInputStream's block list is incomplete.
     </description>
   </property>
+  <property>
+    <name>hbase.client.table.metrics.enable</name>
+    <value>false</value>
+    <description>
+      If true, collect Table level metrics in HBase Client. Currently, metrics from only
+      HTable#batch() API is collected.
+    </description>
+  </property>
 </configuration>


### PR DESCRIPTION
Summary of the change:
- Introduced new class `DelegateTableRunnableWithMetrics` to wrap a runnable and track metrics like execution time and queue wait time. Wrapped existing runnable used by `HTable#batch()` API within `DelegateTableRunnableWithMetrics`.
- Introduced class `TableThreadMetricsHolder` to hold metrics for a runnable. There is one-to-one mapping b/w instance of `DelegateTableRunnableWithMetrics` and `TableThreadMetricsHolder`. 
- Introduced class `TableMetrics` to collect `TableThreadMetricsHolder` objects. There is one TableMetrics object per HTable object. 
- Exposes list of `TableThreadMetricsHolder` objects by clients so, that clients can aggregate the metrics as per their requirement. Thus, giving them flexibility. But have provided one basic implementation of aggregating metrics from `TableThreadMetricsHolder` objects list.

Looking for inputs/suggestions around:
- Overall design of the changes.
- `TableMetrics` uses synchronized list to store `TableThreadMetricsHolder` objects. Understanding is that its very unlikely that multiple threads are trying to add `TableThreadMetricsHolder` objects to the list simultaneously. But wondering if this can cause batch calls to see increase in latency.
- Introduced a config `hbase.client.table.metrics.enable` to skip wrapping runnable inside `DelegateTableRunnableWithMetrics`. Not sure why anyone would want to skip wrapping the runnable given whether to consume metrics is totally upto end user. Maybe we can remove config?

Pending:
- Adding test coverage.