### PR TITLE
HBASE-29544: Assertion errors in BackupAndRestoreThread are not causing IntegrationTestBackupRestore to fail

### DIFF
--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestBackupRestore.java
@@ -109,26 +109,26 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
    */
   protected class BackupAndRestoreThread implements Runnable {
     private final TableName table;
-    private Exception exc;
+    private Throwable throwable;
 
     public BackupAndRestoreThread(TableName table) {
       this.table = table;
-      this.exc = null;
+      this.throwable = null;
     }
 
-    public Exception getException() {
-      return this.exc;
+    public Throwable getThrowable() {
+      return this.throwable;
     }
 
     @Override
     public void run() {
       try {
         runTestSingle(this.table);
-      } catch (Exception e) {
+      } catch (Throwable t) {
         LOG.error(
-          "An exception occurred in thread {} when performing a backup and restore with table {}: ",
-          Thread.currentThread().getName(), this.table.getNameAsString(), e);
-        this.exc = e;
+          "An error occurred in thread {} when performing a backup and restore with table {}: ",
+          Thread.currentThread().getName(), this.table.getNameAsString(), t);
+        this.throwable = t;
       }
     }
   }
@@ -218,23 +218,23 @@ public class IntegrationTestBackupRestore extends IntegrationTestBase {
       workers[i].start();
     }
     // Wait for all workers to finish and check for errors
-    Exception error = null;
-    Exception threadExc;
+    Throwable error = null;
+    Throwable threadThrowable;
     for (int i = 0; i < numTables; i++) {
       Uninterruptibles.joinUninterruptibly(workers[i]);
-      threadExc = backupAndRestoreThreads[i].getException();
-      if (threadExc == null) {
+      threadThrowable = backupAndRestoreThreads[i].getThrowable();
+      if (threadThrowable == null) {
         continue;
       }
       if (error == null) {
-        error = threadExc;
+        error = threadThrowable;
       } else {
-        error.addSuppressed(threadExc);
+        error.addSuppressed(threadThrowable);
       }
     }
     // Throw any found errors after all threads have completed
     if (error != null) {
-      throw error;
+      throw new AssertionError("An error occurred in a backup and restore thread", error);
     }
     LOG.info("IT backup & restore finished");
   }


### PR DESCRIPTION
## Summary 

https://issues.apache.org/jira/browse/HBASE-29544

This is a cherry-pick from PR #7243.

`IntegrationTestBackupRestore` runs the backup and restore processes in a separate thread (or threads).  PR #7203 ([HBASE-29503](https://issues.apache.org/jira/browse/HBASE-29503)) fixed an issue where the test would still pass even if an exception occurred in one of the threads.  However, that fix only handles exceptions.  It does not handle other throwables, such as `AssertionError`.  This pull request extends the functionality implemented in PR #7203 to handle all throwables instead of just exceptions.

## Manual Testing of Errors

### Exceptions

I added a `RuntimeException` to `BackupAndRestoreThread.run()` to test exception handling:

```
public void run() {
  try {
    # Added this to force an exception
    throw new RuntimeException("Do we see this?");
  } catch (Throwable t) {
    LOG.error(
      "An error occurred in thread {} when performing a backup and restore with table {}: ",
      Thread.currentThread().getName(), this.table.getNameAsString(), t);
    this.throwable = t;
  }
}
```

Error message (note the `Caused by...`):

```
java.lang.AssertionError: An error occurred in a backup and restore thread

	at org.apache.hadoop.hbase.IntegrationTestBackupRestore.runTestMulti(IntegrationTestBackupRestore.java:238)
	at org.apache.hadoop.hbase.IntegrationTestBackupRestore.testBackupRestore(IntegrationTestBackupRestore.java:207)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.lang.RuntimeException: Do we see this?
	at org.apache.hadoop.hbase.IntegrationTestBackupRestore$BackupAndRestoreThread.run(IntegrationTestBackupRestore.java:127)
	at java.base/java.lang.Thread.run(Thread.java:840)
```

## AssertionErrors

I forced an `AssertionError` by modifying the `assertEquals()` in `restoreVerifyTable()`: 

```
Assert.assertEquals(-1, util.countRows(hTable));
```

Error message (note the `Caused by...`):

```
java.lang.AssertionError: An error occurred in a backup and restore thread

	at org.apache.hadoop.hbase.IntegrationTestBackupRestore.runTestMulti(IntegrationTestBackupRestore.java:238)
	at org.apache.hadoop.hbase.IntegrationTestBackupRestore.testBackupRestore(IntegrationTestBackupRestore.java:207)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
	at java.base/jdk.internal.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:77)
	at java.base/jdk.internal.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
	at java.base/java.lang.reflect.Method.invoke(Method.java:569)
	at org.junit.runners.model.FrameworkMethod$1.runReflectiveCall(FrameworkMethod.java:59)
	at org.junit.internal.runners.model.ReflectiveCallable.run(ReflectiveCallable.java:12)
	at org.junit.runners.model.FrameworkMethod.invokeExplosively(FrameworkMethod.java:56)
	at org.junit.internal.runners.statements.InvokeMethod.evaluate(InvokeMethod.java:17)
	at org.junit.internal.runners.statements.RunBefores.evaluate(RunBefores.java:26)
	at org.junit.internal.runners.statements.RunAfters.evaluate(RunAfters.java:27)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.BlockJUnit4ClassRunner$1.evaluate(BlockJUnit4ClassRunner.java:100)
	at org.junit.runners.ParentRunner.runLeaf(ParentRunner.java:366)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:103)
	at org.junit.runners.BlockJUnit4ClassRunner.runChild(BlockJUnit4ClassRunner.java:63)
	at org.junit.runners.ParentRunner$4.run(ParentRunner.java:331)
	at org.junit.runners.ParentRunner$1.schedule(ParentRunner.java:79)
	at org.junit.runners.ParentRunner.runChildren(ParentRunner.java:329)
	at org.junit.runners.ParentRunner.access$100(ParentRunner.java:66)
	at org.junit.runners.ParentRunner$2.evaluate(ParentRunner.java:293)
	at org.junit.runners.ParentRunner$3.evaluate(ParentRunner.java:306)
	at org.junit.runners.ParentRunner.run(ParentRunner.java:413)
	at org.junit.runner.JUnitCore.run(JUnitCore.java:137)
	at com.intellij.junit4.JUnit4IdeaTestRunner.startRunnerWithArgs(JUnit4IdeaTestRunner.java:69)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater$1.execute(IdeaTestRunner.java:38)
	at com.intellij.rt.execution.junit.TestsRepeater.repeat(TestsRepeater.java:11)
	at com.intellij.rt.junit.IdeaTestRunner$Repeater.startRunnerWithArgs(IdeaTestRunner.java:35)
	at com.intellij.rt.junit.JUnitStarter.prepareStreamsAndStart(JUnitStarter.java:232)
	at com.intellij.rt.junit.JUnitStarter.main(JUnitStarter.java:55)
Caused by: java.lang.AssertionError: expected:<-1> but was:<10000>
	at org.junit.Assert.fail(Assert.java:89)
	at org.junit.Assert.failNotEquals(Assert.java:835)
	at org.junit.Assert.assertEquals(Assert.java:647)
	at org.junit.Assert.assertEquals(Assert.java:633)
	at org.apache.hadoop.hbase.IntegrationTestBackupRestore.restoreVerifyTable(IntegrationTestBackupRestore.java:346)
	at org.apache.hadoop.hbase.IntegrationTestBackupRestore.runTestSingle(IntegrationTestBackupRestore.java:319)
	at org.apache.hadoop.hbase.IntegrationTestBackupRestore$BackupAndRestoreThread.run(IntegrationTestBackupRestore.java:127)
	at java.base/java.lang.Thread.run(Thread.java:840)
```