### PR TITLE
HBASE-29503: IntegrationTestBackupRestore is passing even if an exception occurs in the thread(s) it creates

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
@@ -101,6 +101,38 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
 
   private static String BACKUP_ROOT_DIR = "backupIT";
 
+  /*
+   * This class is used to run the backup and restore thread(s). Throwing an exception in this
+   * thread will not cause the test to fail, so the purpose of this class is to both kick off the
+   * backup and restore and record any exceptions that occur so they can be thrown in the main
+   * thread.
+   */
+  protected class BackupAndRestoreThread implements Runnable {
+    private final TableName table;
+    private Exception exc;
+
+    public BackupAndRestoreThread(TableName table) {
+      this.table = table;
+      this.exc = null;
+    }
+
+    public Exception getException() {
+      return this.exc;
+    }
+
+    @Override
+    public void run() {
+      try {
+        runTestSingle(this.table);
+      } catch (Exception e) {
+        LOG.error(
+          "An exception occurred in thread {} when performing a backup and restore with table {}: ",
+          Thread.currentThread().getName(), this.table.getNameAsString(), e);
+        this.exc = e;
+      }
+    }
+  }
+
   @Override
   @Before
   public void setUp() throws Exception {
@@ -174,28 +206,35 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
     runTestMulti();
   }
 
-  private void runTestMulti() throws IOException {
+  private void runTestMulti() throws Exception {
     LOG.info("IT backup & restore started");
     Thread[] workers = new Thread[numTables];
+    BackupAndRestoreThread[] backupAndRestoreThreads = new BackupAndRestoreThread[numTables];
     for (int i = 0; i < numTables; i++) {
       final TableName table = tableNames[i];
-      Runnable r = new Runnable() {
-        @Override
-        public void run() {
-          try {
-            runTestSingle(table);
-          } catch (IOException e) {
-            LOG.error("Failed", e);
-            Assert.fail(e.getMessage());
-          }
-        }
-      };
-      workers[i] = new Thread(r);
+      BackupAndRestoreThread backupAndRestoreThread = new BackupAndRestoreThread(table);
+      backupAndRestoreThreads[i] = backupAndRestoreThread;
+      workers[i] = new Thread(backupAndRestoreThread);
       workers[i].start();
     }
-    // Wait all workers to finish
-    for (Thread t : workers) {
-      Uninterruptibles.joinUninterruptibly(t);
+    // Wait for all workers to finish and check for errors
+    Exception error = null;
+    Exception threadExc;
+    for (int i = 0; i < numTables; i++) {
+      Uninterruptibles.joinUninterruptibly(workers[i]);
+      threadExc = backupAndRestoreThreads[i].getException();
+      if (threadExc == null) {
+        continue;
+      }
+      if (error == null) {
+        error = threadExc;
+      } else {
+        error.addSuppressed(threadExc);
+      }
+    }
+    // Throw any found errors after all threads have completed
+    if (error != null) {
+      throw error;
     }
     LOG.info("IT backup & restore finished");
   }
@@ -229,8 +268,7 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
   }
 
   private String backup(BackupRequest request, BackupAdmin client) throws IOException {
-    String backupId = client.backupTables(request);
-    return backupId;
+    return client.backupTables(request);
   }
 
   private void restore(RestoreRequest request, BackupAdmin client) throws IOException {
@@ -300,7 +338,6 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
 
   private void restoreVerifyTable(Connection conn, BackupAdmin client, TableName table,
     String backupId, long expectedRows) throws IOException {
-
     TableName[] tablesRestoreIncMultiple = new TableName[] { table };
     restore(
       createRestoreRequest(BACKUP_ROOT_DIR, backupId, false, tablesRestoreIncMultiple, null, true),


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-29503

This is a cherry-pick of PR #7203, which was merged into master as https://github.com/apache/hbase/commit/d80bbefb612098c11f4ddd874aead35bbc780d14.

Currently, IntegrationTestBackupRestore is creating a separate thread to run the full/incremental backup and restore processes.  With this implementation, if an exception occurs in this thread, then an error will be logged but the integration test will still pass.  I initially noticed this while working on [HBASE-29411](https://issues.apache.org/jira/browse/HBASE-29411).  I also observed this behavior when I did not have changes from PR #7151 in my branch.

This pull request turns the backup/restore thread into an actual class that implements Runnable.  Within this class, there is an instance variable that starts as `null` and records any exceptions that occur.  The main thread checks this instance variable when it joins the thread.  If this instance variable is not `null`, then the recorded exception is thrown.