### PR TITLE
[ADDENDUM] HBASE-29296 Missing critical snapshot expiration checks

### DIFF
--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRestoreExpiry.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupRestoreExpiry.java
@@ -29,7 +29,7 @@ import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
-import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.impl.BackupAdminImpl;
@@ -64,7 +64,7 @@ public class TestBackupRestoreExpiry extends TestBackupBase {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    TEST_UTIL = new HBaseTestingUtil();
+    TEST_UTIL = new HBaseTestingUtility();
     conf1 = TEST_UTIL.getConfiguration();
     conf1.setLong(HConstants.DEFAULT_SNAPSHOT_TTL_CONFIG_KEY, 30);
     autoRestoreOnFailure = true;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestSnapshotProcedureEarlyExpiration.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestSnapshotProcedureEarlyExpiration.java
@@ -25,7 +25,7 @@ import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
-import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.SnapshotDescription;
 import org.apache.hadoop.hbase.client.SnapshotType;
@@ -53,7 +53,7 @@ public class TestSnapshotProcedureEarlyExpiration extends TestSnapshotProcedure 
   @Override
   public void setup() throws Exception { // Copied from TestSnapshotProcedure with modified
                                          // SnapshotDescription
-    TEST_UTIL = new HBaseTestingUtil();
+    TEST_UTIL = new HBaseTestingUtility();
     Configuration config = TEST_UTIL.getConfiguration();
     // using SnapshotVerifyProcedure to verify snapshot
     config.setInt("hbase.snapshot.remote.verify.threshold", 1);


### PR DESCRIPTION
[ADDENDUM] Fix broken branch-2/branch-2.6 builds

The recent changes in #6970 have caused build failures on the branch-2/branch-2.6, the details see: https://github.com/apache/hbase/pull/6970#issuecomment-3149151194

The root cause was a class name mismatch due to my oversight: the code was using `HBaseTestingUtil` instead of the correct class name `HBaseTestingUtility`.