### PR TITLE
HBASE-29327 Dependency manage byte-buddy and bump it to 1.15.11 (#7003)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -602,6 +602,7 @@
     <opentelemetry-javaagent.version>1.15.0</opentelemetry-javaagent.version>
     <log4j2.version>2.17.2</log4j2.version>
     <mockito.version>4.11.0</mockito.version>
+    <byte-buddy.version>1.15.11</byte-buddy.version>
     <!--Internally we use a different version of protobuf. See hbase-protocol-shaded-->
     <external.protobuf.groupid>com.google.protobuf</external.protobuf.groupid>
     <external.protobuf.version>2.5.0</external.protobuf.version>
@@ -1370,6 +1371,16 @@
         <groupId>org.hamcrest</groupId>
         <artifactId>hamcrest-library</artifactId>
         <version>${hamcrest.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy</artifactId>
+        <version>${byte-buddy.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>net.bytebuddy</groupId>
+        <artifactId>byte-buddy-agent</artifactId>
+        <version>${byte-buddy.version}</version>
       </dependency>
       <dependency>
         <groupId>org.mockito</groupId>


### PR DESCRIPTION
* This change is required for being able to handle recent Java bytecodes
* Move to latest version which works with maven-shade-plugin 3.6.0

Signed-off-by: Istvan Toth <stoty@apache.org>

(cherry picked from commit 279398254459f296adfee5f1c87a50d4fba5e593)