### PR TITLE
HBASE-29621: Remove the leading whitespace in the active.cluster.suffix.id filename

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1682,7 +1682,7 @@ public final class HConstants {
   public final static boolean HBASE_GLOBAL_READONLY_ENABLED_DEFAULT = false;
 
   /** name of the file having active cluster suffix */
-  public static final String ACTIVE_CLUSTER_SUFFIX_FILE_NAME = " active.cluster.suffix.id";
+  public static final String ACTIVE_CLUSTER_SUFFIX_FILE_NAME = "active.cluster.suffix.id";
 
   private HConstants() {
     // Can't be instantiated with this ctor.


### PR DESCRIPTION
Jira: [HBASE-29621](https://issues.apache.org/jira/browse/HBASE-29621)