### PR TITLE
HBASE-29562 Add RegionServer Metrics for excluded DataNodes

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSource.java
@@ -647,4 +647,10 @@ public interface MetricsRegionServerSource extends BaseSource, JvmPauseMonitorSo
     "Count of scanners which were expired due to scanner lease timeout";
   String CURRENT_REGION_CACHE_RATIO = "currentRegionCacheRatio";
   String CURRENT_REGION_CACHE_RATIO_DESC = "The percentage of caching completed for this region.";
+
+  String EXCLUDE_DATA_NODES_COUNT = "excludedDataNodesCount";
+  String EXCLUDE_DATA_NODES_COUNT_DESC =
+    "Count of slow/connect error DataNodes excluded during WAL write operation";
+  String EXCLUDE_DATA_NODES_DETAILS = "excludedDataNodesDetails";
+  String EXCLUDE_DATA_NODES_DETAILS_DESC = "Excluded DataNodes info";
 }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/regionserver/MetricsRegionServerSourceImpl.java
@@ -369,7 +369,8 @@ public class MetricsRegionServerSourceImpl extends BaseSourceImpl
 
     // rsWrap can be null because this function is called inside of init.
     if (rsWrap != null) {
-      addGaugesToMetricsRecordBuilder(mrb)
+      MetricsRecordBuilder metricsRecordBuilder = addGaugesToMetricsRecordBuilder(mrb);
+      metricsRecordBuilder
         .addCounter(Interns.info(TOTAL_REQUEST_COUNT, TOTAL_REQUEST_COUNT_DESC),
           rsWrap.getTotalRequestCount())
         .addCounter(
@@ -496,10 +497,17 @@ public class MetricsRegionServerSourceImpl extends BaseSourceImpl
           rsWrap.getHedgedReadOpsInCurThread())
         .addCounter(Interns.info(BLOCKED_REQUESTS_COUNT, BLOCKED_REQUESTS_COUNT_DESC),
           rsWrap.getBlockedRequestsCount())
+        .addCounter(Interns.info(EXCLUDE_DATA_NODES_COUNT, EXCLUDE_DATA_NODES_COUNT_DESC),
+          rsWrap.getWALExcludeDNs().size())
         .tag(Interns.info(ZOOKEEPER_QUORUM_NAME, ZOOKEEPER_QUORUM_DESC),
           rsWrap.getZookeeperQuorum())
         .tag(Interns.info(SERVER_NAME_NAME, SERVER_NAME_DESC), rsWrap.getServerName())
         .tag(Interns.info(CLUSTER_ID_NAME, CLUSTER_ID_DESC), rsWrap.getClusterId());
+      if (!rsWrap.getWALExcludeDNs().isEmpty()) {
+        metricsRecordBuilder.tag(
+          Interns.info(EXCLUDE_DATA_NODES_DETAILS, EXCLUDE_DATA_NODES_DETAILS_DESC),
+          rsWrap.getWALExcludeDNs().toString());
+      }
     }
 
     metricsRegistry.snapshot(mrb, all);


### PR DESCRIPTION
Add and expose updated ‘ExcludeDNs’ information (with exclusion cause) to RegionServer metrics. This enhancement will allow operators and monitoring systems to track which DataNodes are excluded and understand the reasons directly through RS metrics, improving cluster observability and troubleshooting efficiency.