### PR TITLE
HBASE-29162 Fix Maven build warnings

### DIFF
--- a/hbase-examples/pom.xml
+++ b/hbase-examples/pom.xml
@@ -200,11 +200,6 @@
       <artifactId>log4j-slf4j-impl</artifactId>
       <scope>test</scope>
     </dependency>
-    <dependency>
-      <groupId>org.apache.logging.log4j</groupId>
-      <artifactId>log4j-1.2-api</artifactId>
-      <scope>test</scope>
-    </dependency>
   </dependencies>
   <build>
     <plugins>

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -450,6 +450,20 @@
               </resources>
             </configuration>
           </execution>
+          <execution>
+            <!-- Add the generated sources -->
+            <id>jspcSource-packageInfo-source</id>
+            <goals>
+              <goal>add-source</goal>
+            </goals>
+            <phase>generate-sources</phase>
+            <configuration>
+              <sources>
+                <source>${project.build.directory}/generated-jamon</source>
+                <source>${project.build.directory}/generated-sources/java</source>
+              </sources>
+            </configuration>
+          </execution>
         </executions>
       </plugin>
       <plugin>
@@ -537,26 +551,6 @@
                 <mkdir dir="${build.webapps}/regionserver/WEB-INF"/>
                 <jspcompiler outputdir="${generated.sources}/java" package="org.apache.hadoop.hbase.generated.regionserver" uriroot="${src.webapps}/regionserver" webxml="${build.webapps}/regionserver/WEB-INF/web.xml"/>
               </target>
-            </configuration>
-          </execution>
-        </executions>
-      </plugin>
-      <plugin>
-        <groupId>org.codehaus.mojo</groupId>
-        <artifactId>build-helper-maven-plugin</artifactId>
-        <executions>
-          <!-- Add the generated sources -->
-          <execution>
-            <id>jspcSource-packageInfo-source</id>
-            <goals>
-              <goal>add-source</goal>
-            </goals>
-            <phase>generate-sources</phase>
-            <configuration>
-              <sources>
-                <source>${project.build.directory}/generated-jamon</source>
-                <source>${project.build.directory}/generated-sources/java</source>
-              </sources>
             </configuration>
           </execution>
         </executions>


### PR DESCRIPTION
On master the Maven build prints the following warnings:

````
[WARNING] Some problems were encountered while building the effective model for org.apache.hbase:hbase-server:jar:4.0.0-alpha-1-SNAPSHOT
[WARNING] 'build.plugins.plugin.(groupId:artifactId)' must be unique but found duplicate declaration of plugin org.codehaus.mojo:build-helper-maven-plugin @ org.apache.hbase:hbase-server:${revision}, /home/david/projects/hbase/hbase-server/pom.xml, line 544, column 15
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.apache.hbase:hbase-examples:jar:4.0.0-alpha-1-SNAPSHOT
[WARNING] 'dependencies.dependency.(groupId:artifactId:type:classifier)' must be unique: org.apache.logging.log4j:log4j-1.2-api:jar -> duplicate declaration of version (?) @ org.apache.hbase:hbase-examples:${revision}, /home/david/projects/hbase/hbase-examples/pom.xml, line 203, column 17
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
```

Merged the executions of two usages of the build-helper-maven-plugin.

Removed duplicated log4j-1.2-api dependency in hbase-examples.