### PR TITLE
HBASE-29056 Bump commons-io:commons-io from 2.14.0 to 2.18.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -577,7 +577,7 @@
     <avro.version>1.11.4</avro.version>
     <caffeine.version>2.8.1</caffeine.version>
     <commons-codec.version>1.15</commons-codec.version>
-    <commons-io.version>2.14.0</commons-io.version>
+    <commons-io.version>2.18.0</commons-io.version>
     <commons-lang3.version>3.9</commons-lang3.version>
     <commons-math.version>3.6.1</commons-math.version>
     <commons-cli.version>1.5.0</commons-cli.version>


### PR DESCRIPTION
- Backports #6579 (to let CI run through the change once on branch-2)