### PR TITLE
HBASE-29388 mvn spotless:apply changes line endings (CRLF to LF) on Windows

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -3100,7 +3100,7 @@
             We're instructing it to respect the line ending definitions in .gitattributes
             for these files.
             For more details, please refer to HBASE-29388.
-           -->
+          -->
           <lineEndings>GIT_ATTRIBUTES</lineEndings>
           <!-- define a language-specific format -->
           <java>

--- a/pom.xml
+++ b/pom.xml
@@ -3095,6 +3095,13 @@
             -->
             <enabled>false</enabled>
           </upToDateChecking>
+          <!--
+            On Windows, spotless might convert the line endings of these files to LF.
+            We're instructing it to respect the line ending definitions in .gitattributes
+            for these files.
+            For more details, please refer to HBASE-29388.
+           -->
+          <lineEndings>GIT_ATTRIBUTES</lineEndings>
           <!-- define a language-specific format -->
           <java>
             <excludes>
@@ -3175,13 +3182,6 @@
               <!-- define the steps to apply to those files -->
               <trimTrailingWhitespace/>
               <endWithNewline/>
-              <!--
-                On Windows, spotless might convert the line endings of these files to LF.
-                We're instructing it to respect the line ending definitions in .gitattributes
-                for these files.
-                For more details, please refer to HBASE-29388.
-               -->
-              <lineEndings>GIT_ATTRIBUTES</lineEndings>
             </format>
             <format>
               <!--

--- a/pom.xml
+++ b/pom.xml
@@ -3175,6 +3175,13 @@
               <!-- define the steps to apply to those files -->
               <trimTrailingWhitespace/>
               <endWithNewline/>
+              <!--
+                On Windows, spotless might convert the line endings of these files to LF.
+                We're instructing it to respect the line ending definitions in .gitattributes
+                for these files.
+                For more details, please refer to HBASE-29388.
+               -->
+              <lineEndings>GIT_ATTRIBUTES</lineEndings>
             </format>
             <format>
               <!--


### PR DESCRIPTION
Details see: [HBASE-29388](https://issues.apache.org/jira/browse/HBASE-29388)

Before applying this change. 
Afet executing `mvn spotless:apply` on Windows
```bash
git diff

warning: LF will be replaced by CRLF in CHANGES.txt.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in LICENSE.txt.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in NOTICE.txt.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in README.md.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in conf/hbase-policy.xml.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in conf/hbase-site.xml.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in dev-support/HBase Code Template.xml.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in dev-support/HOW_TO_YETUS_LOCAL.md.
The file will have its original line endings in your working directory
warning: LF will be replaced by CRLF in dev-support/Jenkinsfile.
...
```

After applying this change. 
Afet executing `mvn spotless:apply` on Windows
```bash
git status
On branch hbase_HBASE-29388
Your branch is up to date with 'origin/hbase_HBASE-29388'.

nothing to commit, working tree clean
```


