### PR TITLE
HBASE-29137 Verify CF configuration set via setConfiguration

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/TableDescriptorChecker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/TableDescriptorChecker.java
@@ -84,7 +84,8 @@ public final class TableDescriptorChecker {
     warnOrThrowExceptionForFailure(logWarn, () -> ConfigKey.validate(conf));
     warnOrThrowExceptionForFailure(logWarn, () -> {
       for (ColumnFamilyDescriptor cfd : td.getColumnFamilies()) {
-        ConfigKey.validate(new CompoundConfiguration().addBytesMap(cfd.getValues()));
+        ConfigKey.validate(new CompoundConfiguration().addStringMap(cfd.getConfiguration())
+          .addBytesMap(cfd.getValues()));
       }
     });
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestTableDescriptorChecker.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestTableDescriptorChecker.java
@@ -66,21 +66,32 @@ public class TestTableDescriptorChecker {
     t.setValue(key, "1");
     TableDescriptorChecker.sanityCheck(conf, t.build());
 
-    // Error in column family configuration.
-    cf.setValue(key, "xx");
-    t.removeColumnFamily("cf".getBytes());
-    t.setColumnFamily(cf.build());
-    try {
-      TableDescriptorChecker.sanityCheck(conf, t.build());
-      fail("Should have thrown IllegalArgumentException");
-    } catch (DoNotRetryIOException e) {
-      // Expected
-    }
+    // Verify column family configuration.
+    for (boolean viaSetValue : new boolean[] { true, false }) {
+      // Error in column family configuration.
+      if (viaSetValue) {
+        cf.setValue(key, "xx");
+      } else {
+        cf.setConfiguration(key, "xx");
+      }
+      t.removeColumnFamily("cf".getBytes());
+      t.setColumnFamily(cf.build());
+      try {
+        TableDescriptorChecker.sanityCheck(conf, t.build());
+        fail("Should have thrown IllegalArgumentException");
+      } catch (DoNotRetryIOException e) {
+        // Expected
+      }
 
-    // Fix the error.
-    cf.setValue(key, "1");
-    t.removeColumnFamily("cf".getBytes());
-    t.setColumnFamily(cf.build());
-    TableDescriptorChecker.sanityCheck(conf, t.build());
+      // Fix the error.
+      if (viaSetValue) {
+        cf.setValue(key, "");
+      } else {
+        cf.setConfiguration(key, "");
+      }
+      t.removeColumnFamily("cf".getBytes());
+      t.setColumnFamily(cf.build());
+      TableDescriptorChecker.sanityCheck(conf, t.build());
+    }
   }
 }


### PR DESCRIPTION
Related #6986

Also verify CF configuration set via `setConfiguration` in addition to `setValue`. This is not required for `alter` command of HBase shell because it only uses `setValue`.