### PR TITLE
HBASE-29092 hbase-vote.sh is stymied by the new robots.txt on dist.apache.org

### DIFF
--- a/dev-support/hbase-vote.sh
+++ b/dev-support/hbase-vote.sh
@@ -121,7 +121,14 @@ function download_and_import_keys() {
 
 function download_release_candidate () {
     # get all files from release candidate repo
-    wget -r -np -N -nH --cut-dirs 4 "${SOURCE_URL}"
+    wget \
+      --execute robots=off \
+      --recursive \
+      --no-parent \
+      --timestamping \
+      --no-host-directories \
+      --cut-dirs 4 \
+      "${SOURCE_URL}"
 }
 
 function verify_signatures() {


### PR DESCRIPTION
Uses the long-form of arguments, hopefully, to improve readability. The new `execute` line is what fixes the issue.