### PR TITLE
[FOLLOWUP] HBASE-25459:WAL can't be cleaned in some scenes

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/SequenceIdAccounting.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/SequenceIdAccounting.java
@@ -252,7 +252,12 @@ public class SequenceIdAccounting {
   private static long getLowestSequenceId(Map<?, Long> sequenceids) {
     long lowest = HConstants.NO_SEQNUM;
     for (Map.Entry<?, Long> entry : sequenceids.entrySet()) {
-      if (entry.getKey().toString().equals("METAFAMILY")) {
+      Object key = entry.getKey();
+      String keyVal = key.toString();
+      if(key instanceof ImmutableByteArray){
+        keyVal = ((ImmutableByteArray)key).toStringUtf8();
+      }
+      if ("METAFAMILY".equals(keyVal)){
         continue;
       }
       Long sid = entry.getValue();


### PR DESCRIPTION
The first version of the patch directly used the toString method to get the value of the key. However, if the type of the key is ImmutableByteArray, the toStringUtf8 method should be used to obtain the value. Otherwise, we will end up with the object's hash code.

like this:
org.apache.hadoop.hbase.util.ImmutableByteArray@4f