### PR TITLE
HBASE-29155 Upgrade checkstyle to fix website build

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -903,14 +903,14 @@
     <!--
       When updating checkstyle.version, please make the same change in `.idea/checkstyle-idea.xml`
     -->
-    <checkstyle.version>8.29</checkstyle.version>
+    <checkstyle.version>10.21.3</checkstyle.version>
     <exec.maven.version>3.1.0</exec.maven.version>
     <error-prone.version>2.28.0</error-prone.version>
     <jamon.plugin.version>2.4.2</jamon.plugin.version>
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
     <maven.antrun.version>1.8</maven.antrun.version>
     <maven.bundle.version>3.3.0</maven.bundle.version>
-    <maven.checkstyle.version>3.1.0</maven.checkstyle.version>
+    <maven.checkstyle.version>3.6.0</maven.checkstyle.version>
     <maven.eclipse.version>2.10</maven.eclipse.version>
     <maven.gpg.version>3.0.1</maven.gpg.version>
     <maven.javadoc.version>3.4.0</maven.javadoc.version>


### PR DESCRIPTION
The website build failed with the following error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.12.0:site (default-site) on project hbase: Error generating maven-checkstyle-plugin:3.1.0:checkstyle-aggregate report: Failed during checkstyle configuration: Exception was thrown while processing hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/replicas/ReplicaKey.java: IllegalStateException occurred while parsing file hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/replicas/ReplicaKey.java. hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/replicas/ReplicaKey.java:43:35: expecting RPAREN, found 'other' -> [Help 1]
```

Checkstyle is not able to parse ReplicaKey.java (because of instanceOf pattern match syntax).

Upgraded the maven-checkstyle-plugin plugin version and the checkstyle version which it uses.