### PR TITLE
[ADDENDUM] HBASE-28596 Optimise BucketCache usage upon regions splits/merges.

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -2268,7 +2268,7 @@ public class BucketCache implements BlockCache, HeapSize {
         ReentrantReadWriteLock lock = offsetLock.getLock(entry.getOffset());
         lock.readLock().lock();
         locks.add(lock);
-        if (backingMap.containsKey(entry) && entry.getBlockType() == BlockType.DATA) {
+        if (backingMap.containsKey(entry) && entry.getBlockType().isData()) {
           count.increment();
         }
       });


### PR DESCRIPTION


The merge of HBASE-28596 on branch-2.6 has broken HBASE-29243. This addendum commit fixes this issue.