### PR TITLE
HBASE-29293 Upgrade to latest opentelemetry libraries (#6969)

### DIFF
--- a/hbase-assembly/src/main/assembly/client.xml
+++ b/hbase-assembly/src/main/assembly/client.xml
@@ -157,6 +157,7 @@
         <include>org.slf4j:*</include>
         <include>org.apache.logging.log4j:*</include>
         <include>io.opentelemetry:*</include>
+        <include>io.opentelemetry.semconv:*</include>
       </includes>
     </dependencySet>
     <dependencySet>

--- a/hbase-assembly/src/main/assembly/hadoop-three-compat.xml
+++ b/hbase-assembly/src/main/assembly/hadoop-three-compat.xml
@@ -211,6 +211,7 @@
         <include>org.slf4j:*</include>
         <include>org.apache.logging.log4j:*</include>
         <include>io.opentelemetry:*</include>
+        <include>io.opentelemetry.semconv:*</include>
       </includes>
     </dependencySet>
     <dependencySet>

--- a/hbase-assembly/src/main/assembly/hadoop-two-compat.xml
+++ b/hbase-assembly/src/main/assembly/hadoop-two-compat.xml
@@ -211,6 +211,7 @@
         <include>org.slf4j:*</include>
         <include>org.apache.logging.log4j:*</include>
         <include>io.opentelemetry:*</include>
+        <include>io.opentelemetry.semconv:*</include>
       </includes>
     </dependencySet>
     <dependencySet>

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/SpanDataMatchers.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/trace/hamcrest/SpanDataMatchers.java
@@ -26,9 +26,9 @@ import io.opentelemetry.api.trace.SpanKind;
 import io.opentelemetry.api.trace.StatusCode;
 import io.opentelemetry.sdk.trace.data.EventData;
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.time.Duration;
 import java.util.Objects;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.hamcrest.Description;
 import org.hamcrest.FeatureMatcher;
 import org.hamcrest.Matcher;
@@ -87,7 +87,7 @@ public final class SpanDataMatchers {
   }
 
   public static Matcher<SpanData> hasExceptionWithType(Matcher<? super String> matcher) {
-    return hasException(containsEntry(is(SemanticAttributes.EXCEPTION_TYPE), matcher));
+    return hasException(containsEntry(is(HBaseSemanticAttributes.EXCEPTION_TYPE), matcher));
   }
 
   public static Matcher<SpanData> hasException(Matcher<? super Attributes> matcher) {
@@ -96,7 +96,7 @@ public final class SpanDataMatchers {
       @Override
       protected Attributes featureValueOf(SpanData actual) {
         return actual.getEvents().stream()
-          .filter(e -> Objects.equals(SemanticAttributes.EXCEPTION_EVENT_NAME, e.getName()))
+          .filter(e -> Objects.equals(HBaseSemanticAttributes.EXCEPTION_EVENT_NAME, e.getName()))
           .map(EventData::getAttributes).findFirst().orElse(null);
       }
     };

--- a/hbase-common/pom.xml
+++ b/hbase-common/pom.xml
@@ -102,7 +102,7 @@
       <artifactId>opentelemetry-api</artifactId>
     </dependency>
     <dependency>
-      <groupId>io.opentelemetry</groupId>
+      <groupId>io.opentelemetry.semconv</groupId>
       <artifactId>opentelemetry-semconv</artifactId>
     </dependency>
     <dependency>

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/trace/HBaseSemanticAttributes.java
@@ -18,7 +18,7 @@
 package org.apache.hadoop.hbase.trace;
 
 import io.opentelemetry.api.common.AttributeKey;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
+import io.opentelemetry.semconv.SemanticAttributes;
 import java.nio.ByteBuffer;
 import java.util.List;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -56,6 +56,10 @@ public final class HBaseSemanticAttributes {
   public static final AttributeKey<Boolean> ROW_LOCK_READ_LOCK_KEY =
     AttributeKey.booleanKey("db.hbase.rowlock.readlock");
   public static final AttributeKey<String> WAL_IMPL = AttributeKey.stringKey("db.hbase.wal.impl");
+
+  public static final AttributeKey<String> EXCEPTION_TYPE = SemanticAttributes.EXCEPTION_TYPE;
+  public static final AttributeKey<String> EXCEPTION_MESSAGE = SemanticAttributes.EXCEPTION_MESSAGE;
+  public static final String EXCEPTION_EVENT_NAME = SemanticAttributes.EXCEPTION_EVENT_NAME;
 
   /**
    * Indicates the amount of data was read into a {@link ByteBuffer} of type

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableMapReduceUtil.java
@@ -792,7 +792,7 @@ public class TableMapReduceUtil {
       com.codahale.metrics.MetricRegistry.class, // metrics-core
       org.apache.commons.lang3.ArrayUtils.class, // commons-lang
       io.opentelemetry.api.trace.Span.class, // opentelemetry-api
-      io.opentelemetry.semconv.trace.attributes.SemanticAttributes.class, // opentelemetry-semconv
+      io.opentelemetry.semconv.SemanticAttributes.class, // opentelemetry-semconv
       io.opentelemetry.context.Context.class); // opentelemetry-context
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/AbstractTestAsyncTableScan.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/AbstractTestAsyncTableScan.java
@@ -32,7 +32,6 @@ import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.fail;
 
 import io.opentelemetry.sdk.trace.data.SpanData;
-import io.opentelemetry.semconv.trace.attributes.SemanticAttributes;
 import java.io.IOException;
 import java.io.UncheckedIOException;
 import java.util.Arrays;
@@ -55,6 +54,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.ipc.RemoteWithExtrasException;
 import org.apache.hadoop.hbase.regionserver.NoSuchColumnFamilyException;
+import org.apache.hadoop.hbase.trace.HBaseSemanticAttributes;
 import org.apache.hadoop.hbase.trace.OpenTelemetryClassRule;
 import org.apache.hadoop.hbase.trace.OpenTelemetryTestRule;
 import org.apache.hadoop.hbase.trace.TraceUtil;
@@ -283,12 +283,12 @@ public abstract class AbstractTestAsyncTableScan {
       fail("Found unexpected Exception " + e);
     }
     assertTraceError(anyOf(
-      containsEntry(is(SemanticAttributes.EXCEPTION_TYPE),
+      containsEntry(is(HBaseSemanticAttributes.EXCEPTION_TYPE),
         endsWith(NoSuchColumnFamilyException.class.getName())),
       allOf(
-        containsEntry(is(SemanticAttributes.EXCEPTION_TYPE),
+        containsEntry(is(HBaseSemanticAttributes.EXCEPTION_TYPE),
           endsWith(RemoteWithExtrasException.class.getName())),
-        containsEntry(is(SemanticAttributes.EXCEPTION_MESSAGE),
+        containsEntry(is(HBaseSemanticAttributes.EXCEPTION_MESSAGE),
           containsString(NoSuchColumnFamilyException.class.getName())))));
   }
 

--- a/hbase-shaded/hbase-shaded-client/pom.xml
+++ b/hbase-shaded/hbase-shaded-client/pom.xml
@@ -86,6 +86,7 @@
                   <exclude>commons-logging:*</exclude>
                   <exclude>org.javassist:*</exclude>
                   <exclude>io.opentelemetry:*</exclude>
+                  <exclude>io.opentelemetry.semconv:*</exclude>
                 </excludes>
               </artifactSet>
             </configuration>

--- a/hbase-shaded/hbase-shaded-testing-util/pom.xml
+++ b/hbase-shaded/hbase-shaded-testing-util/pom.xml
@@ -137,6 +137,7 @@
                   <exclude>commons-logging:*</exclude>
                   <exclude>org.javassist:*</exclude>
                   <exclude>io.opentelemetry:*</exclude>
+                  <exclude>io.opentelemetry.semconv:*</exclude>
                 </excludes>
               </artifactSet>
             </configuration>

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -132,6 +132,7 @@
                     <exclude>commons-logging:*</exclude>
                     <exclude>org.javassist:*</exclude>
                     <exclude>io.opentelemetry:*</exclude>
+                    <exclude>io.opentelemetry.semconv:*</exclude>
                   </excludes>
                 </artifactSet>
                 <relocations>

--- a/pom.xml
+++ b/pom.xml
@@ -596,8 +596,9 @@
     <jruby.version>9.2.13.0</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
-    <opentelemetry.version>1.15.0</opentelemetry.version>
-    <opentelemetry-javaagent.version>1.15.0</opentelemetry-javaagent.version>
+    <opentelemetry.version>1.49.0</opentelemetry.version>
+    <opentelemetry-semconv.version>1.29.0-alpha</opentelemetry-semconv.version>
+    <opentelemetry-javaagent.version>2.15.0</opentelemetry-javaagent.version>
     <log4j2.version>2.17.2</log4j2.version>
     <mockito.version>4.11.0</mockito.version>
     <!--Internally we use a different version of protobuf. See hbase-protocol-shaded-->
@@ -1380,9 +1381,9 @@
         <scope>import</scope>
       </dependency>
       <dependency>
-        <groupId>io.opentelemetry</groupId>
+        <groupId>io.opentelemetry.semconv</groupId>
         <artifactId>opentelemetry-semconv</artifactId>
-        <version>${opentelemetry.version}-alpha</version>
+        <version>${opentelemetry-semconv.version}</version>
       </dependency>
       <dependency>
         <groupId>io.opentelemetry.javaagent</groupId>


### PR DESCRIPTION
* Move from `io.opentelemetry:opentelemetry-semconv` to relocated groupid `io.opentelemetry.semconv:opentelemetry-semconv` and change imports accordingly.
* Refactoring to keep all semantic attributes inside `HBaseSemanticAttributes`
* Add appropriate excludes and includes for renamed groupid `io.opentelemetry.semconv:opentelemetry-semconv` from `io.opentelemetry:opentelemetry-semconv`

Signed-off-by: Istvan Toth <stoty@apache.org>
Signed-off-by: Nick Dimiduk <ndimiduk@apache.org>

 (cherry picked from commit 82a2ddf789d161877b3920decab9565f56e6aa4b)