### PR TITLE
Backport "HBASE-29262 StochasticLoadBalancer should use the CostFunction epsilo…" to branch-2

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -730,8 +730,12 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
 
       newCost = computeCost(cluster, currentCost);
 
+      double costImprovement = currentCost - newCost;
+      double minimumImprovement =
+        Math.max(CostFunction.getCostEpsilon(currentCost), CostFunction.getCostEpsilon(newCost));
+      boolean costsImproved = costImprovement > minimumImprovement;
       boolean conditionalsSimilarCostsImproved =
-        (newCost < currentCost && conditionalViolationsChange == 0 && !isViolatingConditionals);
+        (costsImproved && conditionalViolationsChange == 0 && !isViolatingConditionals);
       // Our first priority is to reduce conditional violations
       // Our second priority is to reduce balancer cost
       // change, regardless of cost change


### PR DESCRIPTION
…n when evaluating whether a move improved costs (#6907)