### PR TITLE
HBASE-29317 Bump hbase-thirdparty to 4.1.11 (#6993) 

### DIFF
--- a/hbase-build-configuration/pom.xml
+++ b/hbase-build-configuration/pom.xml
@@ -82,6 +82,8 @@
                 <arg>-XDcompilePolicy=simple</arg>
                 <!-- All -Xep need to be on single line see: https://github.com/google/error-prone/pull/1115 -->
                 <arg>-Xplugin:ErrorProne -XepDisableWarningsInGeneratedCode -XepExcludedPaths:.*/target/.* -Xep:FallThrough:OFF -Xep:MutablePublicArray:OFF -Xep:ClassNewInstance:ERROR -Xep:MissingDefault:ERROR -Xep:BanJNDI:WARN</arg>
+                <!-- Required by error prone >= 2.36.0. See https://github.com/google/error-prone/commit/e71db1f369a9367f6f2db34c4fbd006b6d6238fd !-->
+                <arg>--should-stop=ifError=FLOW</arg>
               </compilerArgs>
               <annotationProcessorPaths>
                 <path>

--- a/hbase-shaded/hbase-shaded-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
+++ b/hbase-shaded/hbase-shaded-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
@@ -96,7 +96,8 @@ allowed_expr+="|^PropertyList-1.0.dtd$"
 # Shaded jetty resources
 allowed_expr+="|^about.html$"
 allowed_expr+="|^jetty-dir.css$"
-
+# Coming from Guava, see https://github.com/google/guava/commit/2cc8c5eddb587db3ac12dacdd5563e79a4681ec4
+allowed_expr+="|^org/jspecify/$|^org/jspecify/annotations/$|^org/jspecify/annotations/.*\.class$"
 
 if [ -n "${allow_hadoop}" ]; then
   #   * classes in packages that start with org.apache.hadoop, which by

--- a/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
+++ b/hbase-shaded/hbase-shaded-with-hadoop-check-invariants/src/test/resources/ensure-jars-have-correct-contents.sh
@@ -96,7 +96,8 @@ allowed_expr+="|^PropertyList-1.0.dtd$"
 # Shaded jetty resources
 allowed_expr+="|^about.html$"
 allowed_expr+="|^jetty-dir.css$"
-
+# Coming from Guava, see https://github.com/google/guava/commit/2cc8c5eddb587db3ac12dacdd5563e79a4681ec4
+allowed_expr+="|^org/jspecify/$|^org/jspecify/annotations/$|^org/jspecify/annotations/.*\.class$"
 
 if [ -n "${allow_hadoop}" ]; then
   #   * classes in packages that start with org.apache.hadoop, which by

--- a/hbase-shaded/pom.xml
+++ b/hbase-shaded/pom.xml
@@ -90,7 +90,7 @@
         <plugin>
           <groupId>org.apache.maven.plugins</groupId>
           <artifactId>maven-shade-plugin</artifactId>
-          <version>3.5.1</version>
+          <version>3.6.0</version>
           <executions>
             <execution>
               <id>aggregate-into-a-jar-with-relocated-third-parties</id>

--- a/pom.xml
+++ b/pom.xml
@@ -674,7 +674,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.11-SNAPSHOT</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.11</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>
@@ -1596,15 +1596,11 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <!-- TODO Remove below block, added just for testing -->
   <repositories>
     <repository>
-      <snapshots>
-        <enabled>true</enabled>
-        <updatePolicy>always</updatePolicy>
-      </snapshots>
-      <id>apache.snapshots</id>
-      <url>https://repository.apache.org/content/repositories/snapshots</url>
+      <id>staging</id>
+      <name>staging</name>
+      <url>https://repository.apache.org/content/repositories/orgapachehbase-1577</url>
     </repository>
   </repositories>
   <build>

--- a/pom.xml
+++ b/pom.xml
@@ -1596,13 +1596,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-  <repositories>
-    <repository>
-      <id>staging</id>
-      <name>staging</name>
-      <url>https://repository.apache.org/content/repositories/orgapachehbase-1577</url>
-    </repository>
-  </repositories>
   <build>
     <!-- Plugin versions are inherited from ASF parent pom: https://maven.apache.org/pom/asf/
          For specific version use a property and define it in the parent pom.

--- a/pom.xml
+++ b/pom.xml
@@ -564,7 +564,7 @@
       in the dependencyManagement section as it could still lead to different versions of netty
       modules and cause trouble if we only rely on transitive dependencies.
     -->
-    <netty4.version>4.1.119.Final</netty4.version>
+    <netty4.version>4.1.121.Final</netty4.version>
     <!-- end HBASE-15925 default hadoop compatibility values -->
     <audience-annotations.version>0.13.0</audience-annotations.version>
     <!--
@@ -587,8 +587,8 @@
       Note that the version of jackson-[annotations,core,databind] must be kept in sync with the
       version of jackson-jaxrs-json-provider shipped in hbase-thirdparty.
     -->
-    <jackson.version>2.17.2</jackson.version>
-    <jackson.databind.version>2.17.2</jackson.databind.version>
+    <jackson.version>2.19.0</jackson.version>
+    <jackson.databind.version>2.19.0</jackson.databind.version>
     <jaxb-api.version>2.3.1</jaxb-api.version>
     <servlet.api.version>3.1.0</servlet.api.version>
     <wx.rs.api.version>2.1.1</wx.rs.api.version>
@@ -610,7 +610,7 @@
       Version of protobuf that hbase uses internally (we shade our pb) Must match what is out
       in hbase-thirdparty include.
     -->
-    <internal.protobuf.version>4.28.2</internal.protobuf.version>
+    <internal.protobuf.version>4.30.2</internal.protobuf.version>
     <protobuf.plugin.version>0.6.1</protobuf.plugin.version>
     <thrift.path>thrift</thrift.path>
     <thrift.version>0.14.1</thrift.version>
@@ -637,7 +637,7 @@
     -->
     <checkstyle.version>8.29</checkstyle.version>
     <exec.maven.version>3.1.0</exec.maven.version>
-    <error-prone.version>2.28.0</error-prone.version>
+    <error-prone.version>2.38.0</error-prone.version>
     <jamon.plugin.version>2.4.2</jamon.plugin.version>
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
     <maven.antrun.version>1.8</maven.antrun.version>
@@ -672,7 +672,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.10</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.11-SNAPSHOT</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>
@@ -1594,6 +1594,17 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
+  <!-- TODO Remove below block, added just for testing -->
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+      <id>apache.snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
   <build>
     <!-- Plugin versions are inherited from ASF parent pom: https://maven.apache.org/pom/asf/
          For specific version use a property and define it in the parent pom.

--- a/pom.xml
+++ b/pom.xml
@@ -637,7 +637,9 @@
     -->
     <checkstyle.version>8.29</checkstyle.version>
     <exec.maven.version>3.1.0</exec.maven.version>
-    <error-prone.version>2.38.0</error-prone.version>
+    <!-- Error Prone 2.31.0 is the latest version which supports running on JDK 11, see
+    https://github.com/google/error-prone/releases/tag/v2.31.0 for details -->
+    <error-prone.version>2.31.0</error-prone.version>
     <jamon.plugin.version>2.4.2</jamon.plugin.version>
     <lifecycle.mapping.version>1.0.0</lifecycle.mapping.version>
     <maven.antrun.version>1.8</maven.antrun.version>


### PR DESCRIPTION
* Update allowed_expr to allow `org/jspecify/annotation/*.class` which is coming from guava due to https://github.com/google/guava/commit/2cc8c5eddb587db3ac12dacdd5563e79a4681ec4
* Bump maven-shade-plugin to 3.6.0 as we see failure `META-INF/versions/22/com/fasterxml/jackson/core/internal/shaded/fdp/v2_19_0/FastDoubleSwar.class: java.lang.IllegalArgumentException: Unsupported class file major version 66` due to https://github.com/FasterXML/jackson-core/commit/7d8dc09bb772ffb0981e3dcf8e9d95b2273bd756
* Add `--should-stop=ifError=FLOW` as `compilerArgs`. This is required by error prone >= 2.36.0, otherwise compile fails. See https://github.com/google/error-prone/commit/e71db1f369a9367f6f2db34c4fbd006b6d6238fd for details! But since we do not upgrade to 2.36.0 on branch-2.x we have kept this change just to keep code in sync across branches.
* Error Prone 2.31.0 is the latest version which supports running on JDK 11