### PR TITLE
HBASE-29292 Revise TestRecreateCluster

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestRecreateCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestRecreateCluster.java
@@ -28,9 +28,9 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
-import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.SingleProcessHBaseCluster;
+import org.apache.hadoop.hbase.StartTestingClusterOption;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.client.Get;
@@ -38,13 +38,12 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Table;
-import org.apache.hadoop.hbase.master.region.MasterRegionFactory;
-import org.apache.hadoop.hbase.procedure2.store.wal.WALProcedureStore;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.zookeeper.ZKUtil;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.ClassRule;
 import org.junit.Rule;
@@ -72,9 +71,16 @@ public class TestRecreateCluster {
   private static final long MASTER_INIT_TIMEOUT_MS = Duration.ofSeconds(45).toMillis();
 
   @Before
-  public void setup() {
+  public void setup() throws Exception {
     TEST_UTIL.getConfiguration().setLong("hbase.master.init.timeout.localHBaseCluster",
       MASTER_INIT_TIMEOUT_MS);
+    TEST_UTIL.startMiniCluster(StartTestingClusterOption.builder().numRegionServers(NUM_RS)
+      .numDataNodes(NUM_RS).createWALDir(true).build());
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
   }
 
   @Test
@@ -89,21 +95,18 @@ public class TestRecreateCluster {
 
   @Test
   public void testRecreateCluster_UserTableEnabled_CleanupZNodes() throws Exception {
-    // this is no longer failing and is a different behavior compared to branch-2
+    // this is no longer failing because master region stores the information the region servers
+    // as long as it's gracefully flushed before shutdown
     validateRecreateClusterWithUserTableEnabled(false, true);
   }
 
-  @Test(expected = IOException.class)
+  @Test
   public void testRecreateCluster_UserTableEnabled_CleanupWALAndZNodes() throws Exception {
-    // master fails with InitMetaProcedure because it cannot delete existing meta table directory,
-    // region server cannot join and time-out the cluster starts.
     validateRecreateClusterWithUserTableEnabled(true, true);
   }
 
   private void validateRecreateClusterWithUserDisabled(boolean cleanupWALs, boolean cleanUpZNodes)
     throws Exception {
-    TEST_UTIL.startMiniCluster(NUM_RS);
-    try {
       TableName tableName = TableName.valueOf("t1");
       prepareDataBeforeRecreate(TEST_UTIL, tableName);
       TEST_UTIL.getAdmin().disableTable(tableName);
@@ -111,22 +114,14 @@ public class TestRecreateCluster {
       restartHBaseCluster(cleanupWALs, cleanUpZNodes);
       TEST_UTIL.getAdmin().enableTable(tableName);
       validateDataAfterRecreate(TEST_UTIL, tableName);
-    } finally {
-      TEST_UTIL.shutdownMiniCluster();
-    }
   }
 
   private void validateRecreateClusterWithUserTableEnabled(boolean cleanupWALs,
     boolean cleanUpZNodes) throws Exception {
-    TEST_UTIL.startMiniCluster(NUM_RS);
-    try {
       TableName tableName = TableName.valueOf("t1");
       prepareDataBeforeRecreate(TEST_UTIL, tableName);
       restartHBaseCluster(cleanupWALs, cleanUpZNodes);
       validateDataAfterRecreate(TEST_UTIL, tableName);
-    } finally {
-      TEST_UTIL.shutdownMiniCluster();
-    }
   }
 
   private void restartHBaseCluster(boolean cleanUpWALs, boolean cleanUpZnodes) throws Exception {
@@ -147,17 +142,7 @@ public class TestRecreateCluster {
     TEST_UTIL.shutdownMiniHBaseCluster();
 
     if (cleanUpWALs) {
-      TEST_UTIL.getDFSCluster().getFileSystem()
-        .delete(new Path(rootDirPath, MasterRegionFactory.MASTER_STORE_DIR), true);
-      TEST_UTIL.getDFSCluster().getFileSystem()
-        .delete(new Path(walRootDirPath, MasterRegionFactory.MASTER_STORE_DIR), true);
-      TEST_UTIL.getDFSCluster().getFileSystem()
-        .delete(new Path(walRootDirPath, WALProcedureStore.MASTER_PROCEDURE_LOGDIR), true);
-
-      TEST_UTIL.getDFSCluster().getFileSystem()
-        .delete(new Path(walRootDirPath, HConstants.HREGION_LOGDIR_NAME), true);
-      TEST_UTIL.getDFSCluster().getFileSystem()
-        .delete(new Path(walRootDirPath, HConstants.HREGION_OLDLOGDIR_NAME), true);
+      TEST_UTIL.getDFSCluster().getFileSystem().delete(walRootDirPath, true);
     }
 
     if (cleanUpZnodes) {
@@ -200,7 +185,6 @@ public class TestRecreateCluster {
     SingleProcessHBaseCluster hbaseCluster = TEST_UTIL.getHBaseCluster();
     assertTrue("Please start more than 1 regionserver",
       hbaseCluster.getRegionServerThreads().size() > 1);
-
     int userTableServerNum = getServerNumForTableWithOnlyOneRegion(userTable);
     int systemTableServerNum = getServerNumForTableWithOnlyOneRegion(systemTable);
 
@@ -241,5 +225,4 @@ public class TestRecreateCluster {
       Bytes.toString(cell.getValueArray(), cell.getValueOffset(), cell.getValueLength()));
     assertFalse(result.advance());
   }
-
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestRecreateCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestRecreateCluster.java
@@ -107,21 +107,21 @@ public class TestRecreateCluster {
 
   private void validateRecreateClusterWithUserDisabled(boolean cleanupWALs, boolean cleanUpZNodes)
     throws Exception {
-      TableName tableName = TableName.valueOf("t1");
-      prepareDataBeforeRecreate(TEST_UTIL, tableName);
-      TEST_UTIL.getAdmin().disableTable(tableName);
-      TEST_UTIL.waitTableDisabled(tableName.getName());
-      restartHBaseCluster(cleanupWALs, cleanUpZNodes);
-      TEST_UTIL.getAdmin().enableTable(tableName);
-      validateDataAfterRecreate(TEST_UTIL, tableName);
+    TableName tableName = TableName.valueOf("t1");
+    prepareDataBeforeRecreate(TEST_UTIL, tableName);
+    TEST_UTIL.getAdmin().disableTable(tableName);
+    TEST_UTIL.waitTableDisabled(tableName.getName());
+    restartHBaseCluster(cleanupWALs, cleanUpZNodes);
+    TEST_UTIL.getAdmin().enableTable(tableName);
+    validateDataAfterRecreate(TEST_UTIL, tableName);
   }
 
   private void validateRecreateClusterWithUserTableEnabled(boolean cleanupWALs,
     boolean cleanUpZNodes) throws Exception {
-      TableName tableName = TableName.valueOf("t1");
-      prepareDataBeforeRecreate(TEST_UTIL, tableName);
-      restartHBaseCluster(cleanupWALs, cleanUpZNodes);
-      validateDataAfterRecreate(TEST_UTIL, tableName);
+    TableName tableName = TableName.valueOf("t1");
+    prepareDataBeforeRecreate(TEST_UTIL, tableName);
+    restartHBaseCluster(cleanupWALs, cleanUpZNodes);
+    validateDataAfterRecreate(TEST_UTIL, tableName);
   }
 
   private void restartHBaseCluster(boolean cleanUpWALs, boolean cleanUpZnodes) throws Exception {


### PR DESCRIPTION
TestRecreateCluster has a logic error and and would cleanup the master region in the root directory, this is not the right case we would like to support in the cloud storage that we expect the hbase cluster to shutdown gracefully and master region to be flushed to permanent storage as HFiles. 