### PR TITLE
HBASE-29281 Atomic request throttles are missing QuotaSettingsFactory support

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaSettingsFactory.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/quotas/QuotaSettingsFactory.java
@@ -168,6 +168,18 @@ public class QuotaSettingsFactory {
       settings.add(ThrottleSettings.fromTimedQuota(userName, tableName, namespace, regionServer,
         ThrottleType.WRITE_CAPACITY_UNIT, throttle.getWriteCapacityUnit()));
     }
+    if (throttle.hasAtomicReadSize()) {
+      settings.add(ThrottleSettings.fromTimedQuota(userName, tableName, namespace, regionServer,
+        ThrottleType.ATOMIC_READ_SIZE, throttle.getAtomicReadSize()));
+    }
+    if (throttle.hasAtomicWriteSize()) {
+      settings.add(ThrottleSettings.fromTimedQuota(userName, tableName, namespace, regionServer,
+        ThrottleType.ATOMIC_WRITE_SIZE, throttle.getAtomicWriteSize()));
+    }
+    if (throttle.hasAtomicReqNum()) {
+      settings.add(ThrottleSettings.fromTimedQuota(userName, tableName, namespace, regionServer,
+        ThrottleType.ATOMIC_REQUEST_NUMBER, throttle.getAtomicReqNum()));
+    }
     return settings;
   }
 


### PR DESCRIPTION
While rolling out atomic throttles at my day job, I realized that we're unable to fetch our atomic throttle settings. This is because, in https://issues.apache.org/jira/browse/HBASE-29229, I forgot to wire up atomic throttles in the QuotaSettingsFactory.

I've also added a test that will make it much harder to make this same mistake down the road