### PR TITLE
HBASE-29503: IntegrationTestBackupRestore is passing even if an exception occurs in the thread(s) it creates

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
@@ -103,11 +103,11 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
   private static String BACKUP_ROOT_DIR = "backupIT";
 
   /*
-  This class is used to run the backup and restore thread(s). Throwing an exception in this
-  thread will not cause the test to fail, so the purpose of this class is to both kick off the
-  backup and restore and record any exceptions that occur so they can be thrown in the main
-  thread.
-  */
+   * This class is used to run the backup and restore thread(s). Throwing an exception in this
+   * thread will not cause the test to fail, so the purpose of this class is to both kick off the
+   * backup and restore and record any exceptions that occur so they can be thrown in the main
+   * thread.
+   */
   protected class BackupAndRestoreThread implements Runnable {
     private final TableName table;
     private Exception exc;
@@ -211,8 +211,7 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
     BackupAndRestoreThread[] backupAndRestoreThreads = new BackupAndRestoreThread[numTables];
     for (int i = 0; i < numTables; i++) {
       final TableName table = tableNames[i];
-      BackupAndRestoreThread backupAndRestoreThread
-        = new BackupAndRestoreThread(table);
+      BackupAndRestoreThread backupAndRestoreThread = new BackupAndRestoreThread(table);
       backupAndRestoreThreads[i] = backupAndRestoreThread;
       workers[i] = new Thread(backupAndRestoreThread);
       workers[i].start();


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-29503

Currently, IntegrationTestBackupRestore is creating a separate thread to run the full/incremental backup and restore processes.  With this implementation, if an exception occurs in this thread, then an error will be logged but the integration test will still pass.  I initially noticed this while working on [HBASE-29411](https://issues.apache.org/jira/browse/HBASE-29411).  I also observed this behavior when I did not have changes from PR #7151 in my branch.

This pull request turns the backup/restore thread into an actual class that implements Runnable.  Within this class, there is an instance variable that starts as `null` and records any exceptions that occur.  The main thread checks this instance variable when it joins the thread.  If this instance variable is not `null`, then the recorded exception is thrown.