### PR TITLE
Backport "HBASE-29103 Avoid excessive allocations during reverse scanning when …" to branch-2.5

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileScanner.java
@@ -490,7 +490,7 @@ public class StoreFileScanner implements KeyValueScanner {
             this.cur = null;
             return false;
           }
-          Cell curCell = hfs.getCell();
+          Cell curCell = hfs.getKey();
           Cell firstKeyOfPreviousRow = PrivateCellUtil.createFirstOnRow(curCell);
 
           if (seekCount != null) seekCount.increment();


### PR DESCRIPTION
…seeking to next row (#6643)

cc @rmdmattingly 