### PR TITLE
HBASE-29458 SFT removeStoreFiles api to only archive physical files and ignore virtual links

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionFileSystem.java
@@ -441,29 +441,6 @@ public class HRegionFileSystem {
   }
 
   /**
-   * Archives the specified store file from the specified family.
-   * @param familyName Family that contains the store files
-   * @param filePath   {@link Path} to the store file to remove
-   * @throws IOException if the archiving fails
-   */
-  public void removeStoreFile(final String familyName, final Path filePath) throws IOException {
-    HFileArchiver.archiveStoreFile(this.conf, this.fs, this.regionInfoForFs, this.tableDir,
-      Bytes.toBytes(familyName), filePath);
-  }
-
-  /**
-   * Closes and archives the specified store files from the specified family.
-   * @param familyName Family that contains the store files
-   * @param storeFiles set of store files to remove
-   * @throws IOException if the archiving fails
-   */
-  public void removeStoreFiles(String familyName, Collection<HStoreFile> storeFiles)
-    throws IOException {
-    HFileArchiver.archiveStoreFiles(this.conf, this.fs, this.regionInfoForFs, this.tableDir,
-      Bytes.toBytes(familyName), storeFiles);
-  }
-
-  /**
    * Bulk load: Add a specified store file to the specified family. If the source file is on the
    * same different file-system is moved from the source location to the destination location,
    * otherwise is copied over.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStore.java
@@ -2328,8 +2328,9 @@ public class HStore
         LOG.debug("Moving the files {} to archive", filesToRemove);
         // Only if this is successful it has to be removed
         try {
-          getRegionFileSystem().removeStoreFiles(this.getColumnFamilyDescriptor().getNameAsString(),
-            filesToRemove);
+          StoreFileTracker storeFileTracker =
+            StoreFileTrackerFactory.create(conf, isPrimaryReplicaStore(), storeContext);
+          storeFileTracker.removeStoreFiles(filesToRemove);
         } catch (FailedArchiveException fae) {
           // Even if archiving some files failed, we still need to clear out any of the
           // files which were successfully archived. Otherwise we will receive a

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
@@ -351,8 +351,7 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
       results.removeAll(filesToRemove);
       if (!filesToRemove.isEmpty() && ctx.isPrimaryReplicaStore()) {
         LOG.debug("Moving the files {} to archive", filesToRemove);
-        ctx.getRegionFileSystem().removeStoreFiles(ctx.getFamily().getNameAsString(),
-          filesToRemove);
+        storeFileTracker.removeStoreFiles(filesToRemove);
       }
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/MigrationStoreFileTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/MigrationStoreFileTracker.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import java.util.Collection;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.regionserver.HStoreFile;
 import org.apache.hadoop.hbase.regionserver.StoreContext;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -86,6 +87,11 @@ class MigrationStoreFileTracker extends StoreFileTrackerBase {
   protected void doSetStoreFiles(Collection<StoreFileInfo> files) throws IOException {
     throw new UnsupportedOperationException(
       "Should not call this method on " + getClass().getSimpleName());
+  }
+
+  @Override
+  public void removeStoreFiles(List<HStoreFile> storeFiles) throws IOException {
+    dst.removeStoreFiles(storeFiles);
   }
 
   static Class<? extends StoreFileTracker> getSrcTrackerClass(Configuration conf) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTracker.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.io.Reference;
 import org.apache.hadoop.hbase.regionserver.CreateStoreFileWriterParams;
+import org.apache.hadoop.hbase.regionserver.HStoreFile;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -146,4 +147,10 @@ public interface StoreFileTracker {
   String createFromHFileLink(final String hfileName, final boolean createBackRef)
     throws IOException;
 
+  /**
+   * Closes and archives the specified store files from the specified family.
+   * @param storeFiles set of store files to remove
+   * @throws IOException if the archiving fails
+   */
+  void removeStoreFiles(List<HStoreFile> storeFiles) throws IOException;
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerBase.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.backup.HFileArchiver;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.io.HFileLink;
@@ -44,6 +45,7 @@ import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
 import org.apache.hadoop.hbase.regionserver.CreateStoreFileWriterParams;
+import org.apache.hadoop.hbase.regionserver.HStoreFile;
 import org.apache.hadoop.hbase.regionserver.StoreContext;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
@@ -371,6 +373,16 @@ abstract class StoreFileTrackerBase implements StoreFileTracker {
     }
     return createHFileLink(TableName.valueOf(m.group(1), m.group(2)), m.group(3), m.group(4),
       createBackRef);
+  }
+
+  public void removeStoreFiles(List<HStoreFile> storeFiles) throws IOException {
+    archiveStoreFiles(storeFiles);
+  }
+
+  protected void archiveStoreFiles(List<HStoreFile> storeFiles) throws IOException {
+    HFileArchiver.archiveStoreFiles(this.conf, ctx.getRegionFileSystem().getFileSystem(),
+      ctx.getRegionInfo(), ctx.getRegionFileSystem().getTableDir(), ctx.getFamily().getName(),
+      storeFiles);
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHRegion.java
@@ -66,6 +66,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -5710,7 +5711,6 @@ public class TestHRegion {
 
       // move the file of the primary region to the archive, simulating a compaction
       Collection<HStoreFile> storeFiles = primaryRegion.getStore(families[0]).getStorefiles();
-      primaryRegion.getRegionFileSystem().removeStoreFiles(Bytes.toString(families[0]), storeFiles);
       HRegionFileSystem regionFs = primaryRegion.getRegionFileSystem();
       StoreFileTracker sft = StoreFileTrackerFactory.create(primaryRegion.getBaseConf(), false,
         StoreContext.getBuilder()
@@ -5718,6 +5718,7 @@ public class TestHRegion {
           .withFamilyStoreDirectoryPath(
             new Path(regionFs.getRegionDir(), Bytes.toString(families[0])))
           .withRegionFileSystem(regionFs).build());
+      sft.removeStoreFiles(storeFiles.stream().collect(Collectors.toList()));
       Collection<StoreFileInfo> storeFileInfos = sft.load();
       Assert.assertTrue(storeFileInfos == null || storeFileInfos.isEmpty());
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestHStore.java
@@ -1033,8 +1033,10 @@ public class TestHStore {
     for (int i = 0; i <= index; i++) {
       sf = it.next();
     }
-    store.getRegionFileSystem().removeStoreFiles(store.getColumnFamilyName(),
-      Lists.newArrayList(sf));
+    StoreFileTracker sft =
+      StoreFileTrackerFactory.create(store.getRegionFileSystem().getFileSystem().getConf(),
+        store.isPrimaryReplicaStore(), store.getStoreContext());
+    sft.removeStoreFiles(Lists.newArrayList(sf));
   }
 
   private void closeCompactedFile(int index) throws IOException {


### PR DESCRIPTION
Post [HBASE-28564](https://issues.apache.org/jira/browse/HBASE-28564), HStoreFile creation is SFT aware and Reference file creations are moved to SFT.
To enable virtual links from [HBASE-27826](https://issues.apache.org/jira/browse/HBASE-27826), HFileArchival should be routed via SFT instead of HRegionFileSystem, to identify and archive only physical files and skip virtual links