### PR TITLE
HBASE-29826: Backup merge is failing because .backup.manifest cannot be found

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalTableBackupClient.java
@@ -103,7 +103,7 @@ public class IncrementalTableBackupClient extends TableBackupClient {
   }
 
   /**
-   * Check if a given path is belongs to active WAL directory
+   * Check if a given path belongs to active WAL directory
    * @param p path
    * @return true, if yes
    */
@@ -126,9 +126,9 @@ public class IncrementalTableBackupClient extends TableBackupClient {
 
   /**
    * Reads bulk load records from backup table, iterates through the records and forms the paths for
-   * bulk loaded hfiles. Copies the bulk loaded hfiles to backup destination. This method does NOT
-   * clean up the entries in the bulk load system table. Those entries should not be cleaned until
-   * the backup is marked as complete.
+   * bulk loaded hfiles. Copies the bulk loaded hfiles to the backup destination. This method does
+   * NOT clean up the entries in the bulk load system table. Those entries should not be cleaned
+   * until the backup is marked as complete.
    * @param tablesToBackup list of tables to be backed up
    */
   protected List<BulkLoad> handleBulkLoad(List<TableName> tablesToBackup,
@@ -403,13 +403,17 @@ public class IncrementalTableBackupClient extends TableBackupClient {
       failBackup(conn, backupInfo, backupManager, e, "Unexpected Exception : ",
         BackupType.INCREMENTAL, conf);
       throw new IOException(e);
+    } finally {
+      if (backupInfo.isContinuousBackupEnabled()) {
+        deleteBulkLoadDirectory();
+      }
     }
   }
 
   protected void incrementalCopyHFiles(String[] files, String backupDest) throws IOException {
     boolean diskBasedSortingOriginalValue = HFileOutputFormat2.diskBasedSortingEnabled(conf);
     try {
-      LOG.debug("Incremental copy HFiles is starting. dest=" + backupDest);
+      LOG.debug("Incremental copy HFiles is starting. dest={}", backupDest);
       // set overall backup phase: incremental_copy
       backupInfo.setPhase(BackupPhase.INCREMENTAL_COPY);
       // get incremental backup file list and prepare parms for DistCp


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-29826

This pull request makes a change that deletes the bulk load output directory when a continuous incremental backup is complete.

### Summary

Originally, a continuous incremental backup was creating a `backupRootDir/.tmp/backup_XXXX` directory for bulk load output, but this directory was not being deleted after.  This would cause an issue in `MapReduceBackupMergeJob` when performing a merge.  During the merge, it tries to move the backup directory to the `.tmp` directory.  Since the backup directory already exists inside of `.tmp`, the location of the backup manifest ends up being `.tmp/backup_XXXX/backup_XXXX/.backup.manifest`.  As a result, the backup manifest cannot be found and an error is thrown  because the code is looking for the file in `.tmp/backup_XXXX/.backup.manifest` and not `.tmp/backup_XXXX/backup_XXXX/.backup.manifest`.

### Testing

- I have added an `assert` statement to a continuous incremental backup unit test that verifies the backup directory has been deleted after the incremental backup is complete.
- I have manually verified the bulk load directory is empty right before it is deleted, but this check has not been implemented into a unit test.  I looked into how this could be tested.  This check would need to be performed after `IncrementalTableBackupClient.handleBulkLoad()`.  The only place I see this method in current test code is in [TestBackupBase](https://github.com/apache/hbase/blob/master/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupBase.java#L196), and this code is for non-continuous incremental backups.  Based on what I have found, handling this test case would require code changes beyond the scope of this PR that involve creating a test similar to the one in `TestBackupBase` or overriding `IncrementalTableBackupClient.execute()` in a test class to have it check the directory is empty and then delete.