### PR TITLE
HBASE-29218: Pass around an HFileDecompressionContext to reduce calls to Configuration.get()

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressionCodec.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressionCodec.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.io.compress;
 
+import org.apache.hadoop.conf.Configuration;
 import org.apache.yetus.audience.InterfaceAudience;
 
 @InterfaceAudience.Private
@@ -25,5 +26,8 @@ public interface ByteBuffDecompressionCodec {
   Class<? extends ByteBuffDecompressor> getByteBuffDecompressorType();
 
   ByteBuffDecompressor createByteBuffDecompressor();
+
+  Compression.HFileDecompressionContext
+    getDecompressionContextFromConfiguration(Configuration conf);
 
 }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ByteBuffDecompressor.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.io.compress;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.Closeable;
 import java.io.IOException;
 import org.apache.hadoop.hbase.nio.ByteBuff;
@@ -44,5 +45,12 @@ public interface ByteBuffDecompressor extends Closeable {
    * combinations of these, so always check.
    */
   boolean canDecompress(ByteBuff output, ByteBuff input);
+
+  /**
+   * Call before every use of {@link #canDecompress(ByteBuff, ByteBuff)} and
+   * {@link #decompress(ByteBuff, ByteBuff, int)} to reinitialize the decompressor with settings
+   * from the HFileInfo. This can matter because ByteBuffDecompressors are reused many times.
+   */
+  void reinit(@Nullable Compression.HFileDecompressionContext newHFileDecompressionContext);
 
 }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/DictionaryCache.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/DictionaryCache.java
@@ -17,11 +17,12 @@
  */
 package org.apache.hadoop.hbase.io.compress;
 
+import com.github.benmanes.caffeine.cache.Cache;
+import com.github.benmanes.caffeine.cache.Caffeine;
 import java.io.ByteArrayOutputStream;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
-import java.util.concurrent.ExecutionException;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
@@ -30,10 +31,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
-
-import org.apache.hbase.thirdparty.com.google.common.cache.CacheBuilder;
-import org.apache.hbase.thirdparty.com.google.common.cache.CacheLoader;
-import org.apache.hbase.thirdparty.com.google.common.cache.LoadingCache;
 
 /**
  * A utility class for managing compressor/decompressor dictionary loading and caching of load
@@ -48,7 +45,8 @@ public final class DictionaryCache {
   public static final String RESOURCE_SCHEME = "resource://";
 
   private static final Logger LOG = LoggerFactory.getLogger(DictionaryCache.class);
-  private static volatile LoadingCache<String, byte[]> CACHE;
+  private static final Cache<String, byte[]> BYTE_ARRAY_CACHE =
+    Caffeine.newBuilder().maximumSize(100).expireAfterAccess(10, TimeUnit.MINUTES).build();
 
   private DictionaryCache() {
   }
@@ -59,40 +57,27 @@ public final class DictionaryCache {
    * @param path the hadoop Path where the dictionary is located, as a String
    * @return the dictionary bytes if successful, null otherwise
    */
-  public static byte[] getDictionary(final Configuration conf, final String path)
-    throws IOException {
+  public static byte[] getDictionary(final Configuration conf, final String path) {
     if (path == null || path.isEmpty()) {
       return null;
     }
-    // Create the dictionary loading cache if we haven't already
-    if (CACHE == null) {
-      synchronized (DictionaryCache.class) {
-        if (CACHE == null) {
-          final int maxSize = conf.getInt(DICTIONARY_MAX_SIZE_KEY, DEFAULT_DICTIONARY_MAX_SIZE);
-          CACHE = CacheBuilder.newBuilder().maximumSize(100).expireAfterAccess(10, TimeUnit.MINUTES)
-            .build(new CacheLoader<String, byte[]>() {
-              @Override
-              public byte[] load(String s) throws Exception {
-                byte[] bytes;
-                if (path.startsWith(RESOURCE_SCHEME)) {
-                  bytes = loadFromResource(conf, path, maxSize);
-                } else {
-                  bytes = loadFromHadoopFs(conf, path, maxSize);
-                }
-                LOG.info("Loaded dictionary from {} (size {})", s, bytes.length);
-                return bytes;
-              }
-            });
-        }
-      }
-    }
 
     // Get or load the dictionary for the given path
-    try {
-      return CACHE.get(path);
-    } catch (ExecutionException e) {
-      throw new IOException(e);
-    }
+    return BYTE_ARRAY_CACHE.get(path, s -> {
+      final int maxSize = conf.getInt(DICTIONARY_MAX_SIZE_KEY, DEFAULT_DICTIONARY_MAX_SIZE);
+      byte[] bytes;
+      try {
+        if (path.startsWith(RESOURCE_SCHEME)) {
+          bytes = loadFromResource(conf, path, maxSize);
+        } else {
+          bytes = loadFromHadoopFs(conf, path, maxSize);
+        }
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+      LOG.info("Loaded dictionary from {} (size {})", s, bytes.length);
+      return bytes;
+    });
   }
 
   // Visible for testing
@@ -101,7 +86,7 @@ public final class DictionaryCache {
     if (!s.startsWith(RESOURCE_SCHEME)) {
       throw new IOException("Path does not start with " + RESOURCE_SCHEME);
     }
-    final String path = s.substring(RESOURCE_SCHEME.length(), s.length());
+    final String path = s.substring(RESOURCE_SCHEME.length());
     LOG.info("Loading resource {}", path);
     final InputStream in = DictionaryCache.class.getClassLoader().getResourceAsStream(path);
     if (in == null) {
@@ -155,10 +140,7 @@ public final class DictionaryCache {
 
   // Visible for testing
   public static boolean contains(String dictionaryPath) {
-    if (CACHE != null) {
-      return CACHE.asMap().containsKey(dictionaryPath);
-    }
-    return false;
+    return BYTE_ARRAY_CACHE.asMap().containsKey(dictionaryPath);
   }
 
 }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/HFileBlockDefaultDecodingContext.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/encoding/HFileBlockDefaultDecodingContext.java
@@ -139,9 +139,7 @@ public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingConte
     Compression.Algorithm compression = fileContext.getCompression();
     ByteBuffDecompressor decompressor = compression.getByteBuffDecompressor();
     try {
-      if (decompressor instanceof CanReinit) {
-        ((CanReinit) decompressor).reinit(conf);
-      }
+      decompressor.reinit(fileContext.getDecompressionContext());
       decompressor.decompress(blockBufferWithoutHeader, onDiskBlock, onDiskSizeWithoutHeader);
     } finally {
       compression.returnByteBuffDecompressor(decompressor);
@@ -160,9 +158,7 @@ public class HFileBlockDefaultDecodingContext implements HFileBlockDecodingConte
     } else {
       ByteBuffDecompressor decompressor = fileContext.getCompression().getByteBuffDecompressor();
       try {
-        if (decompressor instanceof CanReinit) {
-          ((CanReinit) decompressor).reinit(conf);
-        }
+        decompressor.reinit(fileContext.getDecompressionContext());
         // Even if we have a ByteBuffDecompressor, we still need to check if it can decompress
         // our particular ByteBuffs
         return decompressor.canDecompress(blockBufferWithoutHeader, onDiskBlock);

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileContext.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileContext.java
@@ -17,6 +17,8 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.InnerStoreCellComparator;
@@ -50,6 +52,11 @@ public class HFileContext implements HeapSize, Cloneable {
   private boolean includesTags;
   /** Compression algorithm used **/
   private Compression.Algorithm compressAlgo = Compression.Algorithm.NONE;
+  /**
+   * Details used by compression algorithm that are more efficiently loaded once and then reused
+   **/
+  @Nullable
+  private Compression.HFileDecompressionContext decompressionContext = null;
   /** Whether tags to be compressed or not **/
   private boolean compressTags;
   /** the checksum type **/
@@ -80,6 +87,7 @@ public class HFileContext implements HeapSize, Cloneable {
     this.includesMvcc = context.includesMvcc;
     this.includesTags = context.includesTags;
     this.compressAlgo = context.compressAlgo;
+    this.decompressionContext = context.decompressionContext;
     this.compressTags = context.compressTags;
     this.checksumType = context.checksumType;
     this.bytesPerChecksum = context.bytesPerChecksum;
@@ -95,14 +103,16 @@ public class HFileContext implements HeapSize, Cloneable {
   }
 
   HFileContext(boolean useHBaseChecksum, boolean includesMvcc, boolean includesTags,
-    Compression.Algorithm compressAlgo, boolean compressTags, ChecksumType checksumType,
-    int bytesPerChecksum, int blockSize, DataBlockEncoding encoding,
-    Encryption.Context cryptoContext, long fileCreateTime, String hfileName, byte[] columnFamily,
-    byte[] tableName, CellComparator cellComparator, IndexBlockEncoding indexBlockEncoding) {
+    Compression.Algorithm compressAlgo, Compression.HFileDecompressionContext decompressionContext,
+    boolean compressTags, ChecksumType checksumType, int bytesPerChecksum, int blockSize,
+    DataBlockEncoding encoding, Encryption.Context cryptoContext, long fileCreateTime,
+    String hfileName, byte[] columnFamily, byte[] tableName, CellComparator cellComparator,
+    IndexBlockEncoding indexBlockEncoding) {
     this.usesHBaseChecksum = useHBaseChecksum;
     this.includesMvcc = includesMvcc;
     this.includesTags = includesTags;
     this.compressAlgo = compressAlgo;
+    this.decompressionContext = decompressionContext;
     this.compressTags = compressTags;
     this.checksumType = checksumType;
     this.bytesPerChecksum = bytesPerChecksum;
@@ -139,6 +149,20 @@ public class HFileContext implements HeapSize, Cloneable {
 
   public Compression.Algorithm getCompression() {
     return compressAlgo;
+  }
+
+  /**
+   * Get an object that, if non-null, may be cast into a codec-specific type that exposes some
+   * information from the store-file-specific Configuration that is relevant to decompression. For
+   * example, ZSTD tables can have "hbase.io.compress.zstd.dictionary" on their table descriptor,
+   * and decompressions of blocks in that table must use that dictionary. It's cheaper for HBase to
+   * load these settings into an object of their own once and check this upon each block
+   * decompression, than it is to call into {@link Configuration#get(String)} on each block
+   * decompression.
+   */
+  @Nullable
+  public Compression.HFileDecompressionContext getDecompressionContext() {
+    return decompressionContext;
   }
 
   public boolean isUseHBaseChecksum() {
@@ -238,6 +262,9 @@ public class HFileContext implements HeapSize, Cloneable {
     if (this.tableName != null) {
       size += ClassSize.sizeOfByteArray(this.tableName.length);
     }
+    if (this.decompressionContext != null) {
+      size += this.decompressionContext.heapSize();
+    }
     return size;
   }
 
@@ -274,6 +301,8 @@ public class HFileContext implements HeapSize, Cloneable {
     sb.append(compressAlgo);
     sb.append(", compressTags=");
     sb.append(compressTags);
+    sb.append(", decompressionContext=");
+    sb.append(decompressionContext);
     sb.append(", cryptoContext=[");
     sb.append(cryptoContext);
     sb.append("]");

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileContextBuilder.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileContextBuilder.java
@@ -17,8 +17,10 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
+import edu.umd.cs.findbugs.annotations.Nullable;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.compress.Compression.Algorithm;
 import org.apache.hadoop.hbase.io.crypto.Encryption;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
@@ -42,6 +44,8 @@ public class HFileContextBuilder {
   private boolean includesTags = false;
   /** Compression algorithm used **/
   private Algorithm compression = Algorithm.NONE;
+  @Nullable
+  private Compression.HFileDecompressionContext decompressionContext = null;
   /** Whether tags to be compressed or not **/
   private boolean compressTags = false;
   /** the checksum type **/
@@ -73,6 +77,7 @@ public class HFileContextBuilder {
     this.includesMvcc = hfc.isIncludesMvcc();
     this.includesTags = hfc.isIncludesTags();
     this.compression = hfc.getCompression();
+    this.decompressionContext = hfc.getDecompressionContext();
     this.compressTags = hfc.isCompressTags();
     this.checkSumType = hfc.getChecksumType();
     this.bytesPerChecksum = hfc.getBytesPerChecksum();
@@ -104,6 +109,12 @@ public class HFileContextBuilder {
 
   public HFileContextBuilder withCompression(Algorithm compression) {
     this.compression = compression;
+    return this;
+  }
+
+  public HFileContextBuilder
+    withDecompressionContext(@Nullable Compression.HFileDecompressionContext decompressionContext) {
+    this.decompressionContext = decompressionContext;
     return this;
   }
 
@@ -169,7 +180,8 @@ public class HFileContextBuilder {
 
   public HFileContext build() {
     return new HFileContext(usesHBaseChecksum, includesMvcc, includesTags, compression,
-      compressTags, checkSumType, bytesPerChecksum, blockSize, encoding, cryptoContext,
-      fileCreateTime, hfileName, columnFamily, tableName, cellComparator, indexBlockEncoding);
+      decompressionContext, compressTags, checkSumType, bytesPerChecksum, blockSize, encoding,
+      cryptoContext, fileCreateTime, hfileName, columnFamily, tableName, cellComparator,
+      indexBlockEncoding);
   }
 }

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdByteBuffDecompressor.java
@@ -22,10 +22,9 @@ import com.github.luben.zstd.ZstdDictDecompress;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
-import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.compress.BlockDecompressorHelper;
 import org.apache.hadoop.hbase.io.compress.ByteBuffDecompressor;
-import org.apache.hadoop.hbase.io.compress.CanReinit;
+import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.SingleByteBuff;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -34,21 +33,18 @@ import org.apache.yetus.audience.InterfaceAudience;
  * Glue for ByteBuffDecompressor on top of zstd-jni
  */
 @InterfaceAudience.Private
-public class ZstdByteBuffDecompressor implements ByteBuffDecompressor, CanReinit {
+public class ZstdByteBuffDecompressor implements ByteBuffDecompressor {
 
   protected int dictId;
-  @Nullable
-  protected ZstdDictDecompress dict;
   protected ZstdDecompressCtx ctx;
   // Intended to be set to false by some unit tests
   private boolean allowByteBuffDecompression;
 
-  ZstdByteBuffDecompressor(@Nullable byte[] dictionary) {
+  ZstdByteBuffDecompressor(@Nullable byte[] dictionaryBytes) {
     ctx = new ZstdDecompressCtx();
-    if (dictionary != null) {
-      this.dictId = ZstdCodec.getDictionaryId(dictionary);
-      this.dict = new ZstdDictDecompress(dictionary);
-      this.ctx.loadDict(this.dict);
+    if (dictionaryBytes != null) {
+      this.ctx.loadDict(new ZstdDictDecompress(dictionaryBytes));
+      dictId = ZstdCodec.getDictionaryId(dictionaryBytes);
     }
     allowByteBuffDecompression = true;
   }
@@ -115,44 +111,29 @@ public class ZstdByteBuffDecompressor implements ByteBuffDecompressor, CanReinit
   }
 
   @Override
-  public void close() {
-    ctx.close();
-    if (dict != null) {
-      dict.close();
+  public void reinit(@Nullable Compression.HFileDecompressionContext newHFileDecompressionContext) {
+    if (newHFileDecompressionContext != null) {
+      if (newHFileDecompressionContext instanceof ZstdHFileDecompressionContext) {
+        ZstdHFileDecompressionContext zstdContext =
+          (ZstdHFileDecompressionContext) newHFileDecompressionContext;
+        allowByteBuffDecompression = zstdContext.isAllowByteBuffDecompression();
+        if (zstdContext.getDict() == null && dictId != 0) {
+          ctx.loadDict((byte[]) null);
+          dictId = 0;
+        } else if (zstdContext.getDictId() != dictId) {
+          this.ctx.loadDict(zstdContext.getDict());
+          this.dictId = zstdContext.getDictId();
+        }
+      } else {
+        throw new IllegalArgumentException(
+          "ZstdByteBuffDecompression#reinit() was given an HFileDecompressionContext that was not a ZstdHFileDecompressionContext, this should never happen");
+      }
     }
   }
 
   @Override
-  public void reinit(Configuration conf) {
-    if (conf != null) {
-      // Dictionary may have changed
-      byte[] b = ZstdCodec.getDictionary(conf);
-      if (b != null) {
-        // Don't casually create dictionary objects; they consume native memory
-        int thisDictId = ZstdCodec.getDictionaryId(b);
-        if (dict == null || dictId != thisDictId) {
-          dictId = thisDictId;
-          ZstdDictDecompress oldDict = dict;
-          dict = new ZstdDictDecompress(b);
-          ctx.loadDict(dict);
-          if (oldDict != null) {
-            oldDict.close();
-          }
-        }
-      } else {
-        ZstdDictDecompress oldDict = dict;
-        dict = null;
-        dictId = 0;
-        // loadDict((byte[]) accepts null to clear the dictionary
-        ctx.loadDict((byte[]) null);
-        if (oldDict != null) {
-          oldDict.close();
-        }
-      }
-
-      // unit test helper
-      this.allowByteBuffDecompression =
-        conf.getBoolean("hbase.io.compress.zstd.allowByteBuffDecompression", true);
-    }
+  public void close() {
+    ctx.close();
   }
+
 }

--- a/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdHFileDecompressionContext.java
+++ b/hbase-compression/hbase-compression-zstd/src/main/java/org/apache/hadoop/hbase/io/compress/zstd/ZstdHFileDecompressionContext.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress.zstd;
+
+import com.github.luben.zstd.ZstdDictDecompress;
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.hfile.HFileContext;
+import org.apache.hadoop.hbase.util.ClassSize;
+import org.apache.hadoop.hbase.util.Pair;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Holds HFile-level settings used by ZstdByteBuffDecompressor. It's expensive to pull these from a
+ * Configuration object every time we decompress a block, so pull them upon opening an HFile, and
+ * reuse them in every block that gets decompressed.
+ */
+@InterfaceAudience.Private
+public class ZstdHFileDecompressionContext extends Compression.HFileDecompressionContext {
+
+  public static final long FIXED_OVERHEAD = ClassSize.estimateBase(HFileContext.class, false);
+
+  @Nullable
+  private final ZstdDictDecompress dict;
+  private final int dictId;
+  // Intended to be set to false by some unit tests
+  private final boolean allowByteBuffDecompression;
+
+  private ZstdHFileDecompressionContext(@Nullable ZstdDictDecompress dict, int dictId,
+    boolean allowByteBuffDecompression) {
+    this.dict = dict;
+    this.dictId = dictId;
+    this.allowByteBuffDecompression = allowByteBuffDecompression;
+  }
+
+  @Nullable
+  public ZstdDictDecompress getDict() {
+    return dict;
+  }
+
+  public int getDictId() {
+    return dictId;
+  }
+
+  public boolean isAllowByteBuffDecompression() {
+    return allowByteBuffDecompression;
+  }
+
+  public static ZstdHFileDecompressionContext fromConfiguration(Configuration conf) {
+    boolean allowByteBuffDecompression =
+      conf.getBoolean("hbase.io.compress.zstd.allowByteBuffDecompression", true);
+    Pair<ZstdDictDecompress, Integer> dictAndId = ZstdCodec.getDecompressDictionary(conf);
+    if (dictAndId != null) {
+      return new ZstdHFileDecompressionContext(dictAndId.getFirst(), dictAndId.getSecond(),
+        allowByteBuffDecompression);
+    } else {
+      return new ZstdHFileDecompressionContext(null, 0, allowByteBuffDecompression);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (dict != null) {
+      dict.close();
+    }
+  }
+
+  @Override
+  public long heapSize() {
+    // ZstdDictDecompress objects are cached and shared between ZstdHFileDecompressionContexts, so
+    // don't include ours in our heap size.
+    return FIXED_OVERHEAD;
+  }
+
+  @Override
+  public String toString() {
+    return "ZstdHFileDecompressionContext{dictId=" + dictId + ", allowByteBuffDecompression="
+      + allowByteBuffDecompression + '}';
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileInfo.java
@@ -407,6 +407,8 @@ public class HFileInfo implements SortedMap<byte[], byte[]> {
     throws IOException {
     HFileContextBuilder builder = new HFileContextBuilder().withHBaseCheckSum(true)
       .withHFileName(path.getName()).withCompression(trailer.getCompressionCodec())
+      .withDecompressionContext(
+        trailer.getCompressionCodec().getHFileDecompressionContextForConfiguration(conf))
       .withCellComparator(FixedFileTrailer.createComparator(trailer.getComparatorClassName()));
     // Check for any key material available
     byte[] keyBytes = trailer.getEncryptionKey();


### PR DESCRIPTION
Use of the `org.apache.hadoop.conf.Configuration` class to look up values is not super fast. It's fine most of the time, but in a very hot code path, it takes up noticeable CPU time.

`ByteBuffDecompressor`'s are pooled and reused to avoid garbage collection churn. This means that sometimes their settings are not right for the block they're being asked to decompress. To handle this, before every decompression action, we call `ByteBuffDecompressor#reinit(Configuration)`, so it can pull settings from the Configuration in preparation for the decompression it's about to do. The `Configuration#get()` inside `reinit()` happens once per block, even though the settings it deals with are consistent across an entire table.

Because the settings used by a `ByteBuffDecompressor` don't actually change within a table, we can pull the settings it needs from a `Configuration` when opening the HFile, and then not check again.