### PR TITLE
HBASE-29314 TableDescriptorChecker should verify CF configuration set via setConfiguration (branch-2)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/TableDescriptorChecker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/TableDescriptorChecker.java
@@ -84,7 +84,8 @@ public final class TableDescriptorChecker {
     warnOrThrowExceptionForFailure(logWarn, () -> ConfigKey.validate(conf));
     warnOrThrowExceptionForFailure(logWarn, () -> {
       for (ColumnFamilyDescriptor cfd : td.getColumnFamilies()) {
-        ConfigKey.validate(new CompoundConfiguration().addBytesMap(cfd.getValues()));
+        ConfigKey.validate(new CompoundConfiguration().addStringMap(cfd.getConfiguration())
+          .addBytesMap(cfd.getValues()));
       }
     });
 


### PR DESCRIPTION
HBASE-29137 was backported to branch-2 in #6799, but @guluo2016 pointed out that it doesn't perform verification of the column-familiy level configuration.

* See https://github.com/apache/hbase/pull/6799#discussion_r2084374632

This was due to the change of the alter command of HBase shell in #1959 in master branch which decided to use `setValue` instead of `setConfiguration`. So in branch-2, we need to check the values in the `configuration`, instead of `values`. But in this patch, I updated the code to check both.

The unit test was unable to detect this because it was using `setValue` instead of `setConfiguration`.

@Apache9 Do you think we also need this in master branch? Could you explain the difference between "values" and "configuration"? Are we phasing out the latter?