### PR TITLE
HBASE-28023 ITBLL's RollingBatchSuspendResumeRsAction uses waitForRegionServerToSuspend to verify the success of the suspendRs action.

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/ClusterManager.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/ClusterManager.java
@@ -93,6 +93,18 @@ interface ClusterManager extends Configurable {
    */
   boolean isRunning(ServiceType service, String hostname, int port) throws IOException;
 
+  /**
+   * Returns whether the service is suspended on the remote host. This only checks whether the
+   * service status is suspended.
+   */
+  boolean isSuspended(ServiceType service, String hostname, int port) throws IOException;
+
+  /**
+   * Returns whether the service is resumed on the remote host. This only checks whether the service
+   * status is resumed.
+   */
+  boolean isResumed(ServiceType service, String hostname, int port) throws IOException;
+
   /*
    * TODO: further API ideas: //return services running on host: ServiceType[]
    * getRunningServicesOnHost(String hostname); //return which services can be run on host (for

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/RESTApiClusterManager.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/RESTApiClusterManager.java
@@ -264,6 +264,16 @@ public class RESTApiClusterManager extends Configured implements ClusterManager 
     hBaseClusterManager.resume(service, hostname, port);
   }
 
+  @Override
+  public boolean isSuspended(ServiceType service, String hostname, int port) throws IOException {
+    return hBaseClusterManager.isSuspended(service, hostname, port);
+  }
+
+  @Override
+  public boolean isResumed(ServiceType service, String hostname, int port) throws IOException {
+    return hBaseClusterManager.isResumed(service, hostname, port);
+  }
+
   // Convenience method to execute command against role on hostname. Only graceful commands are
   // supported since cluster management APIs don't tend to let you SIGKILL things.
   private void performClusterManagerCommand(ServiceType role, String hostname,

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/ZNodeClusterManager.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/ZNodeClusterManager.java
@@ -111,6 +111,18 @@ public class ZNodeClusterManager extends Configured implements ClusterManager {
       CmdType.bool.toString() + getCommandProvider(service).isRunningCommand(service)));
   }
 
+  @Override
+  public boolean isSuspended(ServiceType service, String hostname, int port) throws IOException {
+    String ret = createZNode(hostname, getCommandProvider(service).getStateCommand(service));
+    return ret != null && ret.trim().equals("T");
+  }
+
+  @Override
+  public boolean isResumed(ServiceType service, String hostname, int port) throws IOException {
+    String ret = createZNode(hostname, getCommandProvider(service).getStateCommand(service));
+    return ret != null && !ret.trim().equals("T");
+  }
+
   enum CmdType {
     exec,
     bool

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/Action.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/Action.java
@@ -197,7 +197,7 @@ public abstract class Action {
     getLogger().info("Suspending regionserver {}", server);
     cluster.suspendRegionServer(server);
     if (!(cluster instanceof MiniHBaseCluster)) {
-      cluster.waitForRegionServerToStop(server, killRsTimeout);
+      cluster.waitForRegionServerToSuspend(server, killRsTimeout);
     }
     getLogger().info("Suspending regionserver {}. Reported num of rs:{}", server,
       cluster.getClusterMetrics().getLiveServerMetrics().size());
@@ -207,7 +207,7 @@ public abstract class Action {
     getLogger().info("Resuming regionserver {}", server);
     cluster.resumeRegionServer(server);
     if (!(cluster instanceof MiniHBaseCluster)) {
-      cluster.waitForRegionServerToStart(server.getHostname(), server.getPort(), startRsTimeout);
+      cluster.waitForRegionServerToResume(server, startRsTimeout);
     }
     getLogger().info("Resuming regionserver {}. Reported num of rs:{}", server,
       cluster.getClusterMetrics().getLiveServerMetrics().size());

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/RollingBatchSuspendResumeRsAction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/actions/RollingBatchSuspendResumeRsAction.java
@@ -65,7 +65,7 @@ public class RollingBatchSuspendResumeRsAction extends Action {
 
   @Override
   public void perform() throws Exception {
-    getLogger().info("Performing action: Rolling batch restarting {}% of region servers",
+    getLogger().info("Performing action: Rolling batch suspending {}% of region servers",
       (int) (ratio * 100));
     List<ServerName> selectedServers = selectServers();
     Queue<ServerName> serversToBeSuspended = new ArrayDeque<>(selectedServers);

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/monkies/PolicyBasedChaosMonkey.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/chaos/monkies/PolicyBasedChaosMonkey.java
@@ -85,6 +85,7 @@ public class PolicyBasedChaosMonkey extends ChaosMonkey {
   private static ExecutorService buildMonkeyThreadPool(final int size) {
     return Executors.newFixedThreadPool(size, new ThreadFactoryBuilder().setDaemon(false)
       .setNameFormat("ChaosMonkey-%d").setUncaughtExceptionHandler((t, e) -> {
+        LOG.error("Uncaught exception in thread {}", t.getName(), e);
         throw new RuntimeException(e);
       }).build());
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseCluster.java
@@ -176,11 +176,25 @@ public abstract class HBaseCluster implements Closeable, Configurable {
   public abstract void suspendRegionServer(ServerName serverName) throws IOException;
 
   /**
+   * Wait for the specified region server to suspend the thread / process.
+   * @throws IOException if something goes wrong or timeout occurs
+   */
+  public abstract void waitForRegionServerToSuspend(ServerName serverName, long timeout)
+    throws IOException;
+
+  /**
    * Resume the region server
    * @param serverName the hostname to resume the regionserver on
    * @throws IOException if something goes wrong
    */
   public abstract void resumeRegionServer(ServerName serverName) throws IOException;
+
+  /**
+   * Wait for the specified region server to resume the thread / process.
+   * @throws IOException if something goes wrong or timeout occurs
+   */
+  public abstract void waitForRegionServerToResume(ServerName serverName, long timeout)
+    throws IOException;
 
   /**
    * Starts a new zookeeper node on the given hostname or if this is a mini/local cluster, silently

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/MiniHBaseCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/MiniHBaseCluster.java
@@ -303,6 +303,16 @@ public class MiniHBaseCluster extends HBaseCluster {
   }
 
   @Override
+  public void waitForRegionServerToSuspend(ServerName serverName, long timeout) throws IOException {
+    LOG.warn("Waiting for regionserver to suspend on mini cluster is not supported");
+  }
+
+  @Override
+  public void waitForRegionServerToResume(ServerName serverName, long timeout) throws IOException {
+    LOG.warn("Waiting for regionserver to resume on mini cluster is not supported");
+  }
+
+  @Override
   public void startZkNode(String hostname, int port) throws IOException {
     LOG.warn("Starting zookeeper nodes on mini cluster is not supported");
   }


### PR DESCRIPTION
Add missed changes in the BackPort