### PR TITLE
HBASE-29352 Use JRuby 9.2.21.0 to fix shell on Apple M-series processors

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -593,7 +593,7 @@
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
     <tomcat.jasper.version>9.0.93</tomcat.jasper.version>
-    <jruby.version>9.2.13.0</jruby.version>
+    <jruby.version>9.2.21.0</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
     <opentelemetry.version>1.15.0</opentelemetry.version>


### PR DESCRIPTION
Upgrade JRuby to 9.2.21.0 to fix the following error when launching HBase shell on Apple M-series systems:

    NotImplementedError: fstat unimplemented unsupported or native support failed to load

9.2.21.0 is the final release in 9.2 line and the minimum version required to fix the issue.

Reference: https://github.com/jruby/jruby/releases/tag/9.2.21.0

> Support for Apple's M processors has been backported.
> It has not been heavily tested, but it has been confirmed working by users.