### PR TITLE
HBASE-29093 Load userSnapshots.jsp only on master status page

### DIFF
--- a/hbase-server/src/main/resources/hbase-webapps/static/js/tab.js
+++ b/hbase-server/src/main/resources/hbase-webapps/static/js/tab.js
@@ -20,19 +20,23 @@
 
 $(document).ready(
   function(){
-    var prefix = "tab_";
-	$('.tabbable .nav-pills a').click(function (e) {
+    const prefix = "tab_";
+    $('.tabbable .nav-pills a').click(function (e) {
         e.preventDefault();
         location.hash = $(e.target).attr('href').substr(1).replace(prefix, "");
         $(this).tab('show');
     });
 
-  $.ajax({url:"/userSnapshots.jsp", success:function(result){
-    $("#tab_userSnapshots").html(result);
-  }});
-            
+    const $userSnapshotsTab = $("#tab_userSnapshots");
+    const isUserSnapshotsTabExists = $userSnapshotsTab.length;
+    if (isUserSnapshotsTabExists) {
+      $.ajax({url:"/userSnapshots.jsp", success:function(result){
+        $userSnapshotsTab.html(result);
+      }});
+    }
+
     if (location.hash !== '') {
-      var tabItem = $('a[href="' + location.hash.replace("#", "#"+prefix) + '"]');
+      const tabItem = $('a[href="' + location.hash.replace("#", "#"+prefix) + '"]');
       tabItem.tab('show');
       $(document).scrollTop(0);  
       return false;  


### PR DESCRIPTION
Before HBase UI always tried to load `userSnapshots.jsp` with an AJAX request on all UI pages - **NOK**.

This happened even on RegionServer UI or REST UI where this call always failed with HTTP 500.

From now on HBase UI only loads `userSnapshots.jsp` when the Snapshots tab (div with `tab_userSnapshots` ID) exists on the page.

Also did a minor improvement to `tab.js`: use `const` instead of `var` as `var` has so many problems:
> With block-level scope, no hoisting, and the ability to declare constants, let and const make code more predictable, maintainable, and less error-prone. By using let and const instead of var, developers can avoid common pitfalls and write more declarative code.

Also fixed a whitespace.

(cherry picked from commit ed007404b0f31a51e2c5960c21340993073b7f06)