### PR TITLE
HBASE-29507: IntegrationTestBackupRestore is failing because it cannot restore from backup directory

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
@@ -85,7 +85,7 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
   protected static final int DEFAULT_REGIONSERVER_COUNT = 5;
   protected static final int DEFAULT_NUMBER_OF_TABLES = 1;
   protected static final int DEFAULT_NUM_ITERATIONS = 10;
-  protected static final int DEFAULT_ROWS_IN_ITERATION = 500000;
+  protected static final int DEFAULT_ROWS_IN_ITERATION = 10000;
   protected static final String SLEEP_TIME_KEY = "sleeptime";
   // short default interval because tests don't run very long.
   protected static final long SLEEP_TIME_DEFAULT = 50000L;


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-29507

This pull request reduces the value for `DEFAULT_ROWS_IN_ITERATION` in IntegrationTestBackupRestore.java from 500,000 to 10,000.  The change prevents an OutOfMemoryError from occurring when running IntegrationTestBackupRestore locally. The error was discovered while testing the fix for PR #7203.  If we still want to use 500,000 rows for an actual integration test on a distributed cluster, then the row count can be overridden via the command line by using the `rows_in_iteration` arg (see `ROWS_PER_ITERATION_KEY` on [this line](https://github.com/apache/hbase/blob/master/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java#L429-L431)).