### PR TITLE
HBASE-29318 Bump jruby to 9.4.12.1 to fix jruby-openssl CVEs (#6997)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -842,7 +842,7 @@
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
     <tomcat.jasper.version>9.0.104</tomcat.jasper.version>
-    <jruby.version>9.4.9.0</jruby.version>
+    <jruby.version>9.4.12.1</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
     <opentelemetry.version>1.49.0</opentelemetry.version>
@@ -866,8 +866,8 @@
     <jamon-runtime.version>2.4.1</jamon-runtime.version>
     <jettison.version>1.5.4</jettison.version>
     <!--Make sure these joni/jcodings are compatible with the versions used by jruby-->
-    <joni.version>2.2.1</joni.version>
-    <jcodings.version>1.0.58</jcodings.version>
+    <joni.version>2.2.3</joni.version>
+    <jcodings.version>1.0.61</jcodings.version>
     <spy.version>2.12.3</spy.version>
     <bouncycastle.version>1.78</bouncycastle.version>
     <skyscreamer.version>1.5.1</skyscreamer.version>


### PR DESCRIPTION
- Drops moderate jruby-openssl CVE: CVE-2025-46551 and GHSA-72qj-48g4-5xgx  from our classpath.
- Also fixes performance problem in IRB where pasting clipboard content is extremely slow.