### PR TITLE
HBASE-29193: Allow ZstdByteBuffDecompressor to take direct ByteBuffer as input and heap ByteBuffer as output, or vice versa

### DIFF
--- a/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/test/java/org/apache/hadoop/hbase/io/compress/zstd/TestZstdByteBuffDecompressor.java
@@ -62,8 +62,8 @@ public class TestZstdByteBuffDecompressor {
     try (ZstdByteBuffDecompressor decompressor = new ZstdByteBuffDecompressor(null)) {
       assertTrue(decompressor.canDecompress(emptySingleHeapBuff, emptySingleHeapBuff));
       assertTrue(decompressor.canDecompress(emptySingleDirectBuff, emptySingleDirectBuff));
-      assertFalse(decompressor.canDecompress(emptySingleHeapBuff, emptySingleDirectBuff));
-      assertFalse(decompressor.canDecompress(emptySingleDirectBuff, emptySingleHeapBuff));
+      assertTrue(decompressor.canDecompress(emptySingleHeapBuff, emptySingleDirectBuff));
+      assertTrue(decompressor.canDecompress(emptySingleDirectBuff, emptySingleHeapBuff));
       assertFalse(decompressor.canDecompress(emptyMultiHeapBuff, emptyMultiHeapBuff));
       assertFalse(decompressor.canDecompress(emptyMultiDirectBuff, emptyMultiDirectBuff));
       assertFalse(decompressor.canDecompress(emptySingleHeapBuff, emptyMultiHeapBuff));
@@ -72,7 +72,7 @@ public class TestZstdByteBuffDecompressor {
   }
 
   @Test
-  public void testDecompressHeap() throws IOException {
+  public void testDecompressHeapToHeap() throws IOException {
     try (ZstdByteBuffDecompressor decompressor = new ZstdByteBuffDecompressor(null)) {
       ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
       ByteBuff input = new SingleByteBuff(ByteBuffer.wrap(COMPRESSED_PAYLOAD));
@@ -83,12 +83,36 @@ public class TestZstdByteBuffDecompressor {
   }
 
   @Test
-  public void testDecompressDirect() throws IOException {
+  public void testDecompressDirectToDirect() throws IOException {
     try (ZstdByteBuffDecompressor decompressor = new ZstdByteBuffDecompressor(null)) {
       ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
       ByteBuff input = new SingleByteBuff(ByteBuffer.allocateDirect(COMPRESSED_PAYLOAD.length));
       input.put(COMPRESSED_PAYLOAD);
       input.rewind();
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
+    }
+  }
+
+  @Test
+  public void testDecompressDirectToHeap() throws IOException {
+    try (ZstdByteBuffDecompressor decompressor = new ZstdByteBuffDecompressor(null)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = new SingleByteBuff(ByteBuffer.allocateDirect(COMPRESSED_PAYLOAD.length));
+      input.put(COMPRESSED_PAYLOAD);
+      input.rewind();
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
+    }
+  }
+
+  @Test
+  public void testDecompressHeapToDirect() throws IOException {
+    try (ZstdByteBuffDecompressor decompressor = new ZstdByteBuffDecompressor(null)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = new SingleByteBuff(ByteBuffer.wrap(COMPRESSED_PAYLOAD));
       int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
       assertEquals("HBase is fun to use and very fast",
         Bytes.toString(output.toBytes(0, decompressedSize)));

--- a/pom.xml
+++ b/pom.xml
@@ -930,7 +930,7 @@
     <brotli4j.version>1.11.0</brotli4j.version>
     <lz4.version>1.8.0</lz4.version>
     <snappy.version>1.1.10.4</snappy.version>
-    <zstd-jni.version>1.5.5-2</zstd-jni.version>
+    <zstd-jni.version>1.5.7-2</zstd-jni.version>
     <!--
         Note that the version of protobuf shipped in hbase-thirdparty must match the version used
         in hbase-protocol-shaded and hbase-examples. The version of jackson-[annotations,core,


### PR DESCRIPTION
At present, `ZstdByteBuffDecompressor` is limited to decompressing from a direct ByteBuffer to another direct ByteBuffer, or from a heap ByteBuffer to another heap ByteBuffer. Following a [change](https://github.com/luben/zstd-jni/pull/351) I contributed to the zstd-jni project, this limitation can be removed.