### PR TITLE
HBASE-29446 Web UI styling is broken in HBase 2.6.3RC1 hadoop2 bin release

### DIFF
--- a/hbase-server/pom.xml
+++ b/hbase-server/pom.xml
@@ -591,6 +591,115 @@
         <groupId>net.revelc.code</groupId>
         <artifactId>warbucks-maven-plugin</artifactId>
       </plugin>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-dependency-plugin</artifactId>
+        <version>${maven.dependency.version}</version>
+        <executions>
+          <execution>
+            <id>unpack-ui-resources-js</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.webjars</groupId>
+                  <artifactId>bootstrap</artifactId>
+                  <version>${bootstrap.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/js/bootstrap.bundle.min.js</includes>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
+                  </fileMappers>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.webjars</groupId>
+                  <artifactId>jquery</artifactId>
+                  <version>${jquery.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/jquery.min.js</includes>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
+                  </fileMappers>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.webjars</groupId>
+                  <artifactId>tablesorter</artifactId>
+                  <version>${tablesorter.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/jquery.tablesorter.min.js,
+                    **/parsers/parser-date-iso8601.min.js</includes>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
+                  </fileMappers>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.webjars</groupId>
+                  <artifactId>vega</artifactId>
+                  <version>${vega.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/vega.min.js</includes>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
+                  </fileMappers>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.webjars</groupId>
+                  <artifactId>vega-embed</artifactId>
+                  <version>${vega-embed.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/vega-embed.min.js</includes>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
+                  </fileMappers>
+                </artifactItem>
+                <artifactItem>
+                  <groupId>org.webjars</groupId>
+                  <artifactId>vega-lite</artifactId>
+                  <version>${vega-lite.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/vega-lite.min.js</includes>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
+                  </fileMappers>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/hbase-webapps/static/js</outputDirectory>
+            </configuration>
+          </execution>
+          <execution>
+            <id>unpack-ui-resources-css</id>
+            <goals>
+              <goal>unpack</goal>
+            </goals>
+            <phase>process-resources</phase>
+            <configuration>
+              <artifactItems>
+                <artifactItem>
+                  <groupId>org.webjars</groupId>
+                  <artifactId>bootstrap</artifactId>
+                  <version>${bootstrap.version}</version>
+                  <type>jar</type>
+                  <overWrite>true</overWrite>
+                  <includes>**/css/bootstrap.min.css</includes>
+                  <fileMappers>
+                    <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
+                  </fileMappers>
+                </artifactItem>
+              </artifactItems>
+              <outputDirectory>${project.build.directory}/hbase-webapps/static/css</outputDirectory>
+            </configuration>
+          </execution>
+        </executions>
+      </plugin>
     </plugins>
   </build>
   <profiles>
@@ -904,108 +1013,6 @@
                   of the launch container in the mini mr/yarn cluster
                   -->
                   <outputFile>${project.build.directory}/test-classes/mrapp-generated-classpath</outputFile>
-                </configuration>
-              </execution>
-              <execution>
-                <id>unpack-ui-resources-js</id>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <phase>process-resources</phase>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>org.webjars</groupId>
-                      <artifactId>bootstrap</artifactId>
-                      <version>${bootstrap.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <includes>**/js/bootstrap.bundle.min.js</includes>
-                      <fileMappers>
-                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
-                      </fileMappers>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.webjars</groupId>
-                      <artifactId>jquery</artifactId>
-                      <version>${jquery.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <includes>**/jquery.min.js</includes>
-                      <fileMappers>
-                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
-                      </fileMappers>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.webjars</groupId>
-                      <artifactId>tablesorter</artifactId>
-                      <version>${tablesorter.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <includes>**/jquery.tablesorter.min.js,
-                        **/parsers/parser-date-iso8601.min.js</includes>
-                      <fileMappers>
-                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
-                      </fileMappers>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.webjars</groupId>
-                      <artifactId>vega</artifactId>
-                      <version>${vega.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <includes>**/vega.min.js</includes>
-                      <fileMappers>
-                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
-                      </fileMappers>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.webjars</groupId>
-                      <artifactId>vega-embed</artifactId>
-                      <version>${vega-embed.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <includes>**/vega-embed.min.js</includes>
-                      <fileMappers>
-                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
-                      </fileMappers>
-                    </artifactItem>
-                    <artifactItem>
-                      <groupId>org.webjars</groupId>
-                      <artifactId>vega-lite</artifactId>
-                      <version>${vega-lite.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <includes>**/vega-lite.min.js</includes>
-                      <fileMappers>
-                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
-                      </fileMappers>
-                    </artifactItem>
-                  </artifactItems>
-                  <outputDirectory>${project.build.directory}/hbase-webapps/static/js</outputDirectory>
-                </configuration>
-              </execution>
-              <execution>
-                <id>unpack-ui-resources-css</id>
-                <goals>
-                  <goal>unpack</goal>
-                </goals>
-                <phase>process-resources</phase>
-                <configuration>
-                  <artifactItems>
-                    <artifactItem>
-                      <groupId>org.webjars</groupId>
-                      <artifactId>bootstrap</artifactId>
-                      <version>${bootstrap.version}</version>
-                      <type>jar</type>
-                      <overWrite>true</overWrite>
-                      <includes>**/css/bootstrap.min.css</includes>
-                      <fileMappers>
-                        <fileMapper implementation="org.codehaus.plexus.components.io.filemappers.FlattenFileMapper"/>
-                      </fileMappers>
-                    </artifactItem>
-                  </artifactItems>
-                  <outputDirectory>${project.build.directory}/hbase-webapps/static/css</outputDirectory>
                 </configuration>
               </execution>
             </executions>


### PR DESCRIPTION
When backporting HBASE-27802 added the `maven-dependency-plugin` with `unpack-ui-resources-js` and `unpack-ui-resources-css` execution to the `hadoop-3.0` profile which is not OK. This plugin is not specific for hadoop-3.0.
Moved it to the pom of `hbase-server` directly.