### PR TITLE
HBASE-29691: Change TableName.META_TABLE_NAME from being a global static

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/favored/FavoredNodeAssignmentHelper.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/favored/FavoredNodeAssignmentHelper.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hbase.CellBuilderType;
 import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Put;
@@ -131,7 +130,7 @@ public class FavoredNodeAssignmentHelper {
         puts.add(put);
       }
     }
-    try (Table table = connection.getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = connection.getTable(connection.getMetaTableName())) {
       table.put(puts);
     }
     LOG.info("Added " + puts.size() + " region favored nodes in META");

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/SnapshotOfRegionAssignmentFromMeta.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/SnapshotOfRegionAssignmentFromMeta.java
@@ -170,9 +170,10 @@ public class SnapshotOfRegionAssignmentFromMeta {
    * Initialize the region assignment snapshot by scanning the hbase:meta table
    */
   public void initialize() throws IOException {
-    LOG.info("Start to scan the hbase:meta for the current region assignment " + "snappshot");
+    LOG.info("Start to scan {} for the current region assignment snapshot",
+      connection.getMetaTableName());
     // Scan hbase:meta to pick up user regions
-    try (Table metaTable = connection.getTable(TableName.META_TABLE_NAME);
+    try (Table metaTable = connection.getTable(connection.getMetaTableName());
       ResultScanner scanner = metaTable.getScanner(HConstants.CATALOG_FAMILY)) {
       for (;;) {
         Result result = scanner.next();
@@ -187,7 +188,8 @@ public class SnapshotOfRegionAssignmentFromMeta {
         }
       }
     }
-    LOG.info("Finished to scan the hbase:meta for the current region assignment" + "snapshot");
+    LOG.info("Finished scanning {} for the current region assignment snapshot",
+      connection.getMetaTableName());
   }
 
   private void addRegion(RegionInfo regionInfo) {

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/SnapshotOfRegionAssignmentFromMeta.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/SnapshotOfRegionAssignmentFromMeta.java
@@ -171,9 +171,9 @@ public class SnapshotOfRegionAssignmentFromMeta {
    */
   public void initialize() throws IOException {
     LOG.info("Start to scan {} for the current region assignment snapshot",
-      TableName.META_TABLE_NAME);
+      connection.getMetaTableName());
     // Scan hbase:meta to pick up user regions
-    try (Table metaTable = connection.getTable(TableName.META_TABLE_NAME);
+    try (Table metaTable = connection.getTable(connection.getMetaTableName());
       ResultScanner scanner = metaTable.getScanner(HConstants.CATALOG_FAMILY)) {
       for (;;) {
         Result result = scanner.next();
@@ -189,7 +189,7 @@ public class SnapshotOfRegionAssignmentFromMeta {
       }
     }
     LOG.info("Finished scanning {} for the current region assignment snapshot",
-      TableName.META_TABLE_NAME);
+      connection.getMetaTableName());
   }
 
   private void addRegion(RegionInfo regionInfo) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ClientMetaTableAccessor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ClientMetaTableAccessor.java
@@ -196,7 +196,7 @@ public final class ClientMetaTableAccessor {
     final AsyncTable<AdvancedScanResultConsumer> metaTable, final TableName tableName,
     final boolean excludeOfflinedSplitParents) {
     CompletableFuture<List<Pair<RegionInfo, ServerName>>> future = new CompletableFuture<>();
-    if (TableName.META_TABLE_NAME.equals(tableName)) {
+    if (TableName.isMetaTableName(tableName)) {
       future.completeExceptionally(new IOException(
         "This method can't be used to locate meta regions;" + " use MetaTableLocator instead"));
     }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ClientMetaTableAccessor.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ClientMetaTableAccessor.java
@@ -222,7 +222,7 @@ public final class ClientMetaTableAccessor {
     final AsyncTable<AdvancedScanResultConsumer> metaTable, final TableName tableName,
     final boolean excludeOfflinedSplitParents) {
     CompletableFuture<List<Pair<RegionInfo, ServerName>>> future = new CompletableFuture<>();
-    if (TableName.META_TABLE_NAME.equals(tableName)) {
+    if (TableName.isMetaTableName(tableName)) {
       future.completeExceptionally(new IOException(
         "This method can't be used to locate meta regions;" + " use MetaTableLocator instead"));
     }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AbstractRpcBasedConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AbstractRpcBasedConnectionRegistry.java
@@ -36,6 +36,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.exceptions.ClientExceptionsUtil;
 import org.apache.hadoop.hbase.exceptions.MasterRegistryFetchException;
 import org.apache.hadoop.hbase.ipc.HBaseRpcController;
@@ -55,6 +56,8 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetClust
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetClusterIdResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMetaRegionLocationsRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMetaRegionLocationsResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMetaTableNameRequest;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMetaTableNameResponse;
 
 /**
  * Base class for rpc based connection registry implementation.
@@ -248,6 +251,19 @@ abstract class AbstractRpcBasedConnectionRegistry implements ConnectionRegistry 
           GetActiveMasterResponse::hasServerName, "getActiveMaster()")
         .thenApply(resp -> ProtobufUtil.toServerName(resp.getServerName())),
       getClass().getSimpleName() + ".getActiveMaster");
+  }
+
+  @Override
+  public CompletableFuture<TableName> getMetaTableName() {
+    return tracedFuture(() -> this.<GetMetaTableNameResponse> call(
+      (c, s, d) -> s.getMetaTableName(c, GetMetaTableNameRequest.getDefaultInstance(), d),
+      r -> true, "getMetaTableName()").thenApply(resp -> {
+        if (resp.hasTableName() && !resp.getTableName().isEmpty()) {
+          return TableName.valueOf(resp.getTableName());
+        } else {
+          return TableName.META_TABLE_NAME;
+        }
+      }), getClass().getSimpleName() + ".getMetaTableName");
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnection.java
@@ -42,6 +42,17 @@ public interface AsyncConnection extends Closeable {
   Configuration getConfiguration();
 
   /**
+   * Returns the meta table name for this cluster.
+   * <p>
+   * This value is fetched from the cluster during connection establishment and cached for the
+   * lifetime of this connection. For most clusters, this will be "hbase:meta". For read replica
+   * clusters or other specialized configurations, this may return a different table name.
+   * <p>
+   * @return The meta table name for this cluster
+   */
+  TableName getMetaTableName();
+
+  /**
    * Retrieve a AsyncRegionLocator implementation to inspect region information on a table. The
    * returned AsyncRegionLocator is not thread-safe, so a new instance should be created for each
    * using thread. This is a lightweight operation. Pooling or caching of the returned
@@ -102,6 +113,15 @@ public interface AsyncConnection extends Closeable {
    */
   default AsyncTable<ScanResultConsumer> getTable(TableName tableName, ExecutorService pool) {
     return getTableBuilder(tableName, pool).build();
+  }
+
+  /**
+   * Retrieve an {@link AsyncTable} implementation for accessing the meta table. This method returns
+   * the correct meta table for this connection
+   * @return An AsyncTable to use for interactions with the meta table
+   */
+  default AsyncTable<AdvancedScanResultConsumer> getMetaTable() {
+    return getTable(getMetaTableName());
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncConnectionImpl.java
@@ -92,6 +92,8 @@ public class AsyncConnectionImpl implements AsyncConnection {
 
   final ConnectionRegistry registry;
 
+  private final TableName metaTableName;
+
   protected final int rpcTimeout;
 
   protected final RpcClient rpcClient;
@@ -128,14 +130,16 @@ public class AsyncConnectionImpl implements AsyncConnection {
   private volatile ConnectionOverAsyncConnection conn;
 
   public AsyncConnectionImpl(Configuration conf, ConnectionRegistry registry, String clusterId,
-    SocketAddress localAddress, User user) {
-    this(conf, registry, clusterId, localAddress, user, Collections.emptyMap());
+    TableName metaTableName, SocketAddress localAddress, User user) {
+    this(conf, registry, clusterId, metaTableName, localAddress, user, Collections.emptyMap());
   }
 
   public AsyncConnectionImpl(Configuration conf, ConnectionRegistry registry, String clusterId,
-    SocketAddress localAddress, User user, Map<String, byte[]> connectionAttributes) {
+    TableName metaTableName, SocketAddress localAddress, User user,
+    Map<String, byte[]> connectionAttributes) {
     this.conf = conf;
     this.user = user;
+    this.metaTableName = metaTableName;
     this.metricsScope = MetricsConnection.getScope(conf, clusterId, this);
 
     if (user.isLoginFromKeytab()) {
@@ -217,6 +221,10 @@ public class AsyncConnectionImpl implements AsyncConnection {
   @Override
   public Configuration getConfiguration() {
     return conf;
+  }
+
+  public TableName getMetaTableName() {
+    return metaTableName;
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncNonMetaRegionLocator.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncNonMetaRegionLocator.java
@@ -22,7 +22,6 @@ import static org.apache.hadoop.hbase.HConstants.EMPTY_END_ROW;
 import static org.apache.hadoop.hbase.HConstants.NINES;
 import static org.apache.hadoop.hbase.HConstants.USE_META_REPLICAS;
 import static org.apache.hadoop.hbase.HConstants.ZEROES;
-import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
 import static org.apache.hadoop.hbase.client.AsyncRegionLocatorHelper.createRegionLocations;
 import static org.apache.hadoop.hbase.client.AsyncRegionLocatorHelper.isGood;
 import static org.apache.hadoop.hbase.client.ConnectionConfiguration.HBASE_CLIENT_META_CACHE_INVALIDATE_INTERVAL;
@@ -238,14 +237,15 @@ class AsyncNonMetaRegionLocator {
             CatalogReplicaLoadBalanceSimpleSelector.class.getName());
 
         this.metaReplicaSelector = CatalogReplicaLoadBalanceSelectorFactory
-          .createSelector(replicaSelectorClass, META_TABLE_NAME, conn, () -> {
+          .createSelector(replicaSelectorClass, conn.getMetaTableName(), conn, () -> {
             int numOfReplicas = CatalogReplicaLoadBalanceSelector.UNINITIALIZED_NUM_OF_REPLICAS;
             try {
               RegionLocations metaLocations = conn.registry.getMetaRegionLocations()
                 .get(conn.connConf.getMetaReadRpcTimeoutNs(), TimeUnit.NANOSECONDS);
               numOfReplicas = metaLocations.size();
             } catch (Exception e) {
-              LOG.error("Failed to get table {}'s region replication, ", META_TABLE_NAME, e);
+              LOG.error("Failed to get table {}'s region replication, ", conn.getMetaTableName(),
+                e);
             }
             return numOfReplicas;
           });
@@ -427,7 +427,7 @@ class AsyncNonMetaRegionLocator {
         // do nothing
     }
 
-    conn.getTable(META_TABLE_NAME).scan(scan, new AdvancedScanResultConsumer() {
+    conn.getTable(conn.getMetaTableName()).scan(scan, new AdvancedScanResultConsumer() {
 
       private boolean completeNormally = false;
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocator.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.REGION_NAMES_KEY;
 import static org.apache.hadoop.hbase.trace.HBaseSemanticAttributes.SERVER_NAME_KEY;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
@@ -217,7 +216,7 @@ class AsyncRegionLocator {
       new TableSpanBuilder(conn).setName("AsyncRegionLocator.clearCache").setTableName(tableName);
     TraceUtil.trace(() -> {
       LOG.debug("Clear meta cache for {}", tableName);
-      if (tableName.equals(META_TABLE_NAME)) {
+      if (tableName.equals(conn.getMetaTableName())) {
         metaRegionLocator.clearCache();
       } else {
         nonMetaRegionLocator.clearCache(tableName);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableRegionLocatorImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableRegionLocatorImpl.java
@@ -63,7 +63,7 @@ class AsyncTableRegionLocatorImpl implements AsyncTableRegionLocator {
           .thenApply(locs -> Arrays.asList(locs.getRegionLocations()));
       }
       CompletableFuture<List<HRegionLocation>> future = ClientMetaTableAccessor
-        .getTableHRegionLocations(conn.getTable(TableName.META_TABLE_NAME), tableName);
+        .getTableHRegionLocations(conn.getTable(conn.getMetaTableName()), tableName);
       addListener(future, (locs, error) -> locs.forEach(loc -> {
         // the cache assumes that all locations have a serverName. only add if that's true
         if (loc.getServerName() != null) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableRegionLocatorImpl.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncTableRegionLocatorImpl.java
@@ -65,7 +65,7 @@ class AsyncTableRegionLocatorImpl implements AsyncTableRegionLocator {
           .thenApply(locs -> Arrays.asList(locs.getRegionLocations()));
       }
       CompletableFuture<List<HRegionLocation>> future = ClientMetaTableAccessor
-        .getTableHRegionLocations(conn.getTable(TableName.META_TABLE_NAME), tableName);
+        .getTableHRegionLocations(conn.getTable(conn.getMetaTableName()), tableName);
       addListener(future, (locs, error) -> locs.forEach(loc -> {
         // the cache assumes that all locations have a serverName. only add if that's true
         if (loc.getServerName() != null) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Connection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Connection.java
@@ -63,6 +63,17 @@ public interface Connection extends Abortable, Closeable {
   Configuration getConfiguration();
 
   /**
+   * Returns the meta table name for this cluster.
+   * <p>
+   * This value is fetched from the cluster during connection establishment and cached for the
+   * lifetime of this connection. For most clusters, this will be "hbase:meta". For read replica
+   * clusters or other specialized configurations, this may return a different table name.
+   * <p>
+   * @return The meta table name for this cluster
+   */
+  TableName getMetaTableName();
+
+  /**
    * Retrieve a Table implementation for accessing a table. The returned Table is not thread safe, a
    * new instance should be created for each using thread. This is a lightweight operation, pooling
    * or caching of the returned Table is neither required nor desired.
@@ -93,6 +104,15 @@ public interface Connection extends Abortable, Closeable {
    */
   default Table getTable(TableName tableName, ExecutorService pool) throws IOException {
     return getTableBuilder(tableName, pool).build();
+  }
+
+  /**
+   * Retrieve a Table implementation for accessing the meta table. This method returns the correct
+   * meta table for this connection (hbase:meta or hbase:meta_suffix).
+   * @return A Table to use for interactions with the meta table
+   */
+  default Table getMetaTable() throws IOException {
+    return getTable(getMetaTableName());
   }
 
   /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionOverAsyncConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionOverAsyncConnection.java
@@ -89,6 +89,11 @@ class ConnectionOverAsyncConnection implements Connection {
   }
 
   @Override
+  public TableName getMetaTableName() {
+    return conn.getMetaTableName();
+  }
+
+  @Override
   public BufferedMutator getBufferedMutator(BufferedMutatorParams params) throws IOException {
     AsyncBufferedMutatorBuilder builder = conn.getBufferedMutatorBuilder(params.getTableName());
     if (params.getRpcTimeout() != BufferedMutatorParams.UNSET) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionOverAsyncConnection.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionOverAsyncConnection.java
@@ -96,6 +96,11 @@ class ConnectionOverAsyncConnection implements Connection {
   }
 
   @Override
+  public TableName getMetaTableName() {
+    return conn.getMetaTableName();
+  }
+
+  @Override
   public BufferedMutator getBufferedMutator(BufferedMutatorParams params) throws IOException {
     AsyncBufferedMutatorBuilder builder = conn.getBufferedMutatorBuilder(params.getTableName());
     if (params.getRpcTimeout() != BufferedMutatorParams.UNSET) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ConnectionRegistry.java
@@ -21,6 +21,7 @@ import java.io.Closeable;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -47,6 +48,15 @@ public interface ConnectionRegistry extends Closeable {
    * Get the address of active HMaster.
    */
   CompletableFuture<ServerName> getActiveMaster();
+
+  /**
+   * Get the name of the meta table for this cluster.
+   * <p>
+   * Should only be called once, similar to {@link #getClusterId()}.
+   * <p>
+   * @return CompletableFuture containing the meta table name
+   */
+  CompletableFuture<TableName> getMetaTableName();
 
   /**
    * Return the connection string associated with this registry instance. This value is

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MutableRegionInfo.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/MutableRegionInfo.java
@@ -120,7 +120,7 @@ class MutableRegionInfo implements RegionInfo {
     this.replicaId = checkReplicaId(replicaId);
     this.offLine = offLine;
     this.regionName = RegionInfo.createRegionName(this.tableName, this.startKey, this.regionId,
-      this.replicaId, !this.tableName.equals(TableName.META_TABLE_NAME));
+      this.replicaId, !TableName.isMetaTableName(this.tableName));
     this.encodedName = RegionInfo.encodeRegionName(this.regionName);
     this.hashCode = generateHashCode(this.tableName, this.startKey, this.endKey, this.regionId,
       this.replicaId, this.offLine, this.regionName);
@@ -232,7 +232,7 @@ class MutableRegionInfo implements RegionInfo {
   /** Returns true if this region is a meta region */
   @Override
   public boolean isMetaRegion() {
-    return tableName.equals(TableName.META_TABLE_NAME);
+    return TableName.isMetaTableName(tableName);
   }
 
   /** Returns True if has been split and has daughters. */

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.HConstants.HIGH_QOS;
-import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 import static org.apache.hadoop.hbase.util.FutureUtils.unwrapCompletionException;
 
@@ -405,7 +404,7 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
     AsyncAdminBuilderBase builder) {
     this.connection = connection;
     this.retryTimer = retryTimer;
-    this.metaTable = connection.getTable(META_TABLE_NAME);
+    this.metaTable = connection.getTable(connection.getMetaTableName());
     this.rpcTimeoutNs = builder.rpcTimeoutNs;
     this.operationTimeoutNs = builder.operationTimeoutNs;
     this.pauseNs = builder.pauseNs;
@@ -1012,7 +1011,7 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
 
   @Override
   public CompletableFuture<List<RegionInfo>> getRegions(TableName tableName) {
-    if (tableName.equals(META_TABLE_NAME)) {
+    if (tableName.equals(connection.getMetaTableName())) {
       return connection.registry.getMetaRegionLocations()
         .thenApply(locs -> Stream.of(locs.getRegionLocations()).map(HRegionLocation::getRegion)
           .collect(Collectors.toList()));
@@ -1303,7 +1302,7 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
    * List all region locations for the specific table.
    */
   private CompletableFuture<List<HRegionLocation>> getTableHRegionLocations(TableName tableName) {
-    if (TableName.META_TABLE_NAME.equals(tableName)) {
+    if (connection.getMetaTableName().equals(tableName)) {
       CompletableFuture<List<HRegionLocation>> future = new CompletableFuture<>();
       addListener(connection.registry.getMetaRegionLocations(), (metaRegions, err) -> {
         if (err != null) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.HConstants.HIGH_QOS;
-import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
 import static org.apache.hadoop.hbase.util.FutureUtils.addListener;
 import static org.apache.hadoop.hbase.util.FutureUtils.unwrapCompletionException;
 
@@ -409,7 +408,7 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
     AsyncAdminBuilderBase builder) {
     this.connection = connection;
     this.retryTimer = retryTimer;
-    this.metaTable = connection.getTable(META_TABLE_NAME);
+    this.metaTable = connection.getTable(connection.getMetaTableName());
     this.rpcTimeoutNs = builder.rpcTimeoutNs;
     this.operationTimeoutNs = builder.operationTimeoutNs;
     this.pauseNs = builder.pauseNs;
@@ -1016,7 +1015,7 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
 
   @Override
   public CompletableFuture<List<RegionInfo>> getRegions(TableName tableName) {
-    if (tableName.equals(META_TABLE_NAME)) {
+    if (tableName.equals(connection.getMetaTableName())) {
       return connection.registry.getMetaRegionLocations()
         .thenApply(locs -> Stream.of(locs.getRegionLocations()).map(HRegionLocation::getRegion)
           .collect(Collectors.toList()));
@@ -1307,7 +1306,7 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
    * List all region locations for the specific table.
    */
   private CompletableFuture<List<HRegionLocation>> getTableHRegionLocations(TableName tableName) {
-    if (TableName.META_TABLE_NAME.equals(tableName)) {
+    if (connection.getMetaTableName().equals(tableName)) {
       CompletableFuture<List<HRegionLocation>> future = new CompletableFuture<>();
       addListener(connection.registry.getMetaRegionLocations(), (metaRegions, err) -> {
         if (err != null) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfoBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfoBuilder.java
@@ -42,6 +42,8 @@ public class RegionInfoBuilder {
    */
   // TODO: How come Meta regions still do not have encoded region names? Fix.
   // hbase:meta,,1.1588230740 should be the hbase:meta first region name.
+  // TODO: For now, hardcode to default. Future: lazy initialization based on config or make it use
+  // connection
   public static final RegionInfo FIRST_META_REGIONINFO =
     new MutableRegionInfo(1L, TableName.META_TABLE_NAME, RegionInfo.DEFAULT_REPLICA_ID);
 

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfoDisplay.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfoDisplay.java
@@ -82,7 +82,7 @@ public class RegionInfoDisplay {
    */
   public static byte[] getRegionNameForDisplay(RegionInfo ri, Configuration conf) {
     boolean displayKey = conf.getBoolean(DISPLAY_KEYS_KEY, true);
-    if (displayKey || ri.getTable().equals(TableName.META_TABLE_NAME)) {
+    if (displayKey || TableName.isMetaTableName(ri.getTable())) {
       return ri.getRegionName();
     } else {
       // create a modified regionname with the startkey replaced but preserving

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptorBuilder.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/TableDescriptorBuilder.java
@@ -616,7 +616,7 @@ public class TableDescriptorBuilder {
       families.forEach(c -> this.families.put(c.getName(), ColumnFamilyDescriptorBuilder.copy(c)));
       this.values.putAll(values);
       this.values.put(IS_META_KEY,
-        new Bytes(Bytes.toBytes(Boolean.toString(name.equals(TableName.META_TABLE_NAME)))));
+        new Bytes(Bytes.toBytes(Boolean.toString(TableName.isMetaTableName(name)))));
     }
 
     /**

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ZKConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ZKConnectionRegistry.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.exceptions.DeserializationException;
 import org.apache.hadoop.hbase.master.RegionState;
 import org.apache.hadoop.hbase.security.User;
@@ -260,6 +261,17 @@ class ZKConnectionRegistry implements ConnectionRegistry {
             snProto.getStartCode());
         }),
       "ZKConnectionRegistry.getActiveMaster");
+  }
+
+  /**
+   * Returns the meta table name. This implementation always returns the default "hbase:meta"
+   * because ZKConnectionRegistry is deprecated and does not support custom meta table names. Custom
+   * meta table name support requires using RPC-based connection registry.
+   */
+  @Override
+  public CompletableFuture<TableName> getMetaTableName() {
+    return tracedFuture(() -> CompletableFuture.completedFuture(TableName.META_TABLE_NAME),
+      "ZKConnectionRegistry.getMetaTableName");
   }
 
   @Override

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/security/token/ClientTokenUtil.java
@@ -22,7 +22,6 @@ import java.lang.reflect.UndeclaredThrowableException;
 import java.security.PrivilegedExceptionAction;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.HConstants;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.AsyncTable;
 import org.apache.hadoop.hbase.client.Connection;
@@ -73,7 +72,7 @@ public final class ClientTokenUtil {
       future.completeExceptionally(ProtobufUtil.handleRemoteException(injectedException));
       return future;
     }
-    AsyncTable<?> table = conn.getTable(TableName.META_TABLE_NAME);
+    AsyncTable<?> table = conn.getTable(conn.getMetaTableName());
     table.<AuthenticationProtos.AuthenticationService.Interface,
       AuthenticationProtos.GetAuthenticationTokenResponse> coprocessorService(
         AuthenticationProtos.AuthenticationService::newStub,
@@ -102,7 +101,7 @@ public final class ClientTokenUtil {
     try {
       injectFault();
 
-      meta = conn.getTable(TableName.META_TABLE_NAME);
+      meta = conn.getTable(conn.getMetaTableName());
       CoprocessorRpcChannel rpcChannel = meta.coprocessorService(HConstants.EMPTY_START_ROW);
       AuthenticationProtos.AuthenticationService.BlockingInterface service =
         AuthenticationProtos.AuthenticationService.newBlockingStub(rpcChannel);

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -3325,7 +3325,7 @@ public final class ProtobufUtil {
     long regionId = proto.getRegionId();
     int defaultReplicaId = org.apache.hadoop.hbase.client.RegionInfo.DEFAULT_REPLICA_ID;
     int replicaId = proto.hasReplicaId() ? proto.getReplicaId() : defaultReplicaId;
-    if (tableName.equals(TableName.META_TABLE_NAME) && replicaId == defaultReplicaId) {
+    if (TableName.isMetaTableName(tableName) && replicaId == defaultReplicaId) {
       return RegionInfoBuilder.FIRST_META_REGIONINFO;
     }
     byte[] startKey = null;

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/DoNothingConnectionRegistry.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/DoNothingConnectionRegistry.java
@@ -21,6 +21,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -45,6 +46,11 @@ public class DoNothingConnectionRegistry implements ConnectionRegistry {
 
   @Override
   public CompletableFuture<ServerName> getActiveMaster() {
+    return CompletableFuture.completedFuture(null);
+  }
+
+  @Override
+  public CompletableFuture<TableName> getMetaTableName() {
     return CompletableFuture.completedFuture(null);
   }
 

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncAdminRpcPriority.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncAdminRpcPriority.java
@@ -137,8 +137,8 @@ public class TestAsyncAdminRpcPriority {
     }).when(adminStub).stopServer(any(HBaseRpcController.class), any(StopServerRequest.class),
       any());
     User user = UserProvider.instantiate(CONF).getCurrent();
-    conn = new AsyncConnectionImpl(CONF, new DoNothingConnectionRegistry(CONF, user), "test", null,
-      user) {
+    conn = new AsyncConnectionImpl(CONF, new DoNothingConnectionRegistry(CONF, user), "test",
+      TableName.META_TABLE_NAME, null, user) {
 
       @Override
       CompletableFuture<MasterService.Interface> getMasterStub() {
@@ -187,7 +187,7 @@ public class TestAsyncAdminRpcPriority {
   // that we pass the correct priority
   @Test
   public void testCreateMetaTable() {
-    conn.getAdmin().createTable(TableDescriptorBuilder.newBuilder(TableName.META_TABLE_NAME)
+    conn.getAdmin().createTable(TableDescriptorBuilder.newBuilder(conn.getMetaTableName())
       .setColumnFamily(ColumnFamilyDescriptorBuilder.of("cf")).build()).join();
     verify(masterStub, times(1)).createTable(assertPriority(SYSTEMTABLE_QOS),
       any(CreateTableRequest.class), any());

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncConnectionTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncConnectionTracing.java
@@ -28,6 +28,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.Waiter;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.UserProvider;
@@ -67,7 +68,7 @@ public class TestAsyncConnectionTracing {
         return CompletableFuture.completedFuture(masterServer);
       }
     };
-    conn = new AsyncConnectionImpl(CONF, registry, "test", null, user);
+    conn = new AsyncConnectionImpl(CONF, registry, "test", TableName.META_TABLE_NAME, null, user);
   }
 
   @AfterEach

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableRpcPriority.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableRpcPriority.java
@@ -156,8 +156,8 @@ public class TestAsyncTableRpcPriority {
       }
     }).when(stub).get(any(HBaseRpcController.class), any(GetRequest.class), any());
     User user = UserProvider.instantiate(CONF).getCurrent();
-    conn = new AsyncConnectionImpl(CONF, new DoNothingConnectionRegistry(CONF, user), "test", null,
-      user) {
+    conn = new AsyncConnectionImpl(CONF, new DoNothingConnectionRegistry(CONF, user), "test",
+      TableName.META_TABLE_NAME, null, user) {
 
       @Override
       AsyncRegionLocator getLocator() {
@@ -230,7 +230,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testGetMetaTable() {
-    conn.getTable(TableName.META_TABLE_NAME).get(new Get(Bytes.toBytes(0))).join();
+    conn.getTable(conn.getMetaTableName()).get(new Get(Bytes.toBytes(0))).join();
     verify(stub, times(1)).get(assertPriority(SYSTEMTABLE_QOS), any(GetRequest.class), any());
   }
 
@@ -257,7 +257,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testPutMetaTable() {
-    conn.getTable(TableName.META_TABLE_NAME).put(new Put(Bytes.toBytes(0))
+    conn.getTable(conn.getMetaTableName()).put(new Put(Bytes.toBytes(0))
       .addColumn(Bytes.toBytes("cf"), Bytes.toBytes("cq"), Bytes.toBytes("v"))).join();
     verify(stub, times(1)).mutate(assertPriority(SYSTEMTABLE_QOS), any(MutateRequest.class), any());
   }
@@ -284,7 +284,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testDeleteMetaTable() {
-    conn.getTable(TableName.META_TABLE_NAME).delete(new Delete(Bytes.toBytes(0))).join();
+    conn.getTable(conn.getMetaTableName()).delete(new Delete(Bytes.toBytes(0))).join();
     verify(stub, times(1)).mutate(assertPriority(SYSTEMTABLE_QOS), any(MutateRequest.class), any());
   }
 
@@ -313,7 +313,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testAppendMetaTable() {
-    conn.getTable(TableName.META_TABLE_NAME).append(new Append(Bytes.toBytes(0))
+    conn.getTable(conn.getMetaTableName()).append(new Append(Bytes.toBytes(0))
       .addColumn(Bytes.toBytes("cf"), Bytes.toBytes("cq"), Bytes.toBytes("v"))).join();
     verify(stub, times(1)).mutate(assertPriority(SYSTEMTABLE_QOS), any(MutateRequest.class), any());
   }
@@ -341,7 +341,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testIncrementMetaTable() {
-    conn.getTable(TableName.META_TABLE_NAME)
+    conn.getTable(conn.getMetaTableName())
       .incrementColumnValue(Bytes.toBytes(0), Bytes.toBytes("cf"), Bytes.toBytes("cq"), 1).join();
     verify(stub, times(1)).mutate(assertPriority(SYSTEMTABLE_QOS), any(MutateRequest.class), any());
   }
@@ -377,7 +377,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testCheckAndPutMetaTable() {
-    conn.getTable(TableName.META_TABLE_NAME).checkAndMutate(Bytes.toBytes(0), Bytes.toBytes("cf"))
+    conn.getTable(conn.getMetaTableName()).checkAndMutate(Bytes.toBytes(0), Bytes.toBytes("cf"))
       .qualifier(Bytes.toBytes("cq")).ifNotExists().thenPut(new Put(Bytes.toBytes(0))
         .addColumn(Bytes.toBytes("cf"), Bytes.toBytes("cq"), Bytes.toBytes("v")))
       .join();
@@ -410,7 +410,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testCheckAndDeleteMetaTable() {
-    conn.getTable(TableName.META_TABLE_NAME).checkAndMutate(Bytes.toBytes(0), Bytes.toBytes("cf"))
+    conn.getTable(conn.getMetaTableName()).checkAndMutate(Bytes.toBytes(0), Bytes.toBytes("cf"))
       .qualifier(Bytes.toBytes("cq")).ifNotExists().thenPut(new Put(Bytes.toBytes(0))
         .addColumn(Bytes.toBytes("cf"), Bytes.toBytes("cq"), Bytes.toBytes("v")))
       .join();
@@ -450,7 +450,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testCheckAndMutateMetaTable() throws IOException {
-    conn.getTable(TableName.META_TABLE_NAME).checkAndMutate(Bytes.toBytes(0), Bytes.toBytes("cf"))
+    conn.getTable(conn.getMetaTableName()).checkAndMutate(Bytes.toBytes(0), Bytes.toBytes("cf"))
       .qualifier(Bytes.toBytes("cq")).ifEquals(Bytes.toBytes("v"))
       .thenMutate(new RowMutations(Bytes.toBytes(0)).add((Mutation) new Delete(Bytes.toBytes(0))))
       .join();
@@ -537,7 +537,7 @@ public class TestAsyncTableRpcPriority {
   @Test
   public void testScanMetaTable() throws Exception {
     CompletableFuture<Void> renewFuture = mockScanReturnRenewFuture(SYSTEMTABLE_QOS);
-    testForTable(TableName.META_TABLE_NAME, renewFuture, Optional.empty());
+    testForTable(conn.getMetaTableName(), renewFuture, Optional.empty());
   }
 
   private void testForTable(TableName tableName, CompletableFuture<Void> renewFuture,
@@ -580,7 +580,7 @@ public class TestAsyncTableRpcPriority {
 
   @Test
   public void testBatchMetaTable() {
-    conn.getTable(TableName.META_TABLE_NAME).batchAll(Arrays.asList(new Delete(Bytes.toBytes(0))))
+    conn.getTable(conn.getMetaTableName()).batchAll(Arrays.asList(new Delete(Bytes.toBytes(0))))
       .join();
     verify(stub, times(1)).multi(assertPriority(SYSTEMTABLE_QOS),
       any(ClientProtos.MultiRequest.class), any());

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableTracing.java
@@ -204,8 +204,8 @@ public class TestAsyncTableTracing {
       }
     }).when(stub).get(any(HBaseRpcController.class), any(GetRequest.class), any());
     final User user = UserProvider.instantiate(CONF).getCurrent();
-    conn = new AsyncConnectionImpl(CONF, new DoNothingConnectionRegistry(CONF, user), "test", null,
-      user) {
+    conn = new AsyncConnectionImpl(CONF, new DoNothingConnectionRegistry(CONF, user), "test",
+      TableName.META_TABLE_NAME, null, user) {
 
       @Override
       AsyncRegionLocator getLocator() {

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestCompactFromClient.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestCompactFromClient.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase.client;
 
-import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertThrows;
@@ -93,8 +92,9 @@ public class TestCompactFromClient {
       AsyncConnectionImpl connection = mock(AsyncConnectionImpl.class)) {
       mockedMeta.when(() -> ClientMetaTableAccessor.getTableHRegionLocations(any(AsyncTable.class),
         any(TableName.class))).thenReturn(nullLocationsFuture);
+      when(connection.getMetaTableName()).thenReturn(TableName.META_TABLE_NAME);
       AsyncTable<AdvancedScanResultConsumer> metaTable = mock(AsyncTable.class);
-      when(connection.getTable(META_TABLE_NAME)).thenReturn(metaTable);
+      when(connection.getTable(connection.getMetaTableName())).thenReturn(metaTable);
 
       HashedWheelTimer hashedWheelTimer = mock(HashedWheelTimer.class);
       AsyncAdminBuilderBase asyncAdminBuilderBase = mock(AsyncAdminBuilderBase.class);

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestConnectionFactoryApplyURIQueries.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestConnectionFactoryApplyURIQueries.java
@@ -27,6 +27,7 @@ import java.net.URI;
 import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.testclassification.ClientTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.junit.jupiter.api.AfterEach;
@@ -54,6 +55,8 @@ public class TestConnectionFactoryApplyURIQueries {
     mockedConnectionRegistryFactory
       .when(() -> ConnectionRegistryFactory.create(any(), any(), any())).thenReturn(registry);
     when(registry.getClusterId()).thenReturn(CompletableFuture.completedFuture("cluster"));
+    when(registry.getMetaTableName())
+      .thenReturn(CompletableFuture.completedFuture(TableName.META_TABLE_NAME));
   }
 
   @AfterEach
@@ -63,13 +66,15 @@ public class TestConnectionFactoryApplyURIQueries {
 
   @Test
   public void testApplyURIQueries() throws Exception {
-    ConnectionFactory.createConnection(new URI("hbase+rpc://server:16010?a=1&b=2&c"), conf);
-    ArgumentCaptor<Configuration> captor = ArgumentCaptor.forClass(Configuration.class);
-    mockedConnectionRegistryFactory
-      .verify(() -> ConnectionRegistryFactory.create(any(), captor.capture(), any()));
-    Configuration c = captor.getValue();
-    assertEquals("1", c.get("a"));
-    assertEquals("2", c.get("b"));
-    assertEquals("", c.get("c"));
+    try (Connection ignored =
+      ConnectionFactory.createConnection(new URI("hbase+rpc://server:16010?a=1&b=2&c"), conf)) {
+      ArgumentCaptor<Configuration> captor = ArgumentCaptor.forClass(Configuration.class);
+      mockedConnectionRegistryFactory
+        .verify(() -> ConnectionRegistryFactory.create(any(), captor.capture(), any()));
+      Configuration c = captor.getValue();
+      assertEquals("1", c.get("a"));
+      assertEquals("2", c.get("b"));
+      assertEquals("", c.get("c"));
+    }
   }
 }

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestMetricsConnection.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestMetricsConnection.java
@@ -103,13 +103,15 @@ public class TestMetricsConnection {
     String scope = "testScope";
     conf.setBoolean(MetricsConnection.CLIENT_SIDE_METRICS_ENABLED_KEY, true);
 
-    AsyncConnectionImpl impl = new AsyncConnectionImpl(conf, null, "foo", null, User.getCurrent());
+    AsyncConnectionImpl impl = new AsyncConnectionImpl(conf, null, "foo", TableName.META_TABLE_NAME,
+      null, User.getCurrent());
     Optional<MetricsConnection> metrics = impl.getConnectionMetrics();
     assertTrue(metrics.isPresent(), "Metrics should be present");
     assertEquals(clusterId + "@" + Integer.toHexString(impl.hashCode()),
       metrics.get().getMetricScope());
     conf.set(MetricsConnection.METRICS_SCOPE_KEY, scope);
-    impl = new AsyncConnectionImpl(conf, null, "foo", null, User.getCurrent());
+    impl = new AsyncConnectionImpl(conf, null, "foo", TableName.META_TABLE_NAME, null,
+      User.getCurrent());
 
     metrics = impl.getConnectionMetrics();
     assertTrue(metrics.isPresent(), "Metrics should be present");
@@ -129,7 +131,7 @@ public class TestMetricsConnection {
     AsyncConnectionImpl impl;
     List<AsyncConnectionImpl> connList = new ArrayList<AsyncConnectionImpl>();
     for (int i = 0; i < num; i++) {
-      impl = new AsyncConnectionImpl(conf, null, null, null, user);
+      impl = new AsyncConnectionImpl(conf, null, null, TableName.META_TABLE_NAME, null, user);
       connList.add(impl);
     }
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/CellComparatorImpl.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/CellComparatorImpl.java
@@ -786,9 +786,21 @@ public class CellComparatorImpl implements CellComparator {
    * @return CellComparator to use going off the {@code tableName} passed.
    */
   public static CellComparator getCellComparator(byte[] tableName) {
-    // FYI, TableName.toBytes does not create an array; just returns existing array pointer.
-    return Bytes.equals(tableName, TableName.META_TABLE_NAME.toBytes())
+    return isMetaTable(tableName)
       ? MetaCellComparator.META_COMPARATOR
       : CellComparatorImpl.COMPARATOR;
+  }
+
+  /**
+   * @see TableName#isMetaTableName(TableName) for the canonical definition of what qualifies as a
+   *      meta table. Kept as a {@code byte[]}-friendly adapter so we can avoid materializing a
+   *      {@link TableName} on hot comparator-selection paths when the input is malformed.
+   */
+  static boolean isMetaTable(byte[] tableName) {
+    try {
+      return TableName.isMetaTableName(TableName.valueOf(tableName));
+    } catch (IllegalArgumentException e) {
+      return false;
+    }
   }
 }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/InnerStoreCellComparator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/InnerStoreCellComparator.java
@@ -17,7 +17,6 @@
  */
 package org.apache.hadoop.hbase;
 
-import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
 
@@ -75,7 +74,8 @@ public class InnerStoreCellComparator extends CellComparatorImpl {
    * @return CellComparator to use going off the {@code tableName} passed.
    */
   public static CellComparator getInnerStoreCellComparator(byte[] tableName) {
-    return Bytes.equals(tableName, TableName.META_TABLE_NAME.toBytes())
+    // Check if this is a meta table (hbase:meta or hbase:meta_*)
+    return CellComparatorImpl.isMetaTable(tableName)
       ? MetaCellComparator.META_COMPARATOR
       : InnerStoreCellComparator.INNER_STORE_COMPARATOR;
   }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
@@ -22,9 +22,12 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 
@@ -44,6 +47,8 @@ import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
  */
 @InterfaceAudience.Public
 public final class TableName implements Comparable<TableName> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TableName.class);
 
   /** See {@link #createTableNameIfNecessary(ByteBuffer, ByteBuffer)} */
   private static final Set<TableName> tableCache = new CopyOnWriteArraySet<>();
@@ -66,6 +71,7 @@ public final class TableName implements Comparable<TableName> {
     + NAMESPACE_DELIM + ")?)" + "(?:" + VALID_TABLE_QUALIFIER_REGEX + "))";
 
   /** The hbase:meta table's name. */
+  @Deprecated
   public static final TableName META_TABLE_NAME =
     valueOf(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR, "meta");
 
@@ -85,9 +91,32 @@ public final class TableName implements Comparable<TableName> {
   /** One globally disallowed name */
   public static final String DISALLOWED_TABLE_NAME = "zookeeper";
 
-  /** Returns True if <code>tn</code> is the hbase:meta table name. */
+  /**
+   * Pattern that the qualifier of a meta table must match. Either the literal {@code meta} (the
+   * default meta table) or {@code meta_<suffix>} where {@code <suffix>} is one or more lowercase
+   * alphanumeric characters (the form used for cluster-specific meta tables, e.g. read replica meta
+   * tables). This is the single source of truth for what qualifies as a meta table name; all
+   * callers should go through {@link #isMetaTableName(TableName)} rather than reproducing the
+   * check.
+   */
+  private static final Pattern META_QUALIFIER_PATTERN = Pattern.compile("meta(_[a-z0-9]+)?");
+
+  /**
+   * Returns True if <code>tn</code> is a meta table. A meta table is a table in the {@code hbase}
+   * system namespace whose qualifier is either exactly {@code meta} or matches
+   * {@code meta_[a-z0-9]+}. The latter form is reserved for cluster-specific meta tables (e.g. read
+   * replica meta tables) generated from a deterministic suffix.
+   * <p>
+   * Names like {@code hbase:metadata} or {@code hbase:meta_} (no suffix characters) are
+   * intentionally <em>not</em> considered meta table names.
+   */
   public static boolean isMetaTableName(final TableName tn) {
-    return tn.equals(TableName.META_TABLE_NAME);
+    if (
+      tn == null || !tn.getNamespaceAsString().equals(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR)
+    ) {
+      return false;
+    }
+    return META_QUALIFIER_PATTERN.matcher(tn.getQualifierAsString()).matches();
   }
 
   /**
@@ -288,8 +317,8 @@ public final class TableName implements Comparable<TableName> {
       throw new IllegalArgumentException(OLD_ROOT_STR + " has been deprecated.");
     }
     if (qualifierAsString.equals(OLD_META_STR)) {
-      throw new IllegalArgumentException(
-        OLD_META_STR + " no longer exists. The table has been " + "renamed to " + META_TABLE_NAME);
+      throw new IllegalArgumentException(OLD_META_STR + " no longer exists. The table has been "
+        + "renamed to hbase:meta (or a cluster-specific meta table name)");
     }
 
     if (Bytes.equals(NamespaceDescriptor.DEFAULT_NAMESPACE_NAME, namespace)) {

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
@@ -23,6 +23,7 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
+import java.util.regex.Pattern;
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -74,8 +75,15 @@ public final class TableName implements Comparable<TableName> {
 
   /**
    * The name of hbase meta table could either be hbase:meta_xxx or 'hbase:meta' otherwise. Config
-   * hbase.meta.table.suffix will govern the decision of adding suffix to the habase:meta
+   * hbase.meta.table.suffix will govern the decision of adding suffix to the habase:meta.
+   *
+   * @deprecated Prefer discovering the meta table name dynamically via
+   *             {@code ConnectionRegistry#getMetaTableName()} /
+   *             {@code Connection#getMetaTableName()} so that each connection can resolve its own
+   *             cluster's meta table name (e.g. for read-replica clusters with cluster-specific
+   *             meta tables).
    */
+  @Deprecated
   public static final TableName META_TABLE_NAME;
   static {
     Configuration conf = HBaseConfiguration.create();
@@ -123,9 +131,32 @@ public final class TableName implements Comparable<TableName> {
   /** One globally disallowed name */
   public static final String DISALLOWED_TABLE_NAME = "zookeeper";
 
-  /** Returns True if <code>tn</code> is the hbase:meta table name. */
+  /**
+   * Pattern that the qualifier of a meta table must match. Either the literal {@code meta} (the
+   * default meta table) or {@code meta_<suffix>} where {@code <suffix>} is one or more lowercase
+   * alphanumeric characters (the form used for cluster-specific meta tables, e.g. read replica meta
+   * tables). This is the single source of truth for what qualifies as a meta table name; all
+   * callers should go through {@link #isMetaTableName(TableName)} rather than reproducing the
+   * check.
+   */
+  private static final Pattern META_QUALIFIER_PATTERN = Pattern.compile("meta(_[a-z0-9]+)?");
+
+  /**
+   * Returns True if <code>tn</code> is a meta table. A meta table is a table in the {@code hbase}
+   * system namespace whose qualifier is either exactly {@code meta} or matches
+   * {@code meta_[a-z0-9]+}. The latter form is reserved for cluster-specific meta tables (e.g. read
+   * replica meta tables) generated from a deterministic suffix.
+   * <p>
+   * Names like {@code hbase:metadata} or {@code hbase:meta_} (no suffix characters) are
+   * intentionally <em>not</em> considered meta table names.
+   */
   public static boolean isMetaTableName(final TableName tn) {
-    return tn.equals(TableName.META_TABLE_NAME);
+    if (
+      tn == null || !tn.getNamespaceAsString().equals(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR)
+    ) {
+      return false;
+    }
+    return META_QUALIFIER_PATTERN.matcher(tn.getQualifierAsString()).matches();
   }
 
   /**
@@ -326,8 +357,8 @@ public final class TableName implements Comparable<TableName> {
       throw new IllegalArgumentException(OLD_ROOT_STR + " has been deprecated.");
     }
     if (qualifierAsString.equals(OLD_META_STR)) {
-      throw new IllegalArgumentException(
-        OLD_META_STR + " no longer exists. The table has been " + "renamed to " + META_TABLE_NAME);
+      throw new IllegalArgumentException(OLD_META_STR + " no longer exists. The table has been "
+        + "renamed to hbase:meta (or a cluster-specific meta table name)");
     }
 
     if (Bytes.equals(NamespaceDescriptor.DEFAULT_NAMESPACE_NAME, namespace)) {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestHFileOutputFormat2.java
@@ -1201,6 +1201,11 @@ public class TestHFileOutputFormat2 extends HFileOutputFormat2TestBase {
     }
 
     @Override
+    public TableName getMetaTableName() {
+      return delegate.getMetaTableName();
+    }
+
+    @Override
     public Table getTable(TableName tableName) throws IOException {
       return delegate.getTable(tableName);
     }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestMultiTableInputFormatBase.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestMultiTableInputFormatBase.java
@@ -137,6 +137,11 @@ public class TestMultiTableInputFormatBase {
     }
 
     @Override
+    public TableName getMetaTableName() {
+      return null;
+    }
+
+    @Override
     public BufferedMutator getBufferedMutator(TableName tableName) throws IOException {
       return null;
     }

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormatBase.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormatBase.java
@@ -226,6 +226,11 @@ public class TestTableInputFormatBase {
     }
 
     @Override
+    public TableName getMetaTableName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Table getTable(TableName tableName) throws IOException {
       Table table = mock(Table.class);
       when(table.getName()).thenReturn(tableName);

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormatBase.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormatBase.java
@@ -247,6 +247,11 @@ public class TestTableInputFormatBase {
     }
 
     @Override
+    public TableName getMetaTableName() {
+      throw new UnsupportedOperationException();
+    }
+
+    @Override
     public Table getTable(TableName tableName) throws IOException {
       Table table = mock(Table.class);
       when(table.getName()).thenReturn(tableName);

--- a/hbase-protocol-shaded/src/main/protobuf/server/Registry.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/Registry.proto
@@ -73,6 +73,14 @@ message GetBootstrapNodesResponse {
   repeated ServerName server_name = 1;
 }
 
+/** Request and response to get the meta table name for this cluster */
+message GetMetaTableNameRequest {
+}
+message GetMetaTableNameResponse {
+  /** The name of the meta table. Defaults to "hbase:meta" if not set. */
+  optional string table_name = 1;
+}
+
 /**
  * Implements all the RPCs needed by clients to look up cluster meta information needed for
  * connection establishment.
@@ -105,6 +113,11 @@ service ClientMetaService {
    * Get nodes which could be used as ClientMetaService
    */
   rpc GetBootstrapNodes(GetBootstrapNodesRequest) returns (GetBootstrapNodesResponse);
+
+  /**
+   * Get the meta table name for this cluster.
+   */
+  rpc GetMetaTableName(GetMetaTableNameRequest) returns(GetMetaTableNameResponse);
 }
 
 message GetConnectionRegistryRequest {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseRpcServicesBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseRpcServicesBase.java
@@ -89,6 +89,8 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMaste
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMastersResponseEntry;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMetaRegionLocationsRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMetaRegionLocationsResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMetaTableNameRequest;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RegistryProtos.GetMetaTableNameResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.TooSlowLog.SlowLogPayload;
 
 /**
@@ -375,6 +377,23 @@ public abstract class HBaseRpcServicesBase<S extends HBaseServerBase<?>>
       bootstrapNodesReply
         .forEach(serverName -> builder.addServerName(ProtobufUtil.toServerName(serverName)));
     } catch (IOException e) {
+      throw new ServiceException(e);
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public final GetMetaTableNameResponse getMetaTableName(RpcController controller,
+    GetMetaTableNameRequest request) throws ServiceException {
+    GetMetaTableNameResponse.Builder builder = GetMetaTableNameResponse.newBuilder();
+
+    try {
+      TableName metaTableName = server.getMetaTableName();
+      if (metaTableName != null) {
+        builder.setTableName(metaTableName.getNameAsString());
+      }
+    } catch (Exception e) {
       throw new ServiceException(e);
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -710,4 +710,16 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
   protected abstract boolean cacheTableDescriptor();
 
   protected abstract boolean clusterMode();
+
+  protected TableName getDefaultMetaTableName() {
+    return TableName.META_TABLE_NAME;
+  }
+
+  @Override
+  public TableName getMetaTableName() {
+    // For now, it is hbase:meta because we don't support custom meta table name.
+    // After adding support for custom meta table names, we can calculate this from conf and use it
+    // downstream to persist it in Master Region.
+    return getDefaultMetaTableName();
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -745,4 +745,16 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
   protected abstract boolean cacheTableDescriptor();
 
   protected abstract boolean clusterMode();
+
+  protected TableName getDefaultMetaTableName() {
+    return TableName.META_TABLE_NAME;
+  }
+
+  @Override
+  public TableName getMetaTableName() {
+    // For now, it is hbase:meta because we don't support custom meta table name.
+    // After adding support for custom meta table names, we can calculate this from conf and use it
+    // downstream to persist it in Master Region.
+    return getDefaultMetaTableName();
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
@@ -151,7 +151,7 @@ public final class MetaTableAccessor {
     if (connection.isClosed()) {
       throw new IOException("connection is closed");
     }
-    return connection.getTable(TableName.META_TABLE_NAME);
+    return connection.getTable(connection.getMetaTableName());
   }
 
   /**
@@ -366,7 +366,7 @@ public final class MetaTableAccessor {
   public static List<Pair<RegionInfo, ServerName>> getTableRegionsAndLocations(
     Connection connection, @Nullable final TableName tableName,
     final boolean excludeOfflinedSplitParents) throws IOException {
-    if (tableName != null && tableName.equals(TableName.META_TABLE_NAME)) {
+    if (tableName != null && tableName.equals(connection.getMetaTableName())) {
       throw new IOException(
         "This method can't be used to locate meta regions; use MetaTableLocator instead");
     }
@@ -592,7 +592,7 @@ public final class MetaTableAccessor {
    */
   @Nullable
   public static TableState getTableState(Connection conn, TableName tableName) throws IOException {
-    if (tableName.equals(TableName.META_TABLE_NAME)) {
+    if (TableName.isMetaTableName(tableName)) {
       return new TableState(tableName, TableState.State.ENABLED);
     }
     Table metaHTable = getMetaHTable(conn);
@@ -859,7 +859,7 @@ public final class MetaTableAccessor {
   private static void updateTableState(Connection connection, TableState state) throws IOException {
     Put put = makePutFromTableState(state, EnvironmentEdgeManager.currentTime());
     putToMetaTable(connection, put);
-    LOG.info("Updated {} in hbase:meta", state);
+    LOG.info("Updated {} in {}", state, connection.getMetaTableName());
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
@@ -151,7 +151,7 @@ public final class MetaTableAccessor {
     if (connection.isClosed()) {
       throw new IOException("connection is closed");
     }
-    return connection.getTable(TableName.META_TABLE_NAME);
+    return connection.getTable(connection.getMetaTableName());
   }
 
   /**
@@ -366,7 +366,7 @@ public final class MetaTableAccessor {
   public static List<Pair<RegionInfo, ServerName>> getTableRegionsAndLocations(
     Connection connection, @Nullable final TableName tableName,
     final boolean excludeOfflinedSplitParents) throws IOException {
-    if (tableName != null && tableName.equals(TableName.META_TABLE_NAME)) {
+    if (tableName != null && tableName.equals(connection.getMetaTableName())) {
       throw new IOException(
         "This method can't be used to locate meta regions; use MetaTableLocator instead");
     }
@@ -592,7 +592,7 @@ public final class MetaTableAccessor {
    */
   @Nullable
   public static TableState getTableState(Connection conn, TableName tableName) throws IOException {
-    if (tableName.equals(TableName.META_TABLE_NAME)) {
+    if (TableName.isMetaTableName(tableName)) {
       return new TableState(tableName, TableState.State.ENABLED);
     }
     Table metaHTable = getMetaHTable(conn);
@@ -859,7 +859,7 @@ public final class MetaTableAccessor {
   private static void updateTableState(Connection connection, TableState state) throws IOException {
     Put put = makePutFromTableState(state, EnvironmentEdgeManager.currentTime());
     putToMetaTable(connection, put);
-    LOG.info("Updated {} in {}", state, TableName.META_TABLE_NAME);
+    LOG.info("Updated {} in {}", state, connection.getMetaTableName());
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnectionImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/AsyncClusterConnectionImpl.java
@@ -59,8 +59,8 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProto
 class AsyncClusterConnectionImpl extends AsyncConnectionImpl implements AsyncClusterConnection {
 
   public AsyncClusterConnectionImpl(Configuration conf, ConnectionRegistry registry,
-    String clusterId, SocketAddress localAddress, User user) {
-    super(conf, registry, clusterId, localAddress, user, Collections.emptyMap());
+    String clusterId, TableName metaTableName, SocketAddress localAddress, User user) {
+    super(conf, registry, clusterId, metaTableName, localAddress, user, Collections.emptyMap());
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClusterConnectionFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ClusterConnectionFactory.java
@@ -22,6 +22,7 @@ import java.net.SocketAddress;
 import java.net.URI;
 import java.security.PrivilegedExceptionAction;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.util.FutureUtils;
 import org.apache.hadoop.hbase.util.ReflectionUtils;
@@ -42,13 +43,14 @@ public final class ClusterConnectionFactory {
   private static AsyncClusterConnection createAsyncClusterConnection(Configuration conf,
     ConnectionRegistry registry, SocketAddress localAddress, User user) throws IOException {
     String clusterId = FutureUtils.get(registry.getClusterId());
+    TableName metaTableName = FutureUtils.get(registry.getMetaTableName());
     Class<? extends AsyncClusterConnection> clazz =
       conf.getClass(HBASE_SERVER_CLUSTER_CONNECTION_IMPL, AsyncClusterConnectionImpl.class,
         AsyncClusterConnection.class);
     try {
       return user
         .runAs((PrivilegedExceptionAction<? extends AsyncClusterConnection>) () -> ReflectionUtils
-          .newInstance(clazz, conf, registry, clusterId, localAddress, user));
+          .newInstance(clazz, conf, registry, clusterId, metaTableName, localAddress, user));
     } catch (Exception e) {
       throw new IOException(e);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ConnectionRegistryEndpoint.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ConnectionRegistryEndpoint.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Optional;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -54,4 +55,13 @@ public interface ConnectionRegistryEndpoint {
    * Get the location of meta regions.
    */
   List<HRegionLocation> getMetaLocations();
+
+  /**
+   * Get the name of the meta table for this cluster.
+   * <p>
+   * By default, this returns "hbase:meta". Future implementations may support custom meta table
+   * names for read replica clusters.
+   * @return The meta table name
+   */
+  TableName getMetaTableName();
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/SharedAsyncConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/SharedAsyncConnection.java
@@ -53,6 +53,11 @@ public class SharedAsyncConnection implements AsyncConnection {
   }
 
   @Override
+  public TableName getMetaTableName() {
+    return conn.getMetaTableName();
+  }
+
+  @Override
   public AsyncTableRegionLocator getRegionLocator(TableName tableName) {
     return conn.getRegionLocator(tableName);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/SharedConnection.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/SharedConnection.java
@@ -62,6 +62,11 @@ public class SharedConnection implements Connection {
   }
 
   @Override
+  public TableName getMetaTableName() {
+    return this.conn.getMetaTableName();
+  }
+
+  @Override
   public BufferedMutator getBufferedMutator(TableName tableName) throws IOException {
     return this.conn.getBufferedMutator(tableName);
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ShortCircuitConnectionRegistry.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/client/ShortCircuitConnectionRegistry.java
@@ -24,6 +24,7 @@ import java.util.concurrent.CompletableFuture;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -66,6 +67,11 @@ class ShortCircuitConnectionRegistry implements ConnectionRegistry {
       future.completeExceptionally(new IOException("no active master available"));
     }
     return future;
+  }
+
+  @Override
+  public CompletableFuture<TableName> getMetaTableName() {
+    return CompletableFuture.completedFuture(endpoint.getMetaTableName());
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MetaTableMetrics.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MetaTableMetrics.java
@@ -133,7 +133,7 @@ public class MetaTableMetrics implements RegionCoprocessor {
     }
 
     private boolean isMetaTableOp(ObserverContext<? extends RegionCoprocessorEnvironment> e) {
-      return TableName.META_TABLE_NAME.equals(e.getEnvironment().getRegionInfo().getTable());
+      return TableName.isMetaTableName(e.getEnvironment().getRegionInfo().getTable());
     }
 
     private void clientMetricRegisterAndMark() {
@@ -267,8 +267,8 @@ public class MetaTableMetrics implements RegionCoprocessor {
     if (
       env instanceof RegionCoprocessorEnvironment
         && ((RegionCoprocessorEnvironment) env).getRegionInfo().getTable() != null
-        && ((RegionCoprocessorEnvironment) env).getRegionInfo().getTable()
-          .equals(TableName.META_TABLE_NAME)
+        && TableName
+          .isMetaTableName(((RegionCoprocessorEnvironment) env).getRegionInfo().getTable())
     ) {
       RegionCoprocessorEnvironment regionCoprocessorEnv = (RegionCoprocessorEnvironment) env;
       registry = regionCoprocessorEnv.getMetricRegistryForRegionServer();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -511,6 +511,14 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   private ReplicationPeerModificationStateStore replicationPeerModificationStateStore;
 
   /**
+   * Store for the meta table name in the Master Local Region. This provides cluster-specific
+   * storage for dynamic meta table name discovery.
+   */
+  private MetaTableNameStore metaTableNameStore;
+
+  private volatile TableName cachedMetaTableName;
+
+  /**
    * Initializes the HMaster. The steps are as follows:
    * <p>
    * <ol>
@@ -1022,6 +1030,10 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     masterRegion = MasterRegionFactory.create(this);
     rsListStorage = new MasterRegionServerList(masterRegion, this);
 
+    tryMigrateMetaLocationsFromZooKeeper();
+
+    cachedMetaTableName = initMetaTableName();
+
     // Initialize the ServerManager and register it as a configuration observer
     this.serverManager = createServerManager(this, rsListStorage);
     this.configurationManager.registerObserver(this.serverManager);
@@ -1032,8 +1044,6 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     ) {
       this.splitWALManager = new SplitWALManager(this);
     }
-
-    tryMigrateMetaLocationsFromZooKeeper();
 
     createProcedureExecutor();
     Map<Class<?>, List<Procedure<MasterProcedureEnv>>> procsByType = procedureExecutor
@@ -1098,7 +1108,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     startupTaskGroup.addTask("Initializing meta table if this is a new deploy");
     InitMetaProcedure initMetaProc = null;
     // Print out state of hbase:meta on startup; helps debugging.
-    if (!this.assignmentManager.getRegionStates().hasTableRegionStates(TableName.META_TABLE_NAME)) {
+    if (!this.assignmentManager.getRegionStates().hasTableRegionStates(getMetaTableName())) {
       Optional<InitMetaProcedure> optProc = procedureExecutor.getProcedures().stream()
         .filter(p -> p instanceof InitMetaProcedure).map(o -> (InitMetaProcedure) o).findAny();
       initMetaProc = optProc.orElseGet(() -> {
@@ -1162,7 +1172,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
       return;
     }
 
-    TableDescriptor metaDescriptor = tableDescriptors.get(TableName.META_TABLE_NAME);
+    TableDescriptor metaDescriptor = tableDescriptors.get(getMetaTableName());
     final ColumnFamilyDescriptor tableFamilyDesc =
       metaDescriptor.getColumnFamily(HConstants.TABLE_FAMILY);
     final ColumnFamilyDescriptor replBarrierFamilyDesc =
@@ -1180,16 +1190,17 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     if (conf.get(HConstants.META_REPLICAS_NUM) != null) {
       int replicasNumInConf =
         conf.getInt(HConstants.META_REPLICAS_NUM, HConstants.DEFAULT_META_REPLICA_NUM);
-      TableDescriptor metaDesc = tableDescriptors.get(TableName.META_TABLE_NAME);
+      TableDescriptor metaDesc = tableDescriptors.get(getMetaTableName());
       if (metaDesc.getRegionReplication() != replicasNumInConf) {
         // it is possible that we already have some replicas before upgrading, so we must set the
         // region replication number in meta TableDescriptor directly first, without creating a
         // ModifyTableProcedure, otherwise it may cause a double assign for the meta replicas.
         int existingReplicasCount =
-          assignmentManager.getRegionStates().getRegionsOfTable(TableName.META_TABLE_NAME).size();
+          assignmentManager.getRegionStates().getRegionsOfTable(getMetaTableName()).size();
         if (existingReplicasCount > metaDesc.getRegionReplication()) {
-          LOG.info("Update replica count of hbase:meta from {}(in TableDescriptor)"
-            + " to {}(existing ZNodes)", metaDesc.getRegionReplication(), existingReplicasCount);
+          LOG.info(
+            "Update replica count of {} from {} (in TableDescriptor) to {} (existing ZNodes)",
+            getMetaTableName(), metaDesc.getRegionReplication(), existingReplicasCount);
           metaDesc = TableDescriptorBuilder.newBuilder(metaDesc)
             .setRegionReplication(existingReplicasCount).build();
           tableDescriptors.update(metaDesc);
@@ -1198,8 +1209,9 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         if (metaDesc.getRegionReplication() != replicasNumInConf) {
           LOG.info(
             "The {} config is {} while the replica count in TableDescriptor is {}"
-              + " for hbase:meta, altering...",
-            HConstants.META_REPLICAS_NUM, replicasNumInConf, metaDesc.getRegionReplication());
+              + " for {}, altering...",
+            HConstants.META_REPLICAS_NUM, replicasNumInConf, metaDesc.getRegionReplication(),
+            getMetaTableName());
           procedureExecutor.submitProcedure(new ModifyTableProcedure(
             procedureExecutor.getEnvironment(), TableDescriptorBuilder.newBuilder(metaDesc)
               .setRegionReplication(replicasNumInConf).build(),
@@ -1429,7 +1441,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     TableDescriptor newMetaDesc = TableDescriptorBuilder.newBuilder(metaDescriptor)
       .setColumnFamily(FSTableDescriptors.getTableFamilyDescForMeta(conf))
       .setColumnFamily(FSTableDescriptors.getReplBarrierFamilyDescForMeta()).build();
-    long pid = this.modifyTable(TableName.META_TABLE_NAME, () -> newMetaDesc, 0, 0, false);
+    long pid = this.modifyTable(getMetaTableName(), () -> newMetaDesc, 0, 0, false);
     waitForProcedureToComplete(pid, "Failed to add table and rep_barrier CFs to meta");
   }
 
@@ -1656,6 +1668,33 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   @Override
   public TableStateManager getTableStateManager() {
     return tableStateManager;
+  }
+
+  /**
+   * Override base implementation to read from Master Local Region storage. This allows the master
+   * to return the cluster-specific meta table name.
+   */
+  @Override
+  public TableName getMetaTableName() {
+    return cachedMetaTableName;
+  }
+
+  private TableName initMetaTableName() {
+    metaTableNameStore = new MetaTableNameStore(masterRegion);
+    try {
+      TableName metaTableName = metaTableNameStore.load();
+      // If metaTableNameStore is empty (bootstrap case), get meta table name from super, store it,
+      // and return.
+      if (Objects.isNull(metaTableName)) {
+        metaTableName = super.getDefaultMetaTableName();
+        LOG.info("Bootstrap: storing default meta table name in master region: {}", metaTableName);
+        metaTableNameStore.store(metaTableName);
+      }
+      return metaTableName;
+    } catch (IOException e) {
+      LOG.error("Exception loading/storing meta table name from master region", e);
+      throw new RuntimeException("Exception loading/storing meta table name from master region", e);
+    }
   }
 
   /*
@@ -2612,7 +2651,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   }
 
   private static boolean isCatalogTable(final TableName tableName) {
-    return tableName.equals(TableName.META_TABLE_NAME);
+    return TableName.isMetaTableName(tableName);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -517,6 +517,14 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   private ReplicationPeerModificationStateStore replicationPeerModificationStateStore;
 
   /**
+   * Store for the meta table name in the Master Local Region. This provides cluster-specific
+   * storage for dynamic meta table name discovery.
+   */
+  private MetaTableNameStore metaTableNameStore;
+
+  private volatile TableName cachedMetaTableName;
+
+  /**
    * Initializes the HMaster. The steps are as follows:
    * <p>
    * <ol>
@@ -1028,6 +1036,10 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     masterRegion = MasterRegionFactory.create(this);
     rsListStorage = new MasterRegionServerList(masterRegion, this);
 
+    tryMigrateMetaLocationsFromZooKeeper();
+
+    cachedMetaTableName = initMetaTableName();
+
     // Initialize the ServerManager and register it as a configuration observer
     this.serverManager = createServerManager(this, rsListStorage);
     this.configurationManager.registerObserver(this.serverManager);
@@ -1038,8 +1050,6 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     ) {
       this.splitWALManager = new SplitWALManager(this);
     }
-
-    tryMigrateMetaLocationsFromZooKeeper();
 
     createProcedureExecutor();
     Map<Class<?>, List<Procedure<MasterProcedureEnv>>> procsByType = procedureExecutor
@@ -1120,7 +1130,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     if (optProc.isPresent()) {
       initMetaProc = optProc.get();
     } else if (
-      !this.assignmentManager.getRegionStates().hasTableRegionStates(TableName.META_TABLE_NAME)
+      !this.assignmentManager.getRegionStates().hasTableRegionStates(getMetaTableName())
     ) {
       // schedule an init meta procedure if meta has not been deployed yet
       initMetaProc = new InitMetaProcedure();
@@ -1180,7 +1190,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
       return;
     }
 
-    TableDescriptor metaDescriptor = tableDescriptors.get(TableName.META_TABLE_NAME);
+    TableDescriptor metaDescriptor = tableDescriptors.get(getMetaTableName());
     final ColumnFamilyDescriptor tableFamilyDesc =
       metaDescriptor.getColumnFamily(HConstants.TABLE_FAMILY);
     final ColumnFamilyDescriptor replBarrierFamilyDesc =
@@ -1198,17 +1208,17 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     if (conf.get(HConstants.META_REPLICAS_NUM) != null) {
       int replicasNumInConf =
         conf.getInt(HConstants.META_REPLICAS_NUM, HConstants.DEFAULT_META_REPLICA_NUM);
-      TableDescriptor metaDesc = tableDescriptors.get(TableName.META_TABLE_NAME);
+      TableDescriptor metaDesc = tableDescriptors.get(getMetaTableName());
       if (metaDesc.getRegionReplication() != replicasNumInConf) {
         // it is possible that we already have some replicas before upgrading, so we must set the
         // region replication number in meta TableDescriptor directly first, without creating a
         // ModifyTableProcedure, otherwise it may cause a double assign for the meta replicas.
         int existingReplicasCount =
-          assignmentManager.getRegionStates().getRegionsOfTable(TableName.META_TABLE_NAME).size();
+          assignmentManager.getRegionStates().getRegionsOfTable(getMetaTableName()).size();
         if (existingReplicasCount > metaDesc.getRegionReplication()) {
           LOG.info(
-            "Update replica count of {} from {}(in TableDescriptor)" + " to {}(existing ZNodes)",
-            TableName.META_TABLE_NAME, metaDesc.getRegionReplication(), existingReplicasCount);
+            "Update replica count of {} from {} (in TableDescriptor) to {} (existing ZNodes)",
+            getMetaTableName(), metaDesc.getRegionReplication(), existingReplicasCount);
           metaDesc = TableDescriptorBuilder.newBuilder(metaDesc)
             .setRegionReplication(existingReplicasCount).build();
           tableDescriptors.update(metaDesc);
@@ -1219,7 +1229,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
             "The {} config is {} while the replica count in TableDescriptor is {}"
               + " for {}, altering...",
             HConstants.META_REPLICAS_NUM, replicasNumInConf, metaDesc.getRegionReplication(),
-            TableName.META_TABLE_NAME);
+            getMetaTableName());
           procedureExecutor.submitProcedure(new ModifyTableProcedure(
             procedureExecutor.getEnvironment(), TableDescriptorBuilder.newBuilder(metaDesc)
               .setRegionReplication(replicasNumInConf).build(),
@@ -1449,7 +1459,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     TableDescriptor newMetaDesc = TableDescriptorBuilder.newBuilder(metaDescriptor)
       .setColumnFamily(FSTableDescriptors.getTableFamilyDescForMeta(conf))
       .setColumnFamily(FSTableDescriptors.getReplBarrierFamilyDescForMeta()).build();
-    long pid = this.modifyTable(TableName.META_TABLE_NAME, () -> newMetaDesc, 0, 0, false);
+    long pid = this.modifyTable(getMetaTableName(), () -> newMetaDesc, 0, 0, false);
     waitForProcedureToComplete(pid, "Failed to add table and rep_barrier CFs to meta");
   }
 
@@ -1677,6 +1687,33 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   @Override
   public TableStateManager getTableStateManager() {
     return tableStateManager;
+  }
+
+  /**
+   * Override base implementation to read from Master Local Region storage. This allows the master
+   * to return the cluster-specific meta table name.
+   */
+  @Override
+  public TableName getMetaTableName() {
+    return cachedMetaTableName;
+  }
+
+  private TableName initMetaTableName() {
+    metaTableNameStore = new MetaTableNameStore(masterRegion);
+    try {
+      TableName metaTableName = metaTableNameStore.load();
+      // If metaTableNameStore is empty (bootstrap case), get meta table name from super, store it,
+      // and return.
+      if (Objects.isNull(metaTableName)) {
+        metaTableName = super.getDefaultMetaTableName();
+        LOG.info("Bootstrap: storing default meta table name in master region: {}", metaTableName);
+        metaTableNameStore.store(metaTableName);
+      }
+      return metaTableName;
+    } catch (IOException e) {
+      LOG.error("Exception loading/storing meta table name from master region", e);
+      throw new RuntimeException("Exception loading/storing meta table name from master region", e);
+    }
   }
 
   /*
@@ -2633,7 +2670,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   }
 
   private static boolean isCatalogTable(final TableName tableName) {
-    return tableName.equals(TableName.META_TABLE_NAME);
+    return TableName.isMetaTableName(tableName);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterAnnotationReadingPriorityFunction.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterAnnotationReadingPriorityFunction.java
@@ -84,7 +84,7 @@ public class MasterAnnotationReadingPriorityFunction
         if (rst.getRegionInfoList() != null) {
           for (HBaseProtos.RegionInfo info : rst.getRegionInfoList()) {
             TableName tn = ProtobufUtil.toTableName(info.getTableName());
-            if (TableName.META_TABLE_NAME.equals(tn)) {
+            if (TableName.isMetaTableName(tn)) {
               return META_TRANSITION_QOS;
             }
           }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -788,6 +788,15 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
     TableDescriptor tableDescriptor = ProtobufUtil.toTableDescriptor(req.getTableSchema());
     byte[][] splitKeys = ProtobufUtil.getSplitKeysArray(req);
     try {
+      TableName tableName = tableDescriptor.getTableName();
+      if (
+        NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR.equals(tableName.getNamespaceAsString())
+          && tableName.getQualifierAsString().startsWith("meta")
+      ) {
+        throw new DoNotRetryIOException(
+          "Table '" + tableName + "' is reserved and cannot be created by users. "
+            + "Meta tables are managed by the system.");
+      }
       long procId =
         server.createTable(tableDescriptor, splitKeys, req.getNonceGroup(), req.getNonce());
       LOG.info(server.getClientIdAuditPrefix() + " procedure request for creating table: "

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterServices.java
@@ -525,4 +525,10 @@ public interface MasterServices extends Server, KeyManagementService {
    * @return procedure id
    */
   long rollAllWALWriters(long nonceGroup, long nonce) throws IOException;
+
+  /**
+   * Return cluster's meta table name
+   * @return meta table name
+   */
+  TableName getMetaTableName();
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetaTableNameStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetaTableNameStore.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.master.region.MasterRegion;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Stores and retrieves the meta table name for this cluster in the Master Local Region. This
+ * provides cluster-specific storage for the meta table name.
+ */
+@InterfaceAudience.Private
+public class MetaTableNameStore {
+  private static final Logger LOG = LoggerFactory.getLogger(MetaTableNameStore.class);
+  private static final byte[] META_TABLE_NAME_ROW = Bytes.toBytes("meta_table_name");
+  private static final byte[] INFO_FAMILY = Bytes.toBytes("info");
+  private static final byte[] NAME_QUALIFIER = Bytes.toBytes("name");
+
+  private final MasterRegion masterRegion;
+  private volatile TableName cachedMetaTableName;
+
+  public MetaTableNameStore(MasterRegion masterRegion) {
+    this.masterRegion = masterRegion;
+  }
+
+  /**
+   * Store the meta table name in the Master Local Region. This should be called once during cluster
+   * initialization. The stored value is cluster-specific and should not conflict with other
+   * clusters sharing the same HDFS.
+   * @param metaTableName the meta table name to store
+   * @throws IOException if the operation fails
+   */
+  public void store(TableName metaTableName) throws IOException {
+    LOG.info("Storing meta table name in Master Local Region: {}", metaTableName);
+    Put put = new Put(META_TABLE_NAME_ROW);
+    put.addColumn(INFO_FAMILY, NAME_QUALIFIER, Bytes.toBytes(metaTableName.getNameAsString()));
+    masterRegion.update(r -> r.put(put));
+    cachedMetaTableName = metaTableName;
+    LOG.info("Successfully stored meta table name: {}", metaTableName);
+  }
+
+  /**
+   * Load the meta table name from the Master Local Region.
+   * @return the meta table name for this cluster
+   * @throws IOException if the load operation fails
+   */
+  public TableName load() throws IOException {
+    if (cachedMetaTableName != null) {
+      return cachedMetaTableName;
+    }
+
+    synchronized (this) {
+      if (cachedMetaTableName != null) {
+        return cachedMetaTableName;
+      }
+      Get get = new Get(META_TABLE_NAME_ROW);
+      get.addColumn(INFO_FAMILY, NAME_QUALIFIER);
+      Result result = masterRegion.get(get);
+
+      if (!result.isEmpty()) {
+        byte[] value = result.getValue(INFO_FAMILY, NAME_QUALIFIER);
+        cachedMetaTableName = TableName.valueOf(Bytes.toString(value));
+        LOG.debug("Loaded meta table name from Master Local Region: {}", cachedMetaTableName);
+        return cachedMetaTableName;
+      }
+      LOG.info("No stored meta table name found in Master Local Region, will use default");
+      return cachedMetaTableName;
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/RegionPlacementMaintainer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/RegionPlacementMaintainer.java
@@ -605,7 +605,7 @@ public class RegionPlacementMaintainer implements Closeable {
    */
   public void updateAssignmentPlanToMeta(FavoredNodesPlan plan) throws IOException {
     try {
-      LOG.info("Start to update the hbase:meta with the new assignment plan");
+      LOG.info("Started updating {} with the new assignment plan", connection.getMetaTableName());
       Map<String, List<ServerName>> assignmentMap = plan.getAssignmentMap();
       Map<RegionInfo, List<ServerName>> planToUpdate = new HashMap<>(assignmentMap.size());
       Map<String, RegionInfo> regionToRegionInfoMap =
@@ -690,14 +690,14 @@ public class RegionPlacementMaintainer implements Closeable {
   }
 
   public void updateAssignmentPlan(FavoredNodesPlan plan) throws IOException {
-    LOG.info("Start to update the new assignment plan for the hbase:meta table and"
-      + " the region servers");
+    LOG.info("Started updating the new assignment plan for {} and the region servers",
+      connection.getMetaTableName());
     // Update the new assignment plan to META
     updateAssignmentPlanToMeta(plan);
     // Update the new assignment plan to Region Servers
     updateAssignmentPlanToRegionServers(plan);
-    LOG.info("Finish to update the new assignment plan for the hbase:meta table and"
-      + " the region servers");
+    LOG.info("Finished updating the new assignment plan for {} and the region servers",
+      connection.getMetaTableName());
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/RegionPlacementMaintainer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/RegionPlacementMaintainer.java
@@ -605,7 +605,7 @@ public class RegionPlacementMaintainer implements Closeable {
    */
   public void updateAssignmentPlanToMeta(FavoredNodesPlan plan) throws IOException {
     try {
-      LOG.info("Started updating {} with the new assignment plan", TableName.META_TABLE_NAME);
+      LOG.info("Started updating {} with the new assignment plan", connection.getMetaTableName());
       Map<String, List<ServerName>> assignmentMap = plan.getAssignmentMap();
       Map<RegionInfo, List<ServerName>> planToUpdate = new HashMap<>(assignmentMap.size());
       Map<String, RegionInfo> regionToRegionInfoMap =
@@ -615,10 +615,10 @@ public class RegionPlacementMaintainer implements Closeable {
       }
 
       FavoredNodeAssignmentHelper.updateMetaWithFavoredNodesInfo(planToUpdate, conf);
-      LOG.info("Updated {} with the new assignment plan", TableName.META_TABLE_NAME);
+      LOG.info("Updated {} with the new assignment plan", connection.getMetaTableName());
     } catch (Exception e) {
       LOG.error("Failed to update {} with the new assignment plan because {}",
-        TableName.META_TABLE_NAME, e.getMessage());
+        connection.getMetaTableName(), e.getMessage());
     }
   }
 
@@ -691,13 +691,13 @@ public class RegionPlacementMaintainer implements Closeable {
 
   public void updateAssignmentPlan(FavoredNodesPlan plan) throws IOException {
     LOG.info("Started updating the new assignment plan for {} and the region servers",
-      TableName.META_TABLE_NAME);
+      connection.getMetaTableName());
     // Update the new assignment plan to META
     updateAssignmentPlanToMeta(plan);
     // Update the new assignment plan to Region Servers
     updateAssignmentPlanToRegionServers(plan);
     LOG.info("Finished updating the new assignment plan for {} and the region servers",
-      TableName.META_TABLE_NAME);
+      connection.getMetaTableName());
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/TableNamespaceManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/TableNamespaceManager.java
@@ -79,7 +79,7 @@ public class TableNamespaceManager {
     if (!opt.isPresent()) {
       // the procedure is not present, check whether have the ns family in meta table
       TableDescriptor metaTableDesc =
-        masterServices.getTableDescriptors().get(TableName.META_TABLE_NAME);
+        masterServices.getTableDescriptors().get(masterServices.getConnection().getMetaTableName());
       if (metaTableDesc.hasColumnFamily(HConstants.NAMESPACE_FAMILY)) {
         // normal case, upgrading is done or the cluster is created with 3.x code
         migrationDone = true;
@@ -106,7 +106,7 @@ public class TableNamespaceManager {
   }
 
   private void loadFromMeta() throws IOException {
-    try (Table table = masterServices.getConnection().getTable(TableName.META_TABLE_NAME);
+    try (Table table = masterServices.getConnection().getMetaTable();
       ResultScanner scanner = table.getScanner(HConstants.NAMESPACE_FAMILY)) {
       for (Result result;;) {
         result = scanner.next();
@@ -204,7 +204,7 @@ public class TableNamespaceManager {
     Put put = new Put(row, true).addColumn(HConstants.NAMESPACE_FAMILY,
       HConstants.NAMESPACE_COL_DESC_QUALIFIER,
       ProtobufUtil.toProtoNamespaceDescriptor(ns).toByteArray());
-    try (Table table = conn.getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = conn.getMetaTable()) {
       table.put(put);
     }
   }
@@ -212,7 +212,7 @@ public class TableNamespaceManager {
   public void deleteNamespace(String namespaceName) throws IOException {
     checkMigrationDone();
     Delete d = new Delete(Bytes.toBytes(namespaceName));
-    try (Table table = masterServices.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = masterServices.getConnection().getMetaTable()) {
       table.delete(d);
     }
     cache.remove(namespaceName);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/TableStateManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/TableStateManager.java
@@ -86,7 +86,7 @@ public class TableStateManager {
   }
 
   public void setDeletedTable(TableName tableName) throws IOException {
-    if (tableName.equals(TableName.META_TABLE_NAME)) {
+    if (tableName.equals(master.getConnection().getMetaTableName())) {
       // Can't delete the hbase:meta table.
       return;
     }
@@ -147,7 +147,7 @@ public class TableStateManager {
   }
 
   private void updateMetaState(TableName tableName, TableState.State newState) throws IOException {
-    if (tableName.equals(TableName.META_TABLE_NAME)) {
+    if (tableName.equals(master.getConnection().getMetaTableName())) {
       if (
         TableState.State.DISABLING.equals(newState) || TableState.State.DISABLED.equals(newState)
       ) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -354,7 +354,7 @@ public class AssignmentManager {
             if (RegionReplicaUtil.isDefaultReplica(regionInfo.getReplicaId())) {
               setMetaAssigned(regionInfo, state == State.OPEN);
             }
-            LOG.debug("Loaded hbase:meta {}", regionNode);
+            LOG.debug("Loaded {} {}", master.getConnection().getMetaTableName(), regionNode);
           }, result);
       }
     }
@@ -1962,8 +1962,8 @@ public class AssignmentManager {
     boolean meta = isMetaRegion(hri);
     boolean metaLoaded = isMetaLoaded();
     if (!meta && !metaLoaded) {
-      throw new PleaseHoldException(
-        "Master not fully online; hbase:meta=" + meta + ", metaLoaded=" + metaLoaded);
+      throw new PleaseHoldException("Master not fully online; "
+        + master.getConnection().getMetaTableName() + "=" + meta + ", metaLoaded=" + metaLoaded);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -354,7 +354,7 @@ public class AssignmentManager {
             if (RegionReplicaUtil.isDefaultReplica(regionInfo.getReplicaId())) {
               setMetaAssigned(regionInfo, state == State.OPEN);
             }
-            LOG.debug("Loaded {} {}", TableName.META_TABLE_NAME, regionNode);
+            LOG.debug("Loaded {} {}", master.getConnection().getMetaTableName(), regionNode);
           }, result);
       }
     }
@@ -1967,8 +1967,8 @@ public class AssignmentManager {
     boolean meta = isMetaRegion(hri);
     boolean metaLoaded = isMetaLoaded();
     if (!meta && !metaLoaded) {
-      throw new PleaseHoldException("Master not fully online; " + TableName.META_TABLE_NAME + "="
-        + meta + ", metaLoaded=" + metaLoaded);
+      throw new PleaseHoldException("Master not fully online; "
+        + master.getConnection().getMetaTableName() + "=" + meta + ", metaLoaded=" + metaLoaded);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateStore.java
@@ -189,9 +189,9 @@ public class RegionStateStore {
     final int replicaId = regionInfo.getReplicaId();
     final Put put = new Put(CatalogFamilyFormat.getMetaKeyForRegion(regionInfo), time);
     MetaTableAccessor.addRegionInfo(put, regionInfo);
-    final StringBuilder info =
-      new StringBuilder("pid=").append(pid).append(" updating hbase:meta row=")
-        .append(regionInfo.getEncodedName()).append(", regionState=").append(state);
+    final StringBuilder info = new StringBuilder("pid=").append(pid).append(" updating ")
+      .append(master.getConnection().getMetaTableName()).append(" row=")
+      .append(regionInfo.getEncodedName()).append(", regionState=").append(state);
     if (openSeqNum >= 0) {
       Preconditions.checkArgument(state == State.OPEN && regionLocation != null,
         "Open region should be on a server");
@@ -283,7 +283,7 @@ public class RegionStateStore {
         future = FutureUtils.failedFuture(e);
       }
     } else {
-      AsyncTable<?> table = master.getAsyncConnection().getTable(TableName.META_TABLE_NAME);
+      AsyncTable<?> table = master.getAsyncConnection().getMetaTable();
       future = table.put(put);
     }
     FutureUtils.addListener(future, (r, e) -> {
@@ -329,8 +329,7 @@ public class RegionStateStore {
       }
     }
     MutateRowsRequest request = builder.build();
-    AsyncTable<?> table =
-      master.getConnection().toAsyncConnection().getTable(TableName.META_TABLE_NAME);
+    AsyncTable<?> table = master.getAsyncConnection().getMetaTable();
     CompletableFuture<MutateRowsResponse> future = table.<MultiRowMutationService,
       MutateRowsResponse> coprocessorService(MultiRowMutationService::newStub,
         (stub, controller, done) -> stub.mutateRows(controller, request, done), row);
@@ -338,7 +337,7 @@ public class RegionStateStore {
   }
 
   private Table getMetaTable() throws IOException {
-    return master.getConnection().getTable(TableName.META_TABLE_NAME);
+    return master.getConnection().getMetaTable();
   }
 
   private Result getRegionCatalogResult(RegionInfo region) throws IOException {
@@ -476,7 +475,6 @@ public class RegionStateStore {
 
   /**
    * Deletes merge qualifiers for the specified merge region.
-   * @param connection  connection we're using
    * @param mergeRegion the merged region
    */
   public void deleteMergeQualifiers(RegionInfo mergeRegion) throws IOException {
@@ -504,7 +502,7 @@ public class RegionStateStore {
         + " in meta table, they are cleaned up already, Skip.");
       return;
     }
-    try (Table table = master.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = master.getConnection().getMetaTable()) {
       table.delete(delete);
     }
     LOG.info(
@@ -566,7 +564,6 @@ public class RegionStateStore {
   /**
    * Overwrites the specified regions from hbase:meta. Deletes old rows for the given regions and
    * adds new ones. Regions added back have state CLOSED.
-   * @param connection  connection we're using
    * @param regionInfos list of regions to be added to META
    */
   public void overwriteRegions(List<RegionInfo> regionInfos, int regionReplication)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateStore.java
@@ -190,9 +190,9 @@ public class RegionStateStore {
     final int replicaId = regionInfo.getReplicaId();
     final Put put = new Put(CatalogFamilyFormat.getMetaKeyForRegion(regionInfo), time);
     MetaTableAccessor.addRegionInfo(put, regionInfo);
-    final StringBuilder info =
-      new StringBuilder("pid=").append(pid).append(" updating ").append(TableName.META_TABLE_NAME)
-        .append(" row=").append(regionInfo.getEncodedName()).append(", regionState=").append(state);
+    final StringBuilder info = new StringBuilder("pid=").append(pid).append(" updating ")
+      .append(master.getConnection().getMetaTableName()).append(" row=")
+      .append(regionInfo.getEncodedName()).append(", regionState=").append(state);
     if (openSeqNum >= 0) {
       Preconditions.checkArgument(state == State.OPEN && regionLocation != null,
         "Open region should be on a server");
@@ -284,7 +284,7 @@ public class RegionStateStore {
         future = FutureUtils.failedFuture(e);
       }
     } else {
-      AsyncTable<?> table = master.getAsyncConnection().getTable(TableName.META_TABLE_NAME);
+      AsyncTable<?> table = master.getAsyncConnection().getMetaTable();
       future = table.put(put);
     }
     FutureUtils.addListener(future, (r, e) -> {
@@ -330,8 +330,7 @@ public class RegionStateStore {
       }
     }
     MutateRowsRequest request = builder.build();
-    AsyncTable<?> table =
-      master.getConnection().toAsyncConnection().getTable(TableName.META_TABLE_NAME);
+    AsyncTable<?> table = master.getAsyncConnection().getMetaTable();
     CompletableFuture<MutateRowsResponse> future = table.<MultiRowMutationService,
       MutateRowsResponse> coprocessorService(MultiRowMutationService::newStub,
         (stub, controller, done) -> stub.mutateRows(controller, request, done), row);
@@ -339,7 +338,7 @@ public class RegionStateStore {
   }
 
   private Table getMetaTable() throws IOException {
-    return master.getConnection().getTable(TableName.META_TABLE_NAME);
+    return master.getConnection().getMetaTable();
   }
 
   private Result getRegionCatalogResult(RegionInfo region) throws IOException {
@@ -477,7 +476,6 @@ public class RegionStateStore {
 
   /**
    * Deletes merge qualifiers for the specified merge region.
-   * @param connection  connection we're using
    * @param mergeRegion the merged region
    */
   public void deleteMergeQualifiers(RegionInfo mergeRegion) throws IOException {
@@ -505,7 +503,7 @@ public class RegionStateStore {
         + " in meta table, they are cleaned up already, Skip.");
       return;
     }
-    try (Table table = master.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = master.getConnection().getMetaTable()) {
       table.delete(delete);
     }
     LOG.info(
@@ -567,7 +565,6 @@ public class RegionStateStore {
   /**
    * Overwrites the specified regions from hbase:meta. Deletes old rows for the given regions and
    * adds new ones. Regions added back have state CLOSED.
-   * @param connection  connection we're using
    * @param regionInfos list of regions to be added to META
    */
   public void overwriteRegions(List<RegionInfo> regionInfos, int regionReplication)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/ReplicationBarrierCleaner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/cleaner/ReplicationBarrierCleaner.java
@@ -80,9 +80,8 @@ public class ReplicationBarrierCleaner extends ScheduledChore {
     long deletedLastPushedSeqIds = 0;
     TableName tableName = null;
     List<String> peerIds = null;
-    try (Table metaTable = conn.getTable(TableName.META_TABLE_NAME);
-      ResultScanner scanner = metaTable.getScanner(
-        new Scan().addFamily(HConstants.REPLICATION_BARRIER_FAMILY).readAllVersions())) {
+    try (Table metaTable = conn.getTable(conn.getMetaTableName()); ResultScanner scanner = metaTable
+      .getScanner(new Scan().addFamily(HConstants.REPLICATION_BARRIER_FAMILY).readAllVersions())) {
       for (;;) {
         Result result = scanner.next();
         if (result == null) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/http/MetaBrowser.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/http/MetaBrowser.java
@@ -156,7 +156,7 @@ public class MetaBrowser {
 
   public Results getResults() {
     final AsyncTable<AdvancedScanResultConsumer> asyncTable =
-      connection.getTable(TableName.META_TABLE_NAME);
+      connection.getTable(connection.getMetaTableName());
     return new Results(asyncTable.getScanner(buildScan()));
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
@@ -105,7 +105,8 @@ public class CatalogJanitor extends ScheduledChore {
         scan();
       }
     } catch (IOException e) {
-      LOG.warn("Failed initial janitorial scan of hbase:meta table", e);
+      LOG.warn("Failed initial janitorial scan of {} table",
+        services.getConnection().getMetaTableName(), e);
       return false;
     }
     return true;
@@ -145,7 +146,8 @@ public class CatalogJanitor extends ScheduledChore {
           + this.services.getServerManager().isClusterShutdown());
       }
     } catch (IOException e) {
-      LOG.warn("Failed janitorial scan of hbase:meta table", e);
+      LOG.warn("Failed janitorial scan of {} table", services.getConnection().getMetaTableName(),
+        e);
     }
   }
 
@@ -484,7 +486,7 @@ public class CatalogJanitor extends ScheduledChore {
        */
       Get g = new Get(Bytes.toBytes("t2,40,1564119846424.1db8c57d64e0733e0f027aaeae7a0bf0."));
       g.addColumn(HConstants.CATALOG_FAMILY, HConstants.REGIONINFO_QUALIFIER);
-      try (Table t = connection.getTable(TableName.META_TABLE_NAME)) {
+      try (Table t = connection.getTable(connection.getMetaTableName())) {
         Result r = t.get(g);
         byte[] row = g.getRow();
         row[row.length - 2] <<= row[row.length - 2];

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
@@ -105,7 +105,8 @@ public class CatalogJanitor extends ScheduledChore {
         scan();
       }
     } catch (IOException e) {
-      LOG.warn("Failed initial janitorial scan of {} table", TableName.META_TABLE_NAME, e);
+      LOG.warn("Failed initial janitorial scan of {} table",
+        services.getConnection().getMetaTableName(), e);
       return false;
     }
     return true;
@@ -145,7 +146,8 @@ public class CatalogJanitor extends ScheduledChore {
           + this.services.getServerManager().isClusterShutdown());
       }
     } catch (IOException e) {
-      LOG.warn("Failed janitorial scan of {} table", TableName.META_TABLE_NAME, e);
+      LOG.warn("Failed janitorial scan of {} table", services.getConnection().getMetaTableName(),
+        e);
     }
   }
 
@@ -484,7 +486,7 @@ public class CatalogJanitor extends ScheduledChore {
        */
       Get g = new Get(Bytes.toBytes("t2,40,1564119846424.1db8c57d64e0733e0f027aaeae7a0bf0."));
       g.addColumn(HConstants.CATALOG_FAMILY, HConstants.REGIONINFO_QUALIFIER);
-      try (Table t = connection.getTable(TableName.META_TABLE_NAME)) {
+      try (Table t = connection.getTable(connection.getMetaTableName())) {
         Result r = t.get(g);
         byte[] row = g.getRow();
         row[row.length - 2] <<= row[row.length - 2];

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/DeleteTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/DeleteTableProcedure.java
@@ -393,8 +393,7 @@ public class DeleteTableProcedure extends AbstractStateMachineTableProcedure<Del
       .setFilter(new KeyOnlyFilter());
     long now = EnvironmentEdgeManager.currentTime();
     List<Delete> deletes = new ArrayList<>();
-    try (
-      Table metaTable = env.getMasterServices().getConnection().getTable(TableName.META_TABLE_NAME);
+    try (Table metaTable = env.getMasterServices().getConnection().getTable(env.getMetaTableName());
       ResultScanner scanner = metaTable.getScanner(tableScan)) {
       for (;;) {
         Result result = scanner.next();
@@ -405,7 +404,7 @@ public class DeleteTableProcedure extends AbstractStateMachineTableProcedure<Del
       }
       if (!deletes.isEmpty()) {
         LOG.warn("Deleting some vestigial " + deletes.size() + " rows of " + tableName + " from "
-          + TableName.META_TABLE_NAME);
+          + env.getMetaTableName());
         metaTable.delete(deletes);
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/DisableTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/DisableTableProcedure.java
@@ -110,8 +110,8 @@ public class DisableTableProcedure extends AbstractStateMachineTableProcedure<Di
             env.getMasterServices().getTableDescriptors().get(tableName).hasGlobalReplicationScope()
           ) {
             MasterFileSystem fs = env.getMasterFileSystem();
-            try (BufferedMutator mutator = env.getMasterServices().getConnection()
-              .getBufferedMutator(TableName.META_TABLE_NAME)) {
+            try (BufferedMutator mutator =
+              env.getMasterServices().getConnection().getBufferedMutator(env.getMetaTableName())) {
               for (RegionInfo region : env.getAssignmentManager().getRegionStates()
                 .getRegionsOfTable(tableName)) {
                 long maxSequenceId = WALSplitUtil.getMaxRegionSequenceId(
@@ -230,7 +230,7 @@ public class DisableTableProcedure extends AbstractStateMachineTableProcedure<Di
    */
   private boolean prepareDisable(final MasterProcedureEnv env) throws IOException {
     boolean canTableBeDisabled = true;
-    if (tableName.equals(TableName.META_TABLE_NAME)) {
+    if (tableName.equals(env.getMetaTableName())) {
       setFailure("master-disable-table",
         new ConstraintException("Cannot disable " + this.tableName));
       canTableBeDisabled = false;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/InitMetaProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/InitMetaProcedure.java
@@ -67,6 +67,8 @@ public class InitMetaProcedure extends AbstractStateMachineTableProcedure<InitMe
 
   @Override
   public TableName getTableName() {
+    // Always returns default "hbase:meta" for now
+    // Future: will support replica-specific names (e.g., "hbase:meta_replica1")
     return TableName.META_TABLE_NAME;
   }
 
@@ -75,11 +77,11 @@ public class InitMetaProcedure extends AbstractStateMachineTableProcedure<InitMe
     return TableOperationType.CREATE;
   }
 
-  private static TableDescriptor writeFsLayout(Path rootDir, MasterProcedureEnv env)
-    throws IOException {
-    LOG.info("BOOTSTRAP: creating {} region", TableName.META_TABLE_NAME);
+  private static TableDescriptor writeFsLayout(Path rootDir, MasterProcedureEnv env,
+    TableName metaTableName) throws IOException {
+    LOG.info("BOOTSTRAP: creating {} region", metaTableName);
     FileSystem fs = rootDir.getFileSystem(env.getMasterConfiguration());
-    Path tableDir = CommonFSUtils.getTableDir(rootDir, TableName.META_TABLE_NAME);
+    Path tableDir = CommonFSUtils.getTableDir(rootDir, metaTableName);
     if (fs.exists(tableDir) && !deleteMetaTableDirectoryIfPartial(fs, tableDir)) {
       LOG.warn("Can not delete partial created meta table, continue...");
     }
@@ -105,7 +107,7 @@ public class InitMetaProcedure extends AbstractStateMachineTableProcedure<InitMe
         case INIT_META_WRITE_FS_LAYOUT:
           Configuration conf = env.getMasterConfiguration();
           Path rootDir = CommonFSUtils.getRootDir(conf);
-          TableDescriptor td = writeFsLayout(rootDir, env);
+          TableDescriptor td = writeFsLayout(rootDir, env, env.getMetaTableName());
           env.getMasterServices().getTableDescriptors().update(td, true);
           setNextState(InitMetaState.INIT_META_ASSIGN_META);
           return Flow.HAS_MORE_STATE;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MasterProcedureEnv.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MasterProcedureEnv.java
@@ -22,6 +22,7 @@ import java.util.concurrent.ExecutorService;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.conf.ConfigurationObserver;
 import org.apache.hadoop.hbase.ipc.RpcServer;
 import org.apache.hadoop.hbase.master.MasterCoprocessorHost;
@@ -124,6 +125,10 @@ public class MasterProcedureEnv implements ConfigurationObserver {
 
   public MasterFileSystem getMasterFileSystem() {
     return master.getMasterFileSystem();
+  }
+
+  public TableName getMetaTableName() {
+    return master.getMetaTableName();
   }
 
   public boolean isRunning() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MasterProcedureScheduler.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MasterProcedureScheduler.java
@@ -561,11 +561,13 @@ public class MasterProcedureScheduler extends AbstractProcedureScheduler {
   // Meta Queue Lookup Helpers
   // ============================================================================
   private MetaQueue getMetaQueue() {
-    MetaQueue node = AvlTree.get(metaMap, TableName.META_TABLE_NAME, META_QUEUE_KEY_COMPARATOR);
+    // For now, hardcode default. Future: pass metaTableName via constructor from Master
+    TableName metaTableName = TableName.META_TABLE_NAME;
+    MetaQueue node = AvlTree.get(metaMap, metaTableName, META_QUEUE_KEY_COMPARATOR);
     if (node != null) {
       return node;
     }
-    node = new MetaQueue(locking.getMetaLock());
+    node = new MetaQueue(metaTableName, locking.getMetaLock());
     metaMap = AvlTree.insert(metaMap, node);
     return node;
   }
@@ -1079,6 +1081,7 @@ public class MasterProcedureScheduler extends AbstractProcedureScheduler {
         return false;
       }
       waitProcedure(lock, procedure);
+      // TODO: Get dynamic name from MasterServices
       logLockedResource(LockedResourceType.META, TableName.META_TABLE_NAME.getNameAsString());
       return true;
     } finally {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MetaQueue.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MetaQueue.java
@@ -32,8 +32,8 @@ import org.apache.yetus.audience.InterfaceAudience;
 @InterfaceAudience.Private
 class MetaQueue extends Queue<TableName> {
 
-  protected MetaQueue(LockStatus lockStatus) {
-    super(TableName.META_TABLE_NAME, 1, lockStatus);
+  protected MetaQueue(TableName metaTableName, LockStatus lockStatus) {
+    super(metaTableName, 1, lockStatus);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MigrateNamespaceTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/MigrateNamespaceTableProcedure.java
@@ -64,7 +64,7 @@ public class MigrateNamespaceTableProcedure
     try (Table nsTable = conn.getTable(TableName.NAMESPACE_TABLE_NAME);
       ResultScanner scanner = nsTable.getScanner(
         new Scan().addFamily(TableDescriptorBuilder.NAMESPACE_FAMILY_INFO_BYTES).readAllVersions());
-      BufferedMutator mutator = conn.getBufferedMutator(TableName.META_TABLE_NAME)) {
+      BufferedMutator mutator = conn.getBufferedMutator(env.getMetaTableName())) {
       for (Result result;;) {
         result = scanner.next();
         if (result == null) {
@@ -88,7 +88,7 @@ public class MigrateNamespaceTableProcedure
       switch (state) {
         case MIGRATE_NAMESPACE_TABLE_ADD_FAMILY:
           TableDescriptor metaTableDesc =
-            env.getMasterServices().getTableDescriptors().get(TableName.META_TABLE_NAME);
+            env.getMasterServices().getTableDescriptors().get(env.getMetaTableName());
           if (!metaTableDesc.hasColumnFamily(HConstants.NAMESPACE_FAMILY)) {
             TableDescriptor newMetaTableDesc = TableDescriptorBuilder.newBuilder(metaTableDesc)
               .setColumnFamily(

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -110,7 +110,7 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
       for (byte[] family : UNDELETABLE_META_COLUMNFAMILIES) {
         if (!cfs.contains(family)) {
           throw new HBaseIOException(
-            "Delete of hbase:meta column family " + Bytes.toString(family));
+            "Delete of " + env.getMetaTableName() + " column family " + Bytes.toString(family));
         }
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -110,7 +110,7 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
       for (byte[] family : UNDELETABLE_META_COLUMNFAMILIES) {
         if (!cfs.contains(family)) {
           throw new HBaseIOException(
-            "Delete of " + TableName.META_TABLE_NAME + " column family " + Bytes.toString(family));
+            "Delete of " + env.getMetaTableName() + " column family " + Bytes.toString(family));
         }
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SchemaLocking.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/SchemaLocking.java
@@ -174,6 +174,7 @@ class SchemaLocking {
     addToLockedResources(lockedResources, regionLocks, Function.identity(),
       LockedResourceType.REGION);
     addToLockedResources(lockedResources, peerLocks, Function.identity(), LockedResourceType.PEER);
+    // TODO: Get dynamic name from MasterServices
     addToLockedResources(lockedResources, ImmutableMap.of(TableName.META_TABLE_NAME, metaLock),
       tn -> tn.getNameAsString(), LockedResourceType.META);
     addToLockedResources(lockedResources, globalLocks, Function.identity(),
@@ -236,6 +237,7 @@ class SchemaLocking {
       .append("tableLocks", filterUnlocked(tableLocks))
       .append("regionLocks", filterUnlocked(regionLocks))
       .append("peerLocks", filterUnlocked(peerLocks))
+      // TODO: Get dynamic name from MasterServices
       .append("metaLocks", filterUnlocked(ImmutableMap.of(TableName.META_TABLE_NAME, metaLock)))
       .append("globalLocks", filterUnlocked(globalLocks)).build();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/TruncateRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/TruncateRegionProcedure.java
@@ -231,7 +231,7 @@ public class TruncateRegionProcedure
   }
 
   private boolean prepareTruncate() throws IOException {
-    if (getTableName().equals(TableName.META_TABLE_NAME)) {
+    if (TableName.isMetaTableName(getTableName())) {
       throw new IOException("Can't truncate region in catalog tables");
     }
     return true;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -3686,6 +3686,42 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     return metaRegionLocationCache.getMetaRegionLocations();
   }
 
+  /**
+   * Cached meta table name. Resolved lazily from {@link #asyncClusterConnection} on first
+   * successful call to {@link #getMetaTableName()} and never re-fetched, so callers see a stable
+   * value for the lifetime of the server. Before the cluster connection is up we fall back to the
+   * default meta table name, but we deliberately do not cache that fallback so a later call can
+   * still pick up the cluster-specific value once the connection is available.
+   */
+  private volatile TableName cachedMetaTableName;
+
+  /**
+   * RegionServers get the meta table name from Master via the connection registry. The result is
+   * cached after the first successful resolution to avoid the value flipping between the bootstrap
+   * default and the cluster-specific meta table name across calls.
+   */
+  @Override
+  public TableName getMetaTableName() {
+    TableName cached = cachedMetaTableName;
+    if (cached != null) {
+      return cached;
+    }
+    if (asyncClusterConnection != null) {
+      try {
+        TableName resolved = asyncClusterConnection.getMetaTableName();
+        if (resolved != null) {
+          cachedMetaTableName = resolved;
+          return resolved;
+        }
+      } catch (Exception e) {
+        LOG.warn("Failed to get meta table name from Master", e);
+      }
+    }
+    // Bootstrap: connection is not yet available. Return the default but do not cache it; the
+    // next call (after the connection is up) should be able to resolve the real value.
+    return super.getMetaTableName();
+  }
+
   @Override
   protected NamedQueueRecorder createNamedQueueRecord() {
     return NamedQueueRecorder.getInstance(conf);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -3737,6 +3737,42 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     return metaRegionLocationCache.getMetaRegionLocations();
   }
 
+  /**
+   * Cached meta table name. Resolved lazily from {@link #asyncClusterConnection} on first
+   * successful call to {@link #getMetaTableName()} and never re-fetched, so callers see a stable
+   * value for the lifetime of the server. Before the cluster connection is up we fall back to the
+   * default meta table name, but we deliberately do not cache that fallback so a later call can
+   * still pick up the cluster-specific value once the connection is available.
+   */
+  private volatile TableName cachedMetaTableName;
+
+  /**
+   * RegionServers get the meta table name from Master via the connection registry. The result is
+   * cached after the first successful resolution to avoid the value flipping between the bootstrap
+   * default and the cluster-specific meta table name across calls.
+   */
+  @Override
+  public TableName getMetaTableName() {
+    TableName cached = cachedMetaTableName;
+    if (cached != null) {
+      return cached;
+    }
+    if (asyncClusterConnection != null) {
+      try {
+        TableName resolved = asyncClusterConnection.getMetaTableName();
+        if (resolved != null) {
+          cachedMetaTableName = resolved;
+          return resolved;
+        }
+      } catch (Exception e) {
+        LOG.warn("Failed to get meta table name from Master", e);
+      }
+    }
+    // Bootstrap: connection is not yet available. Return the default but do not cache it; the
+    // next call (after the connection is up) should be able to resolve the real value.
+    return super.getMetaTableName();
+  }
+
   @Override
   protected NamedQueueRecorder createNamedQueueRecord() {
     return NamedQueueRecorder.getInstance(conf);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -1928,7 +1928,7 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
           tableName = ProtobufUtil.toTableName(ri.getTableName());
         }
       }
-      if (!TableName.META_TABLE_NAME.equals(tableName)) {
+      if (!server.getConnection().getMetaTableName().equals(tableName)) {
         throw new ServiceException(ie);
       }
       // We are assigning meta, wait a little for regionserver to finish initialization.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/ReplicationBarrierFamilyFormat.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/replication/ReplicationBarrierFamilyFormat.java
@@ -192,7 +192,7 @@ public final class ReplicationBarrierFamilyFormat {
       .addColumn(HConstants.CATALOG_FAMILY, HConstants.STATE_QUALIFIER)
       .addFamily(HConstants.REPLICATION_BARRIER_FAMILY).readAllVersions().setReversed(true)
       .setCaching(10);
-    try (Table table = conn.getTable(TableName.META_TABLE_NAME);
+    try (Table table = conn.getTable(conn.getMetaTableName());
       ResultScanner scanner = table.getScanner(scan)) {
       for (Result result;;) {
         result = scanner.next();
@@ -215,7 +215,7 @@ public final class ReplicationBarrierFamilyFormat {
 
   public static long[] getReplicationBarriers(Connection conn, byte[] regionName)
     throws IOException {
-    try (Table table = conn.getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = conn.getTable(conn.getMetaTableName())) {
       Result result = table.get(new Get(regionName)
         .addColumn(HConstants.REPLICATION_BARRIER_FAMILY, HConstants.SEQNUM_QUALIFIER)
         .readAllVersions());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AccessChecker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AccessChecker.java
@@ -544,7 +544,7 @@ public class AccessChecker {
     TableName tableName, Map<byte[], ? extends Collection<?>> families) {
     // 1. All users need read access to hbase:meta table.
     // this is a very common operation, so deal with it quickly.
-    if (TableName.META_TABLE_NAME.equals(tableName)) {
+    if (TableName.isMetaTableName(tableName)) {
       if (permRequest == Action.READ) {
         return AuthResult.allow(request, "All users allowed", user, permRequest, tableName,
           families);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -658,23 +658,23 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
    * next region. 3) if the endkey of the last region is not empty.
    */
   private void checkRegionIndexValid(int idx, List<Pair<byte[], byte[]>> startEndKeys,
-    TableName tableName) throws IOException {
+    TableName tableName, TableName metaTableName) throws IOException {
     if (idx < 0) {
-      throw new IOException("The first region info for table " + tableName
-        + " can't be found in hbase:meta.Please use hbck tool to fix it first.");
+      throw new IOException("The first region info for table " + tableName + " can't be found in "
+        + metaTableName + ". Please use hbck tool to fix it first.");
     } else if (
       (idx == startEndKeys.size() - 1)
         && !Bytes.equals(startEndKeys.get(idx).getSecond(), HConstants.EMPTY_BYTE_ARRAY)
     ) {
-      throw new IOException("The last region info for table " + tableName
-        + " can't be found in hbase:meta.Please use hbck tool to fix it first.");
+      throw new IOException("The last region info for table " + tableName + " can't be found in "
+        + metaTableName + ". Please use hbck tool to fix it first.");
     } else if (
       idx + 1 < startEndKeys.size() && !(Bytes.compareTo(startEndKeys.get(idx).getSecond(),
         startEndKeys.get(idx + 1).getFirst()) == 0)
     ) {
       throw new IOException("The endkey of one region for table " + tableName
-        + " is not equal to the startkey of the next region in hbase:meta."
-        + "Please use hbck tool to fix it first.");
+        + " is not equal to the startkey of the next region in " + metaTableName + "."
+        + " Please use hbck tool to fix it first.");
     }
   }
 
@@ -714,7 +714,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
         + " > " + Bytes.toStringBinary(last.get()));
     }
     int firstKeyRegionIdx = getRegionIndex(startEndKeys, first.get());
-    checkRegionIndexValid(firstKeyRegionIdx, startEndKeys, tableName);
+    checkRegionIndexValid(firstKeyRegionIdx, startEndKeys, tableName, conn.getMetaTableName());
     boolean lastKeyInRange =
       Bytes.compareTo(last.get(), startEndKeys.get(firstKeyRegionIdx).getSecond()) < 0 || Bytes
         .equals(startEndKeys.get(firstKeyRegionIdx).getSecond(), HConstants.EMPTY_BYTE_ARRAY);
@@ -729,7 +729,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
       // make sure the splitPoint is valid in case region overlap occur, maybe the splitPoint bigger
       // than hfile.endkey w/o this check
       if (splitIdx != firstKeyRegionIdx) {
-        checkRegionIndexValid(splitIdx, startEndKeys, tableName);
+        checkRegionIndexValid(splitIdx, startEndKeys, tableName, conn.getMetaTableName());
       }
       byte[] splitPoint = startEndKeys.get(splitIdx).getSecond();
       List<LoadQueueItem> lqis = splitStoreFile(conn.getRegionLocator(tableName), item,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -658,22 +658,22 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
    * next region. 3) if the endkey of the last region is not empty.
    */
   private void checkRegionIndexValid(int idx, List<Pair<byte[], byte[]>> startEndKeys,
-    TableName tableName) throws IOException {
+    TableName tableName, TableName metaTableName) throws IOException {
     if (idx < 0) {
       throw new IOException("The first region info for table " + tableName + " can't be found in "
-        + TableName.META_TABLE_NAME + ". Please use hbck tool to fix it" + " first.");
+        + metaTableName + ". Please use hbck tool to fix it first.");
     } else if (
       (idx == startEndKeys.size() - 1)
         && !Bytes.equals(startEndKeys.get(idx).getSecond(), HConstants.EMPTY_BYTE_ARRAY)
     ) {
       throw new IOException("The last region info for table " + tableName + " can't be found in "
-        + TableName.META_TABLE_NAME + ". Please use hbck tool to fix it" + " first.");
+        + metaTableName + ". Please use hbck tool to fix it first.");
     } else if (
       idx + 1 < startEndKeys.size() && !(Bytes.compareTo(startEndKeys.get(idx).getSecond(),
         startEndKeys.get(idx + 1).getFirst()) == 0)
     ) {
       throw new IOException("The endkey of one region for table " + tableName
-        + " is not equal to the startkey of the next region in " + TableName.META_TABLE_NAME + "."
+        + " is not equal to the startkey of the next region in " + metaTableName + "."
         + " Please use hbck tool to fix it first.");
     }
   }
@@ -714,7 +714,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
         + " > " + Bytes.toStringBinary(last.get()));
     }
     int firstKeyRegionIdx = getRegionIndex(startEndKeys, first.get());
-    checkRegionIndexValid(firstKeyRegionIdx, startEndKeys, tableName);
+    checkRegionIndexValid(firstKeyRegionIdx, startEndKeys, tableName, conn.getMetaTableName());
     boolean lastKeyInRange =
       Bytes.compareTo(last.get(), startEndKeys.get(firstKeyRegionIdx).getSecond()) < 0 || Bytes
         .equals(startEndKeys.get(firstKeyRegionIdx).getSecond(), HConstants.EMPTY_BYTE_ARRAY);
@@ -729,7 +729,7 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
       // make sure the splitPoint is valid in case region overlap occur, maybe the splitPoint bigger
       // than hfile.endkey w/o this check
       if (splitIdx != firstKeyRegionIdx) {
-        checkRegionIndexValid(splitIdx, startEndKeys, tableName);
+        checkRegionIndexValid(splitIdx, startEndKeys, tableName, conn.getMetaTableName());
       }
       byte[] splitPoint = startEndKeys.get(splitIdx).getSecond();
       List<LoadQueueItem> lqis = splitStoreFile(conn.getRegionLocator(tableName), item,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSTableDescriptors.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSTableDescriptors.java
@@ -143,24 +143,34 @@ public class FSTableDescriptors implements TableDescriptors {
       CommonFSUtils.getRootDir(conf));
   }
 
+  private static TableName getMetaTableNameFromConf(Configuration conf) {
+    // TODO: Support cluster-specific (e.g. read-replica) meta table names. This method is static
+    // and runs from contexts (FS bootstrap) where neither MasterRegion nor a Connection is yet
+    // available, so the dynamic name cannot be resolved here today. A follow-up should plumb the
+    // resolved meta TableName from the caller (e.g. via Configuration once the master has written
+    // it, or by passing a TableName argument from contexts that know it).
+    return TableName.META_TABLE_NAME;
+  }
+
   public static TableDescriptor tryUpdateAndGetMetaTableDescriptor(Configuration conf,
     FileSystem fs, Path rootdir) throws IOException {
     // see if we already have meta descriptor on fs. Write one if not.
-    Optional<Pair<FileStatus, TableDescriptor>> opt = getTableDescriptorFromFs(fs,
-      CommonFSUtils.getTableDir(rootdir, TableName.META_TABLE_NAME), false);
+    TableName metaTableName = getMetaTableNameFromConf(conf);
+    Optional<Pair<FileStatus, TableDescriptor>> opt =
+      getTableDescriptorFromFs(fs, CommonFSUtils.getTableDir(rootdir, metaTableName), false);
     if (opt.isPresent()) {
       return opt.get().getSecond();
     }
     TableDescriptorBuilder builder = createMetaTableDescriptorBuilder(conf);
     TableDescriptor td = StoreFileTrackerFactory.updateWithTrackerConfigs(conf, builder.build());
-    LOG.info("Creating new hbase:meta table descriptor {}", td);
+    LOG.info("Creating new {} table descriptor {}", metaTableName, td);
     TableName tableName = td.getTableName();
     Path tableDir = CommonFSUtils.getTableDir(rootdir, tableName);
     Path p = writeTableDescriptor(fs, td, tableDir, null);
     if (p == null) {
-      throw new IOException("Failed update hbase:meta table descriptor");
+      throw new IOException("Failed update " + metaTableName + " table descriptor");
     }
-    LOG.info("Updated hbase:meta table descriptor to {}", p);
+    LOG.info("Updated {} table descriptor to {}", metaTableName, p);
     return td;
   }
 
@@ -198,7 +208,7 @@ public class FSTableDescriptors implements TableDescriptors {
     // TODO We used to set CacheDataInL1 for META table. When we have BucketCache in file mode, now
     // the META table data goes to File mode BC only. Test how that affect the system. If too much,
     // we have to rethink about adding back the setCacheDataInL1 for META table CFs.
-    return TableDescriptorBuilder.newBuilder(TableName.META_TABLE_NAME)
+    return TableDescriptorBuilder.newBuilder(getMetaTableNameFromConf(conf))
       .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(HConstants.CATALOG_FAMILY)
         .setMaxVersions(
           conf.getInt(HConstants.HBASE_META_VERSIONS, HConstants.DEFAULT_HBASE_META_VERSIONS))

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSTableDescriptors.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSTableDescriptors.java
@@ -143,24 +143,34 @@ public class FSTableDescriptors implements TableDescriptors {
       CommonFSUtils.getRootDir(conf));
   }
 
+  private static TableName getMetaTableNameFromConf(Configuration conf) {
+    // TODO: Support cluster-specific (e.g. read-replica) meta table names. This method is static
+    // and runs from contexts (FS bootstrap) where neither MasterRegion nor a Connection is yet
+    // available, so the dynamic name cannot be resolved here today. A follow-up should plumb the
+    // resolved meta TableName from the caller (e.g. via Configuration once the master has written
+    // it, or by passing a TableName argument from contexts that know it).
+    return TableName.META_TABLE_NAME;
+  }
+
   public static TableDescriptor tryUpdateAndGetMetaTableDescriptor(Configuration conf,
     FileSystem fs, Path rootdir) throws IOException {
     // see if we already have meta descriptor on fs. Write one if not.
-    Optional<Pair<FileStatus, TableDescriptor>> opt = getTableDescriptorFromFs(fs,
-      CommonFSUtils.getTableDir(rootdir, TableName.META_TABLE_NAME), false);
+    TableName metaTableName = getMetaTableNameFromConf(conf);
+    Optional<Pair<FileStatus, TableDescriptor>> opt =
+      getTableDescriptorFromFs(fs, CommonFSUtils.getTableDir(rootdir, metaTableName), false);
     if (opt.isPresent()) {
       return opt.get().getSecond();
     }
     TableDescriptorBuilder builder = createMetaTableDescriptorBuilder(conf);
     TableDescriptor td = StoreFileTrackerFactory.updateWithTrackerConfigs(conf, builder.build());
-    LOG.info("Creating new {} table descriptor {}", TableName.META_TABLE_NAME, td);
+    LOG.info("Creating new {} table descriptor {}", metaTableName, td);
     TableName tableName = td.getTableName();
     Path tableDir = CommonFSUtils.getTableDir(rootdir, tableName);
     Path p = writeTableDescriptor(fs, td, tableDir, null);
     if (p == null) {
-      throw new IOException("Failed update " + TableName.META_TABLE_NAME + " table descriptor");
+      throw new IOException("Failed update " + metaTableName + " table descriptor");
     }
-    LOG.info("Updated {} table descriptor to {}", TableName.META_TABLE_NAME, p);
+    LOG.info("Updated {} table descriptor to {}", metaTableName, p);
     return td;
   }
 
@@ -198,7 +208,7 @@ public class FSTableDescriptors implements TableDescriptors {
     // TODO We used to set CacheDataInL1 for META table. When we have BucketCache in file mode, now
     // the META table data goes to File mode BC only. Test how that affect the system. If too much,
     // we have to rethink about adding back the setCacheDataInL1 for META table CFs.
-    return TableDescriptorBuilder.newBuilder(TableName.META_TABLE_NAME)
+    return TableDescriptorBuilder.newBuilder(getMetaTableNameFromConf(conf))
       .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(HConstants.CATALOG_FAMILY)
         .setMaxVersions(
           conf.getInt(HConstants.HBASE_META_VERSIONS, HConstants.DEFAULT_HBASE_META_VERSIONS))

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsck.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsck.java
@@ -540,7 +540,7 @@ public class HBaseFsck extends Configured implements Closeable {
 
     connection = ConnectionFactory.createConnection(getConf());
     admin = connection.getAdmin();
-    meta = connection.getTable(TableName.META_TABLE_NAME);
+    meta = connection.getTable(connection.getMetaTableName());
     status = admin.getClusterMetrics(EnumSet.of(Option.LIVE_SERVERS, Option.DEAD_SERVERS,
       Option.MASTER, Option.BACKUP_MASTERS, Option.REGIONS_IN_TRANSITION, Option.HBASE_VERSION));
   }
@@ -660,19 +660,19 @@ public class HBaseFsck extends Configured implements Closeable {
     reportUnknownServers();
     // Check if hbase:meta is found only once and in the right place
     if (!checkMetaRegion()) {
-      String errorMsg = TableName.META_TABLE_NAME + " table is not consistent. ";
+      String errorMsg = connection.getMetaTableName() + " table is not consistent. ";
       if (shouldFixAssignments()) {
-        errorMsg += "HBCK will try fixing it. Rerun once " + TableName.META_TABLE_NAME + " is back "
-          + "to consistent state.";
+        errorMsg += "HBCK will try fixing it. Rerun once " + connection.getMetaTableName()
+          + " is back to consistent state.";
       } else {
-        errorMsg += "Run HBCK with proper fix options to fix " + TableName.META_TABLE_NAME
+        errorMsg += "Run HBCK with proper fix options to fix " + connection.getMetaTableName()
           + " inconsistency.";
       }
       errors.reportError(errorMsg + " Exiting...");
       return -2;
     }
     // Not going with further consistency check for tables when hbase:meta itself is not consistent.
-    LOG.info("Loading regionsinfo from the {} table", TableName.META_TABLE_NAME);
+    LOG.info("Loading regionsinfo from the {} table", connection.getMetaTableName());
     boolean success = loadMetaEntries();
     if (!success) return -1;
 
@@ -1221,8 +1221,8 @@ public class HBaseFsck extends Configured implements Closeable {
    * TODO -- need to add tests for this.
    */
   private void reportEmptyMetaCells() {
-    errors.print("Number of empty REGIONINFO_QUALIFIER rows in " + TableName.META_TABLE_NAME + ": "
-      + emptyRegionInfoQualifiers.size());
+    errors.print("Number of empty REGIONINFO_QUALIFIER rows in " + connection.getMetaTableName()
+      + ": " + emptyRegionInfoQualifiers.size());
     if (details) {
       for (Result r : emptyRegionInfoQualifiers) {
         errors.print("  " + r);
@@ -1373,7 +1373,7 @@ public class HBaseFsck extends Configured implements Closeable {
    */
   public void fixEmptyMetaCells() throws IOException {
     if (shouldFixEmptyMetaCells() && !emptyRegionInfoQualifiers.isEmpty()) {
-      LOG.info("Trying to fix empty REGIONINFO_QUALIFIER {} rows.", TableName.META_TABLE_NAME);
+      LOG.info("Trying to fix empty REGIONINFO_QUALIFIER {} rows.", connection.getMetaTableName());
       for (Result region : emptyRegionInfoQualifiers) {
         deleteMetaRegion(region.getRow());
         errors.getErrorList().remove(ERROR_CODE.EMPTY_META_CELL);
@@ -1576,8 +1576,8 @@ public class HBaseFsck extends Configured implements Closeable {
     // Add hbase:meta so this tool keeps working. In hbase2, meta is always enabled though it
     // has no entry in the table states. HBCK doesn't work right w/ hbase2 but just do this in
     // meantime.
-    this.tableStates.put(TableName.META_TABLE_NAME,
-      new TableState(TableName.META_TABLE_NAME, TableState.State.ENABLED));
+    this.tableStates.put(connection.getMetaTableName(),
+      new TableState(connection.getMetaTableName(), TableState.State.ENABLED));
   }
 
   /**
@@ -1606,7 +1606,7 @@ public class HBaseFsck extends Configured implements Closeable {
       TableName tableName = CommonFSUtils.getTableName(path);
       if (
         (!checkMetaOnly && isTableIncluded(tableName))
-          || tableName.equals(TableName.META_TABLE_NAME)
+          || tableName.equals(connection.getMetaTableName())
       ) {
         tableDirs.add(fs.getFileStatus(path));
       }
@@ -1651,7 +1651,7 @@ public class HBaseFsck extends Configured implements Closeable {
    */
   private boolean recordMetaRegion() throws IOException {
     List<HRegionLocation> locs;
-    try (RegionLocator locator = connection.getRegionLocator(TableName.META_TABLE_NAME)) {
+    try (RegionLocator locator = connection.getRegionLocator(connection.getMetaTableName())) {
       locs = locator.getRegionLocations(HConstants.EMPTY_START_ROW, true);
     }
     if (locs == null || locs.isEmpty()) {
@@ -2022,10 +2022,9 @@ public class HBaseFsck extends Configured implements Closeable {
       RegionInfo hri = h.getRegion();
       if (hri == null) {
         LOG.warn(
-          "Unable to close region " + hi.getRegionNameAsString()
-            + " because {} had invalid or missing " + HConstants.CATALOG_FAMILY_STR + ":"
-            + Bytes.toString(HConstants.REGIONINFO_QUALIFIER) + " qualifier value.",
-          TableName.META_TABLE_NAME);
+          "Unable to close region {} because {} had invalid or missing {}:{} qualifier value.",
+          hi.getRegionNameAsString(), connection.getMetaTableName(), HConstants.CATALOG_FAMILY_STR,
+          Bytes.toString(HConstants.REGIONINFO_QUALIFIER));
         continue;
       }
       // close the region -- close files and remove assignment
@@ -2145,7 +2144,7 @@ public class HBaseFsck extends Configured implements Closeable {
     } else if (!inMeta && !inHdfs && isDeployed) {
       errors.reportError(ERROR_CODE.NOT_IN_META_HDFS,
         "Region " + descriptiveName + ", key=" + key + ", not on HDFS or in "
-          + TableName.META_TABLE_NAME + " but " + "deployed on "
+          + connection.getMetaTableName() + " but " + "deployed on "
           + Joiner.on(", ").join(hbi.getDeployedOn()));
       if (shouldFixAssignments()) {
         undeployRegions(hbi);
@@ -2161,7 +2160,7 @@ public class HBaseFsck extends Configured implements Closeable {
         return;
       }
       errors.reportError(ERROR_CODE.NOT_IN_META_OR_DEPLOYED,
-        "Region " + descriptiveName + " on HDFS, but not listed in " + TableName.META_TABLE_NAME
+        "Region " + descriptiveName + " on HDFS, but not listed in " + connection.getMetaTableName()
           + " or deployed on any region server");
       // restore region consistency of an adopted orphan
       if (shouldFixMeta()) {
@@ -2202,7 +2201,8 @@ public class HBaseFsck extends Configured implements Closeable {
             }
           }
         }
-        LOG.info("Patching {} with .regioninfo: " + hbi.getHdfsHRI(), TableName.META_TABLE_NAME);
+        LOG.info("Patching {} with .regioninfo: {}", connection.getMetaTableName(),
+          hbi.getHdfsHRI());
         int numReplicas = admin.getDescriptor(hbi.getTableName()).getRegionReplication();
         HBaseFsckRepair.fixMetaHoleOnlineAndAddReplicas(getConf(), hbi.getHdfsHRI(),
           admin.getClusterMetrics(EnumSet.of(Option.LIVE_SERVERS)).getLiveServerMetrics().keySet(),
@@ -2230,8 +2230,8 @@ public class HBaseFsck extends Configured implements Closeable {
           return;
         }
 
-        LOG.info("Patching {} with with .regioninfo: " + hbi.getHdfsHRI(),
-          TableName.META_TABLE_NAME);
+        LOG.info("Patching {} with .regioninfo: {}", connection.getMetaTableName(),
+          hbi.getHdfsHRI());
         int numReplicas = admin.getDescriptor(hbi.getTableName()).getRegionReplication();
         HBaseFsckRepair.fixMetaHoleOnlineAndAddReplicas(getConf(), hbi.getHdfsHRI(),
           admin.getClusterMetrics(EnumSet.of(Option.LIVE_SERVERS)).getLiveServerMetrics().keySet(),
@@ -2308,7 +2308,7 @@ public class HBaseFsck extends Configured implements Closeable {
       }
     } else if (inMeta && inHdfs && isMultiplyDeployed) {
       errors.reportError(ERROR_CODE.MULTI_DEPLOYED,
-        "Region " + descriptiveName + " is listed in " + TableName.META_TABLE_NAME
+        "Region " + descriptiveName + " is listed in " + connection.getMetaTableName()
           + " on region server " + hbi.getMetaEntry().regionServer + " but is multiply assigned"
           + " to region servers " + Joiner.on(", ").join(hbi.getDeployedOn()));
       // If we are trying to fix the errors
@@ -2320,7 +2320,7 @@ public class HBaseFsck extends Configured implements Closeable {
       }
     } else if (inMeta && inHdfs && isDeployed && !deploymentMatchesMeta) {
       errors.reportError(ERROR_CODE.SERVER_DOES_NOT_MATCH_META,
-        "Region " + descriptiveName + " listed in " + TableName.META_TABLE_NAME
+        "Region " + descriptiveName + " listed in " + connection.getMetaTableName()
           + " on region server " + hbi.getMetaEntry().regionServer + " but found on region server "
           + hbi.getDeployedOn().get(0));
       // If we are trying to fix the errors
@@ -2606,7 +2606,7 @@ public class HBaseFsck extends Configured implements Closeable {
         metaRegions.put(value.getReplicaId(), value);
       }
     }
-    int metaReplication = admin.getDescriptor(TableName.META_TABLE_NAME).getRegionReplication();
+    int metaReplication = admin.getDescriptor(connection.getMetaTableName()).getRegionReplication();
     boolean noProblem = true;
     // There will be always entries in regionInfoMap corresponding to hbase:meta & its replicas
     // Check the deployed servers. It should be exactly one server for each replica.
@@ -2622,10 +2622,10 @@ public class HBaseFsck extends Configured implements Closeable {
           assignMetaReplica(i);
         } else if (servers.size() > 1) {
           errors.reportError(ERROR_CODE.MULTI_META_REGION,
-            TableName.META_TABLE_NAME + ", replicaId " + metaHbckRegionInfo.getReplicaId()
+            connection.getMetaTableName() + ", replicaId " + metaHbckRegionInfo.getReplicaId()
               + " is found on more than one region.");
           if (shouldFixAssignments()) {
-            errors.print("Trying to fix a problem with " + TableName.META_TABLE_NAME
+            errors.print("Trying to fix a problem with " + connection.getMetaTableName()
               + ", replicaId " + metaHbckRegionInfo.getReplicaId() + "..");
             setShouldRerun();
             // try fix it (treat is a dupe assignment)
@@ -2639,11 +2639,11 @@ public class HBaseFsck extends Configured implements Closeable {
     for (Map.Entry<Integer, HbckRegionInfo> entry : metaRegions.entrySet()) {
       noProblem = false;
       errors.reportError(ERROR_CODE.SHOULD_NOT_BE_DEPLOYED,
-        TableName.META_TABLE_NAME + " replicas are deployed in excess. Configured "
+        connection.getMetaTableName() + " replicas are deployed in excess. Configured "
           + metaReplication + ", deployed " + metaRegions.size());
       if (shouldFixAssignments()) {
         errors.print("Trying to undeploy excess replica, replicaId: " + entry.getKey() + " of "
-          + TableName.META_TABLE_NAME + "..");
+          + connection.getMetaTableName() + "..");
         setShouldRerun();
         unassignMetaReplica(entry.getValue());
       }
@@ -2663,9 +2663,9 @@ public class HBaseFsck extends Configured implements Closeable {
   private void assignMetaReplica(int replicaId)
     throws IOException, KeeperException, InterruptedException {
     errors.reportError(ERROR_CODE.NO_META_REGION,
-      TableName.META_TABLE_NAME + ", replicaId " + replicaId + " is not found on any region.");
+      connection.getMetaTableName() + ", replicaId " + replicaId + " is not found on any region.");
     if (shouldFixAssignments()) {
-      errors.print("Trying to fix a problem with " + TableName.META_TABLE_NAME + "..");
+      errors.print("Trying to fix a problem with " + connection.getMetaTableName() + "..");
       setShouldRerun();
       // try to fix it (treat it as unassigned region)
       RegionInfo h = RegionReplicaUtil
@@ -2701,7 +2701,7 @@ public class HBaseFsck extends Configured implements Closeable {
           if (rl == null) {
             emptyRegionInfoQualifiers.add(result);
             errors.reportError(ERROR_CODE.EMPTY_META_CELL,
-              "Empty REGIONINFO_QUALIFIER found in " + TableName.META_TABLE_NAME);
+              "Empty REGIONINFO_QUALIFIER found in " + connection.getMetaTableName());
             return true;
           }
           ServerName sn = null;
@@ -2711,7 +2711,7 @@ public class HBaseFsck extends Configured implements Closeable {
           ) {
             emptyRegionInfoQualifiers.add(result);
             errors.reportError(ERROR_CODE.EMPTY_META_CELL,
-              "Empty REGIONINFO_QUALIFIER found in " + TableName.META_TABLE_NAME);
+              "Empty REGIONINFO_QUALIFIER found in " + connection.getMetaTableName());
             return true;
           }
           RegionInfo hri = rl.getRegionLocation(RegionInfo.DEFAULT_REPLICA_ID).getRegion();
@@ -2740,7 +2740,7 @@ public class HBaseFsck extends Configured implements Closeable {
               previous.setMetaEntry(m);
             } else {
               throw new IOException(
-                "Two entries in " + TableName.META_TABLE_NAME + " are same " + previous);
+                "Two entries in " + connection.getMetaTableName() + " are same " + previous);
             }
           }
           List<RegionInfo> mergeParents = CatalogFamilyFormat.getMergeRegions(result.rawCells());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsckRepair.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/HBaseFsckRepair.java
@@ -28,7 +28,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.ClusterMetrics.Option;
 import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.ServerName;
-import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.ZooKeeperConnectionException;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.AsyncClusterConnection;
@@ -149,7 +148,7 @@ public class HBaseFsckRepair {
   public static void fixMetaHoleOnlineAndAddReplicas(Configuration conf, RegionInfo hri,
     Collection<ServerName> servers, int numReplicas) throws IOException {
     Connection conn = ConnectionFactory.createConnection(conf);
-    Table meta = conn.getTable(TableName.META_TABLE_NAME);
+    Table meta = conn.getTable(conn.getMetaTableName());
     Put put = MetaTableAccessor.makePutFromRegionInfo(hri);
     if (numReplicas > 1) {
       Random rand = ThreadLocalRandom.current();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredHFilesOutputSink.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/wal/BoundedRecoveredHFilesOutputSink.java
@@ -17,8 +17,6 @@
  */
 package org.apache.hadoop.hbase.wal;
 
-import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
-
 import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.HashMap;
@@ -78,7 +76,7 @@ public class BoundedRecoveredHFilesOutputSink extends OutputSink {
   void append(RegionEntryBuffer buffer) throws IOException {
     Map<String, CellSet<ExtendedCell>> familyCells = new HashMap<>();
     Map<String, Long> familySeqIds = new HashMap<>();
-    boolean isMetaTable = buffer.tableName.equals(META_TABLE_NAME);
+    boolean isMetaTable = TableName.isMetaTableName(buffer.tableName);
     // First iterate all Cells to find which column families are present and to stamp Cell with
     // sequence id.
     for (WAL.Entry entry : buffer.entryBuffer) {

--- a/hbase-server/src/main/resources/hbase-webapps/master/catalogTables.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/catalogTables.jsp
@@ -56,7 +56,7 @@
         <td align="center"><%= frags.get(tableName.getNameAsString()) != null ? frags.get(tableName.getNameAsString()) + "%" : "n/a" %></td>
       <% } %>
     <% String description = "";
-        if (tableName.equals(TableName.META_TABLE_NAME)){
+        if (tableName.equals(master.getConnection().getMetaTableName())){
             description = "The hbase:meta table holds references to all User Table regions.";
         } else if (tableName.equals(CanaryTool.DEFAULT_WRITE_TABLE_NAME)){
             description = "The hbase:canary table is used to sniff the write availability of"

--- a/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
+++ b/hbase-server/src/main/resources/hbase-webapps/master/table.jsp
@@ -195,8 +195,8 @@
   Table table = master.getConnection().getTable(TableName.valueOf(fqtn));
   boolean showFragmentation = conf.getBoolean("hbase.master.ui.fragmentation.enabled", false);
   boolean readOnly = !InfoServer.canUserModifyUI(request, getServletContext(), conf);
-  int numMetaReplicas =
-    master.getTableDescriptors().get(TableName.META_TABLE_NAME).getRegionReplication();
+  int numMetaReplicas = master.getTableDescriptors()
+    .get(master.getConnection().getMetaTableName()).getRegionReplication();
   Map<String, Integer> frags = null;
   if (showFragmentation) {
       frags = FSUtils.getTableFragmentation(master);
@@ -317,7 +317,7 @@
 
 <div class="row">
 <% //Meta table.
-  if(fqtn.equals(TableName.META_TABLE_NAME.getNameAsString())) { %>
+  if(fqtn.equals(master.getConnection().getMetaTableName().getNameAsString())) { %>
   <section>
     <h2>Table Regions</h2>
     <div class="tabbable">
@@ -653,7 +653,7 @@
   </div>
   <div class="col-md-8">
     <form action="/table.jsp" method="get" class="row g-1 justify-content-end align-items-center" style="margin: 20px 0">
-      <input type="hidden" name="name" value="<%= TableName.META_TABLE_NAME %>" />
+      <input type="hidden" name="name" value="<%= master.getConnection().getMetaTableName() %>" />
       <div class="col-sm-auto">
         <label for="scan-limit" class="form-label">Scan Limit</label>
       </div>

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/backup/example/TestZooKeeperTableArchiveClient.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/backup/example/TestZooKeeperTableArchiveClient.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.ChoreService;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.Stoppable;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Connection;
@@ -98,6 +99,11 @@ public class TestZooKeeperTableArchiveClient {
     @Override
     public CompletableFuture<String> getClusterId() {
       return CompletableFuture.completedFuture("clusterId");
+    }
+
+    @Override
+    public CompletableFuture<TableName> getMetaTableName() {
+      return CompletableFuture.completedFuture(TableName.META_TABLE_NAME);
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyAsyncClusterConnection.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/DummyAsyncClusterConnection.java
@@ -45,6 +45,11 @@ public class DummyAsyncClusterConnection implements AsyncClusterConnection {
   }
 
   @Override
+  public TableName getMetaTableName() {
+    return null;
+  }
+
+  @Override
   public AsyncTableRegionLocator getRegionLocator(TableName tableName) {
     return null;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAdmin2.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAdmin2.java
@@ -35,6 +35,7 @@ import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.stream.Collectors;
 import org.apache.hadoop.hbase.ClusterMetrics.Option;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HBaseClassTestRule;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
@@ -82,15 +83,11 @@ public class TestAdmin2 extends TestAdminBase {
 
   @Test
   public void testCreateBadTables() throws IOException {
-    String msg = null;
-    try {
-      ADMIN.createTable(TableDescriptorBuilder.newBuilder(TableName.META_TABLE_NAME).build());
-    } catch (TableExistsException e) {
-      msg = e.toString();
-    }
-    assertTrue("Unexcepted exception message " + msg,
-      msg != null && msg.startsWith(TableExistsException.class.getName())
-        && msg.contains(TableName.META_TABLE_NAME.getNameAsString()));
+    DoNotRetryIOException reservedTableEx = assertThrows(DoNotRetryIOException.class, () -> ADMIN
+      .createTable(TableDescriptorBuilder.newBuilder(TableName.META_TABLE_NAME).build()));
+    assertTrue("Unexpected exception message " + reservedTableEx,
+      reservedTableEx.getMessage() != null
+        && reservedTableEx.getMessage().contains(TableName.META_TABLE_NAME.toString()));
 
     // Now try and do concurrent creation with a bunch of threads.
     TableDescriptor tableDescriptor =

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocator.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocator.java
@@ -106,10 +106,10 @@ public class TestAsyncNonMetaRegionLocator {
     admin.balancerSwitch(false, true);
 
     // Enable hbase:meta replication.
-    HBaseTestingUtil.setReplicas(admin, TableName.META_TABLE_NAME, NUM_OF_META_REPLICA);
-    TEST_UTIL.waitFor(30000,
-      () -> TEST_UTIL.getMiniHBaseCluster().getRegions(TableName.META_TABLE_NAME).size()
-          >= NUM_OF_META_REPLICA);
+    HBaseTestingUtil.setReplicas(admin, TEST_UTIL.getConnection().getMetaTableName(),
+      NUM_OF_META_REPLICA);
+    TEST_UTIL.waitFor(30000, () -> TEST_UTIL.getMiniHBaseCluster()
+      .getRegions(TEST_UTIL.getConnection().getMetaTableName()).size() >= NUM_OF_META_REPLICA);
 
     SPLIT_KEYS = new byte[8][];
     for (int i = 111; i < 999; i += 111) {
@@ -129,8 +129,8 @@ public class TestAsyncNonMetaRegionLocator {
     c.set(RegionLocator.LOCATOR_META_REPLICAS_MODE, metaReplicaMode.toString());
     ConnectionRegistry registry =
       ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    conn =
-      new AsyncConnectionImpl(c, registry, registry.getClusterId().get(), null, User.getCurrent());
+    conn = new AsyncConnectionImpl(c, registry, registry.getClusterId().get(),
+      TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent());
     locator = new AsyncNonMetaRegionLocator(conn, AsyncConnectionImpl.RETRY_TIMER);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocator.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocator.java
@@ -103,10 +103,10 @@ public class TestAsyncNonMetaRegionLocator {
     admin.balancerSwitch(false, true);
 
     // Enable hbase:meta replication.
-    HBaseTestingUtil.setReplicas(admin, TableName.META_TABLE_NAME, NUM_OF_META_REPLICA);
-    TEST_UTIL.waitFor(30000,
-      () -> TEST_UTIL.getMiniHBaseCluster().getRegions(TableName.META_TABLE_NAME).size()
-          >= NUM_OF_META_REPLICA);
+    HBaseTestingUtil.setReplicas(admin, TEST_UTIL.getConnection().getMetaTableName(),
+      NUM_OF_META_REPLICA);
+    TEST_UTIL.waitFor(30000, () -> TEST_UTIL.getMiniHBaseCluster()
+      .getRegions(TEST_UTIL.getConnection().getMetaTableName()).size() >= NUM_OF_META_REPLICA);
 
     SPLIT_KEYS = new byte[8][];
     for (int i = 111; i < 999; i += 111) {
@@ -126,8 +126,8 @@ public class TestAsyncNonMetaRegionLocator {
     c.set(RegionLocator.LOCATOR_META_REPLICAS_MODE, metaReplicaMode.toString());
     ConnectionRegistry registry =
       ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    conn =
-      new AsyncConnectionImpl(c, registry, registry.getClusterId().get(), null, User.getCurrent());
+    conn = new AsyncConnectionImpl(c, registry, registry.getClusterId().get(),
+      TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent());
     locator = new AsyncNonMetaRegionLocator(conn, AsyncConnectionImpl.RETRY_TIMER);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocatorConcurrenyLimit.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocatorConcurrenyLimit.java
@@ -126,8 +126,9 @@ public class TestAsyncNonMetaRegionLocatorConcurrenyLimit {
     TEST_UTIL.getAdmin().balancerSwitch(false, true);
     ConnectionRegistry registry =
       ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    CONN = new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry,
-      registry.getClusterId().get(), null, User.getCurrent());
+    CONN =
+      new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry, registry.getClusterId().get(),
+        TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent());
     LOCATOR = new AsyncNonMetaRegionLocator(CONN, AsyncConnectionImpl.RETRY_TIMER);
     SPLIT_KEYS = IntStream.range(1, 256).mapToObj(i -> Bytes.toBytes(String.format("%02x", i)))
       .toArray(byte[][]::new);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocatorConcurrenyLimit.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncNonMetaRegionLocatorConcurrenyLimit.java
@@ -121,8 +121,9 @@ public class TestAsyncNonMetaRegionLocatorConcurrenyLimit {
     TEST_UTIL.getAdmin().balancerSwitch(false, true);
     ConnectionRegistry registry =
       ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    CONN = new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry,
-      registry.getClusterId().get(), null, User.getCurrent());
+    CONN =
+      new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry, registry.getClusterId().get(),
+        TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent());
     LOCATOR = new AsyncNonMetaRegionLocator(CONN, AsyncConnectionImpl.RETRY_TIMER);
     SPLIT_KEYS = IntStream.range(1, 256).mapToObj(i -> Bytes.toBytes(String.format("%02x", i)))
       .toArray(byte[][]::new);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocator.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocator.java
@@ -101,8 +101,9 @@ public class TestAsyncRegionLocator {
     TEST_UTIL.waitTableAvailable(TABLE_NAME);
     ConnectionRegistry registry =
       ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    CONN = new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry,
-      registry.getClusterId().get(), null, User.getCurrent());
+    CONN =
+      new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry, registry.getClusterId().get(),
+        TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent());
     LOCATOR = CONN.getLocator();
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocator.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocator.java
@@ -96,8 +96,9 @@ public class TestAsyncRegionLocator {
     TEST_UTIL.waitTableAvailable(TABLE_NAME);
     ConnectionRegistry registry =
       ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    CONN = new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry,
-      registry.getClusterId().get(), null, User.getCurrent());
+    CONN =
+      new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry, registry.getClusterId().get(),
+        TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent());
     LOCATOR = CONN.getLocator();
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncSingleRequestRpcRetryingCaller.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncSingleRequestRpcRetryingCaller.java
@@ -74,8 +74,9 @@ public class TestAsyncSingleRequestRpcRetryingCaller {
     TEST_UTIL.waitTableAvailable(TABLE_NAME);
     ConnectionRegistry registry =
       ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    CONN = new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry,
-      registry.getClusterId().get(), null, User.getCurrent());
+    CONN =
+      new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry, registry.getClusterId().get(),
+        TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent());
   }
 
   @AfterClass
@@ -165,7 +166,8 @@ public class TestAsyncSingleRequestRpcRetryingCaller {
         }
       };
     try (AsyncConnectionImpl mockedConn = new AsyncConnectionImpl(CONN.getConfiguration(),
-      CONN.registry, CONN.registry.getClusterId().get(), null, User.getCurrent()) {
+      CONN.registry, CONN.registry.getClusterId().get(),
+      TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent()) {
 
       @Override
       AsyncRegionLocator getLocator() {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncSingleRequestRpcRetryingCaller.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncSingleRequestRpcRetryingCaller.java
@@ -69,8 +69,9 @@ public class TestAsyncSingleRequestRpcRetryingCaller {
     TEST_UTIL.waitTableAvailable(TABLE_NAME);
     ConnectionRegistry registry =
       ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    CONN = new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry,
-      registry.getClusterId().get(), null, User.getCurrent());
+    CONN =
+      new AsyncConnectionImpl(TEST_UTIL.getConfiguration(), registry, registry.getClusterId().get(),
+        TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent());
   }
 
   @AfterAll
@@ -160,7 +161,8 @@ public class TestAsyncSingleRequestRpcRetryingCaller {
         }
       };
     try (AsyncConnectionImpl mockedConn = new AsyncConnectionImpl(CONN.getConfiguration(),
-      CONN.registry, CONN.registry.getClusterId().get(), null, User.getCurrent()) {
+      CONN.registry, CONN.registry.getClusterId().get(),
+      TEST_UTIL.getConnection().getMetaTableName(), null, User.getCurrent()) {
 
       @Override
       AsyncRegionLocator getLocator() {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestCatalogReplicaLoadBalanceSimpleSelector.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestCatalogReplicaLoadBalanceSimpleSelector.java
@@ -18,7 +18,6 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.HConstants.EMPTY_START_ROW;
-import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 
@@ -67,14 +66,14 @@ public class TestCatalogReplicaLoadBalanceSimpleSelector {
     admin.balancerSwitch(false, true);
 
     // Enable hbase:meta replication.
-    HBaseTestingUtil.setReplicas(admin, TableName.META_TABLE_NAME, numOfMetaReplica);
-    TEST_UTIL.waitFor(30000,
-      () -> TEST_UTIL.getMiniHBaseCluster().getRegions(TableName.META_TABLE_NAME).size()
-          >= numOfMetaReplica);
+    HBaseTestingUtil.setReplicas(admin, TEST_UTIL.getConnection().getMetaTableName(),
+      numOfMetaReplica);
+    TEST_UTIL.waitFor(30000, () -> TEST_UTIL.getMiniHBaseCluster()
+      .getRegions(TEST_UTIL.getConnection().getMetaTableName()).size() >= numOfMetaReplica);
 
     registry = ConnectionRegistryFactory.create(TEST_UTIL.getConfiguration(), User.getCurrent());
-    CONN = new AsyncConnectionImpl(conf, registry, registry.getClusterId().get(), null,
-      User.getCurrent());
+    CONN = new AsyncConnectionImpl(conf, registry, registry.getClusterId().get(),
+      TableName.META_TABLE_NAME, null, User.getCurrent());
   }
 
   @AfterAll
@@ -89,18 +88,19 @@ public class TestCatalogReplicaLoadBalanceSimpleSelector {
       CONN.getConfiguration().get(RegionLocator.LOCATOR_META_REPLICAS_MODE_LOADBALANCE_SELECTOR,
         CatalogReplicaLoadBalanceSimpleSelector.class.getName());
 
-    CatalogReplicaLoadBalanceSelector metaSelector = CatalogReplicaLoadBalanceSelectorFactory
-      .createSelector(replicaSelectorClass, META_TABLE_NAME, CONN, () -> {
-        int numOfReplicas = CatalogReplicaLoadBalanceSelector.UNINITIALIZED_NUM_OF_REPLICAS;
-        try {
-          RegionLocations metaLocations = CONN.registry.getMetaRegionLocations()
-            .get(CONN.connConf.getMetaReadRpcTimeoutNs(), TimeUnit.NANOSECONDS);
-          numOfReplicas = metaLocations.size();
-        } catch (Exception e) {
-          LOG.error("Failed to get table {}'s region replication, ", META_TABLE_NAME, e);
-        }
-        return numOfReplicas;
-      });
+    CatalogReplicaLoadBalanceSelector metaSelector =
+      CatalogReplicaLoadBalanceSelectorFactory.createSelector(replicaSelectorClass,
+        TEST_UTIL.getConnection().getMetaTableName(), CONN, () -> {
+          int numOfReplicas = CatalogReplicaLoadBalanceSelector.UNINITIALIZED_NUM_OF_REPLICAS;
+          try {
+            RegionLocations metaLocations = CONN.registry.getMetaRegionLocations()
+              .get(CONN.connConf.getMetaReadRpcTimeoutNs(), TimeUnit.NANOSECONDS);
+            numOfReplicas = metaLocations.size();
+          } catch (Exception e) {
+            LOG.error("Failed to get table meta table's region replication, ", e);
+          }
+          return numOfReplicas;
+        });
 
     // Loop for 100 times, it should cover all replica ids.
     int[] replicaIdCount = new int[numOfMetaReplica];
@@ -111,20 +111,20 @@ public class TestCatalogReplicaLoadBalanceSimpleSelector {
     IntStream.range(0, numOfMetaReplica).forEach(i -> assertNotEquals(replicaIdCount[i], 0));
 
     // Change to No meta replica
-    HBaseTestingUtil.setReplicas(admin, TableName.META_TABLE_NAME, 1);
-    TEST_UTIL.waitFor(30000,
-      () -> TEST_UTIL.getMiniHBaseCluster().getRegions(TableName.META_TABLE_NAME).size() == 1);
+    HBaseTestingUtil.setReplicas(admin, TEST_UTIL.getConnection().getMetaTableName(), 1);
+    TEST_UTIL.waitFor(30000, () -> TEST_UTIL.getMiniHBaseCluster()
+      .getRegions(TEST_UTIL.getConnection().getMetaTableName()).size() == 1);
 
     CatalogReplicaLoadBalanceSelector metaSelectorWithNoReplica =
-      CatalogReplicaLoadBalanceSelectorFactory.createSelector(replicaSelectorClass, META_TABLE_NAME,
-        CONN, () -> {
+      CatalogReplicaLoadBalanceSelectorFactory.createSelector(replicaSelectorClass,
+        TEST_UTIL.getConnection().getMetaTableName(), CONN, () -> {
           int numOfReplicas = CatalogReplicaLoadBalanceSelector.UNINITIALIZED_NUM_OF_REPLICAS;
           try {
             RegionLocations metaLocations = CONN.registry.getMetaRegionLocations()
               .get(CONN.connConf.getMetaReadRpcTimeoutNs(), TimeUnit.NANOSECONDS);
             numOfReplicas = metaLocations.size();
           } catch (Exception e) {
-            LOG.error("Failed to get table {}'s region replication, ", META_TABLE_NAME, e);
+            LOG.error("Failed to get table meta table's region replication, ", e);
           }
           return numOfReplicas;
         });

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFallbackToUseReplay.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFallbackToUseReplay.java
@@ -98,8 +98,8 @@ public class TestFallbackToUseReplay {
       done.run(null);
       return null;
     }).when(stub).replay(any(), any(), any());
-    CONN = new AsyncClusterConnectionImpl(CONF, mock(ConnectionRegistry.class), "test", null,
-      User.getCurrent()) {
+    CONN = new AsyncClusterConnectionImpl(CONF, mock(ConnectionRegistry.class), "test",
+      TableName.META_TABLE_NAME, null, User.getCurrent()) {
 
       @Override
       AsyncRegionLocator getLocator() {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFallbackToUseReplay.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestFallbackToUseReplay.java
@@ -93,8 +93,8 @@ public class TestFallbackToUseReplay {
       done.run(null);
       return null;
     }).when(stub).replay(any(), any(), any());
-    CONN = new AsyncClusterConnectionImpl(CONF, mock(ConnectionRegistry.class), "test", null,
-      User.getCurrent()) {
+    CONN = new AsyncClusterConnectionImpl(CONF, mock(ConnectionRegistry.class), "test",
+      TableName.META_TABLE_NAME, null, User.getCurrent()) {
 
       @Override
       AsyncRegionLocator getLocator() {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/MockNoopMasterServices.java
@@ -598,6 +598,11 @@ public class MockNoopMasterServices implements MasterServices {
   }
 
   @Override
+  public TableName getMetaTableName() {
+    return null;
+  }
+
+  @Override
   public KeyManagementService getKeyManagementService() {
     return this;
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMigrateAndMirrorMetaLocations.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMigrateAndMirrorMetaLocations.java
@@ -20,7 +20,7 @@ package org.apache.hadoop.hbase.master;
 import static org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil.lengthOfPBMagic;
 import static org.apache.hadoop.hbase.zookeeper.ZKMetadata.removeMetaData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
-import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -42,6 +42,7 @@ import org.apache.hadoop.hbase.procedure2.Procedure;
 import org.apache.hadoop.hbase.regionserver.RegionScanner;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.zookeeper.ZKUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -89,18 +90,29 @@ public class TestMigrateAndMirrorMetaLocations {
 
   private void checkMirrorLocation(int replicaCount) throws Exception {
     MasterRegion masterRegion = UTIL.getMiniHBaseCluster().getMaster().getMasterRegion();
+    Result locationResult = null;
     try (RegionScanner scanner =
       masterRegion.getRegionScanner(new Scan().addFamily(HConstants.CATALOG_FAMILY))) {
       List<Cell> cells = new ArrayList<>();
-      boolean moreRows = scanner.next(cells);
-      // should only have one row as we have only one meta region, different replicas will be in the
-      // same row
-      assertFalse(moreRows);
-      assertFalse(cells.isEmpty());
-      Result result = Result.create(cells);
-      // make sure we publish the correct location to zookeeper too
-      assertLocationEquals(result, replicaCount);
+      boolean moreRows;
+      do {
+        cells.clear();
+        moreRows = scanner.next(cells);
+        if (!cells.isEmpty()) {
+          Result result = Result.create(cells);
+          // find the row that contains meta region location data; other rows in CATALOG_FAMILY
+          // (e.g. meta_table_name written by MetaTableNameStore) should be skipped
+          if (CatalogFamilyFormat.getRegionLocations(result) != null) {
+            locationResult = result;
+            break;
+          }
+        }
+      } while (moreRows);
     }
+    // should have one meta region row with all replicas in the same row
+    assertNotNull(locationResult, "No meta region location found in MasterRegion CATALOG_FAMILY");
+    // make sure we publish the correct location to zookeeper too
+    assertLocationEquals(locationResult, replicaCount);
   }
 
   private void waitUntilNoSCP() throws IOException {
@@ -108,33 +120,67 @@ public class TestMigrateAndMirrorMetaLocations {
       .filter(p -> p instanceof ServerCrashProcedure).allMatch(Procedure::isSuccess));
   }
 
+  private void deleteAllCatalogFamilyRows(MasterRegion masterRegion) throws IOException {
+    List<byte[]> rows = new ArrayList<>();
+    try (RegionScanner scanner =
+      masterRegion.getRegionScanner(new Scan().addFamily(HConstants.CATALOG_FAMILY))) {
+      List<Cell> cells = new ArrayList<>();
+      boolean moreRows;
+      do {
+        cells.clear();
+        moreRows = scanner.next(cells);
+        if (!cells.isEmpty()) {
+          byte[] row = Result.create(cells).getRow();
+          boolean duplicate = false;
+          for (byte[] existing : rows) {
+            if (Bytes.equals(existing, row)) {
+              duplicate = true;
+              break;
+            }
+          }
+          if (!duplicate) {
+            rows.add(row);
+          }
+        }
+      } while (moreRows);
+    }
+    for (byte[] row : rows) {
+      masterRegion.update(r -> r.delete(new Delete(row).addFamily(HConstants.CATALOG_FAMILY)));
+    }
+    masterRegion.flush(true);
+  }
+
   @Test
   public void test() throws Exception {
     checkMirrorLocation(2);
     MasterRegion masterRegion = UTIL.getMiniHBaseCluster().getMaster().getMasterRegion();
-    try (RegionScanner scanner =
-      masterRegion.getRegionScanner(new Scan().addFamily(HConstants.CATALOG_FAMILY))) {
-      List<Cell> cells = new ArrayList<>();
-      scanner.next(cells);
-      Cell cell = cells.get(0);
-      // delete the only row
-      masterRegion.update(
-        r -> r.delete(new Delete(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength())
-          .addFamily(HConstants.CATALOG_FAMILY)));
-      masterRegion.flush(true);
-    }
+    deleteAllCatalogFamilyRows(masterRegion);
     // restart the whole cluster, to see if we can migrate the data on zookeeper to master local
     // region
     UTIL.shutdownMiniHBaseCluster();
     UTIL.startMiniHBaseCluster(StartTestingClusterOption.builder().numRegionServers(3).build());
     masterRegion = UTIL.getMiniHBaseCluster().getMaster().getMasterRegion();
+    // After ZK migration, master may also persist MetaTableNameStore on the same info family; only
+    // one row should carry hbase:meta replica locations.
     try (RegionScanner scanner =
       masterRegion.getRegionScanner(new Scan().addFamily(HConstants.CATALOG_FAMILY))) {
       List<Cell> cells = new ArrayList<>();
-      boolean moreRows = scanner.next(cells);
-      assertFalse(moreRows);
-      // should have the migrated data
-      assertFalse(cells.isEmpty());
+      int rowsWithMetaLocations = 0;
+      Result migrated = null;
+      boolean moreRows;
+      do {
+        cells.clear();
+        moreRows = scanner.next(cells);
+        if (!cells.isEmpty()) {
+          Result r = Result.create(cells);
+          if (CatalogFamilyFormat.getRegionLocations(r) != null) {
+            rowsWithMetaLocations++;
+            migrated = r;
+          }
+        }
+      } while (moreRows);
+      assertNotNull(migrated, "No migrated meta locations in MasterRegion");
+      assertEquals(1, rowsWithMetaLocations);
     }
     // wait until all meta regions have been assigned
     UTIL.waitFor(30000,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestSerialReplicationChecker.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestSerialReplicationChecker.java
@@ -115,6 +115,7 @@ public class TestSerialReplicationChecker {
     when(source.getReplicationQueueStorage()).thenReturn(QUEUE_STORAGE);
     conn = mock(Connection.class);
     when(conn.isClosed()).thenReturn(false);
+    when(conn.getMetaTableName()).thenReturn(UTIL.getConnection().getMetaTableName());
     doAnswer(new Answer<Table>() {
 
       @Override
@@ -162,7 +163,7 @@ public class TestSerialReplicationChecker {
       put.addColumn(HConstants.REPLICATION_BARRIER_FAMILY, HConstants.SEQNUM_QUALIFIER,
         put.getTimestamp() - barriers.length + i, Bytes.toBytes(barriers[i]));
     }
-    try (Table table = UTIL.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = UTIL.getConnection().getMetaTable()) {
       table.put(put);
     }
   }
@@ -171,7 +172,7 @@ public class TestSerialReplicationChecker {
     Put put = new Put(region.getRegionName(), EnvironmentEdgeManager.currentTime());
     put.addColumn(HConstants.CATALOG_FAMILY, HConstants.STATE_QUALIFIER,
       Bytes.toBytes(state.name()));
-    try (Table table = UTIL.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = UTIL.getConnection().getMetaTable()) {
       table.put(put);
     }
   }
@@ -188,7 +189,7 @@ public class TestSerialReplicationChecker {
     put.addColumn(HConstants.REPLICATION_BARRIER_FAMILY,
       ReplicationBarrierFamilyFormat.REPLICATION_PARENT_QUALIFIER,
       ReplicationBarrierFamilyFormat.getParentsBytes(parents));
-    try (Table table = UTIL.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = UTIL.getConnection().getMetaTable()) {
       table.put(put);
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestSerialReplicationChecker.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestSerialReplicationChecker.java
@@ -109,6 +109,7 @@ public class TestSerialReplicationChecker {
     when(source.getReplicationQueueStorage()).thenReturn(QUEUE_STORAGE);
     conn = mock(Connection.class);
     when(conn.isClosed()).thenReturn(false);
+    when(conn.getMetaTableName()).thenReturn(UTIL.getConnection().getMetaTableName());
     doAnswer(new Answer<Table>() {
 
       @Override
@@ -156,7 +157,7 @@ public class TestSerialReplicationChecker {
       put.addColumn(HConstants.REPLICATION_BARRIER_FAMILY, HConstants.SEQNUM_QUALIFIER,
         put.getTimestamp() - barriers.length + i, Bytes.toBytes(barriers[i]));
     }
-    try (Table table = UTIL.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = UTIL.getConnection().getMetaTable()) {
       table.put(put);
     }
   }
@@ -165,7 +166,7 @@ public class TestSerialReplicationChecker {
     Put put = new Put(region.getRegionName(), EnvironmentEdgeManager.currentTime());
     put.addColumn(HConstants.CATALOG_FAMILY, HConstants.STATE_QUALIFIER,
       Bytes.toBytes(state.name()));
-    try (Table table = UTIL.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = UTIL.getConnection().getMetaTable()) {
       table.put(put);
     }
   }
@@ -182,7 +183,7 @@ public class TestSerialReplicationChecker {
     put.addColumn(HConstants.REPLICATION_BARRIER_FAMILY,
       ReplicationBarrierFamilyFormat.REPLICATION_PARENT_QUALIFIER,
       ReplicationBarrierFamilyFormat.getParentsBytes(parents));
-    try (Table table = UTIL.getConnection().getTable(TableName.META_TABLE_NAME)) {
+    try (Table table = UTIL.getConnection().getMetaTable()) {
       table.put(put);
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
@@ -187,7 +187,7 @@ public class TestWALEntrySinkFilter {
     private final Configuration conf;
 
     public DevNullAsyncClusterConnection(Configuration conf, Object registry, String clusterId,
-      SocketAddress localAddress, User user) {
+      TableName metaTableName, SocketAddress localAddress, User user) {
       this.conf = conf;
     }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/regionserver/TestWALEntrySinkFilter.java
@@ -179,7 +179,7 @@ public class TestWALEntrySinkFilter {
     private final Configuration conf;
 
     public DevNullAsyncClusterConnection(Configuration conf, Object registry, String clusterId,
-      SocketAddress localAddress, User user) {
+      TableName metaTableName, SocketAddress localAddress, User user) {
       this.conf = conf;
     }
 

--- a/hbase-shell/src/main/ruby/hbase/table.rb
+++ b/hbase-shell/src/main/ruby/hbase/table.rb
@@ -748,7 +748,7 @@ EOF
 
     # Checks if current table is one of the 'meta' tables
     def is_meta_table?
-      org.apache.hadoop.hbase.TableName::META_TABLE_NAME.equals(@table.getName)
+      org.apache.hadoop.hbase.TableName.isMetaTableName(@table.getName)
     end
 
     # Given a column specification in the format FAMILY[:QUALIFIER[:CONVERTER]]

--- a/hbase-testing-util/src/main/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
+++ b/hbase-testing-util/src/main/java/org/apache/hadoop/hbase/HBaseTestingUtility.java
@@ -1126,7 +1126,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
     // Populate the master address configuration from mini cluster configuration.
     conf.set(HConstants.MASTER_ADDRS_KEY, MasterRegistry.getMasterAddr(c));
     // Don't leave here till we've done a successful scan of the hbase:meta
-    try (Table t = getConnection().getTable(TableName.META_TABLE_NAME);
+    try (Table t = getConnection().getTable(getConnection().getMetaTableName());
       ResultScanner s = t.getScanner(new Scan())) {
       for (;;) {
         if (s.next() == null) {
@@ -1248,7 +1248,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
       option.getMasterClass(), option.getRsClass());
     // Don't leave here till we've done a successful scan of the hbase:meta
     Connection conn = ConnectionFactory.createConnection(this.conf);
-    Table t = conn.getTable(TableName.META_TABLE_NAME);
+    Table t = conn.getTable(getConnection().getMetaTableName());
     ResultScanner s = t.getScanner(new Scan());
     while (s.next() != null) {
       // do nothing
@@ -2416,7 +2416,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
    */
   public List<RegionInfo> createMultiRegionsInMeta(final Configuration conf,
     final TableDescriptor htd, byte[][] startKeys) throws IOException {
-    Table meta = getConnection().getTable(TableName.META_TABLE_NAME);
+    Table meta = getConnection().getTable(getConnection().getMetaTableName());
     Arrays.sort(startKeys, Bytes.BYTES_COMPARATOR);
     List<RegionInfo> newRegions = new ArrayList<>(startKeys.length);
     MetaTableAccessor.updateTableState(getConnection(), htd.getTableName(),
@@ -2498,7 +2498,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
    */
   public List<byte[]> getMetaTableRows() throws IOException {
     // TODO: Redo using MetaTableAccessor class
-    Table t = getConnection().getTable(TableName.META_TABLE_NAME);
+    Table t = getConnection().getTable(getConnection().getMetaTableName());
     List<byte[]> rows = new ArrayList<>();
     ResultScanner s = t.getScanner(new Scan());
     for (Result result : s) {
@@ -2516,7 +2516,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
    */
   public List<byte[]> getMetaTableRows(TableName tableName) throws IOException {
     // TODO: Redo using MetaTableAccessor.
-    Table t = getConnection().getTable(TableName.META_TABLE_NAME);
+    Table t = getConnection().getTable(getConnection().getMetaTableName());
     List<byte[]> rows = new ArrayList<>();
     ResultScanner s = t.getScanner(new Scan());
     for (Result result : s) {
@@ -2851,7 +2851,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
     monitor.close();
 
     if (checkStatus) {
-      getConnection().getTable(TableName.META_TABLE_NAME).close();
+      getConnection().getTable(getConnection().getMetaTableName()).close();
     }
   }
 
@@ -3376,7 +3376,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
    * Waith until all system table's regions get assigned
    */
   public void waitUntilAllSystemRegionsAssigned() throws IOException {
-    waitUntilAllRegionsAssigned(TableName.META_TABLE_NAME);
+    waitUntilAllRegionsAssigned(getConnection().getMetaTableName());
   }
 
   /**
@@ -3389,7 +3389,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
   public void waitUntilAllRegionsAssigned(final TableName tableName, final long timeout)
     throws IOException {
     if (!TableName.isMetaTableName(tableName)) {
-      try (final Table meta = getConnection().getTable(TableName.META_TABLE_NAME)) {
+      try (final Table meta = getConnection().getTable(getConnection().getMetaTableName())) {
         LOG.debug("Waiting until all regions of table " + tableName + " get assigned. Timeout = "
           + timeout + "ms");
         waitFor(timeout, 200, true, new ExplainingPredicate<IOException>() {
@@ -3607,7 +3607,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
       Bytes.toBytes(String.format(keyFormat, splitEndKey)), numRegions);
 
     if (hbaseCluster != null) {
-      getMiniHBaseCluster().flushcache(TableName.META_TABLE_NAME);
+      getMiniHBaseCluster().flushcache(getConnection().getMetaTableName());
     }
 
     BufferedMutator mutator = getConnection().getBufferedMutator(tableName);
@@ -3822,7 +3822,7 @@ public class HBaseTestingUtility extends HBaseZKTestingUtility {
   }
 
   public static int getMetaRSPort(Connection connection) throws IOException {
-    try (RegionLocator locator = connection.getRegionLocator(TableName.META_TABLE_NAME)) {
+    try (RegionLocator locator = connection.getRegionLocator(connection.getMetaTableName())) {
       return locator.getRegionLocation(Bytes.toBytes("")).getPort();
     }
   }

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftHBaseServiceHandler.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftHBaseServiceHandler.java
@@ -1072,12 +1072,12 @@ public class ThriftHBaseServiceHandler extends HBaseServiceHandler implements Hb
   public TRegionInfo getRegionInfo(ByteBuffer searchRow) throws IOError {
     try {
       byte[] row = getBytes(searchRow);
-      Result startRowResult =
-        getReverseScanResult(TableName.META_TABLE_NAME.getName(), row, HConstants.CATALOG_FAMILY);
+      Result startRowResult = getReverseScanResult(
+        connectionCache.getAdmin().getConnection().getMetaTableName().getName(), row,
+        HConstants.CATALOG_FAMILY);
 
       if (startRowResult == null) {
-        throw new IOException(
-          "Cannot find row in " + TableName.META_TABLE_NAME + ", row=" + Bytes.toStringBinary(row));
+        throw new IOException("Cannot find row in hbase:meta, row=" + Bytes.toStringBinary(row));
       }
 
       // find region start and end keys

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftHBaseServiceHandler.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift/ThriftHBaseServiceHandler.java
@@ -1033,12 +1033,12 @@ public class ThriftHBaseServiceHandler extends HBaseServiceHandler implements Hb
   public TRegionInfo getRegionInfo(ByteBuffer searchRow) throws IOError {
     try {
       byte[] row = getBytes(searchRow);
-      Result startRowResult =
-        getReverseScanResult(TableName.META_TABLE_NAME.getName(), row, HConstants.CATALOG_FAMILY);
+      Result startRowResult = getReverseScanResult(
+        connectionCache.getAdmin().getConnection().getMetaTableName().getName(), row,
+        HConstants.CATALOG_FAMILY);
 
       if (startRowResult == null) {
-        throw new IOException(
-          "Cannot find row in " + TableName.META_TABLE_NAME + ", row=" + Bytes.toStringBinary(row));
+        throw new IOException("Cannot find row in hbase:meta, row=" + Bytes.toStringBinary(row));
       }
 
       // find region start and end keys

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftConnection.java
@@ -370,6 +370,11 @@ public class ThriftConnection implements Connection {
   }
 
   @Override
+  public TableName getMetaTableName() {
+    throw new NotImplementedException("getMetaTableName not supported in ThriftConnection");
+  }
+
+  @Override
   public AsyncConnection toAsyncConnection() {
     throw new NotImplementedException("toAsyncConnection not supported in ThriftTable");
   }


### PR DESCRIPTION
[HBASE-29691: ](https://issues.apache.org/jira/browse/HBASE-29691) Change TableName.META_TABLE_NAME from being a global static 

Change TableName.META_TABLE_NAME from a global static constant to a dynamically discovered value from ConnectionRegistry. 

Please refer to earlier discussion on the PR https://github.com/apache/hbase/pull/7558/ for further details. 

Key changes:
- Add ConnectionRegistry.getMetaTableName() method for dynamic discovery
- Add MetaTableNameStore for persisting meta table name in master region
- Update TableName to support dynamic meta table name
- Update HMaster to integrate with MetaTableNameStore
- Update all client and server code to use dynamic meta table name
- Add protobuf changes for meta table name in Registry.proto

Refactoring for the test classes to be handled separately.