### PR TITLE
HBASE-28990 Modify Incremental Backup for Continuous Backup

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
@@ -519,7 +519,11 @@ public class BackupAdminImpl implements BackupAdmin {
     if (type == BackupType.INCREMENTAL) {
       Set<TableName> incrTableSet;
       try (BackupSystemTable table = new BackupSystemTable(conn)) {
-        incrTableSet = table.getIncrementalBackupTableSet(targetRootDir);
+        if (request.isContinuousBackupEnabled()) {
+          incrTableSet = table.getContinuousBackupTableSet().keySet();
+        } else {
+          incrTableSet = table.getIncrementalBackupTableSet(targetRootDir);
+        }
       }
 
       if (incrTableSet.isEmpty()) {

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupManager.java
@@ -436,4 +436,15 @@ public class BackupManager implements Closeable {
     throws IOException {
     systemTable.addContinuousBackupTableSet(tables, startTimestamp);
   }
+
+  /**
+   * Retrieves the current set of tables covered by continuous backup along with the timestamp
+   * indicating when continuous backup started for each table.
+   * @return a map where the key is the table name and the value is the timestamp representing the
+   *         start time of continuous backup for that table.
+   * @throws IOException if an I/O error occurs while accessing the backup system table.
+   */
+  public Map<TableName, Long> getContinuousBackupTableSet() throws IOException {
+    return systemTable.getContinuousBackupTableSet();
+  }
 }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
@@ -384,6 +384,9 @@ public class IncrementalTableBackupClient extends TableBackupClient {
     List<String> incrBackupFileList = backupInfo.getIncrBackupFileList();
     // Get list of tables in incremental backup set
     Set<TableName> tableSet = backupManager.getIncrementalBackupTableSet();
+    if (backupInfo.isContinuousBackupEnabled()) {
+      tableSet = backupManager.getContinuousBackupTableSet().keySet();
+    }
     // filter missing files out (they have been copied by previous backups)
     incrBackupFileList = filterMissingFiles(incrBackupFileList);
     List<String> tableList = new ArrayList<String>();
@@ -396,7 +399,6 @@ public class IncrementalTableBackupClient extends TableBackupClient {
       }
     }
     walToHFiles(incrBackupFileList, tableList);
-
   }
 
   protected boolean tableExists(TableName table, Connection conn) throws IOException {

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/replication/ContinuousBackupReplicationEndpoint.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/replication/ContinuousBackupReplicationEndpoint.java
@@ -19,8 +19,9 @@ package org.apache.hadoop.hbase.backup.replication;
 
 import java.io.IOException;
 import java.io.UncheckedIOException;
-import java.text.SimpleDateFormat;
-import java.util.Date;
+import java.time.Instant;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import java.util.Map;
 import java.util.UUID;
@@ -282,8 +283,9 @@ public class ContinuousBackupReplicationEndpoint extends BaseReplicationEndpoint
 
   private FSHLogProvider.Writer createWalWriter(long dayInMillis) {
     // Convert dayInMillis to "yyyy-MM-dd" format
-    SimpleDateFormat dateFormat = new SimpleDateFormat(DATE_FORMAT);
-    String dayDirectoryName = dateFormat.format(new Date(dayInMillis));
+    DateTimeFormatter formatter =
+      DateTimeFormatter.ofPattern(DATE_FORMAT).withZone(ZoneId.systemDefault());
+    String dayDirectoryName = formatter.format(Instant.ofEpochMilli(dayInMillis));
 
     FileSystem fs = backupFileSystemManager.getBackupFs();
     Path walsDir = backupFileSystemManager.getWalsDir();

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestContinuousBackup.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestContinuousBackup.java
@@ -259,8 +259,7 @@ public class TestContinuousBackup extends TestBackupBase {
     }
   }
 
-  private String[] buildBackupArgs(String backupType, TableName[] tables,
-    boolean continuousEnabled) {
+  String[] buildBackupArgs(String backupType, TableName[] tables, boolean continuousEnabled) {
     String tableNames =
       Arrays.stream(tables).map(TableName::getNameAsString).collect(Collectors.joining(","));
 
@@ -272,7 +271,7 @@ public class TestContinuousBackup extends TestBackupBase {
     }
   }
 
-  private BackupManifest getLatestBackupManifest(List<BackupInfo> backups) throws IOException {
+  BackupManifest getLatestBackupManifest(List<BackupInfo> backups) throws IOException {
     BackupInfo newestBackup = backups.get(0);
     return HBackupFileSystem.getManifest(conf1, new Path(BACKUP_ROOT_DIR),
       newestBackup.getBackupId());
@@ -286,16 +285,6 @@ public class TestContinuousBackup extends TestBackupBase {
         tableBackupMap.containsKey(table));
 
       assertTrue("Timestamp for table should be greater than 0", tableBackupMap.get(table) > 0);
-    }
-  }
-
-  private void deleteContinuousBackupReplicationPeerIfExists(Admin admin) throws IOException {
-    if (
-      admin.listReplicationPeers().stream()
-        .anyMatch(peer -> peer.getPeerId().equals(CONTINUOUS_BACKUP_REPLICATION_PEER))
-    ) {
-      admin.disableReplicationPeer(CONTINUOUS_BACKUP_REPLICATION_PEER);
-      admin.removeReplicationPeer(CONTINUOUS_BACKUP_REPLICATION_PEER);
     }
   }
 

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupWithContinuous.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupWithContinuous.java
@@ -1,0 +1,155 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup;
+
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.*;
+import static org.apache.hadoop.hbase.backup.replication.ContinuousBackupReplicationEndpoint.CONF_STAGED_WAL_FLUSH_INITIAL_DELAY;
+import static org.apache.hadoop.hbase.backup.replication.ContinuousBackupReplicationEndpoint.CONF_STAGED_WAL_FLUSH_INTERVAL;
+import static org.junit.Assert.*;
+
+import java.io.IOException;
+import java.util.*;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.backup.impl.BackupAdminImpl;
+import org.apache.hadoop.hbase.backup.impl.BackupManifest;
+import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
+import org.apache.hadoop.hbase.backup.util.BackupUtils;
+import org.apache.hadoop.hbase.client.*;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.util.ToolRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.Sets;
+
+@Category(LargeTests.class)
+public class TestIncrementalBackupWithContinuous extends TestContinuousBackup {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestIncrementalBackupWithContinuous.class);
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestIncrementalBackupWithContinuous.class);
+
+  private byte[] ROW = Bytes.toBytes("row1");
+  private final byte[] FAMILY = Bytes.toBytes("family");
+  private final byte[] COLUMN = Bytes.toBytes("col");
+  String backupWalDirName = "TestContinuousBackupWalDir";
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    TEST_UTIL = new HBaseTestingUtil();
+    conf1 = TEST_UTIL.getConfiguration();
+    autoRestoreOnFailure = true;
+    useSecondCluster = false;
+    conf1.setInt(CONF_STAGED_WAL_FLUSH_INTERVAL, 1);
+    conf1.setInt(CONF_STAGED_WAL_FLUSH_INITIAL_DELAY, 1);
+    setUpHelper();
+  }
+
+  @Before
+  public void beforeTest() throws IOException {
+    super.beforeTest();
+  }
+
+  @After
+  public void afterTest() throws IOException {
+    super.afterTest();
+  }
+
+  @Test
+  public void testContinuousBackupWithIncrementalBackupSuccess() throws Exception {
+    LOG.info("Testing incremental backup with continuous backup");
+    String methodName = Thread.currentThread().getStackTrace()[1].getMethodName();
+    TableName tableName = TableName.valueOf("table_" + methodName);
+    Table t1 = TEST_UTIL.createTable(tableName, FAMILY);
+
+    try (BackupSystemTable table = new BackupSystemTable(TEST_UTIL.getConnection())) {
+      int before = table.getBackupHistory().size();
+
+      // Run continuous backup
+      String[] args = buildBackupArgs("full", new TableName[] { tableName }, true);
+      int ret = ToolRunner.run(conf1, new BackupDriver(), args);
+      assertEquals("Full Backup should succeed", 0, ret);
+
+      // Verify backup history increased and all the backups are succeeded
+      LOG.info("Verify backup history increased and all the backups are succeeded");
+      List<BackupInfo> backups = table.getBackupHistory();
+      assertEquals("Backup history should increase", before + 1, backups.size());
+      for (BackupInfo data : List.of(backups.get(0))) {
+        String backupId = data.getBackupId();
+        assertTrue(checkSucceeded(backupId));
+      }
+
+      // Verify backup manifest contains the correct tables
+      LOG.info("Verify backup manifest contains the correct tables");
+      BackupManifest manifest = getLatestBackupManifest(backups);
+      assertEquals("Backup should contain the expected tables", Sets.newHashSet(tableName),
+        new HashSet<>(manifest.getTableList()));
+
+      Put p = new Put(ROW);
+      p.addColumn(FAMILY, COLUMN, COLUMN);
+      t1.put(p);
+      // Thread.sleep(5000);
+
+      // Run incremental backup
+      LOG.info("ANKIT now run incremental backup");
+      before = table.getBackupHistory().size();
+      args = buildBackupArgs("incremental", new TableName[] { tableName }, false);
+      ret = ToolRunner.run(conf1, new BackupDriver(), args);
+      assertEquals("Incremental Backup should succeed", 0, ret);
+
+      // Verify backup history increased and all the backups are succeeded
+      backups = table.getBackupHistory();
+      String incrementalBackupid = null;
+      assertEquals("Backup history should increase", before + 1, backups.size());
+      for (BackupInfo data : List.of(backups.get(0))) {
+        String backupId = data.getBackupId();
+        incrementalBackupid = backupId;
+        assertTrue(checkSucceeded(backupId));
+      }
+
+      TEST_UTIL.truncateTable(tableName);
+      // Restore incremental backup
+      TableName[] tables = new TableName[] { tableName };
+      BackupAdminImpl client = new BackupAdminImpl(TEST_UTIL.getConnection());
+      client.restore(BackupUtils.createRestoreRequest(BACKUP_ROOT_DIR, incrementalBackupid, false,
+        tables, tables, true));
+
+      verifyTable(t1);
+    }
+  }
+
+  private void verifyTable(Table t1) throws IOException {
+    Get g = new Get(ROW);
+    Result r = t1.get(g);
+    assertEquals(1, r.size());
+    assertTrue(CellUtil.matchingQualifier(r.rawCells()[0], COLUMN));
+  }
+}


### PR DESCRIPTION
The incremental backup collects all the WALs generated since the last full or incremental backup and processes them into HFiles for optimized restoration. With the new continuous backup feature, the necessary WALs are already available at the backup location and are used directly, eliminating the need to retrieve them from the source cluster.

The incremental backup command itself remains unchanged.

If previous backups are part of a continuous backup: Uses the WALs already backed up in the backup location.

If previous backups are not part of a continuous backup: Operates as a traditional incremental backup, collecting WALs from the source cluster.

JIRA: https://issues.apache.org/jira/browse/HBASE-28990