### PR TITLE
Backport "HBASE-29239: Subsequent runs of re-splitting HFiles can fail because …" to branch-2

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
@@ -219,6 +219,9 @@ public class IncrementalTableBackupClient extends TableBackupClient {
       result = player.run(args);
     } catch (Exception e) {
       LOG.error("Failed to run MapReduceHFileSplitterJob", e);
+      // Delete the bulkload directory if we fail to run the HFile splitter job for any reason
+      // as it might be re-tried
+      deleteBulkLoadDirectory();
       throw new IOException(e);
     }
 


### PR DESCRIPTION
…we don't cleanup the MR directory (#6876)