### PR TITLE
Major compaction is disabled, but the webui shows that major compaction has been triggered

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
@@ -339,7 +339,7 @@ public abstract class Compactor<T extends CellSink> {
       }
       writer = sinkFactory.createWriter(scanner, fd, dropCache);
       finished = performCompaction(fd, scanner, writer, smallestReadPoint, cleanSeqId,
-        throughputController, request.isAllFiles(), request.getFiles().size());
+        throughputController, request.isMajor(), request.getFiles().size());
       if (!finished) {
         throw new InterruptedIOException("Aborting compaction of store " + store + " in region "
             + store.getRegionInfo().getRegionNameAsString() + " because it was interrupted.");

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/DefaultCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/DefaultCompactor.java
@@ -86,7 +86,7 @@ public class DefaultCompactor extends Compactor<StoreFileWriter> {
   protected List<Path> commitWriter(StoreFileWriter writer, FileDetails fd,
       CompactionRequestImpl request) throws IOException {
     List<Path> newFiles = Lists.newArrayList(writer.getPath());
-    writer.appendMetadata(fd.maxSeqId, request.isAllFiles(), request.getFiles());
+    writer.appendMetadata(fd.maxSeqId, request.isMajor(), request.getFiles());
     writer.close();
     return newFiles;
   }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-29119

When major compaction is disabled, if all hfiles in a single region participate in compaction, they will be automatically marked as major compaction. I think this is wrong and contrary to the expected major compaction. In addition, according to the context, I found that as long as all hfiles participate in compaction, they are automatically deleted. I think this also needs to be adjusted.