### PR TITLE
HBASE-29467: Redundant conditions in CostFunction.scale() method

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CostFunction.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/CostFunction.java
@@ -118,10 +118,6 @@ abstract class CostFunction {
     ) {
       return 0;
     }
-    if (max <= min || Math.abs(max - min) <= costEpsilon) {
-      return 0;
-    }
-
     return Math.max(0d, Math.min(1d, (value - min) / (max - min)));
   }
 }


### PR DESCRIPTION
The first if-block already covers all these cases, making the second if-block completely redundant as it will never be reached with conditions that would make it evaluate differently.

Signed-off by: Jialun Peng <p1070048431@gmail.com>