### PR TITLE
HBASE-25338 Use ClassLoader of current class instead of thread context ClassLoader

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/SaslClientAuthenticationProviders.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/SaslClientAuthenticationProviders.java
@@ -167,7 +167,8 @@ public final class SaslClientAuthenticationProviders {
    */
   static SaslClientAuthenticationProviders instantiate(Configuration conf) {
     ServiceLoader<SaslClientAuthenticationProvider> loader =
-      ServiceLoader.load(SaslClientAuthenticationProvider.class);
+      ServiceLoader.load(SaslClientAuthenticationProvider.class,
+      SaslClientAuthenticationProviders.class.getClassLoader());
     HashMap<Byte, SaslClientAuthenticationProvider> providerMap = new HashMap<>();
     for (SaslClientAuthenticationProvider provider : loader) {
       addProviderIfNotExists(provider, providerMap);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/SaslClientAuthenticationProviders.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/provider/SaslClientAuthenticationProviders.java
@@ -168,7 +168,7 @@ public final class SaslClientAuthenticationProviders {
   static SaslClientAuthenticationProviders instantiate(Configuration conf) {
     ServiceLoader<SaslClientAuthenticationProvider> loader =
       ServiceLoader.load(SaslClientAuthenticationProvider.class,
-      SaslClientAuthenticationProviders.class.getClassLoader());
+        SaslClientAuthenticationProviders.class.getClassLoader());
     HashMap<Byte, SaslClientAuthenticationProvider> providerMap = new HashMap<>();
     for (SaslClientAuthenticationProvider provider : loader) {
       addProviderIfNotExists(provider, providerMap);

--- a/pom.xml
+++ b/pom.xml
@@ -801,7 +801,7 @@
     </site>
   </distributionManagement>
   <properties>
-    <revision>4.0.0-DEFINATELY-DUMMY-1-SNAPSHOT</revision>
+    <revision>4.0.0-alpha-1-SNAPSHOT</revision>
     <!-- override on command line to have generated LICENSE files include
          diagnostic info for verifying notice requirements -->
     <license.debug.print.included>false</license.debug.print.included>

--- a/pom.xml
+++ b/pom.xml
@@ -801,7 +801,7 @@
     </site>
   </distributionManagement>
   <properties>
-    <revision>4.0.0-alpha-1-SNAPSHOT</revision>
+    <revision>4.0.0-DEFINATELY-DUMMY-1-SNAPSHOT</revision>
     <!-- override on command line to have generated LICENSE files include
          diagnostic info for verifying notice requirements -->
     <license.debug.print.included>false</license.debug.print.included>


### PR DESCRIPTION
## Details

When the `ServiceLoader::load` method is invoked with a single argument, it uses the context `ClassLoader` of current thread(by calling `Thread.currentThread.getContextClassLoader()`). (For definition, see [here](https://docs.oracle.com/javase/8/docs/api/java/util/ServiceLoader.html#load-java.lang.Class-).)

Under normal circumstances, this does not cause issues. But there is a problem if you try to:
- load a class at runtime from a jar file (e.g. call `URLClassLoader::loadClass`)
  - (the jar file has a dependency with `hbase-client`)
- from the parent Application.

In my case, I encountered this problem while developing JDBC wrapper for hbase-shell.

If you load the class from the jar file, the `ClassLoader` of current thread is normally the class loader used to load the parent application.
- This "parent" `ClassLoader` is not adaquate to `ServiceLoader` at the `SaslClientAuthenticationProviders`.
- The `ServiceLoader` with the "parent" `ClassLoader` could not access the service info of the jar file(`META-INF/services`).
- Therefore, IllegalStateException is being thrown.

I also attached the full stacktrace of the exception just in case.
<details><summary>Stacktrace</summary>
<p>

```
org.apache.hadoop.hbase.client.RetriesExhaustedException: Failed after attempts=2, exceptions:
2025-04-19T06:02:00.404Z, RpcRetryingCaller{globalStartTime=2025-04-19T06:02:00.241Z, pause=100, maxAttempts=2}, java.io.IOException: Call to address=hbase:16020 failed on local exception: java.io.IOException: java.lang.IllegalStateException: Failed to load SIMPLE, KERBEROS, and DIGEST authentication providers. Classpath is not sane.
2025-04-19T06:02:00.518Z, RpcRetryingCaller{globalStartTime=2025-04-19T06:02:00.241Z, pause=100, maxAttempts=2}, java.io.IOException: Call to address=hbase:16020 failed on local exception: java.io.IOException: java.lang.IllegalStateException: Failed to load SIMPLE, KERBEROS, and DIGEST authentication providers. Classpath is not sane.

	at org.apache.hadoop.hbase.client.RpcRetryingCallerImpl.callWithRetries(RpcRetryingCallerImpl.java:142)
	at org.apache.hadoop.hbase.client.ResultBoundedCompletionService$QueueingFuture.run(ResultBoundedCompletionService.java:74)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: java.io.IOException: Call to address=hbase:16020 failed on local exception: java.io.IOException: java.lang.IllegalStateException: Failed to load SIMPLE, KERBEROS, and DIGEST authentication providers. Classpath is not sane.
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance0(Native Method)
	at java.base/jdk.internal.reflect.NativeConstructorAccessorImpl.newInstance(NativeConstructorAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingConstructorAccessorImpl.newInstance(DelegatingConstructorAccessorImpl.java:45)
	at java.base/java.lang.reflect.Constructor.newInstanceWithCaller(Constructor.java:499)
	at java.base/java.lang.reflect.Constructor.newInstance(Constructor.java:480)
	at org.apache.hadoop.hbase.ipc.IPCUtil.wrapException(IPCUtil.java:270)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient.onCallFinished(AbstractRpcClient.java:395)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient.access$100(AbstractRpcClient.java:94)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient$3.run(AbstractRpcClient.java:430)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient$3.run(AbstractRpcClient.java:425)
	at org.apache.hadoop.hbase.ipc.Call.callComplete(Call.java:116)
	at org.apache.hadoop.hbase.ipc.Call.setException(Call.java:131)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient.callMethod(AbstractRpcClient.java:451)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient.callBlockingMethod(AbstractRpcClient.java:336)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient.access$200(AbstractRpcClient.java:94)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient$BlockingRpcChannelImplementation.callBlockingMethod(AbstractRpcClient.java:606)
	at org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos$ClientService$BlockingStub.scan(ClientProtos.java:44040)
	at org.apache.hadoop.hbase.client.ScannerCallable.openScanner(ScannerCallable.java:365)
	at org.apache.hadoop.hbase.client.ScannerCallable.rpcCall(ScannerCallable.java:261)
	at org.apache.hadoop.hbase.client.ScannerCallable.rpcCall(ScannerCallable.java:62)
	at org.apache.hadoop.hbase.client.RegionServerCallable.call(RegionServerCallable.java:131)
	at org.apache.hadoop.hbase.client.RpcRetryingCallerImpl.callWithoutRetries(RpcRetryingCallerImpl.java:206)
	at org.apache.hadoop.hbase.client.ScannerCallableWithReplicas$RetryingRPC.call(ScannerCallableWithReplicas.java:437)
	at org.apache.hadoop.hbase.client.ScannerCallableWithReplicas$RetryingRPC.call(ScannerCallableWithReplicas.java:405)
	at org.apache.hadoop.hbase.client.RpcRetryingCallerImpl.callWithRetries(RpcRetryingCallerImpl.java:104)
	... 4 more
Caused by: java.io.IOException: java.lang.IllegalStateException: Failed to load SIMPLE, KERBEROS, and DIGEST authentication providers. Classpath is not sane.
	at org.apache.hadoop.hbase.ipc.IPCUtil.toIOE(IPCUtil.java:190)
	... 17 more
Caused by: java.lang.IllegalStateException: Failed to load SIMPLE, KERBEROS, and DIGEST authentication providers. Classpath is not sane.
	at org.apache.hadoop.hbase.security.provider.BuiltInProviderSelector.configure(BuiltInProviderSelector.java:93)
	at org.apache.hadoop.hbase.security.provider.SaslClientAuthenticationProviders.instantiateSelector(SaslClientAuthenticationProviders.java:114)
	at org.apache.hadoop.hbase.security.provider.SaslClientAuthenticationProviders.instantiate(SaslClientAuthenticationProviders.java:187)
	at org.apache.hadoop.hbase.security.provider.SaslClientAuthenticationProviders.getInstance(SaslClientAuthenticationProviders.java:76)
	at org.apache.hadoop.hbase.ipc.RpcConnection.<init>(RpcConnection.java:138)
	at org.apache.hadoop.hbase.ipc.NettyRpcConnection.<init>(NettyRpcConnection.java:108)
	at org.apache.hadoop.hbase.ipc.NettyRpcClient.createConnection(NettyRpcClient.java:91)
	at org.apache.hadoop.hbase.ipc.NettyRpcClient.createConnection(NettyRpcClient.java:47)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient.lambda$getConnection$0(AbstractRpcClient.java:368)
	at org.apache.hadoop.hbase.util.PoolMap.createResource(PoolMap.java:127)
	at org.apache.hadoop.hbase.util.PoolMap$RoundRobinPool.getOrCreate(PoolMap.java:211)
	at org.apache.hadoop.hbase.util.PoolMap.getOrCreate(PoolMap.java:68)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient.getConnection(AbstractRpcClient.java:368)
	at org.apache.hadoop.hbase.ipc.AbstractRpcClient.callMethod(AbstractRpcClient.java:448)
	... 16 more
```

</p>
</details>

I could reproduce this issue with the repository which I made by myself in [here](https://github.com/challenger71498/hbase-25338). You could also look into it for more information.

## Suggestion

As [@AbilashR](https://issues.apache.org/jira/secure/ViewProfile.jspa?name=abi) mentioned at the [issue](https://issues.apache.org/jira/browse/HBASE-25338), this can be fixed by adding ClassLoader of current class explicitly to the parameter.

I have run the test locally and had no issues. Please let me know if there are more tests I should run.

I also tried to add a test case for this, but gave up since reproducing the issue is quite complicated.

Any opinions & suggestions are appriciated. Also, I don't have much experiences in Java, so feel free to make any corrections.

Thank you :)