### PR TITLE
HBASE-29155 Use Java 8-compatible instanceOf syntax in ReplicaKey

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/replicas/ReplicaKey.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/replicas/ReplicaKey.java
@@ -40,9 +40,10 @@ public final class ReplicaKey {
     if (this == o) {
       return true;
     }
-    if (!(o instanceof ReplicaKey other)) {
+    if (!(o instanceof ReplicaKey)) {
       return false;
     }
+    ReplicaKey other = (ReplicaKey) o;
     return Arrays.equals(this.start, other.start) && Arrays.equals(this.stop, other.stop)
       && this.tableName.equals(other.tableName);
   }


### PR DESCRIPTION
The website build failed with the following error:

```
[ERROR] Failed to execute goal org.apache.maven.plugins:maven-site-plugin:3.12.0:site (default-site) on project hbase: Error generating maven-checkstyle-plugin:3.1.0:checkstyle-aggregate report: Failed during checkstyle configuration: Exception was thrown while processing hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/replicas/ReplicaKey.java: IllegalStateException occurred while parsing file hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/replicas/ReplicaKey.java. hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/replicas/ReplicaKey.java:43:35: expecting RPAREN, found 'other' -> [Help 1]
```

Checkstyle is not able to parse ReplicaKey.java (because of instanceOf pattern match syntax).

We have a rule to not use Java11+ grammar on branch-3 as long as we still need to support Java 8 on branch-2.x.