### PR TITLE
HBASE-29273 Remove deprecated boxed primitive constructors in some test classes

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMultiParallel.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestMultiParallel.java
@@ -143,7 +143,7 @@ public class TestMultiParallel {
       byte[] k = starterKeys[kIdx];
       byte[] cp = new byte[k.length + 1];
       System.arraycopy(k, 0, cp, 0, k.length);
-      cp[k.length] = new Integer(i % 256).byteValue();
+      cp[k.length] = (byte) (i % 256);
       keys.add(cp);
     }
 
@@ -156,7 +156,7 @@ public class TestMultiParallel {
       byte[] k = starterKeys[kIdx];
       byte[] cp = new byte[k.length + 1];
       System.arraycopy(k, 0, cp, 0, k.length);
-      cp[k.length] = new Integer(i % 256).byteValue();
+      cp[k.length] = (byte) (i % 256);
       keys.add(cp);
     }
     return keys.toArray(new byte[][] { new byte[] {} });

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestTimestampsFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestTimestampsFilter.java
@@ -192,7 +192,7 @@ public class TestTimestampsFilter {
     ht.put(p);
 
     ArrayList<Long> timestamps = new ArrayList<>();
-    timestamps.add(new Long(3));
+    timestamps.add(3L);
     TimestampsFilter filter = new TimestampsFilter(timestamps);
 
     Get g = new Get(Bytes.toBytes("row"));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileDataBlockEncoder.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileDataBlockEncoder.java
@@ -238,7 +238,7 @@ public class TestHFileDataBlockEncoder {
         HFileDataBlockEncoder dbe = (diskAlgo == DataBlockEncoding.NONE)
           ? NoOpDataBlockEncoder.INSTANCE
           : new HFileDataBlockEncoderImpl(diskAlgo);
-        configurations.add(new Object[] { dbe, new Boolean(includesMemstoreTS) });
+        configurations.add(new Object[] { dbe, includesMemstoreTS });
       }
     }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestDeadServer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestDeadServer.java
@@ -125,10 +125,10 @@ public class TestDeadServer {
     Assert.assertEquals(2, copy.size());
 
     Assert.assertEquals(hostname1234, copy.get(0).getFirst());
-    Assert.assertEquals(new Long(2L), copy.get(0).getSecond());
+    Assert.assertEquals(Long.valueOf(2L), copy.get(0).getSecond());
 
     Assert.assertEquals(hostname12345, copy.get(1).getFirst());
-    Assert.assertEquals(new Long(3L), copy.get(1).getSecond());
+    Assert.assertEquals(Long.valueOf(3L), copy.get(1).getSecond());
 
     EnvironmentEdgeManager.reset();
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScannerWithBulkload.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScannerWithBulkload.java
@@ -177,7 +177,7 @@ public class TestScannerWithBulkload {
       // Set a big MAX_SEQ_ID_KEY. Scan should not look at this seq id in a bulk loaded file.
       // Scan should only look at the seq id appended at the bulk load time, and not skip its
       // kv.
-      writer.appendFileInfo(MAX_SEQ_ID_KEY, Bytes.toBytes(new Long(9999999)));
+      writer.appendFileInfo(MAX_SEQ_ID_KEY, Bytes.toBytes(Long.valueOf(9999999)));
     } else {
       writer.appendFileInfo(BULKLOAD_TIME_KEY, Bytes.toBytes(EnvironmentEdgeManager.currentTime()));
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestLogRolling.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/wal/TestLogRolling.java
@@ -345,7 +345,7 @@ public class TestLogRolling extends AbstractTestLogRolling {
         @Override
         public void preLogRoll(Path oldFile, Path newFile) {
           LOG.debug("preLogRoll: oldFile=" + oldFile + " newFile=" + newFile);
-          preLogRolledCalled.add(new Integer(1));
+          preLogRolledCalled.add(1);
         }
 
         @Override


### PR DESCRIPTION
Details see: [HBASE-29273](https://issues.apache.org/jira/browse/HBASE-29273)