### PR TITLE
HBASE-29376 ReplicationLogCleaner.preClean/getDeletableFiles should return early when asyncClusterConnection closes during HMaster stopping

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/master/ReplicationLogCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/master/ReplicationLogCleaner.java
@@ -28,6 +28,7 @@ import java.util.stream.Stream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.client.AsyncClusterConnection;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.hadoop.hbase.master.cleaner.BaseLogCleanerDelegate;
@@ -65,6 +66,7 @@ public class ReplicationLogCleaner extends BaseLogCleanerDelegate {
   // queue for a given peer, that why we can use a String peerId as key instead of
   // ReplicationQueueId.
   private Map<ServerName, Map<String, Map<String, ReplicationGroupOffset>>> replicationOffsets;
+  private MasterServices masterService;
   private ReplicationLogCleanerBarrier barrier;
   private ReplicationPeerManager rpm;
   private Supplier<Set<ServerName>> getNotFullyDeadServers;
@@ -74,9 +76,12 @@ public class ReplicationLogCleaner extends BaseLogCleanerDelegate {
 
   @Override
   public void preClean() {
-    if (this.getConf() == null) {
+    if (this.getConf() == null || isAsyncClusterConnectionClosed()) {
+      LOG.warn(
+        "Skip replication log cleaner because the configuration is null or Rpc client has been stopped.");
       return;
     }
+
     try {
       if (!rpm.getQueueStorage().hasData()) {
         return;
@@ -192,6 +197,13 @@ public class ReplicationLogCleaner extends BaseLogCleanerDelegate {
     if (this.getConf() == null) {
       return files;
     }
+
+    if (isAsyncClusterConnectionClosed()) {
+      LOG.warn("Skip getting deletable files because Rpc client has been stopped.");
+      // Rpc client has been stopped, we shouldn't delete any files.
+      return Collections.emptyList();
+    }
+
     try {
       if (!rpm.getQueueStorage().hasData()) {
         return files;
@@ -251,11 +263,11 @@ public class ReplicationLogCleaner extends BaseLogCleanerDelegate {
     super.init(params);
     if (MapUtils.isNotEmpty(params)) {
       Object master = params.get(HMaster.MASTER);
-      if (master != null && master instanceof MasterServices) {
-        MasterServices m = (MasterServices) master;
-        barrier = m.getReplicationLogCleanerBarrier();
-        rpm = m.getReplicationPeerManager();
-        getNotFullyDeadServers = () -> getNotFullyDeadServers(m);
+      if (master instanceof MasterServices) {
+        masterService = (MasterServices) master;
+        barrier = masterService.getReplicationLogCleanerBarrier();
+        rpm = masterService.getReplicationPeerManager();
+        getNotFullyDeadServers = () -> getNotFullyDeadServers(masterService);
         return;
       }
     }
@@ -270,5 +282,14 @@ public class ReplicationLogCleaner extends BaseLogCleanerDelegate {
   @Override
   public boolean isStopped() {
     return this.stopped;
+  }
+
+  /**
+   * Check if asyncClusterConnection is closed
+   * @return true if asyncClusterConnection is not null and is closed, false otherwise
+   */
+  private boolean isAsyncClusterConnectionClosed() {
+    AsyncClusterConnection asyncClusterConnection = masterService.getAsyncClusterConnection();
+    return asyncClusterConnection != null && asyncClusterConnection.isClosed();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/master/ReplicationLogCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/master/ReplicationLogCleaner.java
@@ -76,9 +76,9 @@ public class ReplicationLogCleaner extends BaseLogCleanerDelegate {
 
   @Override
   public void preClean() {
-    if (this.getConf() == null || isAsyncClusterConnectionClosed()) {
+    if (this.getConf() == null || isAsyncClusterConnectionClosedOrNull()) {
       LOG.warn(
-        "Skip replication log cleaner because the configuration is null or Rpc client has been stopped.");
+        "Skipping preClean because configuration is null or asyncClusterConnection is unavailable.");
       return;
     }
 
@@ -198,9 +198,9 @@ public class ReplicationLogCleaner extends BaseLogCleanerDelegate {
       return files;
     }
 
-    if (isAsyncClusterConnectionClosed()) {
-      LOG.warn("Skip getting deletable files because Rpc client has been stopped.");
-      // Rpc client has been stopped, we shouldn't delete any files.
+    if (isAsyncClusterConnectionClosedOrNull()) {
+      LOG.warn("Skip getting deletable files because asyncClusterConnection is unavailable.");
+      // asyncClusterConnection is unavailable, we shouldn't delete any files.
       return Collections.emptyList();
     }
 
@@ -285,11 +285,11 @@ public class ReplicationLogCleaner extends BaseLogCleanerDelegate {
   }
 
   /**
-   * Check if asyncClusterConnection is closed
-   * @return true if asyncClusterConnection is not null and is closed, false otherwise
+   * Check if asyncClusterConnection is null or closed.
+   * @return true if asyncClusterConnection is null or is closed, false otherwise
    */
-  private boolean isAsyncClusterConnectionClosed() {
+  private boolean isAsyncClusterConnectionClosedOrNull() {
     AsyncClusterConnection asyncClusterConnection = masterService.getAsyncClusterConnection();
-    return asyncClusterConnection != null && asyncClusterConnection.isClosed();
+    return asyncClusterConnection == null || asyncClusterConnection.isClosed();
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/cleaner/TestLogsCleaner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/cleaner/TestLogsCleaner.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hbase.Server;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.TableNameTestRule;
 import org.apache.hadoop.hbase.Waiter;
+import org.apache.hadoop.hbase.client.AsyncClusterConnection;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.master.MasterServices;
@@ -134,6 +135,9 @@ public class TestLogsCleaner {
     when(masterServices.getConnection()).thenReturn(TEST_UTIL.getConnection());
     when(masterServices.getReplicationLogCleanerBarrier())
       .thenReturn(new ReplicationLogCleanerBarrier());
+    AsyncClusterConnection asyncClusterConnection = mock(AsyncClusterConnection.class);
+    when(masterServices.getAsyncClusterConnection()).thenReturn(asyncClusterConnection);
+    when(asyncClusterConnection.isClosed()).thenReturn(false);
     ReplicationPeerManager rpm = mock(ReplicationPeerManager.class);
     when(masterServices.getReplicationPeerManager()).thenReturn(rpm);
     when(rpm.getQueueStorage()).thenReturn(queueStorage);


### PR DESCRIPTION
Details see: HBASE-29376

### After applying this patch
Setting `hbase.master.cleaner.interval` to `10000ms`, and when stopping the HMaster service, we can observe the following logs.
```
2025-06-05T07:30:03,108 INFO  [RS:0;localhost:16020] regionserver.HRegionServer: Closing user regions
2025-06-05T07:30:08,773 WARN  [master/localhost:16000.Chore.1] master.ReplicationLogCleaner: Rpc client has been stopped.
2025-06-05T07:30:09,124 INFO  [RS:0;localhost:16020] regionserver.HRegionServer: ***** STOPPING region server 'localhost,16020,1749079746517' *****
```