### PR TITLE
HBASE-29360 Bump JRuby to version 9.3.15.0 in branch-2.6

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -595,7 +595,7 @@
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
     <tomcat.jasper.version>9.0.104</tomcat.jasper.version>
-    <jruby.version>9.3.13.0</jruby.version>
+    <jruby.version>9.3.15.0</jruby.version>
     <junit.version>4.13.2</junit.version>
     <hamcrest.version>1.3</hamcrest.version>
     <opentelemetry.version>1.49.0</opentelemetry.version>


### PR DESCRIPTION
Bump JRuby to version 9.3.15.0 — the final release in the 9.3 series (June 2024) — to incorporate the latest bug fixes.

* https://github.com/jruby/jruby/releases/tag/9.3.14.0
* https://github.com/jruby/jruby/releases/tag/9.3.15.0

joni and jcodings are already up-to-date.

* https://github.com/apache/hbase/blob/337a5303e3c669f6fb3e1030215cc6af8f9d595a/pom.xml#L626-L627
* https://github.com/jruby/jruby/blob/9.3.15.0/core/pom.rb#L54-L55

/cc @NihalJain 