### PR TITLE
HBASE-29323 Use Priority Handler for all RegionServerStatus rpc at Master

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterAnnotationReadingPriorityFunction.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterAnnotationReadingPriorityFunction.java
@@ -92,7 +92,7 @@ public class MasterAnnotationReadingPriorityFunction
       }
       return HConstants.HIGH_QOS;
     }
-    // also use HIGH_QOS for region server report
+    // also use HIGH_QOS for all rest methods in RegionServerStatusProtos
     if (param.getClass().getEnclosingClass().equals(RegionServerStatusProtos.class)) {
       return HConstants.HIGH_QOS;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterAnnotationReadingPriorityFunction.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterAnnotationReadingPriorityFunction.java
@@ -93,7 +93,7 @@ public class MasterAnnotationReadingPriorityFunction
       return HConstants.HIGH_QOS;
     }
     // also use HIGH_QOS for all rest methods in RegionServerStatusProtos
-    if (param.getClass().getEnclosingClass().equals(RegionServerStatusProtos.class)) {
+    if (RegionServerStatusProtos.class.equals(param.getClass().getEnclosingClass())) {
       return HConstants.HIGH_QOS;
     }
     // Trust the client-set priorities if set

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterAnnotationReadingPriorityFunction.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterAnnotationReadingPriorityFunction.java
@@ -93,7 +93,7 @@ public class MasterAnnotationReadingPriorityFunction
       return HConstants.HIGH_QOS;
     }
     // also use HIGH_QOS for region server report
-    if (param instanceof RegionServerStatusProtos.RegionServerReportRequest) {
+    if (param.getClass().getEnclosingClass().equals(RegionServerStatusProtos.class)) {
       return HConstants.HIGH_QOS;
     }
     // Trust the client-set priorities if set

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -1851,7 +1851,6 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
-  @QosPriority(priority = HConstants.ADMIN_QOS)
   public ReportRegionStateTransitionResponse reportRegionStateTransition(RpcController c,
     ReportRegionStateTransitionRequest req) throws ServiceException {
     try {
@@ -2559,7 +2558,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
-  @QosPriority(priority = HConstants.ADMIN_QOS)
+  @QosPriority(priority = HConstants.HIGH_QOS)
   public ReportProcedureDoneResponse reportProcedureDone(RpcController controller,
     ReportProcedureDoneRequest request) throws ServiceException {
     // Check Masters is up and ready for duty before progressing. Remote side will keep trying.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -1851,6 +1851,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
+  @QosPriority(priority = HConstants.ADMIN_QOS)
   public ReportRegionStateTransitionResponse reportRegionStateTransition(RpcController c,
     ReportRegionStateTransitionRequest req) throws ServiceException {
     try {
@@ -2558,6 +2559,7 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
+  @QosPriority(priority = HConstants.ADMIN_QOS)
   public ReportProcedureDoneResponse reportProcedureDone(RpcController controller,
     ReportProcedureDoneRequest request) throws ServiceException {
     // Check Masters is up and ready for duty before progressing. Remote side will keep trying.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -608,7 +608,8 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
-  @QosPriority(priority = HConstants.ADMIN_QOS)
+  // priority for all RegionServerStatusProtos rpc's are set HIGH_QOS in
+  // MasterAnnotationReadingPriorityFunction itself
   public GetLastFlushedSequenceIdResponse getLastFlushedSequenceId(RpcController controller,
     GetLastFlushedSequenceIdRequest request) throws ServiceException {
     try {
@@ -623,7 +624,6 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
-  @QosPriority(priority = HConstants.ADMIN_QOS)
   public RegionServerReportResponse regionServerReport(RpcController controller,
     RegionServerReportRequest request) throws ServiceException {
     try {
@@ -659,7 +659,6 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
-  @QosPriority(priority = HConstants.ADMIN_QOS)
   public RegionServerStartupResponse regionServerStartup(RpcController controller,
     RegionServerStartupRequest request) throws ServiceException {
     // Register with server manager
@@ -691,7 +690,6 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
-  @QosPriority(priority = HConstants.ADMIN_QOS)
   public ReportRSFatalErrorResponse reportRSFatalError(RpcController controller,
     ReportRSFatalErrorRequest request) throws ServiceException {
     String errorText = request.getErrorMessage();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -2558,7 +2558,6 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
   }
 
   @Override
-  @QosPriority(priority = HConstants.HIGH_QOS)
   public ReportProcedureDoneResponse reportProcedureDone(RpcController controller,
     ReportProcedureDoneRequest request) throws ServiceException {
     // Check Masters is up and ready for duty before progressing. Remote side will keep trying.

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterQosFunction.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterQosFunction.java
@@ -98,7 +98,7 @@ public class TestMasterQosFunction extends QosTestBase {
 
   @Test
   public void testAnnotations() {
-    checkMethod(conf, "GetLastFlushedSequenceId", HConstants.ADMIN_QOS, qosFunction);
+    checkMethod(conf, "GetRegionInfo", HConstants.ADMIN_QOS, qosFunction);
   }
 
   @Test


### PR DESCRIPTION
These reports are critical for completing region movements and ensuring availability. Any delay in reporting can directly impact system availability.