### PR TITLE
HBASE-29133: Implement "pitr" Command for Point-in-Time Restore

### DIFF
--- a/bin/hbase
+++ b/bin/hbase
@@ -102,6 +102,7 @@ show_usage() {
   echo "  version          Print the version"
   echo "  backup           Backup tables for recovery"
   echo "  restore          Restore tables from existing backup image"
+  echo "  pitr             Restore tables to a specific point in time using backup and WAL replay"
   echo "  completebulkload Run BulkLoadHFiles tool"
   echo "  regionsplitter   Run RegionSplitter tool"
   echo "  rowcounter       Run RowCounter tool"
@@ -612,6 +613,22 @@ elif [ "$COMMAND" = "backup" ] ; then
   fi
 elif [ "$COMMAND" = "restore" ] ; then
   CLASS='org.apache.hadoop.hbase.backup.RestoreDriver'
+  if [ -n "${shaded_jar}" ] ; then
+    for f in "${HBASE_HOME}"/lib/hbase-backup*.jar; do
+      if [ -f "${f}" ]; then
+        CLASSPATH="${CLASSPATH}:${f}"
+        break
+      fi
+    done
+    for f in "${HBASE_HOME}"/lib/commons-lang3*.jar; do
+      if [ -f "${f}" ]; then
+        CLASSPATH="${CLASSPATH}:${f}"
+        break
+      fi
+    done
+  fi
+elif [ "$COMMAND" = "pitr" ] ; then
+  CLASS='org.apache.hadoop.hbase.backup.PointInTimeRestoreDriver'
   if [ -n "${shaded_jar}" ] ; then
     for f in "${HBASE_HOME}"/lib/hbase-backup*.jar; do
       if [ -f "${f}" ]; then

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/AbstractRestoreDriver.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/AbstractRestoreDriver.java
@@ -1,0 +1,227 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup;
+
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_CHECK;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_CHECK_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_OVERWRITE;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_OVERWRITE_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_SET;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_SET_RESTORE_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_LIST_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_MAPPING;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TABLE_MAPPING_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_YARN_QUEUE_NAME_RESTORE_DESC;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Objects;
+import org.apache.commons.lang3.StringUtils;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.backup.impl.BackupManager;
+import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
+import org.apache.hadoop.hbase.backup.util.BackupUtils;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.logging.Log4jUtils;
+import org.apache.hadoop.hbase.util.AbstractHBaseTool;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
+import org.apache.hbase.thirdparty.org.apache.commons.cli.HelpFormatter;
+
+@InterfaceAudience.Private
+public abstract class AbstractRestoreDriver extends AbstractHBaseTool {
+  protected static final Logger LOG = LoggerFactory.getLogger(AbstractRestoreDriver.class);
+  protected CommandLine cmd;
+
+  protected static final String USAGE_FOOTER = "";
+
+  protected AbstractRestoreDriver() {
+    init();
+  }
+
+  protected void init() {
+    Log4jUtils.disableZkAndClientLoggers();
+  }
+
+  protected abstract int executeRestore(boolean check, TableName[] fromTables, TableName[] toTables,
+    boolean isOverwrite);
+
+  private int parseAndRun() throws IOException {
+    if (!BackupManager.isBackupEnabled(getConf())) {
+      System.err.println(BackupRestoreConstants.ENABLE_BACKUP);
+      return -1;
+    }
+
+    if (cmd.hasOption(OPTION_DEBUG)) {
+      Log4jUtils.setLogLevel("org.apache.hadoop.hbase.backup", "DEBUG");
+    }
+
+    boolean overwrite = cmd.hasOption(OPTION_OVERWRITE);
+    if (overwrite) {
+      LOG.debug("Found -overwrite option in restore command, "
+        + "will overwrite to existing table if any in the restore target");
+    }
+
+    boolean check = cmd.hasOption(OPTION_CHECK);
+    if (check) {
+      LOG.debug(
+        "Found -check option in restore command, " + "will check and verify the dependencies");
+    }
+
+    if (cmd.hasOption(OPTION_SET) && cmd.hasOption(OPTION_TABLE)) {
+      System.err.println(
+        "Options -s and -t are mutually exclusive," + " you can not specify both of them.");
+      printToolUsage();
+      return -1;
+    }
+
+    if (!cmd.hasOption(OPTION_SET) && !cmd.hasOption(OPTION_TABLE)) {
+      System.err.println("You have to specify either set name or table list to restore");
+      printToolUsage();
+      return -1;
+    }
+
+    if (cmd.hasOption(OPTION_YARN_QUEUE_NAME)) {
+      String queueName = cmd.getOptionValue(OPTION_YARN_QUEUE_NAME);
+      // Set MR job queuename to configuration
+      getConf().set("mapreduce.job.queuename", queueName);
+    }
+
+    String tables;
+    TableName[] sTableArray;
+    TableName[] tTableArray;
+
+    String tableMapping =
+      cmd.hasOption(OPTION_TABLE_MAPPING) ? cmd.getOptionValue(OPTION_TABLE_MAPPING) : null;
+    try (final Connection conn = ConnectionFactory.createConnection(conf)) {
+      // Check backup set
+      if (cmd.hasOption(OPTION_SET)) {
+        String setName = cmd.getOptionValue(OPTION_SET);
+        try {
+          tables = getTablesForSet(conn, setName);
+        } catch (IOException e) {
+          System.out.println("ERROR: " + e.getMessage() + " for setName=" + setName);
+          printToolUsage();
+          return -2;
+        }
+        if (tables == null) {
+          System.out
+            .println("ERROR: Backup set '" + setName + "' is either empty or does not exist");
+          printToolUsage();
+          return -3;
+        }
+      } else {
+        tables = cmd.getOptionValue(OPTION_TABLE);
+      }
+
+      sTableArray = BackupUtils.parseTableNames(tables);
+      tTableArray = BackupUtils.parseTableNames(tableMapping);
+
+      if (
+        sTableArray != null && tTableArray != null && (sTableArray.length != tTableArray.length)
+      ) {
+        System.out.println("ERROR: table mapping mismatch: " + tables + " : " + tableMapping);
+        printToolUsage();
+        return -4;
+      }
+    }
+
+    return executeRestore(check, sTableArray, tTableArray, overwrite);
+  }
+
+  @Override
+  protected void addOptions() {
+    addOptNoArg(OPTION_OVERWRITE, OPTION_OVERWRITE_DESC);
+    addOptNoArg(OPTION_CHECK, OPTION_CHECK_DESC);
+    addOptNoArg(OPTION_DEBUG, OPTION_DEBUG_DESC);
+    addOptWithArg(OPTION_SET, OPTION_SET_RESTORE_DESC);
+    addOptWithArg(OPTION_TABLE, OPTION_TABLE_LIST_DESC);
+    addOptWithArg(OPTION_TABLE_MAPPING, OPTION_TABLE_MAPPING_DESC);
+    addOptWithArg(OPTION_YARN_QUEUE_NAME, OPTION_YARN_QUEUE_NAME_RESTORE_DESC);
+  }
+
+  @Override
+  protected void processOptions(CommandLine cmd) {
+    this.cmd = cmd;
+  }
+
+  @Override
+  protected int doWork() throws Exception {
+    return parseAndRun();
+  }
+
+  @Override
+  public int run(String[] args) {
+    Objects.requireNonNull(conf, "Tool configuration is not initialized");
+
+    try {
+      cmd = parseArgs(args);
+    } catch (Exception e) {
+      System.out.println("Error parsing command-line arguments: " + e.getMessage());
+      printToolUsage();
+      return EXIT_FAILURE;
+    }
+
+    if (cmd.hasOption(SHORT_HELP_OPTION) || cmd.hasOption(LONG_HELP_OPTION)) {
+      printToolUsage();
+      return EXIT_FAILURE;
+    }
+
+    processOptions(cmd);
+
+    try {
+      return doWork();
+    } catch (Exception e) {
+      LOG.error("Error running restore tool", e);
+      return EXIT_FAILURE;
+    }
+  }
+
+  protected void printToolUsage() {
+    System.out.println(getUsageString());
+    HelpFormatter helpFormatter = new HelpFormatter();
+    helpFormatter.setLeftPadding(2);
+    helpFormatter.setDescPadding(8);
+    helpFormatter.setWidth(100);
+    helpFormatter.setSyntaxPrefix("Options:");
+    helpFormatter.printHelp(" ", null, options, USAGE_FOOTER);
+    System.out.println(BackupRestoreConstants.VERIFY_BACKUP);
+  }
+
+  protected abstract String getUsageString();
+
+  private String getTablesForSet(Connection conn, String name) throws IOException {
+    try (final BackupSystemTable table = new BackupSystemTable(conn)) {
+      List<TableName> tables = table.describeBackupSet(name);
+
+      if (tables == null) {
+        return null;
+      }
+
+      return StringUtils.join(tables, BackupRestoreConstants.TABLENAME_DELIMITER_IN_COMMAND);
+    }
+  }
+}

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupAdmin.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupAdmin.java
@@ -52,6 +52,13 @@ public interface BackupAdmin extends Closeable {
   void restore(RestoreRequest request) throws IOException;
 
   /**
+   * Restore the tables to specific time
+   * @param request Point in Time restore request
+   * @throws IOException exception
+   */
+  void pointInTimeRestore(PointInTimeRestoreRequest request) throws IOException;
+
+  /**
    * Describe backup image command
    * @param backupId backup id
    * @return backup info

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
@@ -96,6 +96,10 @@ public interface BackupRestoreConstants {
   String OPTION_YARN_QUEUE_NAME_DESC = "Yarn queue name to run backup create command on";
   String OPTION_YARN_QUEUE_NAME_RESTORE_DESC = "Yarn queue name to run backup restore command on";
 
+  String OPTION_TO_DATETIME = "td";
+  String LONG_OPTION_TO_DATETIME = "to-datetime";
+  String OPTION_TO_DATETIME_DESC = "Target date and time up to which data should be restored";
+
   String JOB_NAME_CONF_KEY = "mapreduce.job.name";
 
   String BACKUP_CONFIG_STRING =
@@ -121,6 +125,8 @@ public interface BackupRestoreConstants {
   String CONF_STAGING_ROOT = "snapshot.export.staging.root";
 
   String BACKUPID_PREFIX = "backup_";
+
+  String CONF_CONTINUOUS_BACKUP_WAL_DIR = "hbase.backup.continuous.wal.dir";
 
   enum BackupCommand {
     CREATE,

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/PointInTimeRestoreDriver.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/PointInTimeRestoreDriver.java
@@ -17,6 +17,11 @@
  */
 package org.apache.hadoop.hbase.backup;
 
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.CONF_CONTINUOUS_BACKUP_WAL_DIR;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.LONG_OPTION_TO_DATETIME;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TO_DATETIME;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_TO_DATETIME_DESC;
+
 import java.net.URI;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
@@ -27,6 +32,7 @@ import org.apache.hadoop.hbase.backup.util.BackupUtils;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.util.ToolRunner;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -34,31 +40,53 @@ import org.apache.yetus.audience.InterfaceAudience;
  * Command-line entry point for restore operation
  */
 @InterfaceAudience.Private
-public class RestoreDriver extends AbstractRestoreDriver {
+public class PointInTimeRestoreDriver extends AbstractRestoreDriver {
   private static final String USAGE_STRING = """
-      Usage: hbase restore <backup_path> <backup_id> [options]
-        backup_path     Path to a backup destination root
-        backup_id       Backup image ID to restore
+      Usage: hbase pitr <backup_path> [options]
+        <backup_path>                  Path to a backup destination root
         table(s)        Comma-separated list of tables to restore
       """;
 
   @Override
   protected int executeRestore(boolean check, TableName[] fromTables, TableName[] toTables,
     boolean isOverwrite) {
-    // parse main restore command options
+    String walBackupDir = getConf().get(CONF_CONTINUOUS_BACKUP_WAL_DIR);
+    if (walBackupDir == null || walBackupDir.isEmpty()) {
+      System.err.printf(
+        "Point-in-Time Restore requires the WAL backup directory (%s) to replay logs after full and incremental backups. "
+          + "Set this property if you need Point-in-Time Restore. Otherwise, use the normal restore process with the appropriate backup ID.%n",
+        CONF_CONTINUOUS_BACKUP_WAL_DIR);
+      return -1;
+    }
+
     String[] remainArgs = cmd.getArgs();
-    if (remainArgs.length != 2) {
+    if (remainArgs.length != 1) {
       printToolUsage();
       return -1;
     }
 
     String backupRootDir = remainArgs[0];
-    String backupId = remainArgs[1];
 
     try (final Connection conn = ConnectionFactory.createConnection(conf);
       BackupAdmin client = new BackupAdminImpl(conn)) {
-      client.restore(BackupUtils.createRestoreRequest(backupRootDir, backupId, check, fromTables,
-        toTables, isOverwrite));
+      long endTime = EnvironmentEdgeManager.getDelegate().currentTime();
+      if (cmd.hasOption(OPTION_TO_DATETIME)) {
+        String time = cmd.getOptionValue(OPTION_TO_DATETIME);
+        try {
+          endTime = Long.parseLong(time);
+          // Convert seconds to milliseconds if input is in seconds
+          if (endTime < 10_000_000_000L) {
+            endTime *= 1000;
+          }
+        } catch (NumberFormatException e) {
+          System.out.println("ERROR: Invalid timestamp format for --to-datetime: " + time);
+          printToolUsage();
+          return -5;
+        }
+      }
+
+      client.pointInTimeRestore(BackupUtils.createPointInTimeRestoreRequest(backupRootDir, check,
+        fromTables, toTables, isOverwrite, endTime));
     } catch (Exception e) {
       LOG.error("Error while running restore backup", e);
       return -5;
@@ -66,12 +94,18 @@ public class RestoreDriver extends AbstractRestoreDriver {
     return 0;
   }
 
+  @Override
+  protected void addOptions() {
+    super.addOptions();
+    addOptWithArg(OPTION_TO_DATETIME, LONG_OPTION_TO_DATETIME, OPTION_TO_DATETIME_DESC);
+  }
+
   public static void main(String[] args) throws Exception {
     Configuration conf = HBaseConfiguration.create();
-    Path hbasedir = CommonFSUtils.getRootDir(conf);
-    URI defaultFs = hbasedir.getFileSystem(conf).getUri();
+    Path rootDir = CommonFSUtils.getRootDir(conf);
+    URI defaultFs = rootDir.getFileSystem(conf).getUri();
     CommonFSUtils.setFsDefault(conf, new Path(defaultFs));
-    int ret = ToolRunner.run(conf, new RestoreDriver(), args);
+    int ret = ToolRunner.run(conf, new PointInTimeRestoreDriver(), args);
     System.exit(ret);
   }
 

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/PointInTimeRestoreRequest.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/PointInTimeRestoreRequest.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * POJO class for Point In Time Restore request
+ */
+@InterfaceAudience.Private
+public final class PointInTimeRestoreRequest {
+
+  private final String backupRootDir;
+  private final boolean check;
+  private final TableName[] fromTables;
+  private final TableName[] toTables;
+  private final boolean overwrite;
+  private final long toDateTime;
+
+  private PointInTimeRestoreRequest(Builder builder) {
+    this.backupRootDir = builder.backupRootDir;
+    this.check = builder.check;
+    this.fromTables = builder.fromTables;
+    this.toTables = builder.toTables;
+    this.overwrite = builder.overwrite;
+    this.toDateTime = builder.toDateTime;
+  }
+
+  public String getBackupRootDir() {
+    return backupRootDir;
+  }
+
+  public boolean isCheck() {
+    return check;
+  }
+
+  public TableName[] getFromTables() {
+    return fromTables;
+  }
+
+  public TableName[] getToTables() {
+    return toTables;
+  }
+
+  public boolean isOverwrite() {
+    return overwrite;
+  }
+
+  public long getToDateTime() {
+    return toDateTime;
+  }
+
+  public static class Builder {
+    private String backupRootDir;
+    private boolean check = false;
+    private TableName[] fromTables;
+    private TableName[] toTables;
+    private boolean overwrite = false;
+    private long toDateTime;
+
+    public Builder withBackupRootDir(String backupRootDir) {
+      this.backupRootDir = backupRootDir;
+      return this;
+    }
+
+    public Builder withCheck(boolean check) {
+      this.check = check;
+      return this;
+    }
+
+    public Builder withFromTables(TableName[] fromTables) {
+      this.fromTables = fromTables;
+      return this;
+    }
+
+    public Builder withToTables(TableName[] toTables) {
+      this.toTables = toTables;
+      return this;
+    }
+
+    public Builder withOverwrite(boolean overwrite) {
+      this.overwrite = overwrite;
+      return this;
+    }
+
+    public Builder withToDateTime(long dateTime) {
+      this.toDateTime = dateTime;
+      return this;
+    }
+
+    public PointInTimeRestoreRequest build() {
+      return new PointInTimeRestoreRequest(this);
+    }
+  }
+}

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
@@ -17,18 +17,28 @@
  */
 package org.apache.hadoop.hbase.backup.impl;
 
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.CONF_CONTINUOUS_BACKUP_WAL_DIR;
+import static org.apache.hadoop.hbase.backup.replication.BackupFileSystemManager.WALS_DIR;
+import static org.apache.hadoop.hbase.backup.replication.ContinuousBackupReplicationEndpoint.DATE_FORMAT;
+import static org.apache.hadoop.hbase.backup.replication.ContinuousBackupReplicationEndpoint.ONE_DAY_IN_MILLISECONDS;
+
 import java.io.IOException;
+import java.text.ParseException;
+import java.text.SimpleDateFormat;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
+import java.util.Date;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.BackupAdmin;
 import org.apache.hadoop.hbase.backup.BackupClientFactory;
@@ -40,12 +50,17 @@ import org.apache.hadoop.hbase.backup.BackupRestoreConstants;
 import org.apache.hadoop.hbase.backup.BackupRestoreFactory;
 import org.apache.hadoop.hbase.backup.BackupType;
 import org.apache.hadoop.hbase.backup.HBackupFileSystem;
+import org.apache.hadoop.hbase.backup.PointInTimeRestoreRequest;
 import org.apache.hadoop.hbase.backup.RestoreRequest;
+import org.apache.hadoop.hbase.backup.impl.BackupManifest.BackupImage;
 import org.apache.hadoop.hbase.backup.util.BackupSet;
 import org.apache.hadoop.hbase.backup.util.BackupUtils;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.mapreduce.WALInputFormat;
+import org.apache.hadoop.hbase.mapreduce.WALPlayer;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.util.Tool;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -507,6 +522,124 @@ public class BackupAdminImpl implements BackupAdmin {
     }
     // Execute restore request
     new RestoreTablesClient(conn, request).execute();
+  }
+
+  @Override
+  public void pointInTimeRestore(PointInTimeRestoreRequest request) throws IOException {
+    Path backupRootDirPath = new Path(request.getBackupRootDir());
+    List<BackupImage> sortedImages =
+      HBackupFileSystem.getAllBackupImages(conn.getConfiguration(), backupRootDirPath);
+
+    TableName[] sTableArray = request.getFromTables();
+    TableName[] tTableArray = request.getToTables();
+
+    // Ensure target tables array is properly set
+    if (tTableArray == null || tTableArray.length == 0) {
+      tTableArray = sTableArray;
+    }
+
+    for (int i = 0; i < sTableArray.length; i++) {
+      TableName sTableName = sTableArray[i];
+      TableName tTableName = tTableArray[i];
+
+      BackupImage latestBackupImage = findLatestBackupWithTable(sTableName, sortedImages);
+      if (latestBackupImage == null) {
+        LOG.error("No full or incremental backup found for table: {}", sTableName);
+        throw new IOException("No valid backup found for table: " + sTableName);
+      }
+
+      RestoreRequest restoreRequest = BackupUtils.createRestoreRequest(request.getBackupRootDir(),
+        latestBackupImage.getBackupId(), request.isCheck(), new TableName[] { sTableName },
+        new TableName[] { tTableName }, request.isOverwrite());
+
+      restore(restoreRequest);
+
+      long startTime = latestBackupImage.getStartTs();
+      long endTime = request.getToDateTime();
+      // TODO: already verified the existence of the property in the beginning of the process. still
+      // required???
+      String walBackupDir = conn.getConfiguration().get(CONF_CONTINUOUS_BACKUP_WAL_DIR);
+      replayWal(sTableName, tTableName, startTime, endTime, new Path(walBackupDir));
+    }
+
+    LOG.info("Successfully completed Point In Time Restore for all tables.");
+  }
+
+  private BackupImage findLatestBackupWithTable(TableName tableName,
+    List<BackupImage> sortedImages) {
+    return sortedImages.stream().filter(image -> image.hasTable(tableName)).findFirst()
+      .orElse(null);
+  }
+
+  private void replayWal(TableName sourceTableName, TableName targetTableName, long startTime,
+    long endTime, Path walBackupDir) throws IOException {
+    LOG.info(
+      "Starting WAL replay for source: {}, target: {}, time range: {} - {}, WAL backup dir: {}",
+      sourceTableName, targetTableName, startTime, endTime, walBackupDir);
+
+    // TODO: Verify anything before replaying WALs
+    // TODO: Authentication Keys?????
+    Configuration conf = HBaseConfiguration.create();
+    Tool player = new WALPlayer();
+    player.setConf(conf);
+
+    conf.setLong(WALInputFormat.START_TIME_KEY, startTime);
+    conf.setLong(WALInputFormat.END_TIME_KEY, endTime);
+
+    List<String> validDirs = getValidWalDirs(conf, walBackupDir, startTime, endTime);
+    if (validDirs.isEmpty()) {
+      LOG.warn("No valid WAL directories found for time range: {} - {}. Skipping WAL replay.",
+        startTime, endTime);
+      return;
+    }
+
+    String[] playerArgs = { String.join(",", validDirs), sourceTableName.getNameAsString(),
+      targetTableName.getNameAsString() };
+    try {
+      LOG.info("Running WALPlayer with arguments: {}", Arrays.toString(playerArgs));
+      int result = player.run(playerArgs);
+
+      if (result == 0) {
+        LOG.info("WAL replay completed successfully for table: {}", targetTableName);
+      } else {
+        LOG.error("WAL replay failed for table: {} with exit code: {}", targetTableName, result);
+        throw new IOException("WAL replay failed with exit code: " + result);
+      }
+    } catch (Exception e) {
+      LOG.error("Error occurred during WAL replay for table: {}. Exception: {}", targetTableName,
+        e.getMessage(), e);
+      throw new IOException("Exception during WAL replay", e);
+    }
+  }
+
+  private List<String> getValidWalDirs(Configuration conf, Path walBackupDir, long startTime,
+    long endTime) throws IOException {
+    FileSystem backupFs = FileSystem.get(walBackupDir.toUri(), conf);
+    FileStatus[] dayDirs = backupFs.listStatus(new Path(walBackupDir, WALS_DIR));
+    SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
+    List<String> validDirs = new ArrayList<>();
+
+    for (FileStatus dayDir : dayDirs) {
+      if (!dayDir.isDirectory()) {
+        continue; // Skip files, only process directories
+      }
+
+      String dirName = dayDir.getPath().getName();
+      try {
+        Date dirDate = dateFormat.parse(dirName);
+        long dirStartTime = dirDate.getTime(); // Start of that day (00:00:00)
+        long dirEndTime = dirStartTime + ONE_DAY_IN_MILLISECONDS - 1; // End time of the day
+                                                                      // (23:59:59)
+
+        // Check if this day's WAL files overlap with the required time range
+        if (dirEndTime >= startTime && dirStartTime <= endTime) {
+          validDirs.add(dayDir.getPath().toString());
+        }
+      } catch (ParseException e) {
+        LOG.warn("Skipping invalid directory name: " + dirName, e);
+      }
+    }
+    return validDirs;
   }
 
   @Override

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/util/BackupUtils.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/util/BackupUtils.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.BackupInfo;
 import org.apache.hadoop.hbase.backup.BackupRestoreConstants;
 import org.apache.hadoop.hbase.backup.HBackupFileSystem;
+import org.apache.hadoop.hbase.backup.PointInTimeRestoreRequest;
 import org.apache.hadoop.hbase.backup.RestoreRequest;
 import org.apache.hadoop.hbase.backup.impl.BackupManifest;
 import org.apache.hadoop.hbase.backup.impl.BackupManifest.BackupImage;
@@ -662,6 +663,14 @@ public final class BackupUtils {
       builder.withBackupRootDir(backupRootDir).withBackupId(backupId).withCheck(check)
         .withFromTables(fromTables).withToTables(toTables).withOvewrite(isOverwrite).build();
     return request;
+  }
+
+  public static PointInTimeRestoreRequest createPointInTimeRestoreRequest(String backupRootDir,
+    boolean check, TableName[] fromTables, TableName[] toTables, boolean isOverwrite,
+    long toDateTime) {
+    PointInTimeRestoreRequest.Builder builder = new PointInTimeRestoreRequest.Builder();
+    return builder.withBackupRootDir(backupRootDir).withCheck(check).withFromTables(fromTables)
+      .withToTables(toTables).withOverwrite(isOverwrite).withToDateTime(toDateTime).build();
   }
 
   public static boolean validate(List<TableName> tables, BackupManifest backupManifest,


### PR DESCRIPTION
This PR introduces the `pitr` command to restore tables from the most recent backup before `--to-datetime` and replay WAL logs for changes made after the last backup.  

#### **Command Usage:**  
```bash
hbase pitr <backup_path> 
    [-t <table_name[,table_name]>] 
    [-s <backup_set_name>] 
    [-q <name>] 
    [-c] 
    [-m <target_tables>] 
    [-o] 
    [--to-datetime <end_time>]
```  
