### PR TITLE
HBASE-29496 Fix Javadoc typo: 'DsiableTableProcedure' should be 'DisableTableProcedure'

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -1112,7 +1112,7 @@ public class AssignmentManager {
   }
 
   /**
-   * Called by DsiableTableProcedure to unassign all regions for a table. Will skip submit unassign
+   * Called by DisableTableProcedure to unassign all regions for a table. Will skip submit unassign
    * procedure if the region is in transition, so you may need to call this method multiple times.
    * @param tableName the table for closing excess region replicas
    * @param submit    for submitting procedure


### PR DESCRIPTION
jira: [HBASE-29496](https://issues.apache.org/jira/browse/HBASE-29496)