### PR TITLE
HBASE-29222 Avoid expensive tracing calls if tracing is disabled

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlock.java
@@ -1714,9 +1714,7 @@ public class HFileBlock implements Cacheable {
       long onDiskSizeWithHeaderL, boolean pread, boolean verifyChecksum, boolean updateMetrics,
       boolean intoHeap) throws IOException {
       final Span span = Span.current();
-      final AttributesBuilder attributesBuilder = Attributes.builder();
-      Optional.of(Context.current()).map(val -> val.get(CONTEXT_KEY))
-        .ifPresent(c -> c.accept(attributesBuilder));
+      final Attributes attributes = getReadDataBlockInternalAttributes(span);
       if (offset < 0) {
         throw new IOException("Invalid offset=" + offset + " trying to read " + "block (onDiskSize="
           + onDiskSizeWithHeaderL + ")");
@@ -1752,7 +1750,7 @@ public class HFileBlock implements Cacheable {
           if (LOG.isTraceEnabled()) {
             LOG.trace("Extra seek to get block size!", new RuntimeException());
           }
-          span.addEvent("Extra seek to get block size!", attributesBuilder.build());
+          span.addEvent("Extra seek to get block size!", attributes);
           headerBuf = HEAP.allocate(hdrSize);
           readAtOffset(is, headerBuf, hdrSize, false, offset, pread);
           headerBuf.rewind();
@@ -1766,7 +1764,7 @@ public class HFileBlock implements Cacheable {
       if (!checkCheckSumTypeOnHeaderBuf(headerBuf)) {
         if (verifyChecksum) {
           invalidateNextBlockHeader();
-          span.addEvent("Falling back to HDFS checksumming.", attributesBuilder.build());
+          span.addEvent("Falling back to HDFS checksumming.", attributes);
           return null;
         } else {
           throw new IOException(
@@ -1780,7 +1778,7 @@ public class HFileBlock implements Cacheable {
       if (!checkOnDiskSizeWithHeader(onDiskSizeWithHeader)) {
         if (verifyChecksum) {
           invalidateNextBlockHeader();
-          span.addEvent("Falling back to HDFS checksumming.", attributesBuilder.build());
+          span.addEvent("Falling back to HDFS checksumming.", attributes);
           return null;
         } else {
           throw new IOException("Invalid onDiskSizeWithHeader=" + onDiskSizeWithHeader);
@@ -1821,7 +1819,7 @@ public class HFileBlock implements Cacheable {
         // Verify checksum of the data before using it for building HFileBlock.
         if (verifyChecksum && !validateChecksum(offset, curBlock, hdrSize)) {
           invalidateNextBlockHeader();
-          span.addEvent("Falling back to HDFS checksumming.", attributesBuilder.build());
+          span.addEvent("Falling back to HDFS checksumming.", attributes);
           return null;
         }
 
@@ -1838,7 +1836,7 @@ public class HFileBlock implements Cacheable {
             // requested. The block size provided by the caller (presumably from the block index)
             // does not match the block size written to the block header. treat this as
             // HBase-checksum failure.
-            span.addEvent("Falling back to HDFS checksumming.", attributesBuilder.build());
+            span.addEvent("Falling back to HDFS checksumming.", attributes);
             invalidateNextBlockHeader();
             return null;
           }
@@ -1868,7 +1866,7 @@ public class HFileBlock implements Cacheable {
           LOG.warn("Read Block Slow: read {} cost {} ms, threshold = {} ms", hFileBlock, duration,
             this.readWarnTime);
         }
-        span.addEvent("Read block", attributesBuilder.build());
+        span.addEvent("Read block", attributes);
         // Cache next block header if we read it for the next time through here.
         if (nextBlockOnDiskSize != -1) {
           cacheNextBlockHeader(offset + hFileBlock.getOnDiskSizeWithHeader(), onDiskBlock,
@@ -2201,5 +2199,22 @@ public class HFileBlock implements Cacheable {
     ByteBuff deepCloned = ByteBuff
       .wrap(ByteBuffer.wrap(blk.bufWithoutChecksum.toBytes(0, blk.bufWithoutChecksum.limit())));
     return createBuilder(blk, deepCloned).build();
+  }
+
+  /**
+   * Returns OpenTelemetry Attributes for a Span that is reading a data block with relevant
+   * metadata. Will short-circuit if the span isn't going to be captured/OTEL isn't enabled.
+   */
+  private static Attributes getReadDataBlockInternalAttributes(Span span) {
+    // It's expensive to record these attributes, so we avoid the cost of doing this if the span
+    // isn't going to be persisted
+    if (!span.isRecording()) {
+      return Attributes.empty();
+    }
+
+    final AttributesBuilder attributesBuilder = Attributes.builder();
+    Optional.of(Context.current()).map(val -> val.get(CONTEXT_KEY))
+      .ifPresent(c -> c.accept(attributesBuilder));
+    return attributesBuilder.build();
   }
 }


### PR DESCRIPTION
### What
This PR updates expensive tracing calls if tracing is disabled. In particular, the expensive tracing calls as determined by a flamegraph are in BlockIOUtils & HFileBlock. I've audited for other places where tracing is used to eliminate any other expensive calls as well (but couldn't find any outside of BlockIOUtils & HFileBlock). 

This generally just follows the pattern of refactoring to use empty Attributes if we can determine that the Span isn't going to be persisted/saved anywhere via Span.isRecordingEnabled e.g. the same approach taken in https://github.com/apache/hbase/pull/6642 / [HBASE-29099](https://issues.apache.org/jira/browse/HBASE-29099)

### How
I used the Span.isRecordingEnabled API ([OpenTelemetry Docs](https://opentelemetry.io/docs/specs/otel/trace/api/#isrecording)). Based on the following docsnippet, I believe that this will work if OpenTelemetry isn't enabled for HBase:
> This flag SHOULD be used to avoid expensive computations of a Span attributes or events in case when a Span is definitely not recorded. Note that any child span’s recording is determined independently from the value of this flag (typically based on the sampled flag of a TraceFlags on [SpanContext](https://opentelemetry.io/docs/specs/otel/trace/api/#spancontext)).

[HBASE-29222](https://issues.apache.org/jira/browse/HBASE-29222)