### PR TITLE
HBASE-29474 RegionSplitter.rollingSplit is broken

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionSplitter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionSplitter.java
@@ -21,9 +21,9 @@ import java.io.IOException;
 import java.math.BigInteger;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Set;
 import java.util.TreeMap;
 import org.apache.commons.lang3.ArrayUtils;
@@ -460,9 +460,13 @@ public class RegionSplitter {
                 }
               }
 
+              // Sort the ServerNames by the number of regions they have
+              final List<ServerName> serversLeft = Lists.newArrayList(daughterRegions.keySet());
+              serversLeft.sort(Comparator.comparing(rsSizes::get));
+
               // Round-robin through the ServerName list. Choose the lightest-loaded servers
               // first to keep the master from load-balancing regions as we split.
-              for (final ServerName rsLoc : Lists.newArrayList(daughterRegions.keySet())) {
+              for (final ServerName rsLoc : serversLeft) {
                 Pair<byte[], byte[]> dr = null;
                 final LinkedList<Pair<byte[], byte[]>> regionList = daughterRegions.get(rsLoc);
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionSplitter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionSplitter.java
@@ -462,11 +462,9 @@ public class RegionSplitter {
 
               // Round-robin through the ServerName list. Choose the lightest-loaded servers
               // first to keep the master from load-balancing regions as we split.
-              for (Map.Entry<ServerName,
-                LinkedList<Pair<byte[], byte[]>>> daughterRegion : daughterRegions.entrySet()) {
+              for (final ServerName rsLoc : Lists.newArrayList(daughterRegions.keySet())) {
                 Pair<byte[], byte[]> dr = null;
-                ServerName rsLoc = daughterRegion.getKey();
-                LinkedList<Pair<byte[], byte[]>> regionList = daughterRegion.getValue();
+                final LinkedList<Pair<byte[], byte[]>> regionList = daughterRegions.get(rsLoc);
 
                 // Find a region in the ServerName list that hasn't been moved
                 LOG.debug("Finding a region on " + rsLoc);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestRegionSplitter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestRegionSplitter.java
@@ -72,7 +72,7 @@ public class TestRegionSplitter {
 
   @BeforeClass
   public static void setup() throws Exception {
-    UTIL.startMiniCluster();
+    UTIL.startMiniCluster(2);
   }
 
   @AfterClass


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-29474

The first commit breaks the test, and the second commit fixes it.

EDIT: The third commit revives the sorting logic that was mistakenly removed in https://github.com/apache/hbase/commit/5e91b45b166cd5a68457234f0a62ca1c2b5d9211.