### PR TITLE
HBASE-29423 Incremental backups broken for non-default namespaces

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
@@ -468,7 +468,7 @@ public class IncrementalTableBackupClient extends TableBackupClient {
   private Path getTargetDirForTable(TableName table) {
     Path path = new Path(backupInfo.getBackupRootDir() + Path.SEPARATOR + backupInfo.getBackupId());
     path = new Path(path, table.getNamespaceAsString());
-    path = new Path(path, table.getNameAsString());
+    path = new Path(path, table.getQualifierAsString());
     return path;
   }
 


### PR DESCRIPTION
Fixes a URISyntaxException during incremental backup creation for tables that have a (non-default) namespace.