### PR TITLE
HBASE-29315: Cancel Split/MergeTableRegionProcedure if table modification is in progress

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
@@ -450,6 +450,19 @@ public class MergeTableRegionsProcedure
         "Skip merging regions " + regionNamesToLog + ", because we are snapshotting " + tn);
     }
 
+    /*
+     * Sometimes a ModifyTableProcedure has edited a table descriptor to change the number of region
+     * replicas for a table, but it has not yet opened/closed the new replicas. The
+     * ModifyTableProcedure assumes that nobody else will do the opening/closing of the new
+     * replicas, but a concurrent MergeTableRegionProcedure would violate that assumption.
+     */
+    if (isTableModificationInProgress(env)) {
+      setFailure(getClass().getSimpleName(),
+        new IOException("Skip merging regions " + regionNamesToLog
+          + ", because there is an active procedure that is modifying the table " + tn));
+      return false;
+    }
+
     // Mostly the below two checks are not used because we already check the switches before
     // submitting the merge procedure. Just for safety, we are checking the switch again here.
     // Also, in case the switch was set to false after submission, this procedure can be rollbacked,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
@@ -103,6 +103,8 @@ public class SplitTableRegionProcedure
   private RegionInfo daughterTwoRI;
   private byte[] bestSplitRow;
   private RegionSplitPolicy splitPolicy;
+  // exposed for unit testing
+  boolean checkTableModifyInProgress = true;
 
   public SplitTableRegionProcedure() {
     // Required by the Procedure framework to create the procedure on replay
@@ -514,6 +516,20 @@ public class SplitTableRegionProcedure
         + ", because we are taking snapshot for the table " + getParentRegion().getTable()));
       return false;
     }
+
+    /*
+     * Sometimes a ModifyTableProcedure has edited a table descriptor to change the number of region
+     * replicas for a table, but it has not yet opened/closed the new replicas. The
+     * ModifyTableProcedure assumes that nobody else will do the opening/closing of the new
+     * replicas, but a concurrent SplitTableRegionProcedure would violate that assumption.
+     */
+    if (checkTableModifyInProgress && isTableModificationInProgress(env)) {
+      setFailure(new IOException("Skip splitting region " + getParentRegion().getShortNameToLog()
+        + ", because there is an active procedure that is modifying the table "
+        + getParentRegion().getTable()));
+      return false;
+    }
+
     // Check whether the region is splittable
     RegionStateNode node =
       env.getAssignmentManager().getRegionStates().getRegionStateNode(getParentRegion());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/AbstractStateMachineTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/AbstractStateMachineTableProcedure.java
@@ -192,4 +192,15 @@ public abstract class AbstractStateMachineTableProcedure<TState>
     }
     regionNode.checkOnline();
   }
+
+  /**
+   * Some procedures cannot safely run while a table is being modified. Helper method to allow them
+   * to check if such a procedure is running on a table.
+   */
+  protected final boolean isTableModificationInProgress(MasterProcedureEnv env) {
+    return env.getMasterServices().getMasterProcedureExecutor().getProcedures().stream()
+      .filter(p -> !p.isFinished()).filter(p -> p instanceof TableProcedureInterface)
+      .map(p -> (TableProcedureInterface) p).filter(p -> getTableName().equals(p.getTableName()))
+      .anyMatch(TableQueue::requireTableExclusiveLock);
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/RegionServerHostingReplicaSlowOpenCoprocessor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/RegionServerHostingReplicaSlowOpenCoprocessor.java
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.assignment;
+
+import java.util.Optional;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.RegionObserver;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * This coprocessor is used to slow down opening of the replica regions.
+ */
+public class RegionServerHostingReplicaSlowOpenCoprocessor
+  implements RegionCoprocessor, RegionObserver {
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(RegionServerHostingReplicaSlowOpenCoprocessor.class);
+
+  static volatile boolean slowDownReplicaOpen = false;
+
+  @Override
+  public Optional<RegionObserver> getRegionObserver() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public void preOpen(ObserverContext<? extends RegionCoprocessorEnvironment> c) {
+    int replicaId = c.getEnvironment().getRegion().getRegionInfo().getReplicaId();
+    if (replicaId != RegionInfo.DEFAULT_REPLICA_ID) {
+      while (slowDownReplicaOpen) {
+        LOG.info("Slow down replica region open a bit");
+        try {
+          Thread.sleep(250);
+        } catch (InterruptedException ignored) {
+          return;
+        }
+      }
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateRegionProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestTruncateRegionProcedure.java
@@ -35,7 +35,6 @@ import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
-import org.apache.hadoop.hbase.master.assignment.TestSplitTableRegionProcedure;
 import org.apache.hadoop.hbase.procedure2.Procedure;
 import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
 import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
@@ -70,8 +69,6 @@ public class TestTruncateRegionProcedure extends TestTableDDLProcedureBase {
   private static void setupConf(Configuration conf) {
     conf.setInt(MasterProcedureConstants.MASTER_PROCEDURE_THREADS, 1);
     conf.setLong(HConstants.MAJOR_COMPACTION_PERIOD, 0);
-    conf.set("hbase.coprocessor.region.classes",
-      TestSplitTableRegionProcedure.RegionServerHostingReplicaSlowOpenCopro.class.getName());
     conf.setInt("hbase.client.sync.wait.timeout.msec", 60000);
   }
 


### PR DESCRIPTION
When adding new replicas, ModifyTableProcedure roughly does the following:

1. Edits the table descriptor
1. Closes and opens all existing regions
1. Creates replication peer to support the new replica regions
1. Opens new replica regions

When closing a region in step 2, the act of closing it can trigger a split. When the HMaster runs the SplitTableRegionProcedure, it roughly does:

1. Close the region to be split
1. Split the store files
1. Open the new daughter regions (including replicas)

When a split is done as part of a ModifyTableProcedure that adds replicas, we get the following combination of behavior:

1. Edit the table descriptor
1. Close and open all existing regions, adding a SplitTableRegionProcedure to the HMaster's queue
1. To begin the SplitTableRegionProcedure, close region to be split
1. Split store files
1. Open the new daughter regions, including replicas, completing the SplitTableRegionProcedure
1. Create replication peer to support the new replica regions
1.  Open new replica regions, even though some were already opened in step 5. Double-opening doesn't work, and the open procedures get stuck.

There are a few ways to correct this problem, but perhaps the most intuitive way is to use the existing lock mechanisms in the procedure system. The ModifyTableProcedure can lock the table from beginning to end, allowing only itself and its child procedures to modify the table. This would enforce in code what is already an implicit assumption in the implementation of the procedure – that nobody else open regions while it's running.

Also in this PR, I have included some new trace logging that helped me when debugging this issue. I thought it might help others in the future.