### PR TITLE
Backport "HBASE-29262 StochasticLoadBalancer should use the CostFunction epsilo…" to branch-3

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -683,8 +683,12 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
 
       newCost = computeCost(cluster, currentCost);
 
+      double costImprovement = currentCost - newCost;
+      double minimumImprovement =
+        Math.max(CostFunction.getCostEpsilon(currentCost), CostFunction.getCostEpsilon(newCost));
+      boolean costsImproved = costImprovement > minimumImprovement;
       boolean conditionalsSimilarCostsImproved =
-        (newCost < currentCost && conditionalViolationsChange == 0 && !isViolatingConditionals);
+        (costsImproved && conditionalViolationsChange == 0 && !isViolatingConditionals);
       // Our first priority is to reduce conditional violations
       // Our second priority is to reduce balancer cost
       // change, regardless of cost change


### PR DESCRIPTION
…n when evaluating whether a move improved costs (#6907)