### PR TITLE
HBASE-29878 Improve the Documentation UI (addendum) - fix author check in nightly

### DIFF
--- a/.github/workflows/yetus-general-check.yml
+++ b/.github/workflows/yetus-general-check.yml
@@ -115,7 +115,7 @@ jobs:
           SOURCEDIR: "${{ github.workspace }}/src"
           TESTS_FILTER: "checkstyle,javac,pylint,shellcheck,shelldocs,blanks,perlcritic,ruby-lint,rubocop"
           YETUSDIR: "${{ github.workspace }}/yetus"
-          AUTHOR_IGNORE_LIST: "src/main/asciidoc/_chapters/developer.adoc"
+          AUTHOR_IGNORE_LIST: "hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/building-and-developing/developer-guidelines.mdx,hbase-website/public/book.html"
           BLANKS_EOL_IGNORE_FILE: "dev-support/blanks-eol-ignore.txt"
           BLANKS_TABS_IGNORE_FILE: "dev-support/blanks-tabs-ignore.txt"
           EXCLUDE_TESTS_URL: "https://ci-hbase.apache.org/job/HBase-Find-Flaky-Tests/job/${{ github.base_ref }}/lastSuccessfulBuild/artifact/output/excludes"

--- a/.github/workflows/yetus-jdk17-hadoop3-compile-check.yml
+++ b/.github/workflows/yetus-jdk17-hadoop3-compile-check.yml
@@ -114,7 +114,7 @@ jobs:
           SOURCEDIR: "${{ github.workspace }}/src"
           TESTS_FILTER: "javac,javadoc"
           YETUSDIR: "${{ github.workspace }}/yetus"
-          AUTHOR_IGNORE_LIST: "src/main/asciidoc/_chapters/developer.adoc"
+          AUTHOR_IGNORE_LIST: "hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/building-and-developing/developer-guidelines.mdx,hbase-website/public/book.html"
           BLANKS_EOL_IGNORE_FILE: "dev-support/blanks-eol-ignore.txt"
           BLANKS_TABS_IGNORE_FILE: "dev-support/blanks-tabs-ignore.txt"
           BUILD_THREAD: "4"

--- a/.github/workflows/yetus-jdk17-hadoop3-unit-check.yml
+++ b/.github/workflows/yetus-jdk17-hadoop3-unit-check.yml
@@ -132,7 +132,7 @@ jobs:
           SET_JAVA_HOME: "/usr/lib/jvm/java-17"
           SOURCEDIR: "${{ github.workspace }}/src"
           YETUSDIR: "${{ github.workspace }}/yetus"
-          AUTHOR_IGNORE_LIST: "src/main/asciidoc/_chapters/developer.adoc"
+          AUTHOR_IGNORE_LIST: "hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/building-and-developing/developer-guidelines.mdx,hbase-website/public/book.html"
           BLANKS_EOL_IGNORE_FILE: "dev-support/blanks-eol-ignore.txt"
           BLANKS_TABS_IGNORE_FILE: "dev-support/blanks-tabs-ignore.txt"
           EXCLUDE_TESTS_URL: "https://ci-hbase.apache.org/job/HBase-Find-Flaky-Tests/job/${{ github.base_ref }}/lastSuccessfulBuild/artifact/output/excludes"

--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -43,7 +43,7 @@ pipeline {
     PROJECT_PERSONALITY = 'https://raw.githubusercontent.com/apache/hbase/master/dev-support/hbase-personality.sh'
     PERSONALITY_FILE = 'tools/personality.sh'
     // This section of the docs tells folks not to use the javadoc tag. older branches have our old version of the check for said tag.
-    AUTHOR_IGNORE_LIST = 'src/main/asciidoc/_chapters/developer.adoc'
+    AUTHOR_IGNORE_LIST = 'hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/building-and-developing/developer-guidelines.mdx,hbase-website/public/book.html'
     BLANKS_EOL_IGNORE_FILE = 'dev-support/blanks-eol-ignore.txt'
     BLANKS_TABS_IGNORE_FILE = 'dev-support/blanks-tabs-ignore.txt'
     // output from surefire; sadly the archive function in yetus only works on file names.

--- a/dev-support/Jenkinsfile_GitHub
+++ b/dev-support/Jenkinsfile_GitHub
@@ -41,7 +41,7 @@ pipeline {
         GENERAL_CHECK_PLUGINS = 'all,-javadoc,-jira,-shadedjars,-unit'
         JDK_SPECIFIC_PLUGINS = 'compile,github,htmlout,javac,javadoc,maven,mvninstall,shadedjars,unit'
         // This section of the docs tells folks not to use the javadoc tag. older branches have our old version of the check for said tag.
-        AUTHOR_IGNORE_LIST = 'src/main/asciidoc/_chapters/developer.adoc'
+        AUTHOR_IGNORE_LIST = 'hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/building-and-developing/developer-guidelines.mdx,hbase-website/public/book.html'
         BLANKS_EOL_IGNORE_FILE = 'dev-support/blanks-eol-ignore.txt'
         BLANKS_TABS_IGNORE_FILE = 'dev-support/blanks-tabs-ignore.txt'
         // output from surefire; sadly the archive function in yetus only works on file names.

--- a/dev-support/hadoop3-backwards-compatibility-check.Jenkinsfile
+++ b/dev-support/hadoop3-backwards-compatibility-check.Jenkinsfile
@@ -135,7 +135,7 @@ pipeline {
           SKIP_ERRORPRONE = true
           OUTPUT_DIR_RELATIVE = "output-jdk17-hadoop3-backwards-${HADOOP3_VERSION}"
           OUTPUT_DIR = "${WORKSPACE}/${OUTPUT_DIR_RELATIVE}"
-          AUTHOR_IGNORE_LIST = 'src/main/asciidoc/_chapters/developer.adoc'
+          AUTHOR_IGNORE_LIST = 'hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/building-and-developing/developer-guidelines.mdx,hbase-website/public/book.html'
           BLANKS_EOL_IGNORE_FILE = 'dev-support/blanks-eol-ignore.txt'
           BLANKS_TABS_IGNORE_FILE = 'dev-support/blanks-tabs-ignore.txt'
           // output from surefire; sadly the archive function in yetus only works on file names.

--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -290,6 +290,64 @@ function personality_modules
   done
 }
 
+# This is a workaround to fix the author check until YETUS-1266 is released.
+# TODO: Remove this when we upgraded to Yetus having YETUS-1266!
+## @description  Check the current directory for @author tags
+## @audience     private
+## @stability    evolving
+## @replaceable  no
+## @return       0 on success
+## @return       1 on failure
+function author_postcompile
+{
+  # shellcheck disable=SC2155
+  declare -r appname=$(basename "${BASH_SOURCE-$0}")
+  declare -a globalignore
+
+  big_console_header "*** HBase Monkey-Patch: author_postcompile ***"
+
+  yetus_debug "HBase Monkey-Patch: author_postcompile"
+
+  if [[ "${BUILDMODE}" != full ]]; then
+    return
+  fi
+
+  big_console_header "Checking for @author tags: ${BUILDMODE}"
+
+  start_clock
+
+  if [[ -f "${PATCH_DIR}/excluded.txt" ]]; then
+    globalignore=("${GREP}" "-v" "-f" "${PATCH_DIR}/excluded.txt")
+  else
+    globalignore=("cat")
+  fi
+
+  "${GIT}" grep -n -I --extended-regexp -i -e '^[^-].*@author' \
+    | "${GREP}" -v "${appname}" \
+    | "${globalignore[@]}" \
+    >> "${PATCH_DIR}/author-tags-git.txt"
+
+  if [[ -z "${AUTHOR_IGNORE_LIST[0]}" ]]; then
+    cp -p "${PATCH_DIR}/author-tags-git.txt" "${PATCH_DIR}/${AUTHOR_LOGNAME}"
+  else
+    for i in "${AUTHOR_IGNORE_LIST[@]}"; do
+      printf "%s\n" "${i}"
+    done \
+      | "${SED}" 's/[][\\.^$*+?{}()|]/\\&/g' \
+      | "${SED}" 's/^/^/' \
+      > "${PATCH_DIR}/author-tags-filter.txt"
+
+    cat "${PATCH_DIR}/author-tags-filter.txt"
+
+    "${GREP}" -v -E \
+      -f "${PATCH_DIR}/author-tags-filter.txt" \
+      "${PATCH_DIR}/author-tags-git.txt" \
+      > "${PATCH_DIR}/${AUTHOR_LOGNAME}"
+  fi
+
+  author_generic
+}
+
 ## @description places where we override the built in assumptions about what tests to run
 ## @audience    private
 ## @stability   evolving

--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -292,7 +292,7 @@ function personality_modules
 
 # This is a workaround to fix the author check until YETUS-1266 is released.
 # TODO: Remove this when we upgraded to Yetus having YETUS-1266!
-## @description  Check the current directory for @author tags
+## @description  Check the current directory for author tags
 ## @audience     private
 ## @stability    evolving
 ## @replaceable  no

--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -332,9 +332,6 @@ function author_postcompile
       | "${SED}" 's/[][\\.^$*+?{}()|]/\\&/g' \
       | "${SED}" 's/^/^/' \
       > "${PATCH_DIR}/author-tags-filter.txt"
-
-    cat "${PATCH_DIR}/author-tags-filter.txt"
-
     "${GREP}" -v -E \
       -f "${PATCH_DIR}/author-tags-filter.txt" \
       "${PATCH_DIR}/author-tags-git.txt" \

--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -304,10 +304,6 @@ function author_postcompile
   declare -r appname=$(basename "${BASH_SOURCE-$0}")
   declare -a globalignore
 
-  big_console_header "*** HBase Monkey-Patch: author_postcompile ***"
-
-  yetus_debug "HBase Monkey-Patch: author_postcompile"
-
   if [[ "${BUILDMODE}" != full ]]; then
     return
   fi


### PR DESCRIPTION
The author check fails in nightly build:

```
hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/building-and-developing/developer-guidelines.mdx:154:Also, no `@author` tags - that's a rule.
hbase-website/public/book.html:40827:<p>Also, no <code>@author</code> tags - that’s a rule.</p>
```

https://ci-hbase.apache.org/job/HBase%20Nightly/job/master/1420/General_20Nightly_20Build_20Report/

Fix:
Ignore files under hbase-website in author checks.