### PR TITLE
HBASE-29385: Improve performance of AggregrateImplementation quota checks

### DIFF
--- a/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/coprocessor/TestAggregateImplementation.java
+++ b/hbase-endpoint/src/test/java/org/apache/hadoop/hbase/coprocessor/TestAggregateImplementation.java
@@ -99,7 +99,7 @@ public class TestAggregateImplementation {
     when(region.getRegionInfo()).thenReturn(regionInfo);
     when(regionInfo.getRegionNameAsString()).thenReturn("testRegion");
 
-    scan = new Scan().addColumn(CF, CQ);
+    scan = new Scan().addColumn(CF, CQ).setCaching(1);
 
     scanner = mock(RegionScannerImpl.class);
     doAnswer(createMockScanner()).when(scanner).next(any(List.class));


### PR DESCRIPTION
- Check for quota exceeded every `scan.getCaching()` rows, if set. Otherwise, every `hbase.client.scanner.caching` rows, if set. Otherwise, every 1000.
- Move some debug logs to a more appropriate position, so they only print if a response is generated without error
- Save a `Cell` object in `PartialResultContext` instead of a byte array. This is simpler and avoids copying ByteBuff-backed cells into heap.