### PR TITLE
HBASE-29119: Major compaction is disabled, but the webui shows that major compaction has been triggered

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/DefaultMobStoreCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/DefaultMobStoreCompactor.java
@@ -306,7 +306,7 @@ public class DefaultMobStoreCompactor extends DefaultCompactor {
     // Clear old mob references
     mobRefSet.get().clear();
     boolean isUserRequest = userRequest.get();
-    boolean major = request.isAllFiles();
+    boolean major = request.isMajor();
     boolean compactMOBs = major && isUserRequest;
     boolean discardMobMiss = conf.getBoolean(MobConstants.MOB_UNSAFE_DISCARD_MISS_KEY,
       MobConstants.DEFAULT_MOB_DISCARD_MISS);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/DefaultCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/DefaultCompactor.java
@@ -66,7 +66,7 @@ public class DefaultCompactor extends Compactor<StoreFileWriter> {
   protected List<Path> commitWriter(StoreFileWriter writer, FileDetails fd,
     CompactionRequestImpl request) throws IOException {
     List<Path> newFiles = writer.getPaths();
-    writer.appendMetadata(fd.maxSeqId, request.isAllFiles(), request.getFiles());
+    writer.appendMetadata(fd.maxSeqId, request.isMajor(), request.getFiles());
     writer.close();
     return newFiles;
   }


### PR DESCRIPTION
When major compaction is disabled, if all hfiles in a single region participate in compaction, they will be automatically marked as major compaction. I think this is wrong and contrary to the expected major compaction. In addition, according to the context, I found that as long as all hfiles participate in compaction, they are automatically deleted. I think this also needs to be adjusted.