### PR TITLE
HBASE-29179: Fall back to hbase.rpc.rows.warning.threshold if hbase.client.write.buffer.maxmutations is not set (branch-2)

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionConfiguration.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionConfiguration.java
@@ -155,8 +155,8 @@ public class ConnectionConfiguration {
 
     this.maxKeyValueSize = conf.getInt(MAX_KEYVALUE_SIZE_KEY, MAX_KEYVALUE_SIZE_DEFAULT);
 
-    this.bufferedMutatorMaxMutations =
-      conf.getInt(BUFFERED_MUTATOR_MAX_MUTATIONS_KEY, BUFFERED_MUTATOR_MAX_MUTATIONS_DEFAULT);
+    this.bufferedMutatorMaxMutations = conf.getInt(BUFFERED_MUTATOR_MAX_MUTATIONS_KEY,
+      conf.getInt(HConstants.BATCH_ROWS_THRESHOLD_NAME, BUFFERED_MUTATOR_MAX_MUTATIONS_DEFAULT));
 
     this.rpcTimeout =
       conf.getInt(HConstants.HBASE_RPC_TIMEOUT_KEY, HConstants.DEFAULT_HBASE_RPC_TIMEOUT);

--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -1909,6 +1909,8 @@ possible configurations would overwhelm and obscure the important.
     <value>5000</value>
     <description>
       Number of rows in a batch operation above which a warning will be logged.
+      If hbase.client.write.buffer.maxmutations is not set, this will be used as
+      fallback for that setting.
     </description>
   </property>
   <property>


### PR DESCRIPTION
Addendum to [prior PR](https://github.com/apache/hbase/pull/6718) based on [this suggestion](https://issues.apache.org/jira/browse/HBASE-29148?focusedCommentId=17931208&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-17931208). 