### PR TITLE
HBASE-29454: Update hbase-examples scripts to be compatible with Python 3

### DIFF
--- a/hbase-examples/src/main/python/thrift1/DemoClient.py
+++ b/hbase-examples/src/main/python/thrift1/DemoClient.py
@@ -187,7 +187,7 @@ def demo_client(host, port, is_framed_transport):
     r = client.get(t, row, "entry:foo", dummy_attributes)
     # just to be explicit, we get lists back, if it's empty there was no matching row.
     if len(r) > 0:
-      raise "shouldn't get here!"
+      raise Exception("shouldn't get here!")
 
   columnNames = []
   for (col, desc) in list(client.getColumnDescriptors(t).items()):

--- a/hbase-examples/src/main/python/thrift1/DemoClient.py
+++ b/hbase-examples/src/main/python/thrift1/DemoClient.py
@@ -34,16 +34,16 @@ from hbase.ttypes import TThriftServerType
 from hbase.Hbase import Client, ColumnDescriptor, Mutation
 
 def printVersions(row, versions):
-  print "row: " + row + ", values: ",
+  print("row: " + row + ", values: ", end=' ')
   for cell in versions:
-    print cell.value + "; ",
-  print
+    print(cell.value + "; ", end=' ')
+  print()
 
 def printRow(entry):
-  print "row: " + entry.row + ", cols:",
+  print("row: " + entry.row + ", cols:", end=' ')
   for k in sorted(entry.columns):
-    print k + " => " + entry.columns[k].value,
-  print
+    print(k + " => " + entry.columns[k].value, end=' ')
+  print()
 
 
 def demo_client(host, port, is_framed_transport):
@@ -76,14 +76,14 @@ def demo_client(host, port, is_framed_transport):
   #
   # Scan all tables, look for the demo table and delete it.
   #
-  print "scanning tables..."
+  print("scanning tables...")
   for table in client.getTableNames():
-    print "  found: %s" %(table)
+    print("  found: %s" %(table))
     if table == t:
       if client.isTableEnabled(table):
-        print "    disabling table: %s"  %(t)
+        print("    disabling table: %s"  %(t))
         client.disableTable(table)
-      print "    deleting table: %s"  %(t)
+      print("    deleting table: %s"  %(t))
       client.deleteTable(table)
 
   columns = []
@@ -96,16 +96,16 @@ def demo_client(host, port, is_framed_transport):
   columns.append(col)
 
   try:
-    print "creating table: %s" %(t)
+    print("creating table: %s" %(t))
     client.createTable(t, columns)
-  except AlreadyExists, ae:
-    print "WARN: " + ae.message
+  except AlreadyExists as ae:
+    print("WARN: " + ae.message)
 
   cols = client.getColumnDescriptors(t)
-  print "column families in %s" %(t)
-  for col_name in cols.keys():
+  print("column families in %s" %(t))
+  for col_name in list(cols.keys()):
     col = cols[col_name]
-    print "  column: %s, maxVer: %d" % (col.name, col.maxVersions)
+    print("  column: %s, maxVer: %d" % (col.name, col.maxVersions))
 
   dummy_attributes = {}
   #
@@ -116,7 +116,7 @@ def demo_client(host, port, is_framed_transport):
 
   # non-utf8 is fine for data
   mutations = [Mutation(column="entry:foo",value=invalid)]
-  print str(mutations)
+  print(str(mutations))
   client.mutateRow(t, "foo", mutations, dummy_attributes)
 
   # try empty strings
@@ -131,18 +131,18 @@ def demo_client(host, port, is_framed_transport):
   try:
     mutations = [Mutation(column="entry:foo", value=invalid)]
     client.mutateRow(t, invalid, mutations, dummy_attributes)
-  except ttypes.IOError, e:
-    print 'expected exception: %s' %(e.message)
+  except ttypes.IOError as e:
+    print('expected exception: %s' %(e.message))
 
   # Run a scanner on the rows we just created
-  print "Starting scanner..."
+  print("Starting scanner...")
   scanner = client.scannerOpen(t, "", ["entry:"], dummy_attributes)
 
   r = client.scannerGet(scanner)
   while r:
     printRow(r[0])
     r = client.scannerGet(scanner)
-  print "Scanner finished"
+  print("Scanner finished")
 
   #
   # Run some operations on a bunch of rows.
@@ -190,12 +190,12 @@ def demo_client(host, port, is_framed_transport):
       raise "shouldn't get here!"
 
   columnNames = []
-  for (col, desc) in client.getColumnDescriptors(t).items():
-    print "column with name: "+desc.name
-    print desc
+  for (col, desc) in list(client.getColumnDescriptors(t).items()):
+    print("column with name: "+desc.name)
+    print(desc)
     columnNames.append(desc.name+":")
 
-  print "Starting scanner..."
+  print("Starting scanner...")
   scanner = client.scannerOpenWithStop(t, "00020", "00040", columnNames, dummy_attributes)
 
   r = client.scannerGet(scanner)
@@ -204,7 +204,7 @@ def demo_client(host, port, is_framed_transport):
     r = client.scannerGet(scanner)
 
   client.scannerClose(scanner)
-  print "Scanner finished"
+  print("Scanner finished")
 
   transport.close()
 
@@ -213,7 +213,7 @@ if __name__ == '__main__':
 
   import sys
   if len(sys.argv) < 3:
-    print 'usage: %s <host> <port>' % __file__
+    print('usage: %s <host> <port>' % __file__)
     sys.exit(1)
 
   host = sys.argv[1]

--- a/hbase-examples/src/main/python/thrift1/demo_hbase_thrift_over_http_tls.py
+++ b/hbase-examples/src/main/python/thrift1/demo_hbase_thrift_over_http_tls.py
@@ -37,19 +37,19 @@ from hbase.ttypes import ColumnDescriptor
 from hbase.ttypes import Mutation
 from hbase.ttypes import IOError as HBaseIOError
 
-print "[INFO] setup connection"
+print("[INFO] setup connection")
 transport = THttpClient.THttpClient("https://{0}:{1}".format(sys.argv[1], 9090))
 client = Hbase.Client(TBinaryProtocol.TBinaryProtocol(transport))
 
 table='test:thrift_proxy_demo'
 
-print "[INFO] start client"
+print("[INFO] start client")
 transport.open()
 
-print "[INFO] list the current tables"
-print client.getTableNames()
+print("[INFO] list the current tables")
+print(client.getTableNames())
 
-print "[INFO] create a table, place some data"
+print("[INFO] create a table, place some data")
 client.createTable(table, [ColumnDescriptor(name ='family1:')])
 client.mutateRow(table, 'row1', [Mutation(column = 'family1:cq1', value = 'foo'), Mutation(column = 'family1:cq2', value = 'foo')], {})
 client.mutateRow(table, 'row2', [Mutation(column = 'family1:cq1', value = 'bar'), Mutation(column = 'family1:cq2', value = 'bar')], {})
@@ -57,15 +57,15 @@ client.mutateRow(table, 'row3', [Mutation(column = 'family1:cq1', value = 'foo')
 client.mutateRow(table, 'row4', [Mutation(column = 'family1:cq1', value = 'bar'), Mutation(column = 'family1:cq2', value = 'bar')], {})
 
 
-print "[INFO] scan"
+print("[INFO] scan")
 scan_id = client.scannerOpen(table, 'row1', [], {})
 for row in client.scannerGetList(scan_id, 25):
-  print row
+  print(row)
 client.scannerClose(scan_id)
-print "[INFO] get"
+print("[INFO] get")
 for row in client.getRow(table, 'row3', {}):
-  print row
+  print(row)
 
-print "[INFO] clean up"
+print("[INFO] clean up")
 client.disableTable(table)
 client.deleteTable(table)

--- a/hbase-examples/src/main/python/thrift2/DemoClient.py
+++ b/hbase-examples/src/main/python/thrift2/DemoClient.py
@@ -44,8 +44,8 @@ sys.path.append(gen_py_path)
 from hbase import THBaseService
 from hbase.ttypes import *
 
-print "Thrift2 Demo"
-print "This demo assumes you have a table called \"example\" with a column family called \"family1\""
+print("Thrift2 Demo")
+print("This demo assumes you have a table called \"example\" with a column family called \"family1\"")
 
 host = "localhost"
 port = 9090
@@ -69,13 +69,13 @@ if serverType != TThriftServerType.TWO:
 table = "example"
 
 put = TPut(row="row1", columnValues=[TColumnValue(family="family1",qualifier="qualifier1",value="value1")])
-print "Putting:", put
+print("Putting:", put)
 client.put(table, put)
 
 get = TGet(row="row1")
-print "Getting:", get
+print("Getting:", get)
 result = client.get(table, get)
 
-print "Result:", result
+print("Result:", result)
 
 transport.close()


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-29454

Some Python scripts in hbase-examples were never updated from Python 2 to Python 3.  This pull request updates those scripts to be compatible with Python 3.  The scripts were updated using `2to3 -w <script>`.  They were verified using `python3 -m compileall <script>`.  Python 3.11.12 was used for the conversion and verification.