### PR TITLE
HBASE-28881: Adding check and diagnose log for "hbase.master.procedure.threads" when set to non-positive value

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1867,8 +1867,15 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     configurationManager.registerObserver(procEnv);
 
     int cpus = Runtime.getRuntime().availableProcessors();
-    final int numThreads = conf.getInt(MasterProcedureConstants.MASTER_PROCEDURE_THREADS, Math.max(
-      (cpus > 0 ? cpus / 4 : 0), MasterProcedureConstants.DEFAULT_MIN_MASTER_PROCEDURE_THREADS));
+    int defaultNumThreads = Math.max(
+      (cpus > 0 ? cpus / 4 : 0), 
+      MasterProcedureConstants.DEFAULT_MIN_MASTER_PROCEDURE_THREADS);
+    int numThreads = conf.getInt(MasterProcedureConstants.MASTER_PROCEDURE_THREADS, defaultNumThreads);
+    if (numThreads <= 0) {
+      LOG.warn(MasterProcedureConstants.MASTER_PROCEDURE_THREADS + " is set to {}, which is invalid, "
+        + "using default value {} instead", numThreads, defaultNumThreads);
+      numThreads = defaultNumThreads;
+    }
     final boolean abortOnCorruption =
       conf.getBoolean(MasterProcedureConstants.EXECUTOR_ABORT_ON_CORRUPTION,
         MasterProcedureConstants.DEFAULT_EXECUTOR_ABORT_ON_CORRUPTION);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1872,9 +1872,8 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     int numThreads =
       conf.getInt(MasterProcedureConstants.MASTER_PROCEDURE_THREADS, defaultNumThreads);
     if (numThreads <= 0) {
-      LOG.warn(MasterProcedureConstants.MASTER_PROCEDURE_THREADS
-        + " is set to {}, which is invalid, " + "using default value {} instead", numThreads,
-        defaultNumThreads);
+      LOG.warn("{} is set to {}, which is invalid, using default value {} instead",
+        MasterProcedureConstants.MASTER_PROCEDURE_THREADS, numThreads, defaultNumThreads);
       numThreads = defaultNumThreads;
     }
     final boolean abortOnCorruption =

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -1867,13 +1867,14 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     configurationManager.registerObserver(procEnv);
 
     int cpus = Runtime.getRuntime().availableProcessors();
-    int defaultNumThreads = Math.max(
-      (cpus > 0 ? cpus / 4 : 0), 
+    int defaultNumThreads = Math.max((cpus > 0 ? cpus / 4 : 0),
       MasterProcedureConstants.DEFAULT_MIN_MASTER_PROCEDURE_THREADS);
-    int numThreads = conf.getInt(MasterProcedureConstants.MASTER_PROCEDURE_THREADS, defaultNumThreads);
+    int numThreads =
+      conf.getInt(MasterProcedureConstants.MASTER_PROCEDURE_THREADS, defaultNumThreads);
     if (numThreads <= 0) {
-      LOG.warn(MasterProcedureConstants.MASTER_PROCEDURE_THREADS + " is set to {}, which is invalid, "
-        + "using default value {} instead", numThreads, defaultNumThreads);
+      LOG.warn(MasterProcedureConstants.MASTER_PROCEDURE_THREADS
+        + " is set to {}, which is invalid, " + "using default value {} instead", numThreads,
+        defaultNumThreads);
       numThreads = defaultNumThreads;
     }
     final boolean abortOnCorruption =


### PR DESCRIPTION
This PR addresses the issue described in [HBASE-28881](https://issues.apache.org/jira/browse/HBASE-28881) Setting hbase.oldwals.cleaner.thread.size to a negative value can break HMaster and produce hard-to-diagnose logs.

Problem: When setting 'hbase.master.procedure.threads' to a negative value, the HMaster starts normally, but the clients cannot connect to the server. Additionally, there are no related error messages in the HMaster logs, making it difficult for users to diagnose the root cause of the issue.

Solution: Defining the default value of _numThreads_; Changing the declaration of _numThreads_ to local; Adding a value check: when _numThreads_ <= 0, it will be reset to the default value and outputs log info. 

We appreciate your review and feedback! 
Thanks @Apache9 