### PR TITLE
HBASE-29172: Fix to bug in ZstdByteBuffDecompressor

### DIFF
--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
@@ -98,6 +98,7 @@ public class ZstdByteBuffDecompressor implements ByteBuffDecompressor, CanReinit
       output.limit() - output.position(), input, input.position(), inputLen);
 
     output.position(origOutputPos + n);
+    input.position(input.position() + inputLen);
     return n;
   }
 
@@ -109,6 +110,7 @@ public class ZstdByteBuffDecompressor implements ByteBuffDecompressor, CanReinit
       inputLen);
 
     output.position(origOutputPos + n);
+    input.position(input.position() + inputLen);
     return n;
   }
 

--- a/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
@@ -46,8 +46,10 @@ public class TestZstdByteBuffDecompressor {
    * this structure: (block 1: (chunk 1: HBase is), (chunk 2: fun to use)), (block 2: (chunk 1: and
    * very fast))
    */
-  private static final byte[] COMPRESSED_PAYLOAD = Bytes.fromHex(
-    "000000130000001228b52ffd20094900004842617365206973200000001428b52ffd200b59000066756e20746f20757365200000000d0000001628b52ffd200d690000616e6420766572792066617374");
+  private static final byte[] COMPRESSED_PAYLOAD =
+    Bytes.fromHex("000000130000001228b52ffd200949000048426173652069732"
+      + "00000001428b52ffd200b59000066756e20746f207573652"
+      + "00000000d0000001628b52ffd200d690000616e6420766572792066617374");
 
   @Test
   public void testCapabilities() {

--- a/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
@@ -40,10 +40,17 @@ public class TestZstdByteBuffDecompressor {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestZstdByteBuffDecompressor.class);
 
-  // "HBase is awesome" compressed with zstd, and then prepended with metadata as a
-  // BlockCompressorStream would
+  // "HBase is fun to use and very fast" compressed with zstd, and then prepended with metadata as a
+  // BlockCompressorStream would. The phrase is split in three parts and put into the payload in
+  // this structure:
+  //   block 1:
+  //     chunk 1: HBase is
+  //     chunk 2: fun to use
+  //   block 2:
+  //     chunk 1: and very fast
+
   private static final byte[] COMPRESSED_PAYLOAD =
-    Bytes.fromHex("000000100000001928b52ffd2010810000484261736520697320617765736f6d65");
+    Bytes.fromHex("000000130000001228b52ffd20094900004842617365206973200000001428b52ffd200b59000066756e20746f20757365200000000d0000001628b52ffd200d690000616e6420766572792066617374");
 
   @Test
   public void testCapabilities() {
@@ -71,7 +78,7 @@ public class TestZstdByteBuffDecompressor {
       ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
       ByteBuff input = new SingleByteBuff(ByteBuffer.wrap(COMPRESSED_PAYLOAD));
       int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
-      assertEquals("HBase is awesome", Bytes.toString(output.toBytes(0, decompressedSize)));
+      assertEquals("HBase is fun to use and very fast", Bytes.toString(output.toBytes(0, decompressedSize)));
     }
   }
 
@@ -83,7 +90,7 @@ public class TestZstdByteBuffDecompressor {
       input.put(COMPRESSED_PAYLOAD);
       input.rewind();
       int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
-      assertEquals("HBase is awesome", Bytes.toString(output.toBytes(0, decompressedSize)));
+      assertEquals("HBase is fun to use and very fast", Bytes.toString(output.toBytes(0, decompressedSize)));
     }
   }
 

--- a/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
@@ -40,17 +40,14 @@ public class TestZstdByteBuffDecompressor {
   public static final HBaseClassTestRule CLASS_RULE =
     HBaseClassTestRule.forClass(TestZstdByteBuffDecompressor.class);
 
-  // "HBase is fun to use and very fast" compressed with zstd, and then prepended with metadata as a
-  // BlockCompressorStream would. The phrase is split in three parts and put into the payload in
-  // this structure:
-  //   block 1:
-  //     chunk 1: HBase is
-  //     chunk 2: fun to use
-  //   block 2:
-  //     chunk 1: and very fast
-
-  private static final byte[] COMPRESSED_PAYLOAD =
-    Bytes.fromHex("000000130000001228b52ffd20094900004842617365206973200000001428b52ffd200b59000066756e20746f20757365200000000d0000001628b52ffd200d690000616e6420766572792066617374");
+  /*
+   * "HBase is fun to use and very fast" compressed with zstd, and then prepended with metadata as a
+   * BlockCompressorStream would. The phrase is split in three parts and put into the payload in
+   * this structure: (block 1: (chunk 1: HBase is), (chunk 2: fun to use)), (block 2: (chunk 1: and
+   * very fast))
+   */
+  private static final byte[] COMPRESSED_PAYLOAD = Bytes.fromHex(
+    "000000130000001228b52ffd20094900004842617365206973200000001428b52ffd200b59000066756e20746f20757365200000000d0000001628b52ffd200d690000616e6420766572792066617374");
 
   @Test
   public void testCapabilities() {
@@ -78,7 +75,8 @@ public class TestZstdByteBuffDecompressor {
       ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
       ByteBuff input = new SingleByteBuff(ByteBuffer.wrap(COMPRESSED_PAYLOAD));
       int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
-      assertEquals("HBase is fun to use and very fast", Bytes.toString(output.toBytes(0, decompressedSize)));
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
     }
   }
 
@@ -90,7 +88,8 @@ public class TestZstdByteBuffDecompressor {
       input.put(COMPRESSED_PAYLOAD);
       input.rewind();
       int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
-      assertEquals("HBase is fun to use and very fast", Bytes.toString(output.toBytes(0, decompressedSize)));
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
     }
   }
 


### PR DESCRIPTION
My recent contribution in HBASE-29135 has a bug. `ZstdByteBuffDecompressor` doesn't update the position of the input `ByteBuffer` after reading from it. When there are multiple "chunks" in the input buffer, this causes failure to read chunks after the first one.

This PR fixes the bug and adjusts an existing test to verify the fix.