### PR TITLE
HBASE-29432: Provide mechanism to plug in rack or host locality logic into ExportSnapshot

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/snapshot/ExportSnapshot.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/snapshot/ExportSnapshot.java
@@ -174,9 +174,11 @@ public class ExportSnapshot extends AbstractHBaseTool implements Tool {
     static final Option STORAGE_POLICY = new Option(null, "storage-policy", true,
       "Storage policy for export snapshot output directory, with format like: f=HOT&g=ALL_SDD");
     static final Option CUSTOM_FILE_GROUPER = new Option(null, "custom-file-grouper", true,
-      "Fully qualified class name of an implementation of ExportSnapshot.CustomFileGrouper. See JavaDoc on that class for more information.");
+      "Fully qualified class name of an implementation of ExportSnapshot.CustomFileGrouper. "
+        + "See JavaDoc on that class for more information.");
     static final Option FILE_LOCATION_RESOLVER = new Option(null, "file-location-resolver", true,
-      "Fully qualified class name of an implementation of ExportSnapshot.FileLocationResolver. See JavaDoc on that class for more information.");
+      "Fully qualified class name of an implementation of ExportSnapshot.FileLocationResolver. "
+        + "See JavaDoc on that class for more information.");
   }
 
   // Export Map-Reduce Counters, to keep track of the progress
@@ -798,7 +800,6 @@ public class ExportSnapshot extends AbstractHBaseTool implements Tool {
 
     // create balanced groups
     List<List<Pair<SnapshotFileInfo, Long>>> fileGroups = new LinkedList<>();
-    long[] sizeGroups = new long[ngroups];
     int hi = files.size() - 1;
     int lo = 0;
 
@@ -817,7 +818,6 @@ public class ExportSnapshot extends AbstractHBaseTool implements Tool {
       Pair<SnapshotFileInfo, Long> fileInfo = files.get(hi--);
 
       // add the hi one
-      sizeGroups[g] += fileInfo.getSecond();
       group.add(fileInfo);
 
       // change direction when at the end or the beginning
@@ -868,7 +868,8 @@ public class ExportSnapshot extends AbstractHBaseTool implements Tool {
         groups.size());
       int mappersPerGroup = groups.isEmpty() ? 1 : Math.max(mappers / groups.size(), 1);
       LOG.info(
-        "Splitting each group into {} InputSplits, to achieve closest possible amount of mappers to target of {}",
+        "Splitting each group into {} InputSplits, "
+          + "to achieve closest possible amount of mappers to target of {}",
         mappersPerGroup, mappers);
 
       Collection<List<Pair<SnapshotFileInfo, Long>>> balancedGroups =
@@ -911,9 +912,8 @@ public class ExportSnapshot extends AbstractHBaseTool implements Tool {
         }
         this.locations =
           fileLocationResolver.getLocationsForInputFiles(snapshotFiles).toArray(new String[0]);
-        LOG.trace(
-          "This ExportSnapshotInputSplit has files {} of collective size {}, with location hints: {}",
-          files, length, locations);
+        LOG.trace("This ExportSnapshotInputSplit has files {} of collective size {}, "
+          + "with location hints: {}", files, length, locations);
       }
 
       private List<Pair<BytesWritable, Long>> getSplitKeys() {

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/snapshot/ExportSnapshot.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/snapshot/ExportSnapshot.java
@@ -166,7 +166,8 @@ public class ExportSnapshot extends AbstractHBaseTool implements Tool {
       new Option(null, "chmod", true, "Change the permission of the files to the specified one.");
     static final Option MAPPERS = new Option(null, "mappers", true,
       "Number of mappers to use during the copy (mapreduce.job.maps). "
-        + "If you provide a --custom-file-grouper, then --mappers is interpreted as the number of mappers per group.");
+        + "If you provide a --custom-file-grouper, "
+        + "then --mappers is interpreted as the number of mappers per group.");
     static final Option BANDWIDTH =
       new Option(null, "bandwidth", true, "Limit bandwidth to this value in MB/second.");
     static final Option RESET_TTL =


### PR DESCRIPTION
I propose to make ExposeSnapshot accept two plugins: a CustomFileGrouper and a FileLocationResolver. Here's what they will look like:

```
  public interface CustomFileGrouper {
    Collection<Collection<Pair<SnapshotFileInfo, Long>>>
      getGroupedInputFiles(final Collection<Pair<SnapshotFileInfo, Long>> snapshotFiles);
  }

  public interface FileLocationResolver {
    Set<String> getLocationsForInputFiles(final Collection<Pair<SnapshotFileInfo, Long>> files);
  }
```

Users can optionally provide implementations of these interfaces on their classpath, and tell ExportSnapshot to use them via new options. By default, there will be no change in behavior. If users choose to implement these plugins, they can influence ExportSnapshot to be topology-aware in a very flexible way. I plan to write my own plugins optimized for AWS pricing, but that won't be the only way this can be used.