### PR TITLE
HBASE-29215 View block cache as JSON failing for BucketCache implementation

### DIFF
--- a/hbase-external-blockcache/src/main/java/org/apache/hadoop/hbase/io/hfile/MemcachedBlockCache.java
+++ b/hbase-external-blockcache/src/main/java/org/apache/hadoop/hbase/io/hfile/MemcachedBlockCache.java
@@ -82,8 +82,8 @@ public class MemcachedBlockCache implements BlockCache {
   public static final boolean MEMCACHED_OPTIMIZE_DEFAULT = false;
   public static final int STAT_THREAD_PERIOD = 60 * 5;
 
-  private final MemcachedClient client;
-  private final HFileBlockTranscoder tc = new HFileBlockTranscoder();
+  private transient final MemcachedClient client;
+  private transient final HFileBlockTranscoder tc = new HFileBlockTranscoder();
   private final CacheStats cacheStats = new CacheStats("MemcachedBlockCache");
   private final AtomicLong cachedCount = new AtomicLong();
   private final AtomicLong notCachedCount = new AtomicLong();

--- a/hbase-external-blockcache/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMemcachedBlockCache.java
+++ b/hbase-external-blockcache/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMemcachedBlockCache.java
@@ -135,6 +135,8 @@ public class TestMemcachedBlockCache {
       assertEquals(expected.getBlockType(), actual.getBlockType());
       assertEquals(expected.getSerializedLength(), actual.getSerializedLength());
     }
+
+    CacheTestUtils.testConvertToJSON(cache);
   }
 
   @Test

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -168,14 +168,14 @@ public class BucketCache implements BlockCache, HeapSize {
    * together with the region those belong to and the total cached size for the
    * region.TestBlockEvictionOnRegionMovement
    */
-  final Map<String, Pair<String, Long>> fullyCachedFiles = new ConcurrentHashMap<>();
+  transient final Map<String, Pair<String, Long>> fullyCachedFiles = new ConcurrentHashMap<>();
   /**
    * Map of region -> total size of the region prefetched on this region server. This is the total
    * size of hFiles for this region prefetched on this region server
    */
   final Map<String, Long> regionCachedSize = new ConcurrentHashMap<>();
 
-  private BucketCachePersister cachePersister;
+  private transient BucketCachePersister cachePersister;
 
   /**
    * Enum to represent the state of cache
@@ -235,7 +235,7 @@ public class BucketCache implements BlockCache, HeapSize {
   // reset after a successful read/write.
   private volatile long ioErrorStartTime = -1;
 
-  private Configuration conf;
+  private transient Configuration conf;
 
   /**
    * A ReentrantReadWriteLock to lock on a particular block identified by offset. The purpose of
@@ -245,7 +245,7 @@ public class BucketCache implements BlockCache, HeapSize {
    */
   transient final IdReadWriteLock<Long> offsetLock = new IdReadWriteLock<>(ReferenceType.SOFT);
 
-  NavigableSet<BlockCacheKey> blocksByHFile = new ConcurrentSkipListSet<>(
+  transient NavigableSet<BlockCacheKey> blocksByHFile = new ConcurrentSkipListSet<>(
     Comparator.comparing(BlockCacheKey::getHfileName).thenComparingLong(BlockCacheKey::getOffset));
 
   /** Statistics thread schedule pool (for heavy debugging, could remove) */
@@ -298,7 +298,7 @@ public class BucketCache implements BlockCache, HeapSize {
   private long allocFailLogPrevTs; // time of previous log event for allocation failure.
   private static final int ALLOCATION_FAIL_LOG_TIME_PERIOD = 60000; // Default 1 minute.
 
-  private Map<String, HRegion> onlineRegions;
+  private transient Map<String, HRegion> onlineRegions;
 
   private long orphanBlockGracePeriod = 0;
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/CacheTestUtils.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/CacheTestUtils.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.io.hfile;
 
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
@@ -160,6 +161,8 @@ public class CacheTestUtils {
         // expected
       }
     }
+
+    testConvertToJSON(toBeTested);
 
   }
 
@@ -349,6 +352,15 @@ public class CacheTestUtils {
       if (actualBlock != null) {
         actualBlock.release();
       }
+    }
+  }
+
+  public static void testConvertToJSON(BlockCache toBeTested) {
+    try {
+      String json = BlockCacheUtil.toJSON(toBeTested);
+      assertNotNull(json);
+    } catch (Exception e) {
+      fail("conversion to JSON should not fail, exception is:" + e);
     }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestLruAdaptiveBlockCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestLruAdaptiveBlockCache.java
@@ -220,6 +220,8 @@ public class TestLruAdaptiveBlockCache {
       assertEquals(buf.heapSize(), block.heapSize());
     }
 
+    CacheTestUtils.testConvertToJSON(cache);
+
     // Expect no evictions
     assertEquals(0, cache.getStats().getEvictionCount());
     Thread t = new LruAdaptiveBlockCache.StatisticsThread(cache);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestLruBlockCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestLruBlockCache.java
@@ -223,6 +223,8 @@ public class TestLruBlockCache {
       assertEquals(buf.heapSize(), block.heapSize());
     }
 
+    CacheTestUtils.testConvertToJSON(cache);
+
     // Expect no evictions
     assertEquals(0, cache.getStats().getEvictionCount());
     Thread t = new LruBlockCache.StatisticsThread(cache);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestTinyLfuBlockCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestTinyLfuBlockCache.java
@@ -97,6 +97,8 @@ public class TestTinyLfuBlockCache {
 
     // Expect no evictions
     assertEquals(0, cache.getStats().getEvictionCount());
+
+    CacheTestUtils.testConvertToJSON(cache);
   }
 
   @Test


### PR DESCRIPTION
 

Signed-off-by: Wellington Chevreuil <wchevreuil@apache.org>
(cherry picked from f4bcb76a76c05733b2e0b6448b26412ca1e374a4)