### PR TITLE
HBASE-29210: Introduce Validation for PITR-Critical Backup Deletion

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupDriver.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.backup;
 
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.LONG_OPTION_ENABLE_CONTINUOUS_BACKUP;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.LONG_OPTION_FORCE_DELETE;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BACKUP_LIST_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BANDWIDTH;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_BANDWIDTH_DESC;
@@ -25,6 +26,8 @@ import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_DEBUG_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_ENABLE_CONTINUOUS_BACKUP;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_ENABLE_CONTINUOUS_BACKUP_DESC;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_FORCE_DELETE;
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_FORCE_DELETE_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_IGNORECHECKSUM;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_IGNORECHECKSUM_DESC;
 import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.OPTION_KEEP;
@@ -164,6 +167,7 @@ public class BackupDriver extends AbstractHBaseTool {
     addOptWithArg(OPTION_YARN_QUEUE_NAME, OPTION_YARN_QUEUE_NAME_DESC);
     addOptNoArg(OPTION_ENABLE_CONTINUOUS_BACKUP, LONG_OPTION_ENABLE_CONTINUOUS_BACKUP,
       OPTION_ENABLE_CONTINUOUS_BACKUP_DESC);
+    addOptNoArg(OPTION_FORCE_DELETE, LONG_OPTION_FORCE_DELETE, OPTION_FORCE_DELETE_DESC);
   }
 
   @Override

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupRestoreConstants.java
@@ -101,6 +101,11 @@ public interface BackupRestoreConstants {
   String OPTION_ENABLE_CONTINUOUS_BACKUP_DESC =
     "Flag indicating that the full backup is part of a continuous backup process.";
 
+  String OPTION_FORCE_DELETE = "fd";
+  String LONG_OPTION_FORCE_DELETE = "force-delete";
+  String OPTION_FORCE_DELETE_DESC =
+    "Flag to forcefully delete the backup, even if it may be required for Point-in-Time Restore";
+
   String JOB_NAME_CONF_KEY = "mapreduce.job.name";
 
   String BACKUP_CONFIG_STRING =
@@ -133,6 +138,9 @@ public interface BackupRestoreConstants {
     "org.apache.hadoop.hbase.backup.replication.ContinuousBackupReplicationEndpoint";
 
   String CONF_CONTINUOUS_BACKUP_WAL_DIR = "hbase.backup.continuous.wal.dir";
+
+  String CONF_CONTINUOUS_BACKUP_PITR_WINDOW_DAYS = "hbase.backup.continuous.pitr.window.days";
+  long DEFAULT_CONTINUOUS_BACKUP_PITR_WINDOW_DAYS = 30;
 
   enum BackupCommand {
     CREATE,

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -745,7 +745,6 @@ public final class BackupCommands {
       List<TableName> dependentTables = new ArrayList<>();
 
       try (final BackupSystemTable backupSystemTable = new BackupSystemTable(conn)) {
-        List<BackupInfo> backupHistory = backupSystemTable.getBackupInfos(BackupState.COMPLETE);
         BackupInfo targetBackup = backupSystemTable.readBackupInfo(backupId);
 
         if (targetBackup == null) {
@@ -793,6 +792,7 @@ public final class BackupCommands {
           }
 
           // Check if another valid full backup exists for this table
+          List<BackupInfo> backupHistory = backupSystemTable.getBackupInfos(BackupState.COMPLETE);
           long finalPitrMaxStartTime = pitrMaxStartTime;
           boolean hasAnotherValidBackup = backupHistory.stream()
             .anyMatch(backup -> !backup.getBackupId().equals(backupId) && isValidPITRBackup(backup,

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupCommands.java
@@ -793,7 +793,7 @@ public final class BackupCommands {
 
           // Check if another valid full backup exists for this table
           List<BackupInfo> backupHistory = backupSystemTable.getBackupInfos(BackupState.COMPLETE);
-          long finalPitrMaxStartTime = pitrMaxStartTime;
+          final long finalPitrMaxStartTime = pitrMaxStartTime;
           boolean hasAnotherValidBackup = backupHistory.stream()
             .anyMatch(backup -> !backup.getBackupId().equals(backupId) && isValidPITRBackup(backup,
               table, continuousBackupStartTimes, finalPitrMaxStartTime));

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupDelete.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupDelete.java
@@ -17,12 +17,18 @@
  */
 package org.apache.hadoop.hbase.backup;
 
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.CONF_CONTINUOUS_BACKUP_PITR_WINDOW_DAYS;
+import static org.apache.hadoop.hbase.backup.replication.ContinuousBackupReplicationEndpoint.ONE_DAY_IN_MILLISECONDS;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
 
 import java.io.ByteArrayOutputStream;
 import java.io.PrintStream;
 import java.util.List;
+import java.util.Set;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
@@ -32,7 +38,6 @@ import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.util.EnvironmentEdge;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.util.ToolRunner;
-import org.junit.Assert;
 import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -138,7 +143,7 @@ public class TestBackupDelete extends TestBackupBase {
       assertTrue(ret == 0);
     } catch (Exception e) {
       LOG.error("failed", e);
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
     String output = baos.toString();
     LOG.info(baos.toString());
@@ -154,7 +159,7 @@ public class TestBackupDelete extends TestBackupBase {
       assertTrue(ret == 0);
     } catch (Exception e) {
       LOG.error("failed", e);
-      Assert.fail(e.getMessage());
+      fail(e.getMessage());
     }
     output = baos.toString();
     LOG.info(baos.toString());
@@ -182,5 +187,87 @@ public class TestBackupDelete extends TestBackupBase {
     getBackupAdmin().deleteBackups(new String[] { backupId1 });
     assertEquals(Sets.newHashSet(table3),
       backupSystemTable.getIncrementalBackupTableSet(BACKUP_ROOT_DIR));
+  }
+
+  @Test
+  public void testPITRBackupDeletion() throws Exception {
+    conf1.setLong(CONF_CONTINUOUS_BACKUP_PITR_WINDOW_DAYS, 30);
+    BackupSystemTable backupSystemTable = new BackupSystemTable(TEST_UTIL.getConnection());
+    long currentTime = System.currentTimeMillis();
+
+    // Set up a continuous backup state for table2 that started 40 days before
+    long backupStartTime = currentTime - 40 * ONE_DAY_IN_MILLISECONDS;
+    backupSystemTable.addContinuousBackupTableSet(Set.of(table2), backupStartTime);
+
+    String backupId1 = fullTableBackup(Lists.newArrayList(table1));
+    assertTrue(checkSucceeded(backupId1));
+
+    // 31 days back
+    EnvironmentEdgeManager
+      .injectEdge(() -> System.currentTimeMillis() - 31 * ONE_DAY_IN_MILLISECONDS);
+    String backupId2 = fullTableBackup(Lists.newArrayList(table2));
+    assertTrue(checkSucceeded(backupId2));
+
+    // 32 days back
+    EnvironmentEdgeManager
+      .injectEdge(() -> System.currentTimeMillis() - 32 * ONE_DAY_IN_MILLISECONDS);
+    String backupId3 = fullTableBackup(Lists.newArrayList(table2));
+    assertTrue(checkSucceeded(backupId3));
+
+    // 15 days back
+    EnvironmentEdgeManager
+      .injectEdge(() -> System.currentTimeMillis() - 15 * ONE_DAY_IN_MILLISECONDS);
+    String backupId4 = fullTableBackup(Lists.newArrayList(table2));
+    assertTrue(checkSucceeded(backupId4));
+
+    // Reset time mocking
+    EnvironmentEdgeManager.reset();
+
+    String backupId5 = incrementalTableBackup(Lists.newArrayList(table1));
+    assertTrue(checkSucceeded(backupId5));
+
+    // Validate deletion scenarios
+    // Incremental backup deletion allowed
+    assertDeletionSucceeds(backupSystemTable, backupId5, false);
+    // Full backup for non-continuous table allowed
+    assertDeletionSucceeds(backupSystemTable, backupId1, false);
+    // PITR-incomplete backup deletion allowed
+    assertDeletionSucceeds(backupSystemTable, backupId4, false);
+    // Deleting a valid backup with another present
+    assertDeletionSucceeds(backupSystemTable, backupId2, false);
+    // Only valid backup deletion should fail
+    assertDeletionFails(backupSystemTable, backupId3, false);
+    // Force delete should work
+    assertDeletionSucceeds(backupSystemTable, backupId3, true);
+  }
+
+  private void assertDeletionSucceeds(BackupSystemTable table, String backupId,
+    boolean isForceDelete) throws Exception {
+    int ret = deleteBackup(backupId, isForceDelete);
+    assertEquals(0, ret);
+    assertFalse("Backup should be deleted but still exists!", backupExists(table, backupId));
+  }
+
+  private void assertDeletionFails(BackupSystemTable table, String backupId, boolean isForceDelete)
+    throws Exception {
+    int ret = deleteBackup(backupId, isForceDelete);
+    assertNotEquals(0, ret);
+    assertTrue("Backup should still exist after failed deletion!", backupExists(table, backupId));
+  }
+
+  private boolean backupExists(BackupSystemTable table, String backupId) throws Exception {
+    return table.getBackupHistory().stream()
+      .anyMatch(backup -> backup.getBackupId().equals(backupId));
+  }
+
+  private int deleteBackup(String backupId, boolean isForceDelete) throws Exception {
+    String[] args = buildBackupDeleteArgs(backupId, isForceDelete);
+    return ToolRunner.run(conf1, new BackupDriver(), args);
+  }
+
+  private String[] buildBackupDeleteArgs(String backupId, boolean isForceDelete) {
+    return isForceDelete
+      ? new String[] { "delete", "-l", backupId, "-fd" }
+      : new String[] { "delete", "-l", backupId };
   }
 }

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupDeleteWithContinuousBackupAndPITR.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupDeleteWithContinuousBackupAndPITR.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup;
+
+import static org.apache.hadoop.hbase.backup.BackupRestoreConstants.CONF_CONTINUOUS_BACKUP_PITR_WINDOW_DAYS;
+import static org.apache.hadoop.hbase.backup.replication.ContinuousBackupReplicationEndpoint.ONE_DAY_IN_MILLISECONDS;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.List;
+import java.util.Set;
+import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.util.ToolRunner;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
+
+@Category(LargeTests.class)
+public class TestBackupDeleteWithContinuousBackupAndPITR extends TestBackupBase {
+  private BackupSystemTable backupSystemTable;
+  private String backupId1;
+  private String backupId2;
+  private String backupId3;
+  private String backupId4;
+  private String backupId5;
+
+  /**
+   * Sets up the backup environment before each test.
+   * <p>
+   * This includes:
+   * <ul>
+   * <li>Setting a 30-day PITR (Point-In-Time Recovery) window</li>
+   * <li>Registering table2 as a continuous backup table starting 40 days ago</li>
+   * <li>Creating a mix of full and incremental backups at specific time offsets (using
+   * EnvironmentEdge injection) to simulate scenarios like: - backups outside PITR window - valid
+   * PITR backups - incomplete PITR chains</li>
+   * <li>Resetting the system clock after time manipulation</li>
+   * </ul>
+   * This setup enables tests to evaluate deletion behavior of backups based on age, table type, and
+   * PITR chain requirements.
+   */
+  @Before
+  public void setup() throws Exception {
+    conf1.setLong(CONF_CONTINUOUS_BACKUP_PITR_WINDOW_DAYS, 30);
+    backupSystemTable = new BackupSystemTable(TEST_UTIL.getConnection());
+
+    long currentTime = System.currentTimeMillis();
+    long backupStartTime = currentTime - 40 * ONE_DAY_IN_MILLISECONDS;
+    backupSystemTable.addContinuousBackupTableSet(Set.of(table2), backupStartTime);
+
+    backupId1 = fullTableBackup(Lists.newArrayList(table1));
+    assertTrue(checkSucceeded(backupId1));
+
+    // 31 days back
+    EnvironmentEdgeManager
+      .injectEdge(() -> System.currentTimeMillis() - 31 * ONE_DAY_IN_MILLISECONDS);
+    backupId2 = fullTableBackup(Lists.newArrayList(table2));
+    assertTrue(checkSucceeded(backupId2));
+
+    // 32 days back
+    EnvironmentEdgeManager
+      .injectEdge(() -> System.currentTimeMillis() - 32 * ONE_DAY_IN_MILLISECONDS);
+    backupId3 = fullTableBackup(Lists.newArrayList(table2));
+    assertTrue(checkSucceeded(backupId3));
+
+    // 15 days back
+    EnvironmentEdgeManager
+      .injectEdge(() -> System.currentTimeMillis() - 15 * ONE_DAY_IN_MILLISECONDS);
+    backupId4 = fullTableBackup(Lists.newArrayList(table2));
+    assertTrue(checkSucceeded(backupId4));
+
+    // Reset clock
+    EnvironmentEdgeManager.reset();
+
+    backupId5 = incrementalTableBackup(Lists.newArrayList(table1));
+    assertTrue(checkSucceeded(backupId5));
+  }
+
+  @After
+  public void teardown() throws Exception {
+    EnvironmentEdgeManager.reset();
+    // Try to delete all backups forcefully if they exist
+    for (String id : List.of(backupId1, backupId2, backupId3, backupId4, backupId5)) {
+      try {
+        deleteBackup(id, true);
+      } catch (Exception ignored) {
+      }
+    }
+  }
+
+  @Test
+  public void testDeleteIncrementalBackup() throws Exception {
+    assertDeletionSucceeds(backupSystemTable, backupId5, false);
+  }
+
+  @Test
+  public void testDeleteFullBackupNonContinuousTable() throws Exception {
+    assertDeletionSucceeds(backupSystemTable, backupId1, false);
+  }
+
+  @Test
+  public void testDeletePITRIncompleteBackup() throws Exception {
+    assertDeletionSucceeds(backupSystemTable, backupId4, false);
+  }
+
+  @Test
+  public void testDeleteValidPITRBackupWithAnotherPresent() throws Exception {
+    assertDeletionSucceeds(backupSystemTable, backupId2, false);
+  }
+
+  @Test
+  public void testDeleteOnlyValidPITRBackupFails() throws Exception {
+    // Delete backupId2 (31 days ago) — this should succeed
+    assertDeletionSucceeds(backupSystemTable, backupId2, false);
+
+    // Now backupId3 (32 days ago) is the only remaining PITR backup — deletion should fail
+    assertDeletionFails(backupSystemTable, backupId3, false);
+  }
+
+  @Test
+  public void testForceDeleteOnlyValidPITRBackup() throws Exception {
+    // Delete backupId2 (31 days ago)
+    assertDeletionSucceeds(backupSystemTable, backupId2, false);
+
+    // Force delete backupId3 — should succeed despite PITR constraints
+    assertDeletionSucceeds(backupSystemTable, backupId3, true);
+  }
+
+  private void assertDeletionSucceeds(BackupSystemTable table, String backupId,
+    boolean isForceDelete) throws Exception {
+    int ret = deleteBackup(backupId, isForceDelete);
+    assertEquals(0, ret);
+    assertFalse("Backup should be deleted but still exists!", backupExists(table, backupId));
+  }
+
+  private void assertDeletionFails(BackupSystemTable table, String backupId, boolean isForceDelete)
+    throws Exception {
+    int ret = deleteBackup(backupId, isForceDelete);
+    assertNotEquals(0, ret);
+    assertTrue("Backup should still exist after failed deletion!", backupExists(table, backupId));
+  }
+
+  private boolean backupExists(BackupSystemTable table, String backupId) throws Exception {
+    return table.getBackupHistory().stream()
+      .anyMatch(backup -> backup.getBackupId().equals(backupId));
+  }
+
+  private int deleteBackup(String backupId, boolean isForceDelete) throws Exception {
+    String[] args = buildBackupDeleteArgs(backupId, isForceDelete);
+    return ToolRunner.run(conf1, new BackupDriver(), args);
+  }
+
+  private String[] buildBackupDeleteArgs(String backupId, boolean isForceDelete) {
+    return isForceDelete
+      ? new String[] { "delete", "-l", backupId, "-fd" }
+      : new String[] { "delete", "-l", backupId };
+  }
+}

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupDeleteWithContinuousBackupAndPITR.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupDeleteWithContinuousBackupAndPITR.java
@@ -26,12 +26,14 @@ import static org.junit.Assert.assertTrue;
 
 import java.util.List;
 import java.util.Set;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.backup.impl.BackupSystemTable;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.util.ToolRunner;
 import org.junit.After;
 import org.junit.Before;
+import org.junit.ClassRule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
 
@@ -39,6 +41,10 @@ import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
 
 @Category(LargeTests.class)
 public class TestBackupDeleteWithContinuousBackupAndPITR extends TestBackupBase {
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestBackupDeleteWithContinuousBackupAndPITR.class);
+
   private BackupSystemTable backupSystemTable;
   private String backupId1;
   private String backupId2;


### PR DESCRIPTION
This PR introduces validation to prevent the deletion of backups that are essential for Point-In-Time Recovery (PITR). If a backup is the only remaining full backup enabling PITR for certain tables, deletion will be blocked unless the force option is explicitly specified.