### PR TITLE
HBASE-29185 fix: compact ensures the atomicity of all files

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
@@ -287,6 +287,11 @@ public class HStoreFile implements StoreFile {
   }
 
   @Override
+  public String getPathName(){
+    return this.fileInfo.getPathName();
+  }
+
+  @Override
   public Path getEncodedPath() {
     try {
       return new Path(URLEncoder.encode(fileInfo.getPath().toString(), HConstants.UTF8_ENCODING));

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
@@ -370,6 +370,10 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
     refreshStoreFilesInternal(fileInfos);
   }
 
+  public List<StoreFileInfo> getStoreFiles() throws IOException {
+    return storeFileTracker.load();
+  }
+
   public void refreshStoreFiles(Collection<String> newFiles) throws IOException {
     List<StoreFileInfo> storeFiles = new ArrayList<>(newFiles.size());
     for (String file : newFiles) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFile.java
@@ -62,6 +62,8 @@ public interface StoreFile {
   /** Returns Path or null if this StoreFile was made with a Stream. */
   Path getPath();
 
+  String getPathName();
+
   /** Returns Encoded Path if this StoreFile was made with a Stream. */
   Path getEncodedPath();
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileInfo.java
@@ -411,6 +411,10 @@ public class StoreFileInfo implements Configurable {
     return initialPath;
   }
 
+  public String getPathName() {
+    return initialPath.getName();
+  }
+
   /** Returns The {@link FileStatus} of the file */
   public FileStatus getFileStatus() throws IOException {
     return getReferencedFileStatus(fs);


### PR DESCRIPTION
After compact ends abnormally, ensure the consistency of the underlying data files and memory files when exiting