### PR TITLE
HBASE-29597 Supply meta table name for replica to the tests in TestMe…

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestMetaTableForReplica.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestMetaTableForReplica.java
@@ -23,11 +23,10 @@ import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import java.io.IOException;
 import java.lang.invoke.MethodHandles;
 import java.lang.reflect.Field;
 import java.lang.reflect.Modifier;
-
-import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
@@ -144,10 +143,10 @@ public class TestMetaTableForReplica {
       currentMetaName);
 
     // The current meta table name has the configured suffix.
-    assertEquals("META_TABLE_NAME should have the configured suffix",
-      expectedMetaTableName, currentMetaName);
+    assertEquals("META_TABLE_NAME should have the configured suffix", expectedMetaTableName,
+      currentMetaName);
 
-    //restore default value of META_TABLE_NAME
+    // restore default value of META_TABLE_NAME
     setDefaultMetaTableName();
   }
 
@@ -160,7 +159,7 @@ public class TestMetaTableForReplica {
   /**
    * A helper method to modify a static final field using reflection. This is necessary for testing
    * code that reads a configuration only once during class loading.
-   * @param field The field to modify.
+   * @param field    The field to modify.
    * @param newValue The new value to set.
    * @throws Exception if reflection fails.
    */

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestMetaTableForReplica.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestMetaTableForReplica.java
@@ -18,9 +18,14 @@
 package org.apache.hadoop.hbase;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
+
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
 
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
@@ -55,6 +60,8 @@ public class TestMetaTableForReplica {
   private static final Logger LOG = LoggerFactory.getLogger(TestMetaTableForReplica.class);
   private static final HBaseTestingUtil UTIL = new HBaseTestingUtil();
   private static Connection connection;
+  private static Field metaTableName;
+  private static Object originalMetaTableName;
 
   @Rule
   public TestName name = new TestName();
@@ -66,9 +73,11 @@ public class TestMetaTableForReplica {
     c.setInt("hbase.ipc.client.connect.max.retries", 1);
     c.setInt(HConstants.ZK_SESSION_TIMEOUT, 1000);
     // Start cluster having non-default hbase meta table name
-    c.setStrings(HConstants.HBASE_META_TABLE_SUFFIX, "test");
     UTIL.startMiniCluster(3);
     connection = ConnectionFactory.createConnection(c);
+    // Save the original value of META_TABLE_NAME before any test runs.x
+    metaTableName = TableName.class.getDeclaredField("META_TABLE_NAME");
+    originalMetaTableName = metaTableName.get(null);
   }
 
   @AfterClass
@@ -84,18 +93,23 @@ public class TestMetaTableForReplica {
   }
 
   @Test
-  public void testNameOfMetaForReplica() {
+  public void testMetaTableNameForReplicaWithoutSuffix() throws IOException {
+    testNameOfMetaForReplica();
+    testGetNonExistentRegionFromMetaFromReplica();
+    testGetExistentRegionFromMetaFromReplica();
+  }
+
+  private void testNameOfMetaForReplica() {
     // Check the correctness of the meta table for replica
     String metaTableName = TableName.META_TABLE_NAME.getNameWithNamespaceInclAsString();
     assertNotNull(metaTableName);
 
-    // Check if name of the meta table for replica is not same as default table
+    // Check if name of the meta table for replica is same as the default meta table
     assertEquals(0,
       TableName.META_TABLE_NAME.compareTo(TableName.getDefaultNameOfMetaForReplica()));
   }
 
-  @Test
-  public void testGetNonExistentRegionFromMetaFromReplica() throws IOException {
+  private void testGetNonExistentRegionFromMetaFromReplica() throws IOException {
     final String name = this.name.getMethodName();
     LOG.info("Started " + name);
     Pair<RegionInfo, ServerName> pair =
@@ -104,11 +118,60 @@ public class TestMetaTableForReplica {
     LOG.info("Finished " + name);
   }
 
-  @Test
-  public void testGetExistentRegionFromMetaFromReplica() throws IOException {
+  private void testGetExistentRegionFromMetaFromReplica() throws IOException {
     final TableName tableName = TableName.valueOf(name.getMethodName());
     LOG.info("Started " + tableName);
     UTIL.createTable(tableName, HConstants.CATALOG_FAMILY);
     assertEquals(1, MetaTableAccessor.getTableRegions(connection, tableName).size());
+  }
+
+  @Test
+  public void testMetaTableNameForReplicaWithSuffix() throws Exception {
+    // This test actively changes the META_TABLE_NAME to a non-default value and verifies it.
+    Configuration conf = HBaseConfiguration.create();
+    String suffix = "replica1";
+    conf.set(HConstants.HBASE_META_TABLE_SUFFIX, suffix);
+
+    // Re-initialize the static final META_TABLE_NAME for the testing to a non-default value.
+    TableName expectedMetaTableName = TableName.initializeHbaseMetaTableName(conf);
+    setStaticFinalField(metaTableName, expectedMetaTableName);
+
+    TableName currentMetaName = TableName.META_TABLE_NAME;
+    TableName defaultMetaName = TableName.getDefaultNameOfMetaForReplica();
+
+    // The current meta table name is not the default one.
+    assertNotEquals("META_TABLE_NAME should not be the default. ", defaultMetaName,
+      currentMetaName);
+
+    // The current meta table name has the configured suffix.
+    assertEquals("META_TABLE_NAME should have the configured suffix",
+      expectedMetaTableName, currentMetaName);
+
+    //restore default value of META_TABLE_NAME
+    setDefaultMetaTableName();
+  }
+
+  private static void setDefaultMetaTableName() throws Exception {
+    if (originalMetaTableName != null) {
+      setStaticFinalField(metaTableName, originalMetaTableName);
+    }
+  }
+
+  /**
+   * A helper method to modify a static final field using reflection. This is necessary for testing
+   * code that reads a configuration only once during class loading.
+   * @param field The field to modify.
+   * @param newValue The new value to set.
+   * @throws Exception if reflection fails.
+   */
+  private static void setStaticFinalField(Field field, Object newValue) throws Exception {
+    field.setAccessible(true);
+    // Using MethodHandles to get a trusted lookup with the necessary permissions to modify it.
+    // NOTE: For this to work, the JVM running the test must be started with arguments like:
+    // --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+    var lookup = MethodHandles.privateLookupIn(Field.class, MethodHandles.lookup());
+    var handle = lookup.findVarHandle(Field.class, "modifiers", int.class);
+    handle.set(field, field.getModifiers() & ~Modifier.FINAL);
+    field.set(null, newValue);
   }
 }


### PR DESCRIPTION
…taTableForReplica class

Existing test has anomaly where only default meta table name was getting passed. Corrected the tests and now also added a  basic scenario where meta table name is using the suffix value to construct the meta table name. 
