### PR TITLE
HBASE-29733 Use ServerName instead of hostname in unloadRegions log message

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
@@ -607,8 +607,8 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
             isolateRegionInfo = hRegionLocation.getRegion();
             isolateRegionInfoList.add(isolateRegionInfo);
             if (hRegionLocation.getServerName() == server) {
-              LOG.info("Region " + hRegionLocation.getRegion().getEncodedName() + " already exists"
-                + " on server : " + server.getHostname());
+              LOG.info("Region {} already exists on server: {}",
+                hRegionLocation.getRegion().getEncodedName(), server);
             } else {
               Future<Boolean> isolateRegionTask =
                 isolateRegionPool.submit(new MoveWithAck(conn, isolateRegionInfo,
@@ -632,14 +632,14 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
             break;
           }
         } else {
-          LOG.info("All regions already exists on server : " + server.getHostname());
+          LOG.info("All regions already exists on server: {}", server);
         }
         // Once region has been moved to target RS, put the target RS into decommission mode,
         // so master doesn't assign new region to the target RS while we unload the target RS.
         // Also pass 'offload' flag as false since we don't want master to offload the target RS.
         List<ServerName> listOfServer = new ArrayList<>();
         listOfServer.add(server);
-        LOG.info("Putting server : " + server.getHostname() + " in decommission/draining mode");
+        LOG.info("Putting server: {} in decommission/draining mode", server);
         admin.decommissionRegionServers(listOfServer, false);
       }
       List<RegionInfo> regionsToMove = admin.getRegions(server);
@@ -708,10 +708,11 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
     try {
       return task.get(5, TimeUnit.SECONDS);
     } catch (InterruptedException e) {
-      LOG.warn("Interrupted while " + operation + " Regions on " + this.hostname, e);
+      LOG.warn("Interrupted while {} regions on {}:{}", operation, this.hostname, this.port, e);
       throw e;
     } catch (ExecutionException e) {
-      LOG.error("Error while " + operation + " regions on RegionServer " + this.hostname, e);
+      LOG.error("Error while {} regions on RegionServer {}:{}", operation, this.hostname,
+        this.port, e);
       throw e;
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
@@ -711,8 +711,8 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
       LOG.warn("Interrupted while {} regions on {}:{}", operation, this.hostname, this.port, e);
       throw e;
     } catch (ExecutionException e) {
-      LOG.error("Error while {} regions on RegionServer {}:{}", operation, this.hostname,
-        this.port, e);
+      LOG.error("Error while {} regions on RegionServer {}:{}", operation, this.hostname, this.port,
+        e);
       throw e;
     }
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
@@ -876,7 +876,7 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
     if (fileName != null) {
       List<String> servers = readServersFromFile(fileName);
       if (servers.isEmpty()) {
-        LOG.warn("No servers provided in the file: {}." + fileName);
+        LOG.warn("No servers provided in the file: {}.", fileName);
         return;
       }
       Iterator<ServerName> i = regionServers.iterator();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
@@ -652,7 +652,7 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
         break;
       }
       LOG.info("Moving {} regions from {} to {} servers using {} threads .Ack Mode: {}",
-        regionsToMove.size(), this.hostname, regionServers.size(), this.maxthreads, ack);
+        regionsToMove.size(), server, regionServers.size(), this.maxthreads, ack);
 
       Optional<RegionInfo> metaRegion = getMetaRegionInfoIfToBeMoved(regionsToMove);
       if (metaRegion.isPresent()) {


### PR DESCRIPTION
[UnloadRegions log message](https://issues.apache.org/jira/browse/HBASE-29733?filter=-2#L649-L650]) uses the hostname to show where regions are unloading from. When a host runs multiple region servers, the hostname in the log message alone is insufficient to identify which specific region server is unloading regions.

This PR has the change to use ServerName in the log, making it easier to distinguish between region servers on the same host similar to [loadRegions log message](https://github.com/apache/hbase/blob/master/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java#L366-L367).

This PR also fixes a log statement 
