### PR TITLE
HBASE-29570 Set no watches on the node when recursively deleting the node and its child nodes

### DIFF
--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKUtil.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKUtil.java
@@ -966,7 +966,7 @@ public final class ZKUtil {
         ops.add(ZKUtilOp.deleteNodeFailSilent(children.get(i)));
       }
       try {
-        if (zkw.getRecoverableZooKeeper().exists(eachRoot, zkw) != null) {
+        if (zkw.getRecoverableZooKeeper().exists(eachRoot, null) != null) {
           ops.add(ZKUtilOp.deleteNodeFailSilent(eachRoot));
         }
       } catch (InterruptedException e) {


### PR DESCRIPTION
HBASE-29570 Set no watches on the node when recursively deleting the node and its child nodes