### PR TITLE
HBASE-29205 Bump hbase-thirdparty to 4.1.10 in branch-2.5

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/EncryptionUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/EncryptionUtil.java
@@ -120,7 +120,7 @@ public final class EncryptionUtil {
   public static Key unwrapKey(Configuration conf, String subject, byte[] value)
     throws IOException, KeyException {
     EncryptionProtos.WrappedKey wrappedKey =
-      EncryptionProtos.WrappedKey.PARSER.parseDelimitedFrom(new ByteArrayInputStream(value));
+      EncryptionProtos.WrappedKey.parser().parseDelimitedFrom(new ByteArrayInputStream(value));
     String algorithm = conf.get(HConstants.CRYPTO_KEY_ALGORITHM_CONF_KEY, HConstants.CIPHER_AES);
     Cipher cipher = Encryption.getCipher(conf, algorithm);
     if (cipher == null) {
@@ -170,7 +170,7 @@ public final class EncryptionUtil {
   public static Key unwrapWALKey(Configuration conf, String subject, byte[] value)
     throws IOException, KeyException {
     EncryptionProtos.WrappedKey wrappedKey =
-      EncryptionProtos.WrappedKey.PARSER.parseDelimitedFrom(new ByteArrayInputStream(value));
+      EncryptionProtos.WrappedKey.parser().parseDelimitedFrom(new ByteArrayInputStream(value));
     String algorithm = conf.get(HConstants.CRYPTO_WAL_ALGORITHM_CONF_KEY, HConstants.CIPHER_AES);
     Cipher cipher = Encryption.getCipher(conf, algorithm);
     if (cipher == null) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -3071,7 +3071,7 @@ public final class ProtobufUtil {
       int prefixLen = ProtobufMagic.lengthOfPBMagic();
       try {
         ZooKeeperProtos.Master rss =
-          ZooKeeperProtos.Master.PARSER.parseFrom(data, prefixLen, data.length - prefixLen);
+          ZooKeeperProtos.Master.parser().parseFrom(data, prefixLen, data.length - prefixLen);
         org.apache.hadoop.hbase.shaded.protobuf.generated.HBaseProtos.ServerName sn =
           rss.getMaster();
         return ServerName.valueOf(sn.getHostName(), sn.getPort(), sn.getStartCode());

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestHtmlQuoting.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/TestHtmlQuoting.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.http;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import javax.servlet.http.HttpServletRequest;
@@ -94,7 +95,7 @@ public class TestHtmlQuoting {
       quoter.getParameterValues("x"));
 
     Mockito.doReturn(null).when(mockReq).getParameterValues("x");
-    assertArrayEquals("Test that missing parameters dont cause NPE for array", null,
+    assertNull("Test that missing parameters dont cause NPE for array",
       quoter.getParameterValues("x"));
   }
 }

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestsDriver.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestsDriver.java
@@ -77,7 +77,7 @@ public class IntegrationTestsDriver extends AbstractHBaseTool {
 
   @Override
   protected void processOptions(CommandLine cmd) {
-    String testFilterString = cmd.getOptionValue(SHORT_REGEX_ARG, null);
+    String testFilterString = cmd.getOptionValue(SHORT_REGEX_ARG);
     if (testFilterString != null) {
       intTestFilter.setPattern(testFilterString);
     }

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
@@ -227,7 +227,7 @@ public class TableSnapshotInputFormatImpl {
       int len = in.readInt();
       byte[] buf = new byte[len];
       in.readFully(buf);
-      TableSnapshotRegionSplit split = TableSnapshotRegionSplit.PARSER.parseFrom(buf);
+      TableSnapshotRegionSplit split = TableSnapshotRegionSplit.parser().parseFrom(buf);
       this.htd = ProtobufUtil.toTableDescriptor(split.getTable());
       this.regionInfo = HRegionInfo.convert(split.getRegion());
       List<String> locationsList = split.getLocationsList();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/FixedFileTrailer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/FixedFileTrailer.java
@@ -267,7 +267,7 @@ public class FixedFileTrailer {
     // read PB and skip padding
     int start = inputStream.available();
     HFileProtos.FileTrailerProto trailerProto =
-      HFileProtos.FileTrailerProto.PARSER.parseDelimitedFrom(inputStream);
+      HFileProtos.FileTrailerProto.parser().parseDelimitedFrom(inputStream);
     int size = start - inputStream.available();
     inputStream.skip(getTrailerSize() - NOT_PB_SIZE - size);
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/compaction/MajorCompactor.java
@@ -420,7 +420,7 @@ public class MajorCompactor extends Configured implements Tool {
       return -1;
     }
     String tableName = commandLine.getOptionValue("table");
-    String cf = commandLine.getOptionValue("cf", null);
+    String cf = commandLine.getOptionValue("cf");
     Set<String> families = Sets.newHashSet();
     if (cf != null) {
       Iterables.addAll(families, Splitter.on(",").split(cf));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotasWithSnapshots.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestSpaceQuotasWithSnapshots.java
@@ -164,7 +164,7 @@ public class TestSpaceQuotasWithSnapshots {
     // Make sure we see the "final" new size for the table, not some intermediate
     waitForStableRegionSizeReport(conn, tn);
     final long finalSize = getRegionSizeReportForTable(conn, tn);
-    assertNotNull("Did not expect to see a null size", finalSize);
+    assertTrue("Table data size must be greater than zero", finalSize > 0);
     LOG.info("Last seen size: " + finalSize);
 
     // Make sure the QuotaObserverChore has time to reflect the new region size reports
@@ -263,7 +263,7 @@ public class TestSpaceQuotasWithSnapshots {
     // Make sure we see the "final" new size for the table, not some intermediate
     waitForStableRegionSizeReport(conn, tn);
     final long finalSize = getRegionSizeReportForTable(conn, tn);
-    assertNotNull("Did not expect to see a null size", finalSize);
+    assertTrue("Table data size must be greater than zero", finalSize > 0);
     LOG.info("Final observed size of table: " + finalSize);
 
     // Make sure the QuotaObserverChore has time to reflect the new region size reports

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegionInfo.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegionInfo.java
@@ -311,7 +311,7 @@ public class TestHRegionInfo {
     b = new HRegionInfo(t.getTableName(), midway, null);
     assertTrue(a.compareTo(b) < 0);
     assertTrue(b.compareTo(a) > 0);
-    assertEquals(a, a);
+    assertTrue(a.equals(a));
     assertEquals(0, a.compareTo(a));
     a = new HRegionInfo(t.getTableName(), Bytes.toBytes("a"), Bytes.toBytes("d"));
     b = new HRegionInfo(t.getTableName(), Bytes.toBytes("e"), Bytes.toBytes("g"));

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -90,7 +90,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.4.1</version>
+          <version>3.5.1</version>
           <executions>
             <execution>
               <id>aggregate-into-a-jar-with-relocated-third-parties</id>

--- a/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift2/TestThriftHBaseServiceHandler.java
+++ b/hbase-thrift/src/test/java/org/apache/hadoop/hbase/thrift2/TestThriftHBaseServiceHandler.java
@@ -518,7 +518,7 @@ public class TestThriftHBaseServiceHandler {
 
     get = new TGet(wrap(rowName));
     result = handler.get(table, get);
-    assertArrayEquals(null, result.getRow());
+    assertNull(result.getRow());
     assertEquals(0, result.getColumnValuesSize());
   }
 

--- a/pom.xml
+++ b/pom.xml
@@ -629,7 +629,7 @@
     -->
     <checkstyle.version>8.29</checkstyle.version>
     <exec.maven.version>3.1.0</exec.maven.version>
-    <error-prone.version>2.16</error-prone.version>
+    <error-prone.version>2.26.1</error-prone.version>
     <jamon.plugin.version>2.4.2</jamon.plugin.version>
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
     <maven.antrun.version>1.8</maven.antrun.version>

--- a/pom.xml
+++ b/pom.xml
@@ -604,9 +604,11 @@
     <external.protobuf.groupid>com.google.protobuf</external.protobuf.groupid>
     <external.protobuf.version>2.5.0</external.protobuf.version>
     <external.protoc.version>${external.protobuf.version}</external.protoc.version>
-    <!--Version of protobuf that hbase uses internally (we shade our pb)
-         Must match what is out in hbase-thirdparty include. -->
-    <internal.protobuf.version>4.27.3</internal.protobuf.version>
+    <!--
+      Version of protobuf that hbase uses internally (we shade our pb) Must match what is out
+      in hbase-thirdparty include.
+    -->
+    <internal.protobuf.version>4.28.2</internal.protobuf.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
     <thrift.path>thrift</thrift.path>
     <thrift.version>0.14.1</thrift.version>
@@ -667,7 +669,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.8</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.9</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>

--- a/pom.xml
+++ b/pom.xml
@@ -587,8 +587,8 @@
       Note that the version of jackson-[annotations,core,databind] must be kept in sync with the
       version of jackson-jaxrs-json-provider shipped in hbase-thirdparty.
     -->
-    <jackson.version>2.16.1</jackson.version>
-    <jackson.databind.version>2.16.1</jackson.databind.version>
+    <jackson.version>2.17.0</jackson.version>
+    <jackson.databind.version>2.17.0</jackson.databind.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
@@ -606,7 +606,7 @@
     <external.protoc.version>${external.protobuf.version}</external.protoc.version>
     <!--Version of protobuf that hbase uses internally (we shade our pb)
          Must match what is out in hbase-thirdparty include. -->
-    <internal.protobuf.version>3.25.2</internal.protobuf.version>
+    <internal.protobuf.version>4.26.1</internal.protobuf.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
     <thrift.path>thrift</thrift.path>
     <thrift.version>0.14.1</thrift.version>
@@ -667,7 +667,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.6</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.7</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>

--- a/pom.xml
+++ b/pom.xml
@@ -669,7 +669,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.9</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.10</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>

--- a/pom.xml
+++ b/pom.xml
@@ -583,8 +583,12 @@
     <httpclient.version>4.5.13</httpclient.version>
     <httpcore.version>4.4.13</httpcore.version>
     <metrics-core.version>3.2.6</metrics-core.version>
-    <jackson.version>2.15.2</jackson.version>
-    <jackson.databind.version>2.15.2</jackson.databind.version>
+    <!--
+      Note that the version of jackson-[annotations,core,databind] must be kept in sync with the
+      version of jackson-jaxrs-json-provider shipped in hbase-thirdparty.
+    -->
+    <jackson.version>2.16.1</jackson.version>
+    <jackson.databind.version>2.16.1</jackson.databind.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
@@ -602,7 +606,7 @@
     <external.protoc.version>${external.protobuf.version}</external.protoc.version>
     <!--Version of protobuf that hbase uses internally (we shade our pb)
          Must match what is out in hbase-thirdparty include. -->
-    <internal.protobuf.version>3.24.3</internal.protobuf.version>
+    <internal.protobuf.version>3.25.2</internal.protobuf.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
     <thrift.path>thrift</thrift.path>
     <thrift.version>0.14.1</thrift.version>
@@ -657,7 +661,13 @@
     <snappy.version>1.1.10.4</snappy.version>
     <xz.version>1.9</xz.version>
     <zstd-jni.version>1.5.5-2</zstd-jni.version>
-    <hbase-thirdparty.version>4.1.5</hbase-thirdparty.version>
+    <!--
+        Note that the version of protobuf shipped in hbase-thirdparty must match the version used
+        in hbase-protocol-shaded and hbase-examples. The version of jackson-[annotations,core,
+        databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
+        hbase-thirdparty.
+    -->
+    <hbase-thirdparty.version>4.1.6</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>

--- a/pom.xml
+++ b/pom.xml
@@ -587,8 +587,8 @@
       Note that the version of jackson-[annotations,core,databind] must be kept in sync with the
       version of jackson-jaxrs-json-provider shipped in hbase-thirdparty.
     -->
-    <jackson.version>2.17.0</jackson.version>
-    <jackson.databind.version>2.17.0</jackson.databind.version>
+    <jackson.version>2.17.2</jackson.version>
+    <jackson.databind.version>2.17.2</jackson.databind.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
@@ -606,7 +606,7 @@
     <external.protoc.version>${external.protobuf.version}</external.protoc.version>
     <!--Version of protobuf that hbase uses internally (we shade our pb)
          Must match what is out in hbase-thirdparty include. -->
-    <internal.protobuf.version>4.26.1</internal.protobuf.version>
+    <internal.protobuf.version>4.27.3</internal.protobuf.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
     <thrift.path>thrift</thrift.path>
     <thrift.version>0.14.1</thrift.version>
@@ -633,7 +633,7 @@
     -->
     <checkstyle.version>8.29</checkstyle.version>
     <exec.maven.version>3.1.0</exec.maven.version>
-    <error-prone.version>2.26.1</error-prone.version>
+    <error-prone.version>2.28.0</error-prone.version>
     <jamon.plugin.version>2.4.2</jamon.plugin.version>
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
     <maven.antrun.version>1.8</maven.antrun.version>
@@ -667,7 +667,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.7</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.8</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>


### PR DESCRIPTION
We can either squash these into a single commit, or backport the five patches one-by-one (reordered, and with the right commit message).

Which one do you prefer ?