### PR TITLE
HBASE-29272 When Spark reads an HBase snapshot, it always read empty …

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/TableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/TableSnapshotInputFormat.java
@@ -56,10 +56,22 @@ public class TableSnapshotInputFormat implements InputFormat<ImmutableBytesWrita
       this.delegate = delegate;
     }
 
+    /**
+     * Creates a TableSnapshotRegionSplit with the given region information and the estimated length
+     * of the region in bytes. The length is used by the MapReduce framework to balance the
+     * distribution of splits; a value of 0 may cause the framework to skip the split.
+     * @param htd the table descriptor
+     * @param regionInfo the region info
+     * @param locations the locations of the region
+     * @param scan the scan to use
+     * @param restoreDir the directory to restore the snapshot to
+     * @param length the estimated size of the region in bytes
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
     public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
-      List<String> locations, Scan scan, Path restoreDir) {
+      List<String> locations, Scan scan, Path restoreDir, long length) {
       this.delegate =
-        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir);
+        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir, length);
     }
 
     @Override

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormat.java
@@ -95,10 +95,22 @@ public class TableSnapshotInputFormat extends InputFormat<ImmutableBytesWritable
       this.delegate = delegate;
     }
 
+    /**
+     * Creates a TableSnapshotRegionSplit with the given region information and the estimated length
+     * of the region in bytes. The length is used by the MapReduce framework to balance the
+     * distribution of splits; a value of 0 may cause the framework to skip the split.
+     * @param htd the table descriptor
+     * @param regionInfo the region info
+     * @param locations the locations of the region
+     * @param scan the scan to use
+     * @param restoreDir the directory to restore the snapshot to
+     * @param length the estimated size of the region in bytes
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
     public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
-      List<String> locations, Scan scan, Path restoreDir) {
+      List<String> locations, Scan scan, Path restoreDir, long length) {
       this.delegate =
-        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir);
+        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir, length);
     }
 
     @Override

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.mapreduce;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.EOFException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -47,6 +48,8 @@ import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotHelper;
 import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.SnapshotManifest;
+import org.apache.hadoop.hbase.snapshot.RegionSizes;
+import org.apache.hadoop.hbase.snapshot.SnapshotRegionSizeCalculator;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.RegionSplitter;
@@ -145,13 +148,14 @@ public class TableSnapshotInputFormatImpl {
     private String[] locations;
     private String scan;
     private String restoreDir;
+    private long length;
 
     // constructor for mapreduce framework / Writable
     public InputSplit() {
     }
 
     public InputSplit(TableDescriptor htd, RegionInfo regionInfo, List<String> locations, Scan scan,
-      Path restoreDir) {
+      Path restoreDir, long length) {
       this.htd = htd;
       this.regionInfo = regionInfo;
       if (locations == null || locations.isEmpty()) {
@@ -166,6 +170,7 @@ public class TableSnapshotInputFormatImpl {
       }
 
       this.restoreDir = restoreDir.toString();
+      this.length = length;
     }
 
     public TableDescriptor getHtd() {
@@ -181,8 +186,7 @@ public class TableSnapshotInputFormatImpl {
     }
 
     public long getLength() {
-      // TODO: We can obtain the file sizes of the snapshot here.
-      return 0;
+      return length;
     }
 
     public String[] getLocations() {
@@ -219,6 +223,7 @@ public class TableSnapshotInputFormatImpl {
 
       Bytes.writeByteArray(out, Bytes.toBytes(scan));
       Bytes.writeByteArray(out, Bytes.toBytes(restoreDir));
+      out.writeLong(length);
 
     }
 
@@ -235,6 +240,12 @@ public class TableSnapshotInputFormatImpl {
 
       this.scan = Bytes.toString(Bytes.readByteArray(in));
       this.restoreDir = Bytes.toString(Bytes.readByteArray(in));
+      try {
+        this.length = in.readLong();
+      } catch (EOFException e) {
+        // Older serialized splits do not carry length and keep the previous behavior
+        this.length = 0L;
+      }
     }
   }
 
@@ -440,6 +451,8 @@ public class TableSnapshotInputFormatImpl {
       }
     }
 
+    RegionSizes regionSizes =
+      SnapshotRegionSizeCalculator.calculateRegionSizes(conf, manifest);
     List<InputSplit> splits = new ArrayList<>();
     for (RegionInfo hri : regionManifests) {
       // load region descriptor
@@ -455,7 +468,7 @@ public class TableSnapshotInputFormatImpl {
           hosts = calculateLocationsForInputSplit(conf, htd, hri, tableDir);
         }
       }
-
+      long snapshotRegionSize = regionSizes.getRegionSize(hri.getEncodedName());
       if (numSplits > 1) {
         byte[][] sp = sa.split(hri.getStartKey(), hri.getEndKey(), numSplits, true);
         for (int i = 0; i < sp.length - 1; i++) {
@@ -478,7 +491,8 @@ public class TableSnapshotInputFormatImpl {
                 Bytes.compareTo(scan.getStopRow(), sp[i + 1]) < 0 ? scan.getStopRow() : sp[i + 1]);
             }
 
-            splits.add(new InputSplit(htd, hri, hosts, boundedScan, restoreDir));
+            splits.add(new InputSplit(htd, hri, hosts, boundedScan, restoreDir,
+              snapshotRegionSize / numSplits));
           }
         }
       } else {
@@ -487,7 +501,7 @@ public class TableSnapshotInputFormatImpl {
             hri.getEndKey())
         ) {
 
-          splits.add(new InputSplit(htd, hri, hosts, scan, restoreDir));
+          splits.add(new InputSplit(htd, hri, hosts, scan, restoreDir, snapshotRegionSize));
         }
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/RegionSizes.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/RegionSizes.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.snapshot;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Holds the size of each region in a snapshot.
+ */
+@InterfaceAudience.Private
+public class RegionSizes {
+
+  private final Map<String, Long> regionSizeMap;
+
+  RegionSizes(Map<String, Long> regionSizeMap) {
+    this.regionSizeMap = regionSizeMap;
+  }
+
+  /**
+   * Returns the total size of the given region in bytes.
+   * @param encodedRegionName the encoded region name
+   * @return the size of the region, or 0 if the region is not present in the snapshot
+   */
+  public long getRegionSize(String encodedRegionName) {
+    return regionSizeMap.getOrDefault(encodedRegionName, 0L);
+  }
+
+  /**
+   * Returns an unmodifiable view of the region size map.
+   * @return a map of region encoded names to their total size in bytes
+   */
+  public Map<String, Long> getRegionSizeMap() {
+    return Collections.unmodifiableMap(regionSizeMap);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotInfo.java
@@ -53,7 +53,6 @@ import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLine;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.CommandLineParser;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.DefaultParser;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.Option;
-import org.apache.hbase.thirdparty.org.apache.commons.cli.Options;
 import org.apache.hbase.thirdparty.org.apache.commons.cli.ParseException;
 
 import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
@@ -157,6 +156,7 @@ public final class SnapshotInfo extends AbstractHBaseTool {
     private AtomicInteger logsCount = new AtomicInteger();
     private AtomicLong hfilesArchiveSize = new AtomicLong();
     private AtomicLong hfilesSize = new AtomicLong();
+    private Map<String, Long> regionSizeMap = new ConcurrentHashMap<>();
     private AtomicLong hfilesMobSize = new AtomicLong();
     private AtomicLong nonSharedHfilesArchiveSize = new AtomicLong();
     private AtomicLong logSize = new AtomicLong();
@@ -180,6 +180,14 @@ public final class SnapshotInfo extends AbstractHBaseTool {
       this.snapshotTable = TableName.valueOf(snapshot.getTable());
       this.conf = conf;
       this.fs = fs;
+    }
+
+    /**
+     * Returns the map containing region sizes.
+     * @return A map where keys are region names and values are their corresponding sizes.
+     */
+    public Map<String, Long> getRegionSizeMap() {
+      return regionSizeMap;
     }
 
     /** Returns the snapshot descriptor */
@@ -351,6 +359,12 @@ public final class SnapshotInfo extends AbstractHBaseTool {
         hfilesMissing.incrementAndGet();
       }
       return new FileInfo(inArchive, size, isCorrupted);
+    }
+
+    void updateRegionSizeMap(final RegionInfo region,
+      final SnapshotRegionManifest.StoreFile storeFile) {
+      long currentSize = regionSizeMap.getOrDefault(region.getEncodedName(), 0L);
+      regionSizeMap.put(region.getEncodedName(), currentSize + storeFile.getFileSize());
     }
 
     /**
@@ -634,6 +648,7 @@ public final class SnapshotInfo extends AbstractHBaseTool {
           if (!storeFile.hasReference()) {
             stats.addStoreFile(regionInfo, family, storeFile, filesMap);
           }
+          stats.updateRegionSizeMap(regionInfo, storeFile);
         }
       });
     return stats;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionSizeCalculator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionSizeCalculator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.snapshot;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hbase.snapshot.SnapshotInfo.SnapshotStats;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos;
+
+/**
+ * Utility class to calculate the size of each region in a snapshot.
+ */
+@InterfaceAudience.Private
+public class SnapshotRegionSizeCalculator {
+
+  /**
+   * Calculate the size of each region in the snapshot.
+   * @return A map of region encoded names to their total size in bytes.
+   * @throws IOException If an error occurs during calculation.
+   */
+  public static RegionSizes calculateRegionSizes(Configuration conf,
+    SnapshotManifest manifest) throws IOException {
+    FileSystem fs = FileSystem.get(CommonFSUtils.getRootDir(conf).toUri(), conf);
+    SnapshotProtos.SnapshotDescription snapshot =
+      SnapshotDescriptionUtils.readSnapshotInfo(fs, manifest.getSnapshotDir());
+    SnapshotStats stats = SnapshotInfo.getSnapshotStats(conf, snapshot, null);
+    return new RegionSizes(stats.getRegionSizeMap());
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/snapshot/TestSnapshotRegionSizeCalculator.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/snapshot/TestSnapshotRegionSizeCalculator.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos;
+
+@Tag(SmallTests.TAG)
+public class TestSnapshotRegionSizeCalculator {
+
+  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private static FileSystem fs;
+  private static Path rootDir;
+  private static Path snapshotDir;
+  private static SnapshotProtos.SnapshotDescription snapshotDesc;
+  private static SnapshotManifest manifest;
+  private static Admin admin;
+  private static Configuration conf;
+
+  @BeforeAll
+  public static void setupCluster() throws Exception {
+    TEST_UTIL.startMiniCluster(3);
+    conf = TEST_UTIL.getConfiguration();
+    fs = TEST_UTIL.getTestFileSystem();
+    rootDir = TEST_UTIL.getDataTestDir("TestSnapshotRegionSizeCalculator");
+    CommonFSUtils.setRootDir(conf, rootDir);
+    admin = TEST_UTIL.getAdmin();
+  }
+
+  @AfterAll
+  public static void tearDown() throws Exception {
+    fs.delete(rootDir, true);
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testCalculateRegionSize() throws IOException {
+    TableName tableName = TableName.valueOf("test_table");
+    String snapshotName = "test_snapshot";
+
+    // table has no data
+    TEST_UTIL.createTable(tableName, Bytes.toBytes("info"));
+    admin = TEST_UTIL.getConnection().getAdmin();
+    admin.snapshot(snapshotName, tableName);
+    Path snapshotDir = SnapshotDescriptionUtils.getCompletedSnapshotDir(snapshotName,
+      TEST_UTIL.getDefaultRootDirPath());
+    SnapshotProtos.SnapshotDescription snapshotDesc =
+      SnapshotDescriptionUtils.readSnapshotInfo(TEST_UTIL.getTestFileSystem(), snapshotDir);
+    SnapshotManifest manifest = SnapshotManifest.open(TEST_UTIL.getConfiguration(),
+      TEST_UTIL.getTestFileSystem(), snapshotDir, snapshotDesc);
+
+    RegionSizes regionSizes =
+      SnapshotRegionSizeCalculator.calculateRegionSizes(TEST_UTIL.getConfiguration(), manifest);
+
+    for (Map.Entry<String, Long> entry : regionSizes.getRegionSizeMap().entrySet()) {
+      assertEquals(0, (long) entry.getValue(), "Region size should be 0.");
+    }
+
+    admin.deleteSnapshot(snapshotName);
+
+    // table has some data
+    TEST_UTIL.loadTable(admin.getConnection().getTable(tableName), Bytes.toBytes("info"));
+    admin.snapshot(snapshotName, tableName);
+    snapshotDir = SnapshotDescriptionUtils.getCompletedSnapshotDir(snapshotName,
+      TEST_UTIL.getDefaultRootDirPath());
+    snapshotDesc =
+      SnapshotDescriptionUtils.readSnapshotInfo(TEST_UTIL.getTestFileSystem(), snapshotDir);
+    manifest = SnapshotManifest.open(TEST_UTIL.getConfiguration(), TEST_UTIL.getTestFileSystem(),
+      snapshotDir, snapshotDesc);
+    regionSizes =
+      SnapshotRegionSizeCalculator.calculateRegionSizes(TEST_UTIL.getConfiguration(), manifest);
+    for (Map.Entry<String, Long> entry : regionSizes.getRegionSizeMap().entrySet()) {
+      assertTrue(entry.getValue() > 0, "Region size should be greater than 0.");
+    }
+
+    TEST_UTIL.deleteTable(tableName);
+    admin.deleteSnapshot(snapshotName);
+  }
+}


### PR DESCRIPTION
Fix the issue that after Spark 3.2.0, when Spark reads an HBase snapshot, it always read empty,  even if the hbase snapshot actually has data. 

