### PR TITLE
HBASE-27802 Manage static javascript resources programatically (addendum: Fix not working popovers on UI)

### DIFF
--- a/hbase-rest/src/main/resources/hbase-webapps/rest/footer.jsp
+++ b/hbase-rest/src/main/resources/hbase-webapps/rest/footer.jsp
@@ -19,7 +19,7 @@
 --%>
 
     <script src="/static/js/jquery.min.js" type="text/javascript"></script>
-    <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
     <script src="/static/js/tab.js" type="text/javascript"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -784,7 +784,7 @@
                       <version>${bootstrap.version}</version>
                       <type>jar</type>
                       <overWrite>true</overWrite>
-                      <includes>**/js/bootstrap.min.js</includes>
+                      <includes>**/js/bootstrap.bundle.min.js</includes>
                       <fileMappers>
                         <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
                       </fileMappers>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/master/MasterStatusTmpl.jamon
@@ -441,7 +441,7 @@ AssignmentManager assignmentManager = master.getAssignmentManager();
     <script src="/static/js/jquery.min.js" type="text/javascript"></script>
     <script src="/static/js/jquery.tablesorter.min.js" type="text/javascript"></script>
     <script src="/static/js/parser-date-iso8601.min.js" type="text/javascript"></script>
-    <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
     <script src="/static/js/tab.js" type="text/javascript"></script>
     <script src="/static/js/jqSpager.js" type="text/javascript"></script>
     <script>

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/regionserver/RSStatusTmpl.jamon
@@ -256,7 +256,7 @@ org.apache.hadoop.hbase.zookeeper.MasterAddressTracker;
 </div>
 <script src="/static/js/jquery.min.js" type="text/javascript"></script>
 <script src="/static/js/jquery.tablesorter.min.js" type="text/javascript"></script>
-<script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+<script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
 <script src="/static/js/tab.js" type="text/javascript"></script>
 <script>
 $(document).ready(function()

--- a/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/tool/CanaryStatusTmpl.jamon
+++ b/hbase-server/src/main/jamon/org/apache/hadoop/hbase/tmpl/tool/CanaryStatusTmpl.jamon
@@ -136,7 +136,7 @@ org.apache.hadoop.hbase.util.JvmVersion;
     </div> <!-- /container -->
 
     <script src="/static/js/jquery.min.js" type="text/javascript"></script>
-    <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
     <script src="/static/js/tab.js" type="text/javascript"></script>
   </body>
 </html>

--- a/hbase-server/src/main/resources/hbase-webapps/master/scripts.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/scripts.jsp
@@ -18,7 +18,7 @@
 */
 --%>
     <script src="/static/js/jquery.min.js" type="text/javascript"></script>
-    <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
     <script src="/static/js/tab.js" type="text/javascript"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/hbase-server/src/main/resources/hbase-webapps/regionserver/footer.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/regionserver/footer.jsp
@@ -18,7 +18,7 @@
 */
 --%>
     <script src="/static/js/jquery.min.js" type="text/javascript"></script>
-    <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
     <script src="/static/js/tab.js" type="text/javascript"></script>
     <script type="text/javascript">
       $(document).ready(function() {

--- a/hbase-thrift/src/main/resources/hbase-webapps/thrift/footer.jsp
+++ b/hbase-thrift/src/main/resources/hbase-webapps/thrift/footer.jsp
@@ -18,7 +18,7 @@
 */
 --%>
     <script src="/static/js/jquery.min.js" type="text/javascript"></script>
-    <script src="/static/js/bootstrap.min.js" type="text/javascript"></script>
+    <script src="/static/js/bootstrap.bundle.min.js" type="text/javascript"></script>
     <script src="/static/js/tab.js" type="text/javascript"></script>
     <script type="text/javascript">
       $(document).ready(function() {


### PR DESCRIPTION
Popovers ("Metrics" menu) were not working on the UI and the following JS error was logged to browser console:

```
Uncaught TypeError: i.createPopper is not a function
```

This is because popper.js was not available on the page for Bootstrap.

Solution: We use bootstrap.bundle.min.js instead which includes both popper.js and Bootstrap.