### PR TITLE
[DO NOT MERGE] Try hbase-thirdparty 4.1.12-SNAPSHOT

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -675,7 +675,7 @@
         databind] must be kept in sync with the version of jackson-jaxrs-json-provider shipped in
         hbase-thirdparty.
     -->
-    <hbase-thirdparty.version>4.1.11</hbase-thirdparty.version>
+    <hbase-thirdparty.version>4.1.12-SNAPSHOT</hbase-thirdparty.version>
     <!-- Coverage properties -->
     <jacoco.version>0.8.8</jacoco.version>
     <jacocoArgLine/>
@@ -5193,4 +5193,15 @@
       </properties>
     </profile>
   </profiles>
+  <!-- TODO Remove below block, added just for testing -->
+  <repositories>
+    <repository>
+      <snapshots>
+        <enabled>true</enabled>
+        <updatePolicy>always</updatePolicy>
+      </snapshots>
+      <id>apache.snapshots</id>
+      <url>https://repository.apache.org/content/repositories/snapshots</url>
+    </repository>
+  </repositories>
 </project>


### PR DESCRIPTION
Test with latest thirdparty, commit apache/hbase-thirdparty@06062de

Snapshot version: https://repository.apache.org/content/repositories/snapshots/org/apache/hbase/thirdparty/hbase-unsafe/4.1.12-SNAPSHOT/hbase-unsafe-4.1.12-20250730.201108-1.jar