### PR TITLE
Backport "HBASE-29099 Avoid expensive BlockCacheKey.toString() calls when traci…" to branch-2.6

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -1291,13 +1291,17 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
 
     BlockCacheKey cacheKey =
       new BlockCacheKey(path, dataBlockOffset, this.isPrimaryReplicaReader(), expectedBlockType);
-    Attributes attributes = Attributes.of(BLOCK_CACHE_KEY_KEY, cacheKey.toString());
 
     boolean cacheable = cacheBlock && cacheIfCompactionsOff();
 
     boolean useLock = false;
     IdLock.Entry lockEntry = null;
     final Span span = Span.current();
+    // BlockCacheKey#toString() is quite expensive to call, so if tracing isn't enabled, don't
+    // record
+    Attributes attributes = span.isRecording()
+      ? Attributes.of(BLOCK_CACHE_KEY_KEY, cacheKey.toString())
+      : Attributes.empty();
     try {
       while (true) {
         // Check cache for block. If found return.


### PR DESCRIPTION
…ng is disabled (#6642)