### PR TITLE
HBASE-29357 PerformanceEvaluation: Read tests should not drop existing table

### DIFF
--- a/hbase-diagnostics/src/main/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
+++ b/hbase-diagnostics/src/main/java/org/apache/hadoop/hbase/PerformanceEvaluation.java
@@ -422,11 +422,12 @@ public class PerformanceEvaluation extends Configured implements Tool {
         errors.stream().map(s -> '[' + s + ']').collect(Collectors.joining(", "));
 
       if (needsData) {
-        LOG.warn(
-          "Inconsistent table state detected. Consider running a write command first: " + reason);
+        LOG.warn("Unexpected or incorrect options provided for {}. "
+          + "Please verify whether the detected inconsistencies are expected or ignorable: {}. "
+          + "The test will proceed, but the results may not be reliable.", opts.cmdName, reason);
         needsDelete = false;
       } else {
-        LOG.debug(reason);
+        LOG.info("Table will be recreated: " + reason);
       }
     }
 


### PR DESCRIPTION
See https://issues.apache.org/jira/browse/HBASE-29357 for details.

```sh
# Generate data
bin/hbase pe --nomapred --size=2 --presplit=30 sequentialWrite 1

# Perform a read test on the table. Forgot to remove --presplit option, but it's okay.
bin/hbase pe --nomapred --size=2 --presplit=30 --sampleRate=0.1 sequentialRead 1

# Split the regions
bin/hbase shell -n <<< "split 'TestTable'"

# Read tests should not drop existing table

bin/hbase pe --nomapred --size=2 --presplit=30 --sampleRate=0.1 sequentialRead 1
  # Inconsistent table state detected. Consider running a write command first: [--presplit=30, but found 60 regions]

bin/hbase pe --nomapred --size=2 --presplit=30 --replicas=2 --sampleRate=0.1 sequentialRead 1
  # Inconsistent table state detected. Consider running a write command first: [--presplit=30, but found 60 regions], [--replicas=2, but found 1 replicas]

bin/hbase pe --nomapred --size=2 --presplit=30 --replicas=2 --splitPolicy=org.apache.hadoop.hbase.regionserver.DisabledRegionSplitPolicy --sampleRate=0.1 sequentialRead 1
  # Inconsistent table state detected. Consider running a write command first: [--presplit=30, but found 60 regions], [--splitPolicy=org.apache.hadoop.hbase.regionserver.DisabledRegionSplitPolicy, but current policy is null], [--replicas=2, but found 1 replicas]

bin/hbase pe --nomapred --size=2 --presplit=30 --replicas=2 --splitPolicy=org.apache.hadoop.hbase.regionserver.DisabledRegionSplitPolicy --families=2 --sampleRate=0.1 sequentialRead 1
  # java.lang.IllegalStateException: Cannot proceed the test. Run a write command first: --families=2, but found 1 column families
```