### PR TITLE
HBASE-29073 StochasticLoadBalancer will always run the balancer on startup because of uninitialized sumMultiplier

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -421,13 +421,16 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     }
 
     double total = 0.0;
+    float localSumMultiplier = 0; // in case this.sumMultiplier is not initialized
     for (CostFunction c : costFunctions) {
       if (!c.isNeeded()) {
         LOG.trace("{} not needed", c.getClass().getSimpleName());
         continue;
       }
       total += c.cost() * c.getMultiplier();
+      localSumMultiplier += c.getMultiplier();
     }
+    sumMultiplier = localSumMultiplier;
     boolean balanced = (total / sumMultiplier < minCostNeedBalance);
 
     if (balanced) {
@@ -536,12 +539,13 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
 
     initCosts(cluster);
 
-    sumMultiplier = 0;
+    float localSumMultiplier = 0;
     for (CostFunction c : costFunctions) {
       if (c.isNeeded()) {
-        sumMultiplier += c.getMultiplier();
+        localSumMultiplier += c.getMultiplier();
       }
     }
+    sumMultiplier = localSumMultiplier;
     if (sumMultiplier <= 0) {
       LOG.error("At least one cost function needs a multiplier > 0. For example, set "
         + "hbase.master.balancer.stochastic.regionCountCost to a positive value or default");


### PR DESCRIPTION
The sumMultiplier field is used in the needsBalance method, but it is not initialized until calling balanceTable. This is silly and can cause weird behavior on an HMaster's initial balancer run, because the statement:
```java
boolean balanced = (total / sumMultiplier < minCostNeedBalance);
```
will always result to false, given that `total / sumMultiplier` == NaN, so it is not comparable to the min balance cost.

This isn't a huge issue, but I noticed this in my recent work on the balancer and it's worth fixing imo.

The needsBalance method already iterates through all cost functions ahead of using the sumMultiplier field, so we might as well just ensure that we've updated the sumMultiplier field here as well.