### PR TITLE
HBASE-29572 Clean up output directory when copying the manifest fails during snapshot

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/snapshot/ExportSnapshot.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/snapshot/ExportSnapshot.java
@@ -1202,6 +1202,9 @@ public class ExportSnapshot extends AbstractHBaseTool implements Tool {
           conf.getInt(CONF_COPY_MANIFEST_THREADS, DEFAULT_COPY_MANIFEST_THREADS));
       copySucceeded = true;
     } catch (IOException e) {
+      if (outputFs.exists(initialOutputSnapshotDir)) {
+        outputFs.delete(initialOutputSnapshotDir, true);
+      }
       throw new ExportSnapshotException("Failed to copy the snapshot directory: from=" + snapshotDir
         + " to=" + initialOutputSnapshotDir, e);
     } finally {


### PR DESCRIPTION
HBASE-29572 Clean up output directory when copying the manifest fails during snapshot