### PR TITLE
HBASE-29135: ZStandard decompression can operate directly on ByteBuffs

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/BlockDecompressorHelper.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/BlockDecompressorHelper.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.io.compress;
 
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -61,6 +62,10 @@ public class BlockDecompressorHelper {
     return totalDecompressedBytes;
   }
 
+  /**
+   * Read an integer from the buffer in big-endian byte order. Note that {@link ByteBuffer#getInt()}
+   * reads in system-dependent endian-ness, so we can't use that.
+   */
   private static int rawReadInt(ByteBuff input) {
     int b1 = Byte.toUnsignedInt(input.get());
     int b2 = Byte.toUnsignedInt(input.get());

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/BlockDecompressorHelper.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/BlockDecompressorHelper.java
@@ -48,6 +48,10 @@ public class BlockDecompressorHelper {
         int compressedChunkSize = rawReadInt(input);
         compressedBytesConsumed += 4;
         int n = rawDecompressor.decompress(output, input, compressedChunkSize);
+        if (n <= 0) {
+          throw new IOException("Decompression failed. Compressed size: " + compressedChunkSize
+            + ", decompressed size: " + decompressedBlockSize);
+        }
         compressedBytesConsumed += compressedChunkSize;
         decompressedBytesInBlock += n;
         totalDecompressedBytes += n;

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/BlockDecompressorHelper.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/BlockDecompressorHelper.java
@@ -21,6 +21,13 @@ import java.io.IOException;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.yetus.audience.InterfaceAudience;
 
+/**
+ * Helper to decompress a ByteBuff that was created by a
+ * {@link org.apache.hadoop.io.compress.BlockCompressorStream}, or is at least in the same format.
+ * Parses the binary format and delegates actual decompression work to the provided
+ * {@link RawDecompressor}. Note that the use of the word "block" here does not refer to an HFile
+ * block.
+ */
 @InterfaceAudience.Private
 public class BlockDecompressorHelper {
 
@@ -28,12 +35,6 @@ public class BlockDecompressorHelper {
     int decompress(ByteBuff output, ByteBuff input, int inputLen) throws IOException;
   }
 
-  /**
-   * Helper to decompress a ByteBuff that was created by a
-   * {@link org.apache.hadoop.io.compress.BlockCompressorStream}, or is at least in the same format.
-   * Parses the binary format and delegates actual decompression work to the provided
-   * {@link RawDecompressor}.
-   */
   public static int decompress(ByteBuff output, ByteBuff input, int inputSize,
     RawDecompressor rawDecompressor) throws IOException {
     int totalDecompressedBytes = 0;

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/BlockDecompressorHelper.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/BlockDecompressorHelper.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@InterfaceAudience.Private
+public class BlockDecompressorHelper {
+
+  public interface RawDecompressor {
+    int decompress(ByteBuff output, ByteBuff input, int inputLen) throws IOException;
+  }
+
+  /**
+   * Helper to decompress a ByteBuff that was created by a
+   * {@link org.apache.hadoop.io.compress.BlockCompressorStream}, or is at least in the same format.
+   * Parses the binary format and delegates actual decompression work to the provided
+   * {@link RawDecompressor}.
+   */
+  public static int decompress(ByteBuff output, ByteBuff input, int inputSize,
+    RawDecompressor rawDecompressor) throws IOException {
+    int totalDecompressedBytes = 0;
+    int compressedBytesConsumed = 0;
+
+    while (compressedBytesConsumed < inputSize) {
+      int decompressedBlockSize = rawReadInt(input);
+      compressedBytesConsumed += 4;
+      int decompressedBytesInBlock = 0;
+
+      while (decompressedBytesInBlock < decompressedBlockSize) {
+        int compressedChunkSize = rawReadInt(input);
+        compressedBytesConsumed += 4;
+        int n = rawDecompressor.decompress(output, input, compressedChunkSize);
+        compressedBytesConsumed += compressedChunkSize;
+        decompressedBytesInBlock += n;
+        totalDecompressedBytes += n;
+      }
+    }
+    return totalDecompressedBytes;
+  }
+
+  private static int rawReadInt(ByteBuff input) {
+    int b1 = Byte.toUnsignedInt(input.get());
+    int b2 = Byte.toUnsignedInt(input.get());
+    int b3 = Byte.toUnsignedInt(input.get());
+    int b4 = Byte.toUnsignedInt(input.get());
+    return ((b1 << 24) + (b2 << 16) + (b3 << 8) + b4);
+  }
+
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressionCodec.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressionCodec.java
@@ -1,0 +1,31 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress;
+
+import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
+
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface ByteBuffDecompressionCodec {
+
+  Class<? extends ByteBuffDecompressor> getByteBuffDecompressorType();
+
+  ByteBuffDecompressor createByteBuffDecompressor();
+
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressionCodec.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressionCodec.java
@@ -18,10 +18,8 @@
 package org.apache.hadoop.hbase.io.compress;
 
 import org.apache.yetus.audience.InterfaceAudience;
-import org.apache.yetus.audience.InterfaceStability;
 
-@InterfaceAudience.Public
-@InterfaceStability.Evolving
+@InterfaceAudience.Private
 public interface ByteBuffDecompressionCodec {
 
   Class<? extends ByteBuffDecompressor> getByteBuffDecompressorType();

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressor.java
@@ -23,7 +23,7 @@ import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
- * Specification of a block-based decompressor, which can be more efficient than the stream-based
+ * Specification of a ByteBuff-based decompressor, which can be more efficient than the stream-based
  * Decompressor.
  */
 @InterfaceAudience.Private

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressor.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress;
+
+import java.io.Closeable;
+import java.io.IOException;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
+
+/**
+ * Specification of a block-based decompressor, which can be more efficient than the stream-based
+ * Decompressor.
+ */
+@InterfaceAudience.Public
+@InterfaceStability.Evolving
+public interface ByteBuffDecompressor extends Closeable {
+
+  /**
+   * Fills the ouput buffer with uncompressed data. Always call
+   * {@link #canDecompress(ByteBuff, ByteBuff)} first to check if this decompressor can handle your
+   * input and output buffers.
+   * @return The actual number of bytes of uncompressed data.
+   */
+  int decompress(ByteBuff output, ByteBuff input, int inputLen) throws IOException;
+
+  /**
+   * Signals of these two particular {@link ByteBuff}s are compatible with this decompressor.
+   * ByteBuffs can have one or multiple backing buffers, and each of these may be stored in heap or
+   * direct memory. Different {@link ByteBuffDecompressor}s may be able to handle different
+   * combinations of these, so always check.
+   */
+  boolean canDecompress(ByteBuff output, ByteBuff input);
+
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressor.java
@@ -21,14 +21,12 @@ import java.io.Closeable;
 import java.io.IOException;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.yetus.audience.InterfaceAudience;
-import org.apache.yetus.audience.InterfaceStability;
 
 /**
  * Specification of a block-based decompressor, which can be more efficient than the stream-based
  * Decompressor.
  */
-@InterfaceAudience.Public
-@InterfaceStability.Evolving
+@InterfaceAudience.Private
 public interface ByteBuffDecompressor extends Closeable {
 
   /**

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/CodecPool.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/CodecPool.java
@@ -167,7 +167,7 @@ public class CodecPool {
       LOG.info("Got brand-new Decompressor [" + codec.getDefaultExtension() + "]");
     } else {
       if (LOG.isDebugEnabled()) {
-        LOG.debug("Got recycled decompressor");
+        LOG.debug("Got recycled Decompressor");
       }
     }
     if (decompressor != null && !decompressor.getClass().isAnnotationPresent(DoNotPool.class)) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/CodecPool.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/CodecPool.java
@@ -52,6 +52,9 @@ public class CodecPool {
   private static final ConcurrentMap<Class<Decompressor>,
     NavigableSet<Decompressor>> DECOMPRESSOR_POOL = new ConcurrentHashMap<>();
 
+  private static final ConcurrentMap<Class<ByteBuffDecompressor>,
+    NavigableSet<ByteBuffDecompressor>> BYTE_BUFF_DECOMPRESSOR_POOL = new ConcurrentHashMap<>();
+
   private static <T> LoadingCache<Class<T>, AtomicInteger> createCache() {
     return Caffeine.newBuilder().build(key -> new AtomicInteger());
   }
@@ -161,7 +164,7 @@ public class CodecPool {
     Decompressor decompressor = borrow(DECOMPRESSOR_POOL, codec.getDecompressorType());
     if (decompressor == null) {
       decompressor = codec.createDecompressor();
-      LOG.info("Got brand-new decompressor [" + codec.getDefaultExtension() + "]");
+      LOG.info("Got brand-new Decompressor [" + codec.getDefaultExtension() + "]");
     } else {
       if (LOG.isDebugEnabled()) {
         LOG.debug("Got recycled decompressor");
@@ -169,6 +172,20 @@ public class CodecPool {
     }
     if (decompressor != null && !decompressor.getClass().isAnnotationPresent(DoNotPool.class)) {
       updateLeaseCount(decompressorCounts, decompressor, 1);
+    }
+    return decompressor;
+  }
+
+  public static ByteBuffDecompressor getByteBuffDecompressor(ByteBuffDecompressionCodec codec) {
+    ByteBuffDecompressor decompressor =
+      borrow(BYTE_BUFF_DECOMPRESSOR_POOL, codec.getByteBuffDecompressorType());
+    if (decompressor == null) {
+      decompressor = codec.createByteBuffDecompressor();
+      LOG.info("Got brand-new ByteBuffDecompressor " + decompressor.getClass().getName());
+    } else {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Got recycled ByteBuffDecompressor");
+      }
     }
     return decompressor;
   }
@@ -209,6 +226,17 @@ public class CodecPool {
     if (payback(DECOMPRESSOR_POOL, decompressor)) {
       updateLeaseCount(decompressorCounts, decompressor, -1);
     }
+  }
+
+  public static void returnByteBuffDecompressor(ByteBuffDecompressor decompressor) {
+    if (decompressor == null) {
+      return;
+    }
+    // if the decompressor can't be reused, don't pool it.
+    if (decompressor.getClass().isAnnotationPresent(DoNotPool.class)) {
+      return;
+    }
+    payback(BYTE_BUFF_DECOMPRESSOR_POOL, decompressor);
   }
 
   /**

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/Compression.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/Compression.java
@@ -531,7 +531,7 @@ public final class Compression {
         ByteBuffDecompressor decompressor =
           CodecPool.getByteBuffDecompressor((ByteBuffDecompressionCodec) codec);
         if (LOG.isTraceEnabled()) {
-          LOG.trace("Retrieved decompressor " + decompressor + " from pool.");
+          LOG.trace("Retrieved decompressor {} from pool.", decompressor);
         }
         return decompressor;
       } else {
@@ -542,7 +542,7 @@ public final class Compression {
     public void returnByteBuffDecompressor(ByteBuffDecompressor decompressor) {
       if (decompressor != null) {
         if (LOG.isTraceEnabled()) {
-          LOG.trace("Returning decompressor " + decompressor + " to pool.");
+          LOG.trace("Returning decompressor {} to pool.", decompressor);
         }
         CodecPool.returnByteBuffDecompressor(decompressor);
       }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/Compression.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/Compression.java
@@ -26,6 +26,7 @@ import java.io.OutputStream;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.CompressionInputStream;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
@@ -504,6 +505,46 @@ public final class Compression {
           if (LOG.isTraceEnabled()) LOG.trace("Ending decompressor " + decompressor);
           decompressor.end();
         }
+      }
+    }
+
+    /**
+     * Signals if this codec theoretically supports decompression on {@link ByteBuff}s. This can be
+     * faster than using a DecompressionStream. If this method returns true, you can call
+     * {@link #getByteBuffDecompressor()} to obtain a {@link ByteBuffDecompressor}. You must then
+     * also call {@link ByteBuffDecompressor#canDecompress(ByteBuff, ByteBuff)} before attempting
+     * decompression, to verify if that decompressor is capable of handling your particular input
+     * and output buffers.
+     */
+    public boolean supportsByteBuffDecompression() {
+      CompressionCodec codec = getCodec(conf);
+      return codec instanceof ByteBuffDecompressionCodec;
+    }
+
+    /**
+     * Be sure to call {@link #supportsByteBuffDecompression()} before calling this method.
+     * @throws IllegalStateException if the codec does not support block decompression
+     */
+    public ByteBuffDecompressor getByteBuffDecompressor() {
+      CompressionCodec codec = getCodec(conf);
+      if (codec instanceof ByteBuffDecompressionCodec) {
+        ByteBuffDecompressor decompressor =
+          CodecPool.getByteBuffDecompressor((ByteBuffDecompressionCodec) codec);
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Retrieved decompressor " + decompressor + " from pool.");
+        }
+        return decompressor;
+      } else {
+        throw new IllegalStateException("Codec " + codec + " does not support block decompression");
+      }
+    }
+
+    public void returnByteBuffDecompressor(ByteBuffDecompressor decompressor) {
+      if (decompressor != null) {
+        if (LOG.isTraceEnabled()) {
+          LOG.trace("Returning decompressor " + decompressor + " to pool.");
+        }
+        CodecPool.returnByteBuffDecompressor(decompressor);
       }
     }
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/HFileBlockDefaultDecodingContext.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/HFileBlockDefaultDecodingContext.java
@@ -59,8 +59,8 @@ public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingConte
     ByteBuff blockBufferWithoutHeader, ByteBuff onDiskBlock) throws IOException {
 
     // If possible, use the ByteBuffer decompression mechanism to avoid extra copies.
-    if (canFastDecompress(blockBufferWithoutHeader, onDiskBlock)) {
-      fastDecompress(blockBufferWithoutHeader, onDiskBlock, onDiskSizeWithoutHeader);
+    if (canDecompressViaByteBuff(blockBufferWithoutHeader, onDiskBlock)) {
+      decompressViaByteBuff(blockBufferWithoutHeader, onDiskBlock, onDiskSizeWithoutHeader);
       return;
     }
 
@@ -131,10 +131,10 @@ public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingConte
   /**
    * When only decompression is needed (not decryption), and the input and output buffers are
    * SingleByteBuffs, and the decompression algorithm supports it, we can do decompression without
-   * any intermediate heap buffers. Do not call unless you've checked {@link #canFastDecompress}
-   * first.
+   * any intermediate heap buffers. Do not call unless you've checked
+   * {@link #canDecompressViaByteBuff} first.
    */
-  private void fastDecompress(ByteBuff blockBufferWithoutHeader, ByteBuff onDiskBlock,
+  private void decompressViaByteBuff(ByteBuff blockBufferWithoutHeader, ByteBuff onDiskBlock,
     int onDiskSizeWithoutHeader) throws IOException {
     Compression.Algorithm compression = fileContext.getCompression();
     ByteBuffDecompressor decompressor = compression.getByteBuffDecompressor();
@@ -148,7 +148,8 @@ public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingConte
     }
   }
 
-  private boolean canFastDecompress(ByteBuff blockBufferWithoutHeader, ByteBuff onDiskBlock) {
+  private boolean canDecompressViaByteBuff(ByteBuff blockBufferWithoutHeader,
+    ByteBuff onDiskBlock) {
     // Theoretically we can do ByteBuff decompression after doing streaming decryption, but the
     // refactoring necessary to support this has not been attempted. For now, we skip ByteBuff
     // decompression if the input is encrypted.

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/HFileBlockDefaultDecodingContext.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/HFileBlockDefaultDecodingContext.java
@@ -36,8 +36,6 @@ import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.yetus.audience.InterfaceAudience;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A default implementation of {@link HFileBlockDecodingContext}. It assumes the block data section
@@ -46,8 +44,6 @@ import org.slf4j.LoggerFactory;
  */
 @InterfaceAudience.Private
 public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingContext {
-
-  private static final Logger LOG = LoggerFactory.getLogger(HFileBlockDefaultDecodingContext.class);
 
   private final Configuration conf;
   private final HFileContext fileContext;

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/HFileBlockDefaultDecodingContext.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/HFileBlockDefaultDecodingContext.java
@@ -24,6 +24,7 @@ import org.apache.commons.io.IOUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.ByteBuffInputStream;
 import org.apache.hadoop.hbase.io.TagCompressionContext;
+import org.apache.hadoop.hbase.io.compress.ByteBuffDecompressor;
 import org.apache.hadoop.hbase.io.compress.CanReinit;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.crypto.Cipher;
@@ -35,6 +36,8 @@ import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.io.compress.Decompressor;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * A default implementation of {@link HFileBlockDecodingContext}. It assumes the block data section
@@ -43,6 +46,9 @@ import org.apache.yetus.audience.InterfaceAudience;
  */
 @InterfaceAudience.Private
 public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingContext {
+
+  private static final Logger LOG = LoggerFactory.getLogger(HFileBlockDefaultDecodingContext.class);
+
   private final Configuration conf;
   private final HFileContext fileContext;
   private TagCompressionContext tagCompressionContext;
@@ -55,6 +61,13 @@ public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingConte
   @Override
   public void prepareDecoding(int onDiskSizeWithoutHeader, int uncompressedSizeWithoutHeader,
     ByteBuff blockBufferWithoutHeader, ByteBuff onDiskBlock) throws IOException {
+
+    // If possible, use the ByteBuffer decompression mechanism to avoid extra copies.
+    if (canFastDecompress(blockBufferWithoutHeader, onDiskBlock)) {
+      fastDecompress(blockBufferWithoutHeader, onDiskBlock, onDiskSizeWithoutHeader);
+      return;
+    }
+
     final ByteBuffInputStream byteBuffInputStream = new ByteBuffInputStream(onDiskBlock);
     InputStream dataInputStream = new DataInputStream(byteBuffInputStream);
 
@@ -116,6 +129,49 @@ public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingConte
     } finally {
       byteBuffInputStream.close();
       dataInputStream.close();
+    }
+  }
+
+  /**
+   * When only decompression is needed (not decryption), and the input and output buffers are
+   * SingleByteBuffs, and the decompression algorithm supports it, we can do decompression without
+   * any intermediate heap buffers. Do not call unless you've checked {@link #canFastDecompress}
+   * first.
+   */
+  private void fastDecompress(ByteBuff blockBufferWithoutHeader, ByteBuff onDiskBlock,
+    int onDiskSizeWithoutHeader) throws IOException {
+    Compression.Algorithm compression = fileContext.getCompression();
+    ByteBuffDecompressor decompressor = compression.getByteBuffDecompressor();
+    try {
+      if (decompressor instanceof CanReinit) {
+        ((CanReinit) decompressor).reinit(conf);
+      }
+      decompressor.decompress(blockBufferWithoutHeader, onDiskBlock, onDiskSizeWithoutHeader);
+    } finally {
+      compression.returnByteBuffDecompressor(decompressor);
+    }
+  }
+
+  private boolean canFastDecompress(ByteBuff blockBufferWithoutHeader, ByteBuff onDiskBlock) {
+    // Theoretically we can do ByteBuff decompression after doing streaming decryption, but the
+    // refactoring necessary to support this has not been attempted. For now, we skip ByteBuff
+    // decompression if the input is encrypted.
+    if (fileContext.getEncryptionContext() != Encryption.Context.NONE) {
+      return false;
+    } else if (!fileContext.getCompression().supportsByteBuffDecompression()) {
+      return false;
+    } else {
+      ByteBuffDecompressor decompressor = fileContext.getCompression().getByteBuffDecompressor();
+      try {
+        if (decompressor instanceof CanReinit) {
+          ((CanReinit) decompressor).reinit(conf);
+        }
+        // Even if we have a ByteBuffDecompressor, we still need to check if it can decompress
+        // our particular ByteBuffs
+        return decompressor.canDecompress(blockBufferWithoutHeader, onDiskBlock);
+      } finally {
+        fileContext.getCompression().returnByteBuffDecompressor(decompressor);
+      }
     }
   }
 

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
@@ -37,6 +37,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 public class ZstdByteBuffDecompressor implements ByteBuffDecompressor, CanReinit {
 
   protected int dictId;
+  @Nullable
   protected ZstdDictDecompress dict;
   protected ZstdDecompressCtx ctx;
 
@@ -108,7 +109,9 @@ public class ZstdByteBuffDecompressor implements ByteBuffDecompressor, CanReinit
   @Override
   public void close() {
     ctx.close();
-    dict.close();
+    if (dict != null) {
+      dict.close();
+    }
   }
 
   @Override

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
@@ -91,7 +91,6 @@ public class ZstdByteBuffDecompressor implements ByteBuffDecompressor, CanReinit
       output.limit() - output.position(), input, input.position(), inputLen);
 
     output.position(origOutputPos + n);
-    output.limit(output.position());
     return n;
   }
 
@@ -103,7 +102,6 @@ public class ZstdByteBuffDecompressor implements ByteBuffDecompressor, CanReinit
       inputLen);
 
     output.position(origOutputPos + n);
-    output.limit(output.position());
     return n;
   }
 

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress.zstd;
+
+import com.github.luben.zstd.ZstdDecompressCtx;
+import com.github.luben.zstd.ZstdDictDecompress;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.hadoop.hbase.io.compress.BlockDecompressorHelper;
+import org.apache.hadoop.hbase.io.compress.ByteBuffDecompressor;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.hadoop.hbase.nio.SingleByteBuff;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Glue for ByteBuffDecompressor on top of zstd-jni. Note that this doesn't implement CanReinit
+ * because it's faster to avoid reinitializing on each usage.
+ */
+@InterfaceAudience.Private
+public class ZstdByteBuffDecompressor implements ByteBuffDecompressor {
+
+  protected ZstdDictDecompress dict;
+  protected ZstdDecompressCtx ctx;
+
+  ZstdByteBuffDecompressor(@Nullable byte[] dictionary) {
+    ctx = new ZstdDecompressCtx();
+    if (dictionary != null) {
+      this.dict = new ZstdDictDecompress(dictionary);
+      this.ctx.loadDict(this.dict);
+    }
+  }
+
+  @Override
+  public boolean canDecompress(ByteBuff output, ByteBuff input) {
+    if (output instanceof SingleByteBuff && input instanceof SingleByteBuff) {
+      ByteBuffer nioOutput = output.nioByteBuffers()[0];
+      ByteBuffer nioInput = input.nioByteBuffers()[0];
+      if (nioOutput.isDirect() && nioInput.isDirect()) {
+        return true;
+      } else if (!nioOutput.isDirect() && !nioInput.isDirect()) {
+        return true;
+      }
+    }
+
+    return false;
+  }
+
+  @Override
+  public int decompress(ByteBuff output, ByteBuff input, int inputLen) throws IOException {
+    return BlockDecompressorHelper.decompress(output, input, inputLen, this::decompressRaw);
+  }
+
+  private int decompressRaw(ByteBuff output, ByteBuff input, int inputLen) throws IOException {
+    if (output instanceof SingleByteBuff && input instanceof SingleByteBuff) {
+      ByteBuffer nioOutput = output.nioByteBuffers()[0];
+      ByteBuffer nioInput = input.nioByteBuffers()[0];
+      if (nioOutput.isDirect() && nioInput.isDirect()) {
+        return decompressDirectByteBuffers(nioOutput, nioInput, inputLen);
+      } else if (!nioOutput.isDirect() && !nioInput.isDirect()) {
+        return decompressHeapByteBuffers(nioOutput, nioInput, inputLen);
+      }
+    }
+
+    throw new IllegalStateException("One buffer is direct and the other is not, "
+      + "or one or more not SingleByteBuffs. This is not supported");
+  }
+
+  private int decompressDirectByteBuffers(ByteBuffer output, ByteBuffer input, int inputLen) {
+    int origOutputPos = output.position();
+
+    int n = ctx.decompressDirectByteBuffer(output, output.position(),
+      output.limit() - output.position(), input, input.position(), inputLen);
+
+    output.position(origOutputPos + n);
+    output.limit(output.position());
+    return n;
+  }
+
+  private int decompressHeapByteBuffers(ByteBuffer output, ByteBuffer input, int inputLen) {
+    int origOutputPos = output.position();
+
+    int n = ctx.decompressByteArray(output.array(), output.arrayOffset() + output.position(),
+      output.limit() - output.position(), input.array(), input.arrayOffset() + input.position(),
+      inputLen);
+
+    output.position(origOutputPos + n);
+    output.limit(output.position());
+    return n;
+  }
+
+  @Override
+  public void close() {
+    ctx.close();
+    dict.close();
+  }
+}

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdCodec.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdCodec.java
@@ -26,6 +26,8 @@ import java.nio.ByteOrder;
 import org.apache.hadoop.conf.Configurable;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.CommonConfigurationKeys;
+import org.apache.hadoop.hbase.io.compress.ByteBuffDecompressionCodec;
+import org.apache.hadoop.hbase.io.compress.ByteBuffDecompressor;
 import org.apache.hadoop.hbase.io.compress.DictionaryCache;
 import org.apache.hadoop.io.compress.BlockCompressorStream;
 import org.apache.hadoop.io.compress.BlockDecompressorStream;
@@ -42,7 +44,7 @@ import org.apache.yetus.audience.InterfaceAudience;
  * This is data format compatible with Hadoop's native ZStandard codec.
  */
 @InterfaceAudience.Private
-public class ZstdCodec implements Configurable, CompressionCodec {
+public class ZstdCodec implements Configurable, CompressionCodec, ByteBuffDecompressionCodec {
 
   public static final String ZSTD_LEVEL_KEY = "hbase.io.compress.zstd.level";
   public static final String ZSTD_BUFFER_SIZE_KEY = "hbase.io.compress.zstd.buffersize";
@@ -81,6 +83,11 @@ public class ZstdCodec implements Configurable, CompressionCodec {
   }
 
   @Override
+  public ByteBuffDecompressor createByteBuffDecompressor() {
+    return new ZstdByteBuffDecompressor(dictionary);
+  }
+
+  @Override
   public CompressionInputStream createInputStream(InputStream in) throws IOException {
     return createInputStream(in, createDecompressor());
   }
@@ -111,6 +118,11 @@ public class ZstdCodec implements Configurable, CompressionCodec {
   @Override
   public Class<? extends Decompressor> getDecompressorType() {
     return ZstdDecompressor.class;
+  }
+
+  @Override
+  public Class<? extends ByteBuffDecompressor> getByteBuffDecompressorType() {
+    return ZstdByteBuffDecompressor.class;
   }
 
   @Override

--- a/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestHFileCompressionZstd.java
+++ b/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestHFileCompressionZstd.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.compress.HFileTestBase;
 import org.apache.hadoop.hbase.testclassification.IOTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
 import org.junit.Test;
@@ -43,6 +44,11 @@ public class TestHFileCompressionZstd extends HFileTestBase {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
+    HFileTestBase.setUpBeforeClass();
+  }
+
+  @Before
+  public void setUp() throws Exception {
     conf = TEST_UTIL.getConfiguration();
     conf.set(Compression.ZSTD_CODEC_CLASS_KEY, ZstdCodec.class.getCanonicalName());
     Compression.Algorithm.ZSTD.reload(conf);
@@ -50,7 +56,17 @@ public class TestHFileCompressionZstd extends HFileTestBase {
   }
 
   @Test
-  public void test() throws Exception {
+  public void testWithStreamDecompression() throws Exception {
+    conf.setBoolean("hbase.io.compress.zstd.allowByteBuffDecompression", false);
+    Compression.Algorithm.ZSTD.reload(conf);
+
+    Path path =
+      new Path(TEST_UTIL.getDataTestDir(), HBaseTestingUtil.getRandomUUID().toString() + ".hfile");
+    doTest(conf, path, Compression.Algorithm.ZSTD);
+  }
+
+  @Test
+  public void testWithByteBuffDecompression() throws Exception {
     Path path =
       new Path(TEST_UTIL.getDataTestDir(), HBaseTestingUtil.getRandomUUID().toString() + ".hfile");
     doTest(conf, path, Compression.Algorithm.ZSTD);

--- a/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
@@ -1,0 +1,90 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress.zstd;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.hadoop.hbase.nio.MultiByteBuff;
+import org.apache.hadoop.hbase.nio.SingleByteBuff;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(SmallTests.class)
+public class TestZstdByteBuffDecompressor {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestZstdByteBuffDecompressor.class);
+
+  // "HBase is awesome" compressed with zstd, and then prepended with metadata as a
+  // BlockCompressorStream would
+  private static final byte[] COMPRESSED_PAYLOAD =
+    Bytes.fromHex("000000100000001928b52ffd2010810000484261736520697320617765736f6d65");
+
+  @Test
+  public void testCapabilities() {
+    ByteBuff emptySingleHeapBuff = new SingleByteBuff(ByteBuffer.allocate(0));
+    ByteBuff emptyMultiHeapBuff = new MultiByteBuff(ByteBuffer.allocate(0), ByteBuffer.allocate(0));
+    ByteBuff emptySingleDirectBuff = new SingleByteBuff(ByteBuffer.allocateDirect(0));
+    ByteBuff emptyMultiDirectBuff =
+      new MultiByteBuff(ByteBuffer.allocateDirect(0), ByteBuffer.allocateDirect(0));
+
+    try (ZstdByteBuffDecompressor decompressor = new ZstdByteBuffDecompressor(null)) {
+      assertTrue(decompressor.canDecompress(emptySingleHeapBuff, emptySingleHeapBuff));
+      assertTrue(decompressor.canDecompress(emptySingleDirectBuff, emptySingleDirectBuff));
+      assertFalse(decompressor.canDecompress(emptySingleHeapBuff, emptySingleDirectBuff));
+      assertFalse(decompressor.canDecompress(emptySingleDirectBuff, emptySingleHeapBuff));
+      assertFalse(decompressor.canDecompress(emptyMultiHeapBuff, emptyMultiHeapBuff));
+      assertFalse(decompressor.canDecompress(emptyMultiDirectBuff, emptyMultiDirectBuff));
+      assertFalse(decompressor.canDecompress(emptySingleHeapBuff, emptyMultiHeapBuff));
+      assertFalse(decompressor.canDecompress(emptySingleDirectBuff, emptyMultiDirectBuff));
+    }
+  }
+
+  @Test
+  public void testDecompressHeap() throws IOException {
+    try (ZstdByteBuffDecompressor decompressor = new ZstdByteBuffDecompressor(null)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = new SingleByteBuff(ByteBuffer.wrap(COMPRESSED_PAYLOAD));
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is awesome", Bytes.toString(output.toBytes(0, decompressedSize)));
+    }
+  }
+
+  @Test
+  public void testDecompressDirect() throws IOException {
+    try (ZstdByteBuffDecompressor decompressor = new ZstdByteBuffDecompressor(null)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = new SingleByteBuff(ByteBuffer.allocateDirect(COMPRESSED_PAYLOAD.length));
+      input.put(COMPRESSED_PAYLOAD);
+      input.rewind();
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is awesome", Bytes.toString(output.toBytes(0, decompressedSize)));
+    }
+  }
+
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/CompressionContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/wal/CompressionContext.java
@@ -140,6 +140,9 @@ public class CompressionContext {
       }
     }
 
+    /**
+     * Read an integer from the stream in big-endian byte order.
+     */
     private int rawReadInt(InputStream in) throws IOException {
       int b1 = in.read();
       int b2 = in.read();


### PR DESCRIPTION
Each time a block is decoded in `HFileBlockDefaultDecodingContext`, a new `DecompressorStream` is allocated and used. This is a lot of allocation, and the use of the streaming pattern requires copying every byte to be decompressed more times than necessary. Each byte is copied from a `ByteBuff` into a `byte[]`, then decompressed, then copied back to a `ByteBuff`. For decompressors like `org.apache.hadoop.hbase.io.compress.zstd.ZstdDecompressor` that only operate on direct memory, two additional copies are introduced to move from a `byte[]` to a direct NIO `ByteBuffer`, then back to a `byte[]`.

Aside from the copies inherent in the decompression algorithm, and the necessity of copying from an compressed buffer to an uncompressed buffer, all of these other copies can be avoided without sacrificing functionality. Along the way, we'll also avoid allocating objects.

In this PR:
- Introduce the interface `ByteBuffDecompressor` which does exactly what it sounds like
- Provide a `ZstdByteBuffDecompressor` that uses zstd-jni underneath
  - This works when the input and output arguments are both direct `SingleByteBuff`s or both heap `SingleByteBuff`s.
  - I have a plan to improve zstd-jni so we can handle other combinations in HBase in the future.
- The CodecPool now pools `ByteBuffDecompressor`s the same way that it pools `Decompressor`s.
- When decoding an HFile block, if the decompressor supports decompression directly on the `ByteBuff`s, then take the new fast path.

In a subsequent PR I plan to add glue so that any codec offering a `org.apache.hadoop.io.compress.DirectDecompressor`, which several in hadoop-common already do, can be used as a `ByteBuffDecompressor`.

I've already been using this code successfully in production at my company.