### PR TITLE
HBASE-29081: Add HBase Read Replica Cluster feature

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalBackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalBackupManager.java
@@ -28,6 +28,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.util.BackupUtils;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.procedure2.store.wal.WALProcedureStore;
@@ -156,7 +157,7 @@ public class IncrementalBackupManager extends BackupManager {
         LOG.debug("currentLogFile: " + log.getPath().toString());
         if (AbstractFSWALProvider.isMetaFile(log.getPath())) {
           if (LOG.isDebugEnabled()) {
-            LOG.debug("Skip hbase:meta log file: " + log.getPath().getName());
+            LOG.debug("Skip {} log file: {}", TableName.META_TABLE_NAME, log.getPath().getName());
           }
           continue;
         }

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/BackupLogCleaner.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/master/BackupLogCleaner.java
@@ -204,6 +204,6 @@ public class BackupLogCleaner extends BaseLogCleanerDelegate {
     String fn = path.getName();
     return fn.startsWith(WALProcedureStore.LOG_PREFIX)
       || fn.endsWith(MasterRegionFactory.ARCHIVED_WAL_SUFFIX)
-      || path.toString().contains("/%s/".formatted(MasterRegionFactory.MASTER_STORE_DIR));
+      || path.toString().contains("/%s/".formatted(MasterRegionFactory.MASTER_REGION_DIR_NAME));
   }
 }

--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/SnapshotOfRegionAssignmentFromMeta.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/SnapshotOfRegionAssignmentFromMeta.java
@@ -170,7 +170,8 @@ public class SnapshotOfRegionAssignmentFromMeta {
    * Initialize the region assignment snapshot by scanning the hbase:meta table
    */
   public void initialize() throws IOException {
-    LOG.info("Start to scan the hbase:meta for the current region assignment " + "snappshot");
+    LOG.info("Start to scan {} for the current region assignment snapshot",
+      TableName.META_TABLE_NAME);
     // Scan hbase:meta to pick up user regions
     try (Table metaTable = connection.getTable(TableName.META_TABLE_NAME);
       ResultScanner scanner = metaTable.getScanner(HConstants.CATALOG_FAMILY)) {
@@ -187,7 +188,8 @@ public class SnapshotOfRegionAssignmentFromMeta {
         }
       }
     }
-    LOG.info("Finished to scan the hbase:meta for the current region assignment" + "snapshot");
+    LOG.info("Finished scanning {} for the current region assignment snapshot",
+      TableName.META_TABLE_NAME);
   }
 
   private void addRegion(RegionInfo regionInfo) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ActiveClusterSuffix.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ActiveClusterSuffix.java
@@ -1,0 +1,142 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import java.io.IOException;
+import java.util.Objects;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hbase.thirdparty.com.google.common.base.Strings;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ActiveClusterSuffixProtos;
+
+/**
+ * The read-replica cluster id for this cluster. It is serialized to the filesystem and up into
+ * zookeeper. This is a container for the id. Also knows how to serialize and deserialize the
+ * cluster id.
+ */
+@InterfaceAudience.Private
+public class ActiveClusterSuffix implements ClusterIdFile {
+  private final String clusterId;
+  private final String suffix;
+
+  public static class Parser implements ClusterIdFileParser<ActiveClusterSuffix> {
+
+    @Override
+    public String getFileName() {
+      return HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME;
+    }
+
+    /**
+     * Parse the serialized representation of the {@link ActiveClusterSuffix}
+     * @param bytes A pb serialized {@link ActiveClusterSuffix} instance with pb magic prefix
+     * @return An instance of {@link ActiveClusterSuffix} made from <code>bytes</code>
+     * @see #toByteArray()
+     */
+    @Override
+    public ActiveClusterSuffix parseFrom(byte[] bytes) throws DeserializationException {
+      if (ProtobufUtil.isPBMagicPrefix(bytes)) {
+        int pblen = ProtobufUtil.lengthOfPBMagic();
+        ActiveClusterSuffixProtos.ActiveClusterSuffix.Builder builder =
+          ActiveClusterSuffixProtos.ActiveClusterSuffix.newBuilder();
+        ActiveClusterSuffixProtos.ActiveClusterSuffix cs = null;
+        try {
+          ProtobufUtil.mergeFrom(builder, bytes, pblen, bytes.length - pblen);
+          cs = builder.build();
+        } catch (IOException e) {
+          throw new DeserializationException(e);
+        }
+        return convert(cs);
+      } else {
+        // Presume it was written out this way, the old way.
+        return new ActiveClusterSuffix(Bytes.toString(bytes));
+      }
+    }
+
+    @Override
+    public ActiveClusterSuffix readString(String input) {
+      return new ActiveClusterSuffix(input);
+    }
+  }
+
+  public ActiveClusterSuffix(final String clusterId, final String suffix) {
+    this.clusterId = clusterId;
+    this.suffix = suffix;
+  }
+
+  public ActiveClusterSuffix(final String input) {
+    String[] parts = input.split(":", 2);
+    this.clusterId = parts[0];
+    if (parts.length > 1) {
+      this.suffix = parts[1];
+    } else {
+      this.suffix = "";
+    }
+  }
+
+  public static ActiveClusterSuffix parseFrom(byte[] bytes) throws DeserializationException {
+    return new Parser().parseFrom(bytes);
+  }
+
+  public static ActiveClusterSuffix fromConfig(Configuration conf, ClusterId clusterId) {
+    return new ActiveClusterSuffix(clusterId.toString(), conf
+      .get(HConstants.HBASE_META_TABLE_SUFFIX, HConstants.HBASE_META_TABLE_SUFFIX_DEFAULT_VALUE));
+  }
+
+  /** Returns The active cluster suffix serialized using pb w/ pb magic prefix */
+  public byte[] toByteArray() {
+    return ProtobufUtil.prependPBMagic(convert().toByteArray());
+  }
+
+  /** Returns A pb instance to represent this instance. */
+  public ActiveClusterSuffixProtos.ActiveClusterSuffix convert() {
+    return ActiveClusterSuffixProtos.ActiveClusterSuffix.newBuilder().setClusterId(clusterId)
+      .setSuffix(suffix).build();
+  }
+
+  /** Returns A {@link ActiveClusterSuffix} made from the passed in <code>cs</code> */
+  public static ActiveClusterSuffix
+    convert(final ActiveClusterSuffixProtos.ActiveClusterSuffix cs) {
+    return new ActiveClusterSuffix(cs.getClusterId(), cs.getSuffix());
+  }
+
+  /**
+   * @see java.lang.Object#toString()
+   */
+  @Override
+  public String toString() {
+    return String.format("%s:%s", this.clusterId,
+      Strings.isNullOrEmpty(this.suffix) ? "<blank>" : this.suffix);
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (o == null || getClass() != o.getClass()) return false;
+    ActiveClusterSuffix that = (ActiveClusterSuffix) o;
+    return Objects.equals(clusterId, that.clusterId) && Objects.equals(suffix, that.suffix);
+  }
+
+  @Override
+  public int hashCode() {
+    return Objects.hash(clusterId, suffix);
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ClusterId.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ClusterId.java
@@ -31,8 +31,46 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.ClusterIdProtos;
  * is a container for the id. Also knows how to serialize and deserialize the cluster id.
  */
 @InterfaceAudience.Private
-public class ClusterId {
+public class ClusterId implements ClusterIdFile {
   private final String id;
+
+  public static class Parser implements ClusterIdFileParser<ClusterId> {
+
+    @Override
+    public String getFileName() {
+      return HConstants.CLUSTER_ID_FILE_NAME;
+    }
+
+    /**
+     * Parse the serialized representation of the {@link ClusterId}
+     * @param bytes A pb serialized {@link ClusterId} instance with pb magic prefix
+     * @return An instance of {@link ClusterId} made from <code>bytes</code>
+     * @see #toByteArray()
+     */
+    @Override
+    public ClusterId parseFrom(byte[] bytes) throws DeserializationException {
+      if (ProtobufUtil.isPBMagicPrefix(bytes)) {
+        int pblen = ProtobufUtil.lengthOfPBMagic();
+        ClusterIdProtos.ClusterId.Builder builder = ClusterIdProtos.ClusterId.newBuilder();
+        ClusterIdProtos.ClusterId cid = null;
+        try {
+          ProtobufUtil.mergeFrom(builder, bytes, pblen, bytes.length - pblen);
+          cid = builder.build();
+        } catch (IOException e) {
+          throw new DeserializationException(e);
+        }
+        return convert(cid);
+      } else {
+        // Presume it was written out this way, the old way.
+        return new ClusterId(Bytes.toString(bytes));
+      }
+    }
+
+    @Override
+    public ClusterId readString(String input) {
+      return new ClusterId(input);
+    }
+  }
 
   /**
    * New ClusterID. Generates a uniqueid.
@@ -48,30 +86,6 @@ public class ClusterId {
   /** Returns The clusterid serialized using pb w/ pb magic prefix */
   public byte[] toByteArray() {
     return ProtobufUtil.prependPBMagic(convert().toByteArray());
-  }
-
-  /**
-   * Parse the serialized representation of the {@link ClusterId}
-   * @param bytes A pb serialized {@link ClusterId} instance with pb magic prefix
-   * @return An instance of {@link ClusterId} made from <code>bytes</code>
-   * @see #toByteArray()
-   */
-  public static ClusterId parseFrom(final byte[] bytes) throws DeserializationException {
-    if (ProtobufUtil.isPBMagicPrefix(bytes)) {
-      int pblen = ProtobufUtil.lengthOfPBMagic();
-      ClusterIdProtos.ClusterId.Builder builder = ClusterIdProtos.ClusterId.newBuilder();
-      ClusterIdProtos.ClusterId cid = null;
-      try {
-        ProtobufUtil.mergeFrom(builder, bytes, pblen, bytes.length - pblen);
-        cid = builder.build();
-      } catch (IOException e) {
-        throw new DeserializationException(e);
-      }
-      return convert(cid);
-    } else {
-      // Presume it was written out this way, the old way.
-      return new ClusterId(Bytes.toString(bytes));
-    }
   }
 
   /** Returns A pb instance to represent this instance. */

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ClusterIdFile.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ClusterIdFile.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Represents a cluster identification file on the master file system. e.g. Cluster ID = hbase.id
+ * Active read-replica cluster ID = active.cluster.suffix.id
+ */
+@InterfaceAudience.Private
+public interface ClusterIdFile {
+
+  /**
+   * Return file contents in a byte array.
+   */
+  byte[] toByteArray();
+
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ClusterIdFileParser.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ClusterIdFileParser.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Generic parser interface for Cluster Id files.
+ * @see ClusterIdFile
+ */
+@InterfaceAudience.Private
+public interface ClusterIdFileParser<T> {
+
+  /**
+   * Get default file name of cluster id file.
+   */
+  String getFileName();
+
+  /**
+   * Parse cluster id data from byte representation.
+   * @param bytes the protobuf data
+   * @return the cluster id data object
+   */
+  T parseFrom(final byte[] bytes) throws DeserializationException;
+
+  /**
+   * Parser cluster id data from String representation.
+   * @param input the input string
+   * @return the cluster id data object
+   */
+  T readString(String input);
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/WriteAttemptedOnReadOnlyClusterException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/WriteAttemptedOnReadOnlyClusterException.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Thrown when a write is attempted on a read-only HBase cluster.
+ */
+@InterfaceAudience.Public
+public class WriteAttemptedOnReadOnlyClusterException extends DoNotRetryIOException {
+
+  private static final long serialVersionUID = 1L;
+
+  public WriteAttemptedOnReadOnlyClusterException() {
+    super();
+  }
+
+  /**
+   * @param message the message for this exception
+   */
+  public WriteAttemptedOnReadOnlyClusterException(String message) {
+    super(message);
+  }
+
+  /**
+   * @param message   the message for this exception
+   * @param throwable the {@link Throwable} to use for this exception
+   */
+  public WriteAttemptedOnReadOnlyClusterException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+
+  /**
+   * @param throwable the {@link Throwable} to use for this exception
+   */
+  public WriteAttemptedOnReadOnlyClusterException(Throwable throwable) {
+    super(throwable);
+  }
+}

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/Admin.java
@@ -2703,6 +2703,34 @@ public interface Admin extends Abortable, Closeable {
    */
   List<String> getCachedFilesList(ServerName serverName) throws IOException;
 
+  /**
+   * Perform hbase:meta table refresh
+   */
+  long refreshMeta() throws IOException;
+
+  /**
+   * Refresh HFiles for the table
+   * @param tableName table to refresh HFiles for
+   * @return ID of the procedure started for refreshing HFiles
+   * @throws IOException if a remote or network exception occurs
+   */
+  long refreshHFiles(final TableName tableName) throws IOException;
+
+  /**
+   * Refresh HFiles for all the tables under given namespace
+   * @param namespace Namespace for which we should call refresh HFiles for all tables under it
+   * @return ID of the procedure started for refreshing HFiles
+   * @throws IOException if a remote or network exception occurs
+   */
+  long refreshHFiles(final String namespace) throws IOException;
+
+  /**
+   * Refresh HFiles for all the tables
+   * @return ID of the procedure started for refreshing HFiles
+   * @throws IOException if a remote or network exception occurs
+   */
+  long refreshHFiles() throws IOException;
+
   @InterfaceAudience.Private
   void restoreBackupSystemTable(String snapshotName) throws IOException;
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AdminOverAsyncAdmin.java
@@ -1154,6 +1154,26 @@ class AdminOverAsyncAdmin implements Admin {
   }
 
   @Override
+  public long refreshMeta() throws IOException {
+    return get(admin.refreshMeta());
+  }
+
+  @Override
+  public long refreshHFiles(final TableName tableName) throws IOException {
+    return get(admin.refreshHFiles(tableName));
+  }
+
+  @Override
+  public long refreshHFiles(final String namespace) throws IOException {
+    return get(admin.refreshHFiles(namespace));
+  }
+
+  @Override
+  public long refreshHFiles() throws IOException {
+    return get(admin.refreshHFiles());
+  }
+
+  @Override
   public void restoreBackupSystemTable(String snapshotName) throws IOException {
     get(admin.restoreBackupSystemTable(snapshotName));
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncAdmin.java
@@ -1890,6 +1890,26 @@ public interface AsyncAdmin {
    */
   CompletableFuture<List<String>> getCachedFilesList(ServerName serverName);
 
+  /**
+   * Perform hbase:meta table refresh
+   */
+  CompletableFuture<Long> refreshMeta();
+
+  /**
+   * Refresh HFiles for the table
+   */
+  CompletableFuture<Long> refreshHFiles(final TableName tableName);
+
+  /**
+   * Refresh HFiles for all the tables under given namespace
+   */
+  CompletableFuture<Long> refreshHFiles(final String namespace);
+
+  /**
+   * Refresh HFiles for all the tables
+   */
+  CompletableFuture<Long> refreshHFiles();
+
   @InterfaceAudience.Private
   CompletableFuture<Void> restoreBackupSystemTable(String snapshotName);
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncHBaseAdmin.java
@@ -1022,6 +1022,26 @@ class AsyncHBaseAdmin implements AsyncAdmin {
   }
 
   @Override
+  public CompletableFuture<Long> refreshMeta() {
+    return wrap(rawAdmin.refreshMeta());
+  }
+
+  @Override
+  public CompletableFuture<Long> refreshHFiles(final TableName tableName) {
+    return wrap(rawAdmin.refreshHFiles(tableName));
+  }
+
+  @Override
+  public CompletableFuture<Long> refreshHFiles(final String namespace) {
+    return wrap(rawAdmin.refreshHFiles(namespace));
+  }
+
+  @Override
+  public CompletableFuture<Long> refreshHFiles() {
+    return wrap(rawAdmin.refreshHFiles());
+  }
+
+  @Override
   public CompletableFuture<Void> restoreBackupSystemTable(String snapshotName) {
     return wrap(rawAdmin.restoreBackupSystemTable(snapshotName));
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RawAsyncHBaseAdmin.java
@@ -263,6 +263,10 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.OfflineReg
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.OfflineRegionResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.RecommissionRegionServerRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.RecommissionRegionServerResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.RefreshHFilesRequest;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.RefreshHFilesResponse;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.RefreshMetaRequest;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.RefreshMetaResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.ReopenTableRegionsRequest;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.ReopenTableRegionsResponse;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProtos.RestoreSnapshotRequest;
@@ -4696,5 +4700,64 @@ class RawAsyncHBaseAdmin implements AsyncAdmin {
         MasterService.Interface::restoreBackupSystemTable,
         MasterProtos.RestoreBackupSystemTableResponse::getProcId,
         new RestoreBackupSystemTableProcedureBiConsumer());
+  }
+
+  private CompletableFuture<Long> internalRefershHFiles(RefreshHFilesRequest request) {
+    return this.<Long> newMasterCaller()
+      .action((controller, stub) -> this.<RefreshHFilesRequest, RefreshHFilesResponse, Long> call(
+        controller, stub, request, MasterService.Interface::refreshHFiles,
+        RefreshHFilesResponse::getProcId))
+      .call();
+  }
+
+  @Override
+  public CompletableFuture<Long> refreshMeta() {
+    RefreshMetaRequest.Builder request = RefreshMetaRequest.newBuilder();
+    request.setNonceGroup(ng.getNonceGroup()).setNonce(ng.newNonce());
+    return this.<Long> newMasterCaller()
+      .action((controller, stub) -> this.<RefreshMetaRequest, RefreshMetaResponse, Long> call(
+        controller, stub, request.build(), MasterService.Interface::refreshMeta,
+        RefreshMetaResponse::getProcId))
+      .call();
+  }
+
+  @Override
+  public CompletableFuture<Long> refreshHFiles(final TableName tableName) {
+    if (tableName.isSystemTable()) {
+      LOG.warn("Refreshing HFiles for system table {} is not allowed", tableName.getNameAsString());
+      throw new IllegalArgumentException(
+        "Not allowed to refresh HFiles for system table '" + tableName.getNameAsString() + "'");
+    }
+    // Request builder
+    RefreshHFilesRequest.Builder request = RefreshHFilesRequest.newBuilder();
+    request.setTableName(ProtobufUtil.toProtoTableName(tableName));
+    request.setNonceGroup(ng.getNonceGroup()).setNonce(ng.newNonce());
+    return internalRefershHFiles(request.build());
+  }
+
+  @Override
+  public CompletableFuture<Long> refreshHFiles(final String namespace) {
+    if (
+      namespace.equals(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR)
+        || namespace.equals(NamespaceDescriptor.BACKUP_NAMESPACE_NAME_STR)
+    ) {
+      LOG.warn("Refreshing HFiles for reserve namespace {} is not allowed", namespace);
+      throw new IllegalArgumentException(
+        "Not allowed to refresh HFiles for reserve namespace '" + namespace + "'");
+    }
+    // Request builder
+    RefreshHFilesRequest.Builder request = RefreshHFilesRequest.newBuilder();
+    request.setNamespace(namespace);
+    request.setNonceGroup(ng.getNonceGroup()).setNonce(ng.newNonce());
+    return internalRefershHFiles(request.build());
+  }
+
+  @Override
+  public CompletableFuture<Long> refreshHFiles() {
+    // Request builder
+    RefreshHFilesRequest.Builder request = RefreshHFilesRequest.newBuilder();
+    // Set nonce
+    request.setNonceGroup(ng.getNonceGroup()).setNonce(ng.newNonce());
+    return internalRefershHFiles(request.build());
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfo.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/RegionInfo.java
@@ -431,7 +431,7 @@ public interface RegionInfo extends Comparable<RegionInfo> {
    */
   static String prettyPrint(final String encodedRegionName) {
     if (encodedRegionName.equals("1028785192")) {
-      return encodedRegionName + "/hbase:meta";
+      return encodedRegionName + "/" + TableName.META_TABLE_NAME;
     }
     return encodedRegionName;
   }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ZKConnectionRegistry.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/ZKConnectionRegistry.java
@@ -117,7 +117,7 @@ class ZKConnectionRegistry implements ConnectionRegistry {
       return null;
     }
     data = removeMetaData(data);
-    return ClusterId.parseFrom(data).toString();
+    return new ClusterId.Parser().parseFrom(data).toString();
   }
 
   @Override

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/HConstants.java
@@ -1665,6 +1665,29 @@ public final class HConstants {
    */
   public final static boolean REJECT_DECOMMISSIONED_HOSTS_DEFAULT = false;
 
+  /**
+   * Adds a suffix to the meta table name: value='test' -> ‘hbase:meta_test’
+   */
+  public final static String HBASE_META_TABLE_SUFFIX = "hbase.meta.table.suffix";
+
+  /**
+   * Default value of {@link #HBASE_META_TABLE_SUFFIX}
+   */
+  public final static String HBASE_META_TABLE_SUFFIX_DEFAULT_VALUE = "";
+
+  /**
+   * Should HBase only serve Read Requests
+   */
+  public final static String HBASE_GLOBAL_READONLY_ENABLED_KEY = "hbase.global.readonly.enabled";
+
+  /**
+   * Default value of {@link #HBASE_GLOBAL_READONLY_ENABLED_KEY}
+   */
+  public final static boolean HBASE_GLOBAL_READONLY_ENABLED_DEFAULT = false;
+
+  /** name of the file having active cluster suffix */
+  public static final String ACTIVE_CLUSTER_SUFFIX_FILE_NAME = "active.cluster.suffix.id";
+
   private HConstants() {
     // Can't be instantiated with this ctor.
   }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/TableName.java
@@ -17,16 +17,21 @@
  */
 package org.apache.hadoop.hbase;
 
+import com.google.errorprone.annotations.RestrictedApi;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Set;
 import java.util.concurrent.CopyOnWriteArraySet;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
+import org.apache.hbase.thirdparty.com.google.common.base.Strings;
 
 /**
  * Immutable POJO class for representing a table name. Which is of the form: &lt;table
@@ -44,6 +49,7 @@ import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
  */
 @InterfaceAudience.Public
 public final class TableName implements Comparable<TableName> {
+  private static final Logger LOG = LoggerFactory.getLogger(TableName.class);
 
   /** See {@link #createTableNameIfNecessary(ByteBuffer, ByteBuffer)} */
   private static final Set<TableName> tableCache = new CopyOnWriteArraySet<>();
@@ -64,10 +70,42 @@ public final class TableName implements Comparable<TableName> {
   // with NAMESPACE_DELIM as delimiter
   public static final String VALID_USER_TABLE_REGEX = "(?:(?:(?:" + VALID_NAMESPACE_REGEX + "\\"
     + NAMESPACE_DELIM + ")?)" + "(?:" + VALID_TABLE_QUALIFIER_REGEX + "))";
+  public static final String VALID_META_TABLE_SUFFIX_REGEX = "[a-zA-Z0-9]+";
 
-  /** The hbase:meta table's name. */
-  public static final TableName META_TABLE_NAME =
-    valueOf(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR, "meta");
+  /**
+   * The name of hbase meta table could either be hbase:meta_xxx or 'hbase:meta' otherwise. Config
+   * hbase.meta.table.suffix will govern the decision of adding suffix to the habase:meta
+   */
+  public static final TableName META_TABLE_NAME;
+  static {
+    Configuration conf = HBaseConfiguration.create();
+    META_TABLE_NAME = initializeHbaseMetaTableName(conf);
+    LOG.info("Meta table name: {}", META_TABLE_NAME);
+  }
+
+  /* Visible for testing only */
+  @RestrictedApi(explanation = "Should only be called in tests", link = "",
+      allowedOnPath = ".*/src/test/.*")
+  public static TableName getDefaultNameOfMetaForReplica() {
+    return valueOf(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR, "meta");
+  }
+
+  public static TableName initializeHbaseMetaTableName(Configuration conf) {
+    String suffix_val = conf.get(HConstants.HBASE_META_TABLE_SUFFIX,
+      HConstants.HBASE_META_TABLE_SUFFIX_DEFAULT_VALUE);
+    LOG.debug("[Read-replica feature] suffix value: {}",
+      (suffix_val == null || suffix_val.isEmpty()) ? "<blank>" : suffix_val);
+    if (Strings.isNullOrEmpty(suffix_val)) {
+      return valueOf(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR, "meta");
+    } else {
+      if (!suffix_val.matches(VALID_META_TABLE_SUFFIX_REGEX)) {
+        throw new IllegalArgumentException("Invalid value '" + suffix_val + "' for config '"
+          + HConstants.HBASE_META_TABLE_SUFFIX + "'. Suffix must only contain ASCII letters and "
+          + "digits matching: " + VALID_META_TABLE_SUFFIX_REGEX);
+      }
+      return valueOf(NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR, "meta_" + suffix_val);
+    }
+  }
 
   /**
    * The Namespace table's name.

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TestTableName.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TestTableName.java
@@ -181,7 +181,8 @@ public class TestTableName {
     for (String suffix : invalidSuffixes) {
       Configuration conf = HBaseConfiguration.create();
       conf.set(HConstants.HBASE_META_TABLE_SUFFIX, suffix);
-      assertThrows(IllegalArgumentException.class, () -> TableName.initializeHbaseMetaTableName(conf),
+      assertThrows(IllegalArgumentException.class,
+        () -> TableName.initializeHbaseMetaTableName(conf),
         "Expected IllegalArgumentException for suffix: " + suffix);
     }
   }

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TestTableName.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TestTableName.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertThrows;
 import java.nio.ByteBuffer;
 import java.util.HashMap;
 import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -160,5 +161,28 @@ public class TestTableName {
     assertEquals(expected.getNamespaceAsString(), names.ns);
     assertArrayEquals(expected.getNamespace(), names.nsb);
     return expected;
+  }
+
+  @Test
+  public void testValidMetaTableSuffix() {
+    String[] validSuffixes = { "REPL1", "123", "123abc" };
+    for (String suffix : validSuffixes) {
+      Configuration conf = HBaseConfiguration.create();
+      conf.set(HConstants.HBASE_META_TABLE_SUFFIX, suffix);
+      TableName metaTableName = TableName.initializeHbaseMetaTableName(conf);
+      assertEquals("hbase:meta_" + suffix, metaTableName.getNameAsString());
+    }
+  }
+
+  @Test
+  public void testInvalidMetaTableSuffix() {
+    String[] invalidSuffixes = { "test_1", "test-1", "test.1", "test 1", "_test", "-test", ".test",
+      "has!special", "has:colon", " " };
+    for (String suffix : invalidSuffixes) {
+      Configuration conf = HBaseConfiguration.create();
+      conf.set(HConstants.HBASE_META_TABLE_SUFFIX, suffix);
+      assertThrows("Expected IllegalArgumentException for suffix: " + suffix,
+        IllegalArgumentException.class, () -> TableName.initializeHbaseMetaTableName(conf));
+    }
   }
 }

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/TestTableName.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/TestTableName.java
@@ -181,8 +181,8 @@ public class TestTableName {
     for (String suffix : invalidSuffixes) {
       Configuration conf = HBaseConfiguration.create();
       conf.set(HConstants.HBASE_META_TABLE_SUFFIX, suffix);
-      assertThrows("Expected IllegalArgumentException for suffix: " + suffix,
-        IllegalArgumentException.class, () -> TableName.initializeHbaseMetaTableName(conf));
+      assertThrows(IllegalArgumentException.class, () -> TableName.initializeHbaseMetaTableName(conf),
+        "Expected IllegalArgumentException for suffix: " + suffix);
     }
   }
 }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterFileSystemSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterFileSystemSource.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.master;
 
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.metrics.BaseSource;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -49,7 +50,7 @@ public interface MetricsMasterFileSystemSource extends BaseSource {
   String SPLIT_SIZE_NAME = "hlogSplitSize";
 
   String META_SPLIT_TIME_DESC = "Time it takes to finish splitMetaLog()";
-  String META_SPLIT_SIZE_DESC = "Size of hbase:meta WAL files being split";
+  String META_SPLIT_SIZE_DESC = "Size of " + TableName.META_TABLE_NAME + " WAL files being split";
   String SPLIT_TIME_DESC = "Time it takes to finish WAL.splitLog()";
   String SPLIT_SIZE_DESC = "Size of WAL files being split";
 

--- a/hbase-protocol-shaded/src/main/protobuf/server/ActiveClusterSuffix.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/ActiveClusterSuffix.proto
@@ -1,0 +1,36 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+syntax = "proto2";
+// This file contains protocol buffers that are shared throughout HBase
+package hbase.pb;
+
+option java_package = "org.apache.hadoop.hbase.shaded.protobuf.generated";
+option java_outer_classname = "ActiveClusterSuffixProtos";
+option java_generate_equals_and_hash = true;
+option optimize_for = SPEED;
+
+/**
+ * Content of the '/hbase/active_cluster_suffix.id' file to indicate the active cluster.
+ */
+message ActiveClusterSuffix {
+  // This is the active cluster id set by the user in the config, as a String
+  required string cluster_id = 1;
+
+  // This is the active cluster suffix set by the user in the config, as a String
+  required string suffix = 2;
+}

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/Master.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/Master.proto
@@ -807,6 +807,17 @@ message ModifyColumnStoreFileTrackerResponse {
   optional uint64 proc_id = 1;
 }
 
+message RefreshHFilesRequest {
+  optional TableName table_name = 1;
+  optional string namespace = 2;
+  optional uint64 nonce_group = 3 [default = 0];
+  optional uint64 nonce = 4 [default = 0];
+}
+
+message RefreshHFilesResponse {
+  optional uint64 proc_id = 1;
+}
+
 message FlushMasterStoreRequest {}
 message FlushMasterStoreResponse {}
 
@@ -816,6 +827,14 @@ message RollAllWALWritersRequest {
 }
 
 message RollAllWALWritersResponse {
+  optional uint64 proc_id = 1;
+}
+
+message RefreshMetaRequest {
+  optional uint64 nonce_group = 1 [default = 0];
+  optional uint64 nonce = 2 [default = 0];
+}
+message RefreshMetaResponse {
   optional uint64 proc_id = 1;
 }
 
@@ -1303,6 +1322,12 @@ service MasterService {
 
   rpc rollAllWALWriters(RollAllWALWritersRequest)
     returns(RollAllWALWritersResponse);
+
+  rpc RefreshMeta(RefreshMetaRequest)
+    returns(RefreshMetaResponse);
+
+  rpc RefreshHFiles(RefreshHFilesRequest)
+    returns(RefreshHFilesResponse);
 }
 
 // HBCK Service definitions.

--- a/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/server/master/MasterProcedure.proto
@@ -864,3 +864,34 @@ message LogRollRemoteProcedureResult {
   optional ServerName server_name = 1;
   optional uint64 last_highest_wal_filenum = 2;
 }
+
+enum RefreshMetaState {
+  REFRESH_META_INIT = 1;
+  REFRESH_META_SCAN_STORAGE = 2;
+  REFRESH_META_PREPARE = 3;
+  REFRESH_META_APPLY = 4;
+  REFRESH_META_FOLLOWUP = 5;
+  REFRESH_META_FINISH = 6;
+}
+
+message RefreshMetaStateData {
+}
+
+enum RefreshHFilesTableProcedureState {
+  REFRESH_HFILES_PREPARE = 1;
+  REFRESH_HFILES_REFRESH_REGION = 2;
+  REFRESH_HFILES_FINISH = 3;
+}
+
+message RefreshHFilesTableProcedureStateData {
+  optional TableName table_name = 1;
+  optional string namespace_name = 2;
+}
+
+message RefreshHFilesRegionProcedureStateData {
+  required RegionInfo region = 1;
+}
+
+message RefreshHFilesRegionParameter {
+  required RegionInfo region = 1;
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/MetaTableAccessor.java
@@ -753,7 +753,7 @@ public final class MetaTableAccessor {
    * @param connection connection we're using
    * @param deletes    Deletes to add to hbase:meta This list should support #remove.
    */
-  private static void deleteFromMetaTable(final Connection connection, final List<Delete> deletes)
+  public static void deleteFromMetaTable(final Connection connection, final List<Delete> deletes)
     throws IOException {
     try (Table t = getMetaHTable(connection)) {
       debugLogMutations(deletes);
@@ -859,7 +859,7 @@ public final class MetaTableAccessor {
   private static void updateTableState(Connection connection, TableState state) throws IOException {
     Put put = makePutFromTableState(state, EnvironmentEdgeManager.currentTime());
     putToMetaTable(connection, put);
-    LOG.info("Updated {} in hbase:meta", state);
+    LOG.info("Updated {} in {}", state, TableName.META_TABLE_NAME);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/TableDescriptors.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/TableDescriptors.java
@@ -78,4 +78,11 @@ public interface TableDescriptors extends Closeable {
 
   /** Returns Instance of table descriptor or null if none found. */
   TableDescriptor remove(TableName tablename) throws IOException;
+
+  /**
+   * Invalidates the table descriptor cache.
+   */
+  default void invalidateTableDescriptorCache() {
+    // do nothing by default
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/CoprocessorReloadTask.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/CoprocessorReloadTask.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.coprocessor;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.apache.yetus.audience.InterfaceStability;
+
+/**
+ * This interface is used to perform whatever task is necessary for reloading coprocessors on
+ * HMaster, HRegionServer, and HRegion. Since the steps required to reload coprocessors varies for
+ * each of these types, this interface helps with code flexibility by allowing a lamda function to
+ * be provided for the {@link #reload(Configuration) reload()} method. <br>
+ * <br>
+ * See {@link org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil#maybeUpdateCoprocessors
+ * CoprocessorConfigurationUtil.maybeUpdateCoprocessors()} and its usage in
+ * {@link org.apache.hadoop.hbase.conf.ConfigurationObserver#onConfigurationChange
+ * onConfigurationChange()} with HMaster, HRegionServer, and HRegion for an idea of how this
+ * interface is helpful.
+ */
+@InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.COPROC)
+@InterfaceStability.Evolving
+@FunctionalInterface
+public interface CoprocessorReloadTask {
+  void reload(Configuration conf);
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MasterCoprocessorEnvironment.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/coprocessor/MasterCoprocessorEnvironment.java
@@ -23,6 +23,7 @@ import org.apache.hadoop.hbase.CoprocessorEnvironment;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.master.MasterServices;
 import org.apache.hadoop.hbase.metrics.MetricRegistry;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
@@ -88,4 +89,6 @@ public interface MasterCoprocessorEnvironment extends CoprocessorEnvironment<Mas
    * @return A MetricRegistry for the coprocessor class to track and export metrics.
    */
   MetricRegistry getMetricRegistryForMaster();
+
+  MasterServices getMasterServices();
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventType.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/EventType.java
@@ -309,7 +309,13 @@ public enum EventType {
    * RS log roll.<br>
    * RS_LOG_ROLL
    */
-  RS_LOG_ROLL(91, ExecutorType.RS_LOG_ROLL);
+  RS_LOG_ROLL(91, ExecutorType.RS_LOG_ROLL),
+
+  /**
+   * RS refresh hfiles for a region.<br>
+   * RS_REFRESH_HFILES
+   */
+  RS_REFRESH_HFILES(92, ExecutorType.RS_REFRESH_HFILES);
 
   private final int code;
   private final ExecutorType executor;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/ExecutorType.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/executor/ExecutorType.java
@@ -57,7 +57,8 @@ public enum ExecutorType {
   RS_SNAPSHOT_OPERATIONS(36),
   RS_FLUSH_OPERATIONS(37),
   RS_RELOAD_QUOTAS_OPERATIONS(38),
-  RS_LOG_ROLL(39);
+  RS_LOG_ROLL(39),
+  RS_REFRESH_HFILES(39);
 
   ExecutorType(int value) {
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/CachedClusterId.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/CachedClusterId.java
@@ -102,7 +102,7 @@ public class CachedClusterId {
       // the waiting threads.
       try {
         cacheMisses.incrementAndGet();
-        setClusterId(FSUtils.getClusterId(fs, rootDir));
+        setClusterId(FSUtils.getClusterIdFile(fs, rootDir, new ClusterId.Parser()));
       } catch (IOException e) {
         LOG.warn("Error fetching cluster ID", e);
       } finally {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -84,6 +84,7 @@ import org.apache.hadoop.hbase.InvalidFamilyOperationException;
 import org.apache.hadoop.hbase.MasterNotRunningException;
 import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.NamespaceNotFoundException;
 import org.apache.hadoop.hbase.PleaseHoldException;
 import org.apache.hadoop.hbase.PleaseRestartMasterException;
 import org.apache.hadoop.hbase.RegionMetrics;
@@ -170,6 +171,8 @@ import org.apache.hadoop.hbase.master.procedure.ModifyTableProcedure;
 import org.apache.hadoop.hbase.master.procedure.ProcedurePrepareLatch;
 import org.apache.hadoop.hbase.master.procedure.ProcedureSyncWait;
 import org.apache.hadoop.hbase.master.procedure.RSProcedureDispatcher;
+import org.apache.hadoop.hbase.master.procedure.RefreshHFilesTableProcedure;
+import org.apache.hadoop.hbase.master.procedure.RefreshMetaProcedure;
 import org.apache.hadoop.hbase.master.procedure.ReloadQuotasProcedure;
 import org.apache.hadoop.hbase.master.procedure.ReopenTableRegionsProcedure;
 import org.apache.hadoop.hbase.master.procedure.ServerCrashProcedure;
@@ -248,10 +251,12 @@ import org.apache.hadoop.hbase.security.AccessDeniedException;
 import org.apache.hadoop.hbase.security.SecurityConstants;
 import org.apache.hadoop.hbase.security.Superusers;
 import org.apache.hadoop.hbase.security.UserProvider;
+import org.apache.hadoop.hbase.security.access.AbstractReadOnlyController;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.Addressing;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.ConfigurationUtil;
 import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
 import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
@@ -1086,7 +1091,11 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     if (!maintenanceMode) {
       startupTaskGroup.addTask("Initializing master coprocessors");
       setQuotasObserver(conf);
-      this.cpHost = new MasterCoprocessorHost(this, conf);
+      CoprocessorConfigurationUtil.syncReadOnlyConfigurations(conf,
+        CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY);
+      AbstractReadOnlyController.manageActiveClusterIdFile(
+        ConfigurationUtil.isReadOnlyModeEnabledInConf(conf), this.getMasterFileSystem());
+      initializeCoprocessorHost(conf);
     } else {
       // start an in process region server for carrying system regions
       maintenanceRegionServer =
@@ -1188,8 +1197,9 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         int existingReplicasCount =
           assignmentManager.getRegionStates().getRegionsOfTable(TableName.META_TABLE_NAME).size();
         if (existingReplicasCount > metaDesc.getRegionReplication()) {
-          LOG.info("Update replica count of hbase:meta from {}(in TableDescriptor)"
-            + " to {}(existing ZNodes)", metaDesc.getRegionReplication(), existingReplicasCount);
+          LOG.info(
+            "Update replica count of {} from {}(in TableDescriptor)" + " to {}(existing ZNodes)",
+            TableName.META_TABLE_NAME, metaDesc.getRegionReplication(), existingReplicasCount);
           metaDesc = TableDescriptorBuilder.newBuilder(metaDesc)
             .setRegionReplication(existingReplicasCount).build();
           tableDescriptors.update(metaDesc);
@@ -1198,8 +1208,9 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         if (metaDesc.getRegionReplication() != replicasNumInConf) {
           LOG.info(
             "The {} config is {} while the replica count in TableDescriptor is {}"
-              + " for hbase:meta, altering...",
-            HConstants.META_REPLICAS_NUM, replicasNumInConf, metaDesc.getRegionReplication());
+              + " for {}, altering...",
+            HConstants.META_REPLICAS_NUM, replicasNumInConf, metaDesc.getRegionReplication(),
+            TableName.META_TABLE_NAME);
           procedureExecutor.submitProcedure(new ModifyTableProcedure(
             procedureExecutor.getEnvironment(), TableDescriptorBuilder.newBuilder(metaDesc)
               .setRegionReplication(replicasNumInConf).build(),
@@ -3135,8 +3146,8 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
           if (isActiveMaster() && isInitialized() && assignmentManager != null) {
             try {
               Map<TableName, RegionStatesCount> tableRegionStatesCountMap = new HashMap<>();
-              Map<String, TableDescriptor> tableDescriptorMap = getTableDescriptors().getAll();
-              for (TableDescriptor tableDescriptor : tableDescriptorMap.values()) {
+              List<TableDescriptor> tableDescriptors = listTableDescriptors(null, null, null, true);
+              for (TableDescriptor tableDescriptor : tableDescriptors) {
                 TableName tableName = tableDescriptor.getTableName();
                 RegionStatesCount regionStatesCount =
                   assignmentManager.getRegionStatesCount(tableName);
@@ -3840,9 +3851,9 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   }
 
   /**
-   * Return a list of table table descriptors after applying any provided filter parameters. Note
-   * that the user-facing description of this filter logic is presented on the class-level javadoc
-   * of {@link NormalizeTableFilterParams}.
+   * Return a list of table descriptors after applying any provided filter parameters. Note that the
+   * user-facing description of this filter logic is presented on the class-level javadoc of
+   * {@link NormalizeTableFilterParams}.
    */
   private List<TableDescriptor> getTableDescriptors(final List<TableDescriptor> htds,
     final String namespace, final String regex, final List<TableName> tableNameList,
@@ -3851,7 +3862,7 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
       // request for all TableDescriptors
       Collection<TableDescriptor> allHtds;
       if (namespace != null && namespace.length() > 0) {
-        // Do a check on the namespace existence. Will fail if does not exist.
+        // Do a check on the namespace existence. Will fail if it does not exist.
         this.clusterSchemaService.getNamespace(namespace);
         allHtds = tableDescriptors.getByNamespace(namespace).values();
       } else {
@@ -4489,13 +4500,24 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     }
     // append the quotas observer back to the master coprocessor key
     setQuotasObserver(newConf);
-    // update region server coprocessor if the configuration has changed.
-    if (
-      CoprocessorConfigurationUtil.checkConfigurationChange(this.cpHost, newConf,
-        CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY) && !maintenanceMode
-    ) {
-      LOG.info("Update the master coprocessor(s) because the configuration has changed");
-      this.cpHost = new MasterCoprocessorHost(this, newConf);
+
+    boolean originalIsReadOnlyEnabled = CoprocessorConfigurationUtil
+      .areReadOnlyCoprocessorsLoaded(this.conf, CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY);
+
+    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(newConf, originalIsReadOnlyEnabled,
+      this.cpHost, CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY, this.maintenanceMode,
+      this.toString(), conf -> {
+        this.initializeCoprocessorHost(conf);
+        CoprocessorConfigurationUtil.updateCoprocessorListInConf(this.conf, conf,
+          CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY);
+      });
+
+    boolean maybeUpdatedReadOnlyMode = CoprocessorConfigurationUtil
+      .areReadOnlyCoprocessorsLoaded(this.conf, CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY);
+
+    if (maybeUpdatedReadOnlyMode != originalIsReadOnlyEnabled) {
+      AbstractReadOnlyController.manageActiveClusterIdFile(maybeUpdatedReadOnlyMode,
+        this.getMasterFileSystem());
     }
   }
 
@@ -4594,6 +4616,11 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     }
   }
 
+  private void initializeCoprocessorHost(Configuration conf) {
+    // initialize master side coprocessors before we start handling requests
+    this.cpHost = new MasterCoprocessorHost(this, conf);
+  }
+
   @Override
   public long flushTable(TableName tableName, List<byte[]> columnFamilies, long nonceGroup,
     long nonce) throws IOException {
@@ -4647,4 +4674,91 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
     return mobFileCleanerChore;
   }
 
+  public Long refreshMeta(long nonceGroup, long nonce) throws IOException {
+    return MasterProcedureUtil
+      .submitProcedure(new MasterProcedureUtil.NonceProcedureRunnable(this, nonceGroup, nonce) {
+        @Override
+        protected void run() throws IOException {
+          LOG.info("Submitting RefreshMetaProcedure");
+          submitProcedure(new RefreshMetaProcedure(procedureExecutor.getEnvironment()));
+        }
+
+        @Override
+        protected String getDescription() {
+          return "RefreshMetaProcedure";
+        }
+      });
+  }
+
+  public Long refreshHfiles(final TableName tableName, final long nonceGroup, final long nonce)
+    throws IOException {
+    checkInitialized();
+
+    if (!tableDescriptors.exists(tableName)) {
+      LOG.info("RefreshHfilesProcedure failed because table {} does not exist",
+        tableName.getNameAsString());
+      throw new TableNotFoundException(tableName);
+    }
+
+    return MasterProcedureUtil
+      .submitProcedure(new MasterProcedureUtil.NonceProcedureRunnable(this, nonceGroup, nonce) {
+        @Override
+        protected void run() throws IOException {
+          LOG.info("Submitting RefreshHfilesTableProcedure for table {}",
+            tableName.getNameAsString());
+          submitProcedure(
+            new RefreshHFilesTableProcedure(procedureExecutor.getEnvironment(), tableName));
+        }
+
+        @Override
+        protected String getDescription() {
+          return "RefreshHfilesProcedure for a table";
+        }
+      });
+  }
+
+  public Long refreshHfiles(final String namespace, final long nonceGroup, final long nonce)
+    throws IOException {
+    checkInitialized();
+
+    try {
+      this.clusterSchemaService.getNamespace(namespace);
+    } catch (IOException e) {
+      LOG.info("RefreshHfilesProcedure failed because namespace {} does not exist", namespace);
+      throw new NamespaceNotFoundException(namespace);
+    }
+
+    return MasterProcedureUtil
+      .submitProcedure(new MasterProcedureUtil.NonceProcedureRunnable(this, nonceGroup, nonce) {
+        @Override
+        protected void run() throws IOException {
+          LOG.info("Submitting RefreshHfilesProcedure for namespace {}", namespace);
+          submitProcedure(
+            new RefreshHFilesTableProcedure(procedureExecutor.getEnvironment(), namespace));
+        }
+
+        @Override
+        protected String getDescription() {
+          return "RefreshHfilesProcedure for namespace";
+        }
+      });
+  }
+
+  public Long refreshHfiles(final long nonceGroup, final long nonce) throws IOException {
+    checkInitialized();
+
+    return MasterProcedureUtil
+      .submitProcedure(new MasterProcedureUtil.NonceProcedureRunnable(this, nonceGroup, nonce) {
+        @Override
+        protected void run() throws IOException {
+          LOG.info("Submitting RefreshHfilesProcedure for all tables");
+          submitProcedure(new RefreshHFilesTableProcedure(procedureExecutor.getEnvironment()));
+        }
+
+        @Override
+        protected String getDescription() {
+          return "RefreshHfilesProcedure for all tables";
+        }
+      });
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterCoprocessorHost.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterCoprocessorHost.java
@@ -113,6 +113,11 @@ public class MasterCoprocessorHost
     }
 
     @Override
+    public MasterServices getMasterServices() {
+      return services;
+    }
+
+    @Override
     public void shutdown() {
       super.shutdown();
       MetricsCoprocessor.removeRegistry(this.metricRegistry);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterFileSystem.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterFileSystem.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.permission.FsAction;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hbase.ActiveClusterSuffix;
 import org.apache.hadoop.hbase.ClusterId;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.backup.HFileArchiver;
@@ -37,6 +38,7 @@ import org.apache.hadoop.hbase.replication.ReplicationUtils;
 import org.apache.hadoop.hbase.security.access.SnapshotScannerHDFSAclHelper;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.ConfigurationUtil;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
@@ -60,6 +62,8 @@ public class MasterFileSystem {
   private final Configuration conf;
   // Persisted unique cluster ID
   private ClusterId clusterId;
+  // Persisted unique Active Cluster Suffix
+  private ActiveClusterSuffix activeClusterSuffix;
   // Keep around for convenience.
   private final FileSystem fs;
   // Keep around for convenience.
@@ -158,6 +162,8 @@ public class MasterFileSystem {
     if (isSecurityEnabled) {
       fs.setPermission(new Path(rootdir, HConstants.VERSION_FILE_NAME), secureRootFilePerms);
       fs.setPermission(new Path(rootdir, HConstants.CLUSTER_ID_FILE_NAME), secureRootFilePerms);
+      fs.setPermission(new Path(rootdir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME),
+        secureRootFilePerms);
     }
     FsPermission currentRootPerms = fs.getFileStatus(this.rootdir).getPermission();
     if (
@@ -262,10 +268,15 @@ public class MasterFileSystem {
       throw iae;
     }
     // Make sure cluster ID exists
-    if (!FSUtils.checkClusterIdExists(fs, rd, threadWakeFrequency)) {
-      FSUtils.setClusterId(fs, rd, new ClusterId(), threadWakeFrequency);
+    if (
+      !FSUtils.checkFileExistsInHbaseRootDir(fs, rootdir, HConstants.CLUSTER_ID_FILE_NAME,
+        threadWakeFrequency)
+    ) {
+      FSUtils.setClusterIdFile(fs, rootdir, HConstants.CLUSTER_ID_FILE_NAME, new ClusterId(),
+        threadWakeFrequency);
     }
-    clusterId = FSUtils.getClusterId(fs, rd);
+    clusterId = FSUtils.getClusterIdFile(fs, rootdir, new ClusterId.Parser());
+    negotiateActiveClusterSuffixFile(threadWakeFrequency);
   }
 
   /**
@@ -381,5 +392,51 @@ public class MasterFileSystem {
 
   public void logFileSystemState(Logger log) throws IOException {
     CommonFSUtils.logFileSystemState(fs, rootdir, log);
+  }
+
+  private void negotiateActiveClusterSuffixFile(long wait) throws IOException {
+    this.activeClusterSuffix = ActiveClusterSuffix.fromConfig(conf, getClusterId());
+    if (!ConfigurationUtil.isReadOnlyModeEnabledInConf(conf)) {
+      try {
+        // verify the contents against the config set
+        ActiveClusterSuffix acs =
+          FSUtils.getClusterIdFile(fs, rootdir, new ActiveClusterSuffix.Parser());
+        if (acs == null) {
+          throw new FileNotFoundException("[Read-replica feature] Active Cluster Suffix File "
+            + new Path(rootdir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME) + " not found");
+        }
+        LOG.debug(
+          "Negotiating active cluster suffix file. File {} : File Suffix {} : Configured suffix {} :  Cluster ID : {}",
+          new Path(rootdir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME), acs, activeClusterSuffix,
+          getClusterId());
+        // Suffix file exists and we're in read/write mode. Content should match.
+        if (!this.activeClusterSuffix.equals(acs)) {
+          // throw error
+          LOG.error(
+            "[Read-replica feature] Another cluster is running in active (read-write) mode on this "
+              + "storage location. Active cluster ID: {}, This cluster ID {}. Rootdir location {} ",
+            acs, activeClusterSuffix, rootdir);
+          throw new IOException("Cannot start master, because another cluster is running in active "
+            + "(read-write) mode on this storage location. Active Cluster Id: " + acs
+            + ", This cluster Id: " + activeClusterSuffix);
+        }
+        LOG.info(
+          "[Read-replica feature] This is the active cluster on this storage location with cluster id: {}",
+          activeClusterSuffix);
+      } catch (FileNotFoundException fnfe) {
+        // We're in read/write mode, but suffix file missing, let's create it
+        FSUtils.setClusterIdFile(fs, rootdir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME,
+          activeClusterSuffix, wait);
+        LOG.info("[Read-replica feature] Created Active cluster suffix file: {}, with content: {}",
+          HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME, activeClusterSuffix);
+      }
+    } else {
+      // This is a read-only cluster, don't care about suffix file
+      LOG.info("[Read-replica feature] Replica cluster is being started in Read Only Mode");
+    }
+  }
+
+  public ActiveClusterSuffix getActiveClusterSuffix() {
+    return activeClusterSuffix;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MasterRpcServices.java
@@ -3742,4 +3742,35 @@ public class MasterRpcServices extends HBaseRpcServicesBase<HMaster>
       throw new ServiceException(ioe);
     }
   }
+
+  @Override
+  public MasterProtos.RefreshMetaResponse refreshMeta(RpcController controller,
+    MasterProtos.RefreshMetaRequest request) throws ServiceException {
+    try {
+      Long procId = server.refreshMeta(request.getNonceGroup(), request.getNonce());
+      return MasterProtos.RefreshMetaResponse.newBuilder().setProcId(procId).build();
+    } catch (IOException ioe) {
+      throw new ServiceException(ioe);
+    }
+  }
+
+  @Override
+  public MasterProtos.RefreshHFilesResponse refreshHFiles(RpcController controller,
+    MasterProtos.RefreshHFilesRequest request) throws ServiceException {
+    try {
+      Long procId;
+      if (request.hasTableName()) {
+        procId = server.refreshHfiles(ProtobufUtil.toTableName(request.getTableName()),
+          request.getNonceGroup(), request.getNonce());
+      } else if (request.hasNamespace()) {
+        procId =
+          server.refreshHfiles(request.getNamespace(), request.getNonceGroup(), request.getNonce());
+      } else {
+        procId = server.refreshHfiles(request.getNonceGroup(), request.getNonce());
+      }
+      return MasterProtos.RefreshHFilesResponse.newBuilder().setProcId(procId).build();
+    } catch (IOException ioe) {
+      throw new ServiceException(ioe);
+    }
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/RegionPlacementMaintainer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/RegionPlacementMaintainer.java
@@ -605,7 +605,7 @@ public class RegionPlacementMaintainer implements Closeable {
    */
   public void updateAssignmentPlanToMeta(FavoredNodesPlan plan) throws IOException {
     try {
-      LOG.info("Start to update the hbase:meta with the new assignment plan");
+      LOG.info("Started updating {} with the new assignment plan", TableName.META_TABLE_NAME);
       Map<String, List<ServerName>> assignmentMap = plan.getAssignmentMap();
       Map<RegionInfo, List<ServerName>> planToUpdate = new HashMap<>(assignmentMap.size());
       Map<String, RegionInfo> regionToRegionInfoMap =
@@ -615,10 +615,10 @@ public class RegionPlacementMaintainer implements Closeable {
       }
 
       FavoredNodeAssignmentHelper.updateMetaWithFavoredNodesInfo(planToUpdate, conf);
-      LOG.info("Updated the hbase:meta with the new assignment plan");
+      LOG.info("Updated {} with the new assignment plan", TableName.META_TABLE_NAME);
     } catch (Exception e) {
-      LOG.error(
-        "Failed to update hbase:meta with the new assignment" + "plan because " + e.getMessage());
+      LOG.error("Failed to update {} with the new assignment plan because {}",
+        TableName.META_TABLE_NAME, e.getMessage());
     }
   }
 
@@ -690,14 +690,14 @@ public class RegionPlacementMaintainer implements Closeable {
   }
 
   public void updateAssignmentPlan(FavoredNodesPlan plan) throws IOException {
-    LOG.info("Start to update the new assignment plan for the hbase:meta table and"
-      + " the region servers");
+    LOG.info("Started updating the new assignment plan for {} and the region servers",
+      TableName.META_TABLE_NAME);
     // Update the new assignment plan to META
     updateAssignmentPlanToMeta(plan);
     // Update the new assignment plan to Region Servers
     updateAssignmentPlanToRegionServers(plan);
-    LOG.info("Finish to update the new assignment plan for the hbase:meta table and"
-      + " the region servers");
+    LOG.info("Finished updating the new assignment plan for {} and the region servers",
+      TableName.META_TABLE_NAME);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -354,7 +354,7 @@ public class AssignmentManager {
             if (RegionReplicaUtil.isDefaultReplica(regionInfo.getReplicaId())) {
               setMetaAssigned(regionInfo, state == State.OPEN);
             }
-            LOG.debug("Loaded hbase:meta {}", regionNode);
+            LOG.debug("Loaded {} {}", TableName.META_TABLE_NAME, regionNode);
           }, result);
       }
     }
@@ -797,8 +797,10 @@ public class AssignmentManager {
         preTransitCheck(regionNode, STATES_EXPECTED_ON_ASSIGN);
       }
       assert regionNode.getProcedure() == null;
-      return regionNode.setProcedure(
+      TransitRegionStateProcedure proc = regionNode.setProcedure(
         TransitRegionStateProcedure.assign(getProcedureEnvironment(), regionInfo, sn));
+      regionInTransitionTracker.handleRegionStateNodeOperation(regionNode);
+      return proc;
     } finally {
       regionNode.unlock();
     }
@@ -813,8 +815,10 @@ public class AssignmentManager {
     ServerName targetServer) {
     regionNode.lock();
     try {
-      return regionNode.setProcedure(TransitRegionStateProcedure.assign(getProcedureEnvironment(),
-        regionNode.getRegionInfo(), targetServer));
+      TransitRegionStateProcedure proc = regionNode.setProcedure(TransitRegionStateProcedure
+        .assign(getProcedureEnvironment(), regionNode.getRegionInfo(), targetServer));
+      regionInTransitionTracker.handleRegionStateNodeOperation(regionNode);
+      return proc;
     } finally {
       regionNode.unlock();
     }
@@ -1962,8 +1966,8 @@ public class AssignmentManager {
     boolean meta = isMetaRegion(hri);
     boolean metaLoaded = isMetaLoaded();
     if (!meta && !metaLoaded) {
-      throw new PleaseHoldException(
-        "Master not fully online; hbase:meta=" + meta + ", metaLoaded=" + metaLoaded);
+      throw new PleaseHoldException("Master not fully online; " + TableName.META_TABLE_NAME + "="
+        + meta + ", metaLoaded=" + metaLoaded);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
@@ -718,8 +718,10 @@ public class MergeTableRegionsProcedure
           RegionInfo.parseRegionName(p.getRow());
         }
       } catch (IOException e) {
-        LOG.error("Row key of mutation from coprocessor is not parsable as region name. "
-          + "Mutations from coprocessor should only be for hbase:meta table.", e);
+        LOG.error(
+          "Row key of mutation from coprocessor is not parsable as region name. "
+            + "Mutations from coprocessor should only be for {} table.",
+          TableName.META_TABLE_NAME, e);
         throw e;
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStateStore.java
@@ -169,9 +169,10 @@ public class RegionStateStore {
       final long openSeqNum = hrl.getSeqNum();
 
       LOG.debug(
-        "Load hbase:meta entry region={}, regionState={}, lastHost={}, "
+        "Load {} entry region={}, regionState={}, lastHost={}, "
           + "regionLocation={}, openSeqNum={}",
-        regionInfo.getEncodedName(), state, lastHost, regionLocation, openSeqNum);
+        TableName.META_TABLE_NAME, regionInfo.getEncodedName(), state, lastHost, regionLocation,
+        openSeqNum);
       visitor.visitRegionState(result, regionInfo, state, regionLocation, lastHost, openSeqNum);
     }
   }
@@ -190,8 +191,8 @@ public class RegionStateStore {
     final Put put = new Put(CatalogFamilyFormat.getMetaKeyForRegion(regionInfo), time);
     MetaTableAccessor.addRegionInfo(put, regionInfo);
     final StringBuilder info =
-      new StringBuilder("pid=").append(pid).append(" updating hbase:meta row=")
-        .append(regionInfo.getEncodedName()).append(", regionState=").append(state);
+      new StringBuilder("pid=").append(pid).append(" updating ").append(TableName.META_TABLE_NAME)
+        .append(" row=").append(regionInfo.getEncodedName()).append(", regionState=").append(state);
     if (openSeqNum >= 0) {
       Preconditions.checkArgument(state == State.OPEN && regionLocation != null,
         "Open region should be on a server");
@@ -694,7 +695,7 @@ public class RegionStateStore {
       return State.valueOf(state);
     } catch (IllegalArgumentException e) {
       LOG.warn(
-        "BAD value {} in hbase:meta info:state column for region {} , "
+        "BAD value {} in " + TableName.META_TABLE_NAME + " info:state column for region {} , "
           + "Consider using HBCK2 setRegionState ENCODED_REGION_NAME STATE",
         state, regionInfo.getEncodedName());
       return null;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
@@ -907,8 +907,10 @@ public class SplitTableRegionProcedure
           RegionInfo.parseRegionName(p.getRow());
         }
       } catch (IOException e) {
-        LOG.error("pid=" + getProcId() + " row key of mutation from coprocessor not parsable as "
-          + "region name." + "Mutations from coprocessor should only for hbase:meta table.");
+        LOG.error(
+          "pid={} row key of mutation from coprocessor not parsable as region name. "
+            + "Mutations from coprocessor should only be for {} table.",
+          getProcId(), TableName.META_TABLE_NAME);
         throw e;
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/hbck/HbckChore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/hbck/HbckChore.java
@@ -261,7 +261,8 @@ public class HbckChore extends ScheduledChore {
     FileSystem fs = master.getMasterFileSystem().getFileSystem();
 
     int numRegions = 0;
-    List<Path> tableDirs = FSUtils.getTableDirs(fs, rootDir);
+    List<Path> tableDirs =
+      FSUtils.getTableDirs(fs, rootDir).stream().filter(FSUtils::isLocalMetaTable).toList();
     for (Path tableDir : tableDirs) {
       List<Path> regionDirs = FSUtils.getRegionDirs(fs, tableDir);
       for (Path regionDir : regionDirs) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
@@ -105,7 +105,7 @@ public class CatalogJanitor extends ScheduledChore {
         scan();
       }
     } catch (IOException e) {
-      LOG.warn("Failed initial janitorial scan of hbase:meta table", e);
+      LOG.warn("Failed initial janitorial scan of {} table", TableName.META_TABLE_NAME, e);
       return false;
     }
     return true;
@@ -145,7 +145,7 @@ public class CatalogJanitor extends ScheduledChore {
           + this.services.getServerManager().isClusterShutdown());
       }
     } catch (IOException e) {
-      LOG.warn("Failed janitorial scan of hbase:meta table", e);
+      LOG.warn("Failed janitorial scan of {} table", TableName.META_TABLE_NAME, e);
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/MetaFixer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/MetaFixer.java
@@ -203,19 +203,19 @@ public class MetaFixer {
         .flatMap(List::stream).collect(Collectors.toList());
     final List<IOException> createMetaEntriesFailures = addMetaEntriesResults.stream()
       .filter(Either::hasRight).map(Either::getRight).collect(Collectors.toList());
-    LOG.debug("Added {}/{} entries to hbase:meta", createMetaEntriesSuccesses.size(),
-      newRegionInfos.size());
+    LOG.debug("Added {}/{} entries to {}", createMetaEntriesSuccesses.size(), newRegionInfos.size(),
+      TableName.META_TABLE_NAME);
 
     if (!createMetaEntriesFailures.isEmpty()) {
       LOG.warn(
-        "Failed to create entries in hbase:meta for {}/{} RegionInfo descriptors. First"
+        "Failed to create entries in {} for {}/{} RegionInfo descriptors. First"
           + " failure message included; full list of failures with accompanying stack traces is"
           + " available at log level DEBUG. message={}",
-        createMetaEntriesFailures.size(), addMetaEntriesResults.size(),
+        TableName.META_TABLE_NAME, createMetaEntriesFailures.size(), addMetaEntriesResults.size(),
         createMetaEntriesFailures.get(0).getMessage());
       if (LOG.isDebugEnabled()) {
-        createMetaEntriesFailures
-          .forEach(ioe -> LOG.debug("Attempt to fix region hole in hbase:meta failed.", ioe));
+        createMetaEntriesFailures.forEach(ioe -> LOG
+          .debug("Attempt to fix region hole in {} failed.", TableName.META_TABLE_NAME, ioe));
       }
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/ReportMakingVisitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/ReportMakingVisitor.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.client.Result;
@@ -137,8 +138,9 @@ class ReportMakingVisitor implements ClientMetaTableAccessor.CloseableVisitor {
     if (!Bytes.equals(metaTableRow.getRow(), ri.getRegionName())) {
       LOG.warn(
         "INCONSISTENCY: Row name is not equal to serialized info:regioninfo content; "
-          + "row={} {}; See if RegionInfo is referenced in another hbase:meta row? Delete?",
-        Bytes.toStringBinary(metaTableRow.getRow()), ri.getRegionNameAsString());
+          + "row={} {}; See if RegionInfo is referenced in another {} row? Delete?",
+        Bytes.toStringBinary(metaTableRow.getRow()), ri.getRegionNameAsString(),
+        TableName.META_TABLE_NAME);
       return null;
     }
     // Skip split parent region

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/HBCKServerCrashProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/HBCKServerCrashProcedure.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.RegionLocations;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.Result;
@@ -102,14 +103,14 @@ public class HBCKServerCrashProcedure extends ServerCrashProcedure {
       MetaTableAccessor.scanMetaForTableRegions(env.getMasterServices().getConnection(), visitor,
         null);
     } catch (IOException ioe) {
-      LOG.warn("Failed scan of hbase:meta for 'Unknown Servers'", ioe);
+      LOG.warn("Failed scan of {} for 'Unknown Servers'", TableName.META_TABLE_NAME, ioe);
       return ris;
     }
     // create the server state node too
     env.getAssignmentManager().getRegionStates().createServer(getServerName());
-    LOG.info("Found {} mentions of {} in hbase:meta of OPEN/OPENING Regions: {}",
-      visitor.getReassigns().size(), getServerName(), visitor.getReassigns().stream()
-        .map(RegionInfo::getEncodedName).collect(Collectors.joining(",")));
+    LOG.info("Found {} mentions of {} in {} of OPEN/OPENING Regions: {}",
+      visitor.getReassigns().size(), getServerName(), TableName.META_TABLE_NAME, visitor
+        .getReassigns().stream().map(RegionInfo::getEncodedName).collect(Collectors.joining(",")));
     return visitor.getReassigns();
   }
 
@@ -150,8 +151,8 @@ public class HBCKServerCrashProcedure extends ServerCrashProcedure {
         RegionState rs = new RegionState(hrl.getRegion(), state, hrl.getServerName());
         if (rs.isClosing()) {
           // Move region to CLOSED in hbase:meta.
-          LOG.info("Moving {} from CLOSING to CLOSED in hbase:meta",
-            hrl.getRegion().getRegionNameAsString());
+          LOG.info("Moving {} from CLOSING to CLOSED in {}",
+            hrl.getRegion().getRegionNameAsString(), TableName.META_TABLE_NAME);
           try {
             MetaTableAccessor.updateRegionState(this.connection, hrl.getRegion(),
               RegionState.State.CLOSED);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/InitMetaProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/InitMetaProcedure.java
@@ -77,7 +77,7 @@ public class InitMetaProcedure extends AbstractStateMachineTableProcedure<InitMe
 
   private static TableDescriptor writeFsLayout(Path rootDir, MasterProcedureEnv env)
     throws IOException {
-    LOG.info("BOOTSTRAP: creating hbase:meta region");
+    LOG.info("BOOTSTRAP: creating {} region", TableName.META_TABLE_NAME);
     FileSystem fs = rootDir.getFileSystem(env.getMasterConfiguration());
     Path tableDir = CommonFSUtils.getTableDir(rootDir, TableName.META_TABLE_NAME);
     if (fs.exists(tableDir) && !deleteMetaTableDirectoryIfPartial(fs, tableDir)) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/ModifyTableProcedure.java
@@ -110,7 +110,7 @@ public class ModifyTableProcedure extends AbstractStateMachineTableProcedure<Mod
       for (byte[] family : UNDELETABLE_META_COLUMNFAMILIES) {
         if (!cfs.contains(family)) {
           throw new HBaseIOException(
-            "Delete of hbase:meta column family " + Bytes.toString(family));
+            "Delete of " + TableName.META_TABLE_NAME + " column family " + Bytes.toString(family));
         }
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RefreshHFilesRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RefreshHFilesRegionProcedure.java
@@ -1,0 +1,208 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.master.RegionState;
+import org.apache.hadoop.hbase.master.assignment.RegionStateNode;
+import org.apache.hadoop.hbase.master.assignment.RegionStates;
+import org.apache.hadoop.hbase.procedure2.FailedRemoteDispatchException;
+import org.apache.hadoop.hbase.procedure2.Procedure;
+import org.apache.hadoop.hbase.procedure2.ProcedureEvent;
+import org.apache.hadoop.hbase.procedure2.ProcedureStateSerializer;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
+import org.apache.hadoop.hbase.procedure2.ProcedureUtil;
+import org.apache.hadoop.hbase.procedure2.ProcedureYieldException;
+import org.apache.hadoop.hbase.procedure2.RemoteProcedureDispatcher;
+import org.apache.hadoop.hbase.procedure2.RemoteProcedureException;
+import org.apache.hadoop.hbase.regionserver.RefreshHFilesCallable;
+import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ProcedureProtos;
+
+/**
+ * A master-side procedure that handles refreshing HFiles (store files) for a specific region in
+ * HBase. It performs remote procedure dispatch to the RegionServer hosting the region and manages
+ * retries, suspensions, and timeouts as needed. This procedure ensures safe execution by verifying
+ * the region state, handling remote operation results, and applying retry mechanisms in case of
+ * failures. It gives the call to {@link RefreshHFilesCallable} which gets executed on region
+ * server.
+ */
+
+@InterfaceAudience.Private
+public class RefreshHFilesRegionProcedure extends Procedure<MasterProcedureEnv>
+  implements TableProcedureInterface,
+  RemoteProcedureDispatcher.RemoteProcedure<MasterProcedureEnv, ServerName> {
+  private static final Logger LOG = LoggerFactory.getLogger(RefreshHFilesRegionProcedure.class);
+  private RegionInfo region;
+  private ProcedureEvent<?> event;
+  private boolean dispatched;
+  private boolean succ;
+  private RetryCounter retryCounter;
+
+  public RefreshHFilesRegionProcedure() {
+  }
+
+  public RefreshHFilesRegionProcedure(RegionInfo region) {
+    this.region = region;
+  }
+
+  @Override
+  protected void deserializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    MasterProcedureProtos.RefreshHFilesRegionProcedureStateData data =
+      serializer.deserialize(MasterProcedureProtos.RefreshHFilesRegionProcedureStateData.class);
+    this.region = ProtobufUtil.toRegionInfo(data.getRegion());
+  }
+
+  @Override
+  protected void serializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    MasterProcedureProtos.RefreshHFilesRegionProcedureStateData.Builder builder =
+      MasterProcedureProtos.RefreshHFilesRegionProcedureStateData.newBuilder();
+    builder.setRegion(ProtobufUtil.toRegionInfo(region));
+    serializer.serialize(builder.build());
+  }
+
+  @Override
+  protected boolean abort(MasterProcedureEnv env) {
+    return false;
+  }
+
+  @Override
+  protected void rollback(MasterProcedureEnv env) throws IOException, InterruptedException {
+    throw new UnsupportedOperationException();
+  }
+
+  private void setTimeoutForSuspend(MasterProcedureEnv env, String reason) {
+    if (retryCounter == null) {
+      retryCounter = ProcedureUtil.createRetryCounter(env.getMasterConfiguration());
+    }
+    long backoff = retryCounter.getBackoffTimeAndIncrementAttempts();
+    LOG.warn("{} can not run currently because {}, wait {} ms to retry", this, reason, backoff);
+    setTimeout(Math.toIntExact(backoff));
+    setState(ProcedureProtos.ProcedureState.WAITING_TIMEOUT);
+    skipPersistence();
+  }
+
+  @Override
+  protected Procedure<MasterProcedureEnv>[] execute(MasterProcedureEnv env)
+    throws ProcedureYieldException, ProcedureSuspendedException, InterruptedException {
+    if (dispatched) {
+      if (succ) {
+        return null;
+      }
+      dispatched = false;
+    }
+
+    RegionStates regionStates = env.getAssignmentManager().getRegionStates();
+    RegionStateNode regionNode = regionStates.getRegionStateNode(region);
+
+    if (regionNode.getProcedure() != null) {
+      setTimeoutForSuspend(env, String.format("region %s has a TRSP attached %s",
+        region.getRegionNameAsString(), regionNode.getProcedure()));
+      throw new ProcedureSuspendedException();
+    }
+
+    if (!regionNode.isInState(RegionState.State.OPEN)) {
+      LOG.warn("State of region {} is not OPEN. Skip {} ...", region, this);
+      setTimeoutForSuspend(env, String.format("region state of %s is %s",
+        region.getRegionNameAsString(), regionNode.getState()));
+      throw new ProcedureSuspendedException();
+    }
+
+    ServerName targetServer = regionNode.getRegionLocation();
+    if (targetServer == null) {
+      setTimeoutForSuspend(env,
+        String.format("target server of region %s is null", region.getRegionNameAsString()));
+      throw new ProcedureSuspendedException();
+    }
+
+    try {
+      env.getRemoteDispatcher().addOperationToNode(targetServer, this);
+      dispatched = true;
+      event = new ProcedureEvent<>(this);
+      event.suspendIfNotReady(this);
+      throw new ProcedureSuspendedException();
+    } catch (FailedRemoteDispatchException e) {
+      setTimeoutForSuspend(env, "Failed send request to " + targetServer);
+      throw new ProcedureSuspendedException();
+    }
+  }
+
+  @Override
+  public TableOperationType getTableOperationType() {
+    return TableOperationType.REFRESH_HFILES;
+  }
+
+  @Override
+  public TableName getTableName() {
+    return region.getTable();
+  }
+
+  @Override
+  public void remoteOperationFailed(MasterProcedureEnv env, RemoteProcedureException error) {
+    complete(env, error);
+  }
+
+  @Override
+  public void remoteOperationCompleted(MasterProcedureEnv env, byte[] remoteResultData) {
+    complete(env, null);
+  }
+
+  @Override
+  public void remoteCallFailed(MasterProcedureEnv env, ServerName serverName, IOException e) {
+    complete(env, e);
+  }
+
+  private void complete(MasterProcedureEnv env, Throwable error) {
+    if (isFinished()) {
+      LOG.info("This procedure {} is already finished. Skip the rest of the processes",
+        this.getProcId());
+      return;
+    }
+    if (event == null) {
+      LOG.warn("procedure event for {} is null, maybe the procedure is created when recovery",
+        getProcId());
+      return;
+    }
+    if (error == null) {
+      succ = true;
+    }
+    event.wake(env.getProcedureScheduler());
+    event = null;
+  }
+
+  @Override
+  public Optional<RemoteProcedureDispatcher.RemoteOperation> remoteCallBuild(MasterProcedureEnv env,
+    ServerName serverName) {
+    MasterProcedureProtos.RefreshHFilesRegionParameter.Builder builder =
+      MasterProcedureProtos.RefreshHFilesRegionParameter.newBuilder();
+    builder.setRegion(ProtobufUtil.toRegionInfo(region));
+    return Optional
+      .of(new RSProcedureDispatcher.ServerOperation(this, getProcId(), RefreshHFilesCallable.class,
+        builder.build().toByteArray(), env.getMasterServices().getMasterActiveTime()));
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RefreshHFilesTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RefreshHFilesTableProcedure.java
@@ -1,0 +1,165 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.procedure2.ProcedureStateSerializer;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos.RefreshHFilesTableProcedureState;
+
+@InterfaceAudience.Private
+public class RefreshHFilesTableProcedure
+  extends AbstractStateMachineTableProcedure<RefreshHFilesTableProcedureState> {
+  private static final Logger LOG = LoggerFactory.getLogger(RefreshHFilesTableProcedure.class);
+
+  private TableName tableName;
+  private String namespaceName;
+
+  public RefreshHFilesTableProcedure() {
+    super();
+  }
+
+  public RefreshHFilesTableProcedure(MasterProcedureEnv env) {
+    super(env);
+  }
+
+  public RefreshHFilesTableProcedure(MasterProcedureEnv env, TableName tableName) {
+    super(env);
+    this.tableName = tableName;
+  }
+
+  public RefreshHFilesTableProcedure(MasterProcedureEnv env, String namespaceName) {
+    super(env);
+    this.namespaceName = namespaceName;
+  }
+
+  @Override
+  public TableOperationType getTableOperationType() {
+    return TableOperationType.REFRESH_HFILES;
+  }
+
+  @Override
+  protected void serializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    super.serializeStateData(serializer);
+    MasterProcedureProtos.RefreshHFilesTableProcedureStateData.Builder builder =
+      MasterProcedureProtos.RefreshHFilesTableProcedureStateData.newBuilder();
+    if (tableName != null && namespaceName == null) {
+      builder.setTableName(ProtobufUtil.toProtoTableName(tableName));
+    } else if (tableName == null && namespaceName != null) {
+      builder.setNamespaceName(namespaceName);
+    }
+    serializer.serialize(builder.build());
+  }
+
+  @Override
+  protected void deserializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    super.deserializeStateData(serializer);
+    MasterProcedureProtos.RefreshHFilesTableProcedureStateData data =
+      serializer.deserialize(MasterProcedureProtos.RefreshHFilesTableProcedureStateData.class);
+    if (data.hasTableName() && !data.hasNamespaceName()) {
+      this.tableName = ProtobufUtil.toTableName(data.getTableName());
+    } else if (!data.hasTableName() && data.hasNamespaceName()) {
+      this.namespaceName = data.getNamespaceName();
+    }
+  }
+
+  @Override
+  public TableName getTableName() {
+    if (tableName != null && namespaceName == null) {
+      return tableName;
+    }
+    return DUMMY_NAMESPACE_TABLE_NAME;
+  }
+
+  @Override
+  protected RefreshHFilesTableProcedureState getInitialState() {
+    return RefreshHFilesTableProcedureState.REFRESH_HFILES_PREPARE;
+  }
+
+  @Override
+  protected int getStateId(RefreshHFilesTableProcedureState state) {
+    return state.getNumber();
+  }
+
+  @Override
+  protected RefreshHFilesTableProcedureState getState(int stateId) {
+    return RefreshHFilesTableProcedureState.forNumber(stateId);
+  }
+
+  @Override
+  protected void rollbackState(MasterProcedureEnv env, RefreshHFilesTableProcedureState state)
+    throws IOException, InterruptedException {
+    // Refresh HFiles is idempotent operation hence rollback is not needed
+    LOG.trace("Rollback not implemented for RefreshHFilesTableProcedure state: {}", state);
+  }
+
+  @Override
+  protected Flow executeFromState(MasterProcedureEnv env, RefreshHFilesTableProcedureState state) {
+    LOG.info("Executing RefreshHFilesTableProcedureState state: {}", state);
+
+    try {
+      return switch (state) {
+        case REFRESH_HFILES_PREPARE -> prepare(env);
+        case REFRESH_HFILES_REFRESH_REGION -> refreshHFiles(env);
+        case REFRESH_HFILES_FINISH -> finish();
+        default -> throw new UnsupportedOperationException("Unhandled state: " + state);
+      };
+    } catch (Exception ex) {
+      LOG.error("Error in RefreshHFilesTableProcedure state {}", state, ex);
+      setFailure("RefreshHFilesTableProcedure", ex);
+      return Flow.NO_MORE_STATE;
+    }
+  }
+
+  private Flow prepare(final MasterProcedureEnv env) {
+    setNextState(RefreshHFilesTableProcedureState.REFRESH_HFILES_REFRESH_REGION);
+    return Flow.HAS_MORE_STATE;
+  }
+
+  private void refreshHFilesForTable(final MasterProcedureEnv env, TableName tableName) {
+    addChildProcedure(env.getAssignmentManager().getTableRegions(tableName, true).stream()
+      .map(RefreshHFilesRegionProcedure::new).toArray(RefreshHFilesRegionProcedure[]::new));
+  }
+
+  private Flow refreshHFiles(final MasterProcedureEnv env) throws IOException {
+    if (tableName != null && namespaceName == null) {
+      refreshHFilesForTable(env, tableName);
+    } else if (tableName == null && namespaceName != null) {
+      env.getMasterServices().listTableNamesByNamespace(namespaceName)
+        .forEach(table -> refreshHFilesForTable(env, table));
+    } else {
+      env.getMasterServices().getTableDescriptors().getAll().values().stream()
+        .map(TableDescriptor::getTableName).filter(table -> !table.isSystemTable())
+        .forEach(table -> refreshHFilesForTable(env, table));
+    }
+
+    setNextState(RefreshHFilesTableProcedureState.REFRESH_HFILES_FINISH);
+    return Flow.HAS_MORE_STATE;
+  }
+
+  private Flow finish() {
+    return Flow.NO_MORE_STATE;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RefreshMetaProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RefreshMetaProcedure.java
@@ -1,0 +1,480 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.apache.hadoop.hbase.shaded.protobuf.generated.ProcedureProtos.ProcedureState.WAITING_TIMEOUT;
+
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Set;
+import java.util.function.Function;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.MetaTableAccessor;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.TableState;
+import org.apache.hadoop.hbase.procedure2.ProcedureStateSerializer;
+import org.apache.hadoop.hbase.procedure2.ProcedureSuspendedException;
+import org.apache.hadoop.hbase.procedure2.ProcedureUtil;
+import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hbase.util.FSUtils;
+import org.apache.hadoop.hbase.util.RetryCounter;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.collect.Lists;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos.RefreshMetaState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos.RefreshMetaStateData;
+
+@InterfaceAudience.Private
+public class RefreshMetaProcedure extends AbstractStateMachineTableProcedure<RefreshMetaState> {
+  private static final Logger LOG = LoggerFactory.getLogger(RefreshMetaProcedure.class);
+  private static final String HIDDEN_DIR_PATTERN = "^[._-].*";
+
+  private List<RegionInfo> currentRegions;
+  private List<RegionInfo> latestRegions;
+  private List<Mutation> pendingMutations;
+  private RetryCounter retryCounter;
+  private static final int MUTATION_BATCH_SIZE = 100;
+  private List<RegionInfo> newlyAddedRegions;
+  private List<TableName> deletedTables;
+
+  public RefreshMetaProcedure() {
+    super();
+  }
+
+  public RefreshMetaProcedure(MasterProcedureEnv env) {
+    super(env);
+  }
+
+  @Override
+  public TableName getTableName() {
+    return TableName.META_TABLE_NAME;
+  }
+
+  @Override
+  public TableOperationType getTableOperationType() {
+    return TableOperationType.EDIT;
+  }
+
+  @Override
+  protected Flow executeFromState(MasterProcedureEnv env, RefreshMetaState refreshMetaState) {
+    LOG.info("Executing RefreshMetaProcedure state: {}", refreshMetaState);
+
+    try {
+      return switch (refreshMetaState) {
+        case REFRESH_META_INIT -> executeInit(env);
+        case REFRESH_META_SCAN_STORAGE -> executeScanStorage(env);
+        case REFRESH_META_PREPARE -> executePrepare();
+        case REFRESH_META_APPLY -> executeApply(env);
+        case REFRESH_META_FOLLOWUP -> executeFollowup(env);
+        case REFRESH_META_FINISH -> executeFinish(env);
+        default -> throw new UnsupportedOperationException("Unhandled state: " + refreshMetaState);
+      };
+    } catch (Exception ex) {
+      LOG.error("Error in RefreshMetaProcedure state {}", refreshMetaState, ex);
+      setFailure("RefreshMetaProcedure", ex);
+      return Flow.NO_MORE_STATE;
+    }
+  }
+
+  private Flow executeInit(MasterProcedureEnv env) throws IOException {
+    LOG.trace("Getting current regions from {} table", TableName.META_TABLE_NAME);
+    try {
+      currentRegions = getCurrentRegions(env.getMasterServices().getConnection());
+      LOG.info("Found {} current regions in meta table", currentRegions.size());
+      setNextState(RefreshMetaState.REFRESH_META_SCAN_STORAGE);
+      return Flow.HAS_MORE_STATE;
+    } catch (IOException ioe) {
+      LOG.error("Failed to get current regions from meta table", ioe);
+      throw ioe;
+    }
+  }
+
+  private Flow executeScanStorage(MasterProcedureEnv env) throws IOException {
+    try {
+      latestRegions = scanBackingStorage(env.getMasterServices().getConnection());
+      LOG.info("Found {} regions in backing storage", latestRegions.size());
+      setNextState(RefreshMetaState.REFRESH_META_PREPARE);
+      return Flow.HAS_MORE_STATE;
+    } catch (IOException ioe) {
+      LOG.error("Failed to scan backing storage", ioe);
+      throw ioe;
+    }
+  }
+
+  private Flow executePrepare() throws IOException {
+    if (currentRegions == null || latestRegions == null) {
+      LOG.error(
+        "Can not execute update on null lists. " + "Meta Table Regions - {}, Storage Regions - {}",
+        currentRegions, latestRegions);
+      throw new IOException(
+        (currentRegions == null ? "current regions" : "latest regions") + " list is null");
+    }
+    LOG.info("Comparing regions. Current regions: {}, Latest regions: {}", currentRegions.size(),
+      latestRegions.size());
+
+    this.newlyAddedRegions = new ArrayList<>();
+    this.deletedTables = new ArrayList<>();
+
+    pendingMutations = prepareMutations(
+      currentRegions.stream()
+        .collect(Collectors.toMap(RegionInfo::getEncodedName, Function.identity())),
+      latestRegions.stream()
+        .collect(Collectors.toMap(RegionInfo::getEncodedName, Function.identity())));
+
+    if (pendingMutations.isEmpty()) {
+      LOG.info("RefreshMetaProcedure completed, No update needed.");
+      setNextState(RefreshMetaState.REFRESH_META_FINISH);
+    } else {
+      LOG.info("Prepared {} region mutations and {} tables for cleanup.", pendingMutations.size(),
+        deletedTables.size());
+      setNextState(RefreshMetaState.REFRESH_META_APPLY);
+    }
+    return Flow.HAS_MORE_STATE;
+  }
+
+  private Flow executeApply(MasterProcedureEnv env) throws ProcedureSuspendedException {
+    try {
+      if (pendingMutations != null && !pendingMutations.isEmpty()) {
+        applyMutations(env.getMasterServices().getConnection(), pendingMutations);
+        LOG.debug("RefreshMetaProcedure applied {} mutations to meta table",
+          pendingMutations.size());
+      }
+    } catch (IOException ioe) {
+      if (retryCounter == null) {
+        retryCounter = ProcedureUtil.createRetryCounter(env.getMasterConfiguration());
+      }
+      long backoff = retryCounter.getBackoffTimeAndIncrementAttempts();
+      LOG.warn("Failed to apply mutations to meta table, suspending for {} ms", backoff, ioe);
+      setTimeout(Math.toIntExact(backoff));
+      setState(WAITING_TIMEOUT);
+      skipPersistence();
+      throw new ProcedureSuspendedException();
+    }
+
+    if (
+      (this.newlyAddedRegions != null && !this.newlyAddedRegions.isEmpty())
+        || (this.deletedTables != null && !this.deletedTables.isEmpty())
+    ) {
+      setNextState(RefreshMetaState.REFRESH_META_FOLLOWUP);
+    } else {
+      LOG.info("RefreshMetaProcedure completed. No follow-up actions were required.");
+      setNextState(RefreshMetaState.REFRESH_META_FINISH);
+    }
+    return Flow.HAS_MORE_STATE;
+  }
+
+  private Flow executeFollowup(MasterProcedureEnv env) throws IOException {
+
+    LOG.info("Submitting assignment for new regions: {}", this.newlyAddedRegions);
+    addChildProcedure(env.getAssignmentManager().createAssignProcedures(newlyAddedRegions));
+
+    for (TableName tableName : this.deletedTables) {
+      LOG.debug("Submitting deletion for empty table {}", tableName);
+      env.getMasterServices().getAssignmentManager().deleteTable(tableName);
+      env.getMasterServices().getTableStateManager().setDeletedTable(tableName);
+      env.getMasterServices().getTableDescriptors().remove(tableName);
+    }
+    setNextState(RefreshMetaState.REFRESH_META_FINISH);
+    return Flow.HAS_MORE_STATE;
+  }
+
+  private Flow executeFinish(MasterProcedureEnv env) {
+    invalidateTableDescriptorCache(env);
+    LOG.info("RefreshMetaProcedure completed successfully. All follow-up actions finished.");
+    currentRegions = null;
+    latestRegions = null;
+    pendingMutations = null;
+    deletedTables = null;
+    newlyAddedRegions = null;
+    return Flow.NO_MORE_STATE;
+  }
+
+  private void invalidateTableDescriptorCache(MasterProcedureEnv env) {
+    LOG.debug("Invalidating the table descriptor cache to ensure new tables are discovered");
+    env.getMasterServices().getTableDescriptors().invalidateTableDescriptorCache();
+  }
+
+  /**
+   * Prepares mutations by comparing the current regions in hbase:meta with the latest regions from
+   * backing storage. Also populates newlyAddedRegions and deletedTables lists for follow-up
+   * actions.
+   * @param currentMap Current regions from hbase:meta
+   * @param latestMap  Latest regions from backing storage
+   * @return List of mutations to apply to the meta table
+   * @throws IOException If there is an error creating mutations
+   */
+  private List<Mutation> prepareMutations(Map<String, RegionInfo> currentMap,
+    Map<String, RegionInfo> latestMap) throws IOException {
+    List<Mutation> mutations = new ArrayList<>();
+
+    for (String regionId : Stream.concat(currentMap.keySet().stream(), latestMap.keySet().stream())
+      .collect(Collectors.toSet())) {
+      RegionInfo currentRegion = currentMap.get(regionId);
+      RegionInfo latestRegion = latestMap.get(regionId);
+
+      if (latestRegion != null) {
+        if (currentRegion == null || hasBoundaryChanged(currentRegion, latestRegion)) {
+          mutations.add(MetaTableAccessor.makePutFromRegionInfo(latestRegion));
+          newlyAddedRegions.add(latestRegion);
+        }
+      } else {
+        mutations.add(MetaTableAccessor.makeDeleteFromRegionInfo(currentRegion,
+          EnvironmentEdgeManager.currentTime()));
+      }
+    }
+
+    if (!currentMap.isEmpty() || !latestMap.isEmpty()) {
+      Set<TableName> currentTables =
+        currentMap.values().stream().map(RegionInfo::getTable).collect(Collectors.toSet());
+      Set<TableName> latestTables =
+        latestMap.values().stream().map(RegionInfo::getTable).collect(Collectors.toSet());
+
+      Set<TableName> tablesToDeleteState = new HashSet<>(currentTables);
+      tablesToDeleteState.removeAll(latestTables);
+      if (!tablesToDeleteState.isEmpty()) {
+        LOG.warn(
+          "The following tables have no regions on storage and WILL BE REMOVED from the meta: {}",
+          tablesToDeleteState);
+        this.deletedTables.addAll(tablesToDeleteState);
+      }
+
+      Set<TableName> tablesToRestoreState = new HashSet<>(latestTables);
+      tablesToRestoreState.removeAll(currentTables);
+      if (!tablesToRestoreState.isEmpty()) {
+        LOG.info("Adding missing table:state entry for recovered tables: {}", tablesToRestoreState);
+        for (TableName tableName : tablesToRestoreState) {
+          TableState tableState = new TableState(tableName, TableState.State.ENABLED);
+          mutations.add(MetaTableAccessor.makePutFromTableState(tableState,
+            EnvironmentEdgeManager.currentTime()));
+        }
+      }
+    }
+    return mutations;
+  }
+
+  private void applyMutations(Connection connection, List<Mutation> mutations) throws IOException {
+    List<List<Mutation>> chunks = Lists.partition(mutations, MUTATION_BATCH_SIZE);
+
+    for (int i = 0; i < chunks.size(); i++) {
+      List<Mutation> chunk = chunks.get(i);
+
+      List<Put> puts =
+        chunk.stream().filter(m -> m instanceof Put).map(m -> (Put) m).collect(Collectors.toList());
+
+      List<Delete> deletes = chunk.stream().filter(m -> m instanceof Delete).map(m -> (Delete) m)
+        .collect(Collectors.toList());
+
+      if (!puts.isEmpty()) {
+        MetaTableAccessor.putsToMetaTable(connection, puts);
+      }
+      if (!deletes.isEmpty()) {
+        MetaTableAccessor.deleteFromMetaTable(connection, deletes);
+      }
+      LOG.debug("Successfully processed batch {}/{}", i + 1, chunks.size());
+    }
+  }
+
+  boolean hasBoundaryChanged(RegionInfo region1, RegionInfo region2) {
+    return !Arrays.equals(region1.getStartKey(), region2.getStartKey())
+      || !Arrays.equals(region1.getEndKey(), region2.getEndKey());
+  }
+
+  /**
+   * Scans the backing storage for all regions and returns a list of RegionInfo objects. This method
+   * scans the filesystem for region directories and reads their .regioninfo files.
+   * @param connection The HBase connection to use.
+   * @return List of RegionInfo objects found in the backing storage.
+   * @throws IOException If there is an error accessing the filesystem or reading region info files.
+   */
+  List<RegionInfo> scanBackingStorage(Connection connection) throws IOException {
+    List<RegionInfo> regions = new ArrayList<>();
+    Configuration conf = connection.getConfiguration();
+    FileSystem fs = FileSystem.get(conf);
+    Path rootDir = CommonFSUtils.getRootDir(conf);
+    Path dataDir = new Path(rootDir, HConstants.BASE_NAMESPACE_DIR);
+
+    LOG.info("Scanning backing storage under: {}", dataDir);
+
+    if (!fs.exists(dataDir)) {
+      LOG.warn("Data directory does not exist: {}", dataDir);
+      return regions;
+    }
+
+    FileStatus[] namespaceDirs =
+      fs.listStatus(dataDir, path -> !path.getName().matches(HIDDEN_DIR_PATTERN));
+    LOG.debug("Found {} namespace directories in data dir", Arrays.stream(namespaceDirs).toList());
+
+    for (FileStatus nsDir : namespaceDirs) {
+      String namespaceName = nsDir.getPath().getName();
+      if (NamespaceDescriptor.SYSTEM_NAMESPACE_NAME_STR.equals(namespaceName)) {
+        LOG.info("Skipping system namespace {}", namespaceName);
+        continue;
+      }
+      try {
+        List<RegionInfo> namespaceRegions = scanTablesInNamespace(fs, nsDir.getPath());
+        regions.addAll(namespaceRegions);
+        LOG.debug("Found {} regions in namespace {}", namespaceRegions.size(),
+          nsDir.getPath().getName());
+      } catch (IOException e) {
+        LOG.error("Failed to scan namespace directory: {}", nsDir.getPath(), e);
+      }
+    }
+    LOG.info("Scanned backing storage and found {} regions", regions.size());
+    return regions;
+  }
+
+  private List<RegionInfo> scanTablesInNamespace(FileSystem fs, Path namespacePath)
+    throws IOException {
+    LOG.debug("Scanning namespace {}", namespacePath.getName());
+    List<Path> tableDirs = FSUtils.getLocalTableDirs(fs, namespacePath);
+
+    return tableDirs.stream().flatMap(tableDir -> {
+      try {
+        List<RegionInfo> tableRegions = scanRegionsInTable(fs, FSUtils.getRegionDirs(fs, tableDir));
+        LOG.debug("Found {} regions in table {} in namespace {}", tableRegions.size(),
+          tableDir.getName(), namespacePath.getName());
+        return tableRegions.stream();
+      } catch (IOException e) {
+        LOG.warn("Failed to scan table directory: {} for namespace {}", tableDir,
+          namespacePath.getName(), e);
+        return Stream.empty();
+      }
+    }).toList();
+  }
+
+  private List<RegionInfo> scanRegionsInTable(FileSystem fs, List<Path> regionDirs)
+    throws IOException {
+    return regionDirs.stream().map(regionDir -> {
+      String encodedRegionName = regionDir.getName();
+      try {
+        Path regionInfoPath = new Path(regionDir, HRegionFileSystem.REGION_INFO_FILE);
+        if (fs.exists(regionInfoPath)) {
+          RegionInfo ri = readRegionInfo(fs, regionInfoPath);
+          if (ri != null && isValidRegionInfo(ri, encodedRegionName)) {
+            LOG.debug("Found region: {} -> {}", encodedRegionName, ri.getRegionNameAsString());
+            return ri;
+          } else {
+            LOG.warn("Invalid RegionInfo in file: {}", regionInfoPath);
+          }
+        } else {
+          LOG.debug("No .regioninfo file found in region directory: {}", regionDir);
+        }
+      } catch (Exception e) {
+        LOG.warn("Failed to read region info from directory: {}", encodedRegionName, e);
+      }
+      return null;
+    }).filter(Objects::nonNull).collect(Collectors.toList());
+  }
+
+  private boolean isValidRegionInfo(RegionInfo regionInfo, String expectedEncodedName) {
+    if (!expectedEncodedName.equals(regionInfo.getEncodedName())) {
+      LOG.warn("RegionInfo encoded name mismatch: directory={}, regioninfo={}", expectedEncodedName,
+        regionInfo.getEncodedName());
+      return false;
+    }
+    return true;
+  }
+
+  private RegionInfo readRegionInfo(FileSystem fs, Path regionInfoPath) {
+    try (FSDataInputStream inputStream = fs.open(regionInfoPath);
+      DataInputStream dataInputStream = new DataInputStream(inputStream)) {
+      return RegionInfo.parseFrom(dataInputStream);
+    } catch (Exception e) {
+      LOG.warn("Failed to parse .regioninfo file: {}", regionInfoPath, e);
+      return null;
+    }
+  }
+
+  /**
+   * Retrieves the current regions from the hbase:meta table.
+   * @param connection The HBase connection to use.
+   * @return List of RegionInfo objects representing the current regions in meta.
+   * @throws IOException If there is an error accessing the meta table.
+   */
+  List<RegionInfo> getCurrentRegions(Connection connection) throws IOException {
+    LOG.info("Getting all regions from meta table");
+    return MetaTableAccessor.getAllRegions(connection, true);
+  }
+
+  @Override
+  protected synchronized boolean setTimeoutFailure(MasterProcedureEnv env) {
+    setState(
+      org.apache.hadoop.hbase.shaded.protobuf.generated.ProcedureProtos.ProcedureState.RUNNABLE);
+    env.getProcedureScheduler().addFront(this);
+    return false;
+  }
+
+  @Override
+  protected void rollbackState(MasterProcedureEnv env, RefreshMetaState refreshMetaState)
+    throws IOException, InterruptedException {
+    // No specific rollback needed as it is generally safe to re-run the procedure.
+    LOG.trace("Rollback not implemented for RefreshMetaProcedure state: {}", refreshMetaState);
+  }
+
+  @Override
+  protected RefreshMetaState getState(int stateId) {
+    return RefreshMetaState.forNumber(stateId);
+  }
+
+  @Override
+  protected int getStateId(RefreshMetaState refreshMetaState) {
+    return refreshMetaState.getNumber();
+  }
+
+  @Override
+  protected RefreshMetaState getInitialState() {
+    return RefreshMetaState.REFRESH_META_INIT;
+  }
+
+  @Override
+  protected void serializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    // For now, we'll use a simple approach since we do not need to store any state data
+    RefreshMetaStateData.Builder builder = RefreshMetaStateData.newBuilder();
+    serializer.serialize(builder.build());
+  }
+
+  @Override
+  protected void deserializeStateData(ProcedureStateSerializer serializer) throws IOException {
+    // For now, we'll use a simple approach since we do not need to store any state data
+    serializer.deserialize(RefreshMetaStateData.class);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/TableProcedureInterface.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/TableProcedureInterface.java
@@ -51,7 +51,8 @@ public interface TableProcedureInterface {
     REGION_GC,
     MERGED_REGIONS_GC/* region operations */,
     REGION_TRUNCATE,
-    RESTORE_BACKUP_SYSTEM_TABLE
+    RESTORE_BACKUP_SYSTEM_TABLE,
+    REFRESH_HFILES,
   }
 
   /** Returns the name of the table the procedure is operating on */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/TableQueue.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/TableQueue.java
@@ -73,6 +73,7 @@ class TableQueue extends Queue<TableName> {
       case MERGED_REGIONS_GC:
       case REGION_SNAPSHOT:
       case REGION_TRUNCATE:
+      case REFRESH_HFILES:
         return false;
       default:
         break;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/region/MasterRegionFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/region/MasterRegionFactory.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.master.region;
 import java.io.IOException;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
@@ -33,6 +34,8 @@ import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFac
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.ReflectionUtils;
 import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hbase.thirdparty.com.google.common.base.Strings;
 
 /**
  * The factory class for creating a {@link MasterRegion}.
@@ -54,7 +57,24 @@ public final class MasterRegionFactory {
 
   public static final String USE_HSYNC_KEY = "hbase.master.store.region.wal.hsync";
 
-  public static final String MASTER_STORE_DIR = "MasterData";
+  // Default master data dir
+  private static final String MASTER_REGION_DIR_NAME_DEFAULT = "MasterData";
+
+  public static final String MASTER_REGION_DIR_NAME;
+  static {
+    Configuration conf = HBaseConfiguration.create();
+    MASTER_REGION_DIR_NAME = initMasterRegionDirName(conf);
+  }
+
+  public static String initMasterRegionDirName(Configuration conf) {
+    String suffix = conf.get(HConstants.HBASE_META_TABLE_SUFFIX,
+      HConstants.HBASE_META_TABLE_SUFFIX_DEFAULT_VALUE);
+    if (Strings.isNullOrEmpty(suffix)) {
+      return MASTER_REGION_DIR_NAME_DEFAULT;
+    } else {
+      return MASTER_REGION_DIR_NAME_DEFAULT + "_" + suffix;
+    }
+  }
 
   private static final String FLUSH_SIZE_KEY = "hbase.master.store.region.flush.size";
 
@@ -116,7 +136,7 @@ public final class MasterRegionFactory {
   public static MasterRegion create(MasterServices server) throws IOException {
     Configuration conf = server.getConfiguration();
     MasterRegionParams params = new MasterRegionParams().server(server)
-      .regionDirName(MASTER_STORE_DIR).tableDescriptor(withTrackerConfigs(conf));
+      .regionDirName(getMasterRegionDirName()).tableDescriptor(withTrackerConfigs(conf));
     long flushSize = conf.getLong(FLUSH_SIZE_KEY, DEFAULT_FLUSH_SIZE);
     long flushPerChanges = conf.getLong(FLUSH_PER_CHANGES_KEY, DEFAULT_FLUSH_PER_CHANGES);
     long flushIntervalMs = conf.getLong(FLUSH_INTERVAL_MS_KEY, DEFAULT_FLUSH_INTERVAL_MS);
@@ -133,5 +153,9 @@ public final class MasterRegionFactory {
     params.rollPeriodMs(rollPeriodMs).archivedWalSuffix(ARCHIVED_WAL_SUFFIX)
       .archivedHFileSuffix(ARCHIVED_HFILE_SUFFIX);
     return MasterRegion.create(params);
+  }
+
+  public static String getMasterRegionDirName() {
+    return MASTER_REGION_DIR_NAME;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/procedure2/store/region/HFileProcedurePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/procedure2/store/region/HFileProcedurePrettyPrinter.java
@@ -85,7 +85,7 @@ public class HFileProcedurePrettyPrinter extends AbstractHBaseTool {
 
   private void addAllHFiles() throws IOException {
     Path masterProcDir =
-      new Path(CommonFSUtils.getRootDir(conf), MasterRegionFactory.MASTER_STORE_DIR);
+      new Path(CommonFSUtils.getRootDir(conf), MasterRegionFactory.getMasterRegionDirName());
     Path tableDir = CommonFSUtils.getTableDir(masterProcDir, MasterRegionFactory.TABLE_NAME);
     FileSystem fs = tableDir.getFileSystem(conf);
     Path regionDir =

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CompactSplit.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CompactSplit.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.hbase.regionserver.throttle.CompactionThroughputControl
 import org.apache.hadoop.hbase.regionserver.throttle.ThroughputController;
 import org.apache.hadoop.hbase.security.Superusers;
 import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.util.ConfigurationUtil;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.StealJobQueue;
 import org.apache.hadoop.ipc.RemoteException;
@@ -344,6 +345,12 @@ public class CompactSplit implements CompactionRequester, PropagatingConfigurati
       return;
     }
 
+    // Should not allow compaction if cluster is in read-only mode
+    if (ConfigurationUtil.isReadOnlyModeEnabledInConf(conf)) {
+      LOG.info("Ignoring compaction request for " + region + ",because read-only mode is on.");
+      return;
+    }
+
     if (
       this.server.isStopped() || (region.getTableDescriptor() != null
         && !region.getTableDescriptor().isCompactionEnabled())
@@ -442,6 +449,13 @@ public class CompactSplit implements CompactionRequester, PropagatingConfigurati
       LOG.info(String.format("User has disabled compactions"));
       return Optional.empty();
     }
+
+    // Should not allow compaction if cluster is in read-only mode
+    if (ConfigurationUtil.isReadOnlyModeEnabledInConf(conf)) {
+      LOG.info(String.format("Compaction request skipped as read-only mode is on"));
+      return Optional.empty();
+    }
+
     Optional<CompactionContext> compaction = store.requestCompaction(priority, tracker, user);
     if (!compaction.isPresent() && region.getRegionInfo() != null) {
       String reason = "Not compacting " + region.getRegionInfo().getRegionNameAsString()

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -178,6 +178,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CancelableProgressable;
 import org.apache.hadoop.hbase.util.ClassSize;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.ConfigurationUtil;
 import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSUtils;
@@ -939,6 +940,10 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
       : this.htableDescriptor.getDurability();
 
     decorateRegionConfiguration(conf);
+
+    CoprocessorConfigurationUtil.syncReadOnlyConfigurations(this.conf,
+      CoprocessorHost.REGION_COPROCESSOR_CONF_KEY);
+
     if (rsServices != null) {
       this.rsAccounting = this.rsServices.getRegionServerAccounting();
       // don't initialize coprocessors if not running within a regionserver
@@ -8509,7 +8514,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
     ServiceDescriptor serviceDesc = instance.getDescriptorForType();
     String serviceName = CoprocessorRpcUtils.getServiceName(serviceDesc);
     if (coprocessorServiceHandlers.containsKey(serviceName)) {
-      LOG.error("Coprocessor service {} already registered, rejecting request from {} in region {}",
+      LOG.warn("Coprocessor service {} already registered, rejecting request from {} in region {}",
         serviceName, instance, this);
       return false;
     }
@@ -8980,17 +8985,28 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
    * {@inheritDoc}
    */
   @Override
-  public void onConfigurationChange(Configuration conf) {
-    this.storeHotnessProtector.update(conf);
-    // update coprocessorHost if the configuration has changed.
-    if (
-      CoprocessorConfigurationUtil.checkConfigurationChange(this.coprocessorHost, conf,
-        CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,
-        CoprocessorHost.USER_REGION_COPROCESSOR_CONF_KEY)
-    ) {
-      LOG.info("Update the system coprocessors because the configuration has changed");
-      decorateRegionConfiguration(conf);
-      this.coprocessorHost = new RegionCoprocessorHost(this, rsServices, conf);
+  public void onConfigurationChange(Configuration newConf) {
+    this.storeHotnessProtector.update(newConf);
+
+    boolean originalIsReadOnlyEnabled = CoprocessorConfigurationUtil
+      .areReadOnlyCoprocessorsLoaded(this.conf, CoprocessorHost.REGION_COPROCESSOR_CONF_KEY);
+
+    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(newConf, originalIsReadOnlyEnabled,
+      this.coprocessorHost, CoprocessorHost.REGION_COPROCESSOR_CONF_KEY, false, this.toString(),
+      conf -> {
+        decorateRegionConfiguration(conf);
+        this.coprocessorHost = new RegionCoprocessorHost(this, rsServices, conf);
+        CoprocessorConfigurationUtil.updateCoprocessorListInConf(this.conf, conf,
+          CoprocessorHost.REGION_COPROCESSOR_CONF_KEY);
+      });
+
+    boolean newReadOnlyEnabled = ConfigurationUtil.isReadOnlyModeEnabledInConf(newConf);
+
+    if (originalIsReadOnlyEnabled && !newReadOnlyEnabled) {
+      LOG.info("Cluster Read Only mode disabled");
+      for (HStore store : stores.values()) {
+        store.getStoreEngine().getStoreFileTracker().onTransitionToActive();
+      }
     }
   }
 
@@ -9134,5 +9150,11 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
       allowedOnPath = ".*/src/test/.*")
   boolean isReadsEnabled() {
     return this.writestate.readsEnabled;
+  }
+
+  @RestrictedApi(explanation = "Should only be called in tests", link = "",
+      allowedOnPath = ".*/src/test/.*")
+  public ConfigurationManager getConfigurationManager() {
+    return configurationManager;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -315,6 +315,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
   private LeaseManager leaseManager;
 
   private volatile boolean dataFsOk;
+  private volatile boolean isGlobalReadOnlyEnabled;
 
   static final String ABORT_TIMEOUT = "hbase.regionserver.abort.timeout";
   // Default abort timeout is 1200 seconds for safe
@@ -828,6 +829,10 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     try {
       if (!isStopped() && !isAborted()) {
         installShutdownHook();
+
+        CoprocessorConfigurationUtil.syncReadOnlyConfigurations(conf,
+          CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY);
+
         // Initialize the RegionServerCoprocessorHost now that our ephemeral
         // node was created, in case any coprocessors want to use ZooKeeper
         this.rsHost = new RegionServerCoprocessorHost(this, this.conf);
@@ -1982,6 +1987,10 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
     final int logRollThreads = conf.getInt("hbase.regionserver.executor.log.roll.threads", 1);
     executorService.startExecutorService(executorService.new ExecutorConfig()
       .setExecutorType(ExecutorType.RS_LOG_ROLL).setCorePoolSize(logRollThreads));
+    final int rsRefreshHFilesThreads =
+      conf.getInt("hbase.regionserver.executor.refresh.hfiles.threads", 3);
+    executorService.startExecutorService(executorService.new ExecutorConfig()
+      .setExecutorType(ExecutorType.RS_REFRESH_HFILES).setCorePoolSize(rsRefreshHFilesThreads));
 
     Threads.setDaemonThreadRunning(this.walRoller, getName() + ".logRoller",
       uncaughtExceptionHandler);
@@ -3487,14 +3496,16 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
       LOG.warn("Failed to initialize SuperUsers on reloading of the configuration");
     }
 
-    // update region server coprocessor if the configuration has changed.
-    if (
-      CoprocessorConfigurationUtil.checkConfigurationChange(this.rsHost, newConf,
-        CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY)
-    ) {
-      LOG.info("Update region server coprocessors because the configuration has changed");
-      this.rsHost = new RegionServerCoprocessorHost(this, newConf);
-    }
+    boolean originalIsReadOnlyEnabled = CoprocessorConfigurationUtil
+      .areReadOnlyCoprocessorsLoaded(this.conf, CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY);
+
+    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(newConf, originalIsReadOnlyEnabled,
+      this.rsHost, CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY, false, this.toString(),
+      conf -> {
+        this.rsHost = new RegionServerCoprocessorHost(this, conf);
+        CoprocessorConfigurationUtil.updateCoprocessorListInConf(this.conf, conf,
+          CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY);
+      });
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RefreshHFilesCallable.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RefreshHFilesCallable.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.executor.EventType;
+import org.apache.hadoop.hbase.procedure2.BaseRSProcedureCallable;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.MasterProcedureProtos;
+
+/**
+ * This is a RegionServer-side callable used by the HBase Master Procedure framework to perform the
+ * actual HFiles refresh operation on a specific region. It is dispatched from the
+ * {@link org.apache.hadoop.hbase.master.procedure.RefreshHFilesRegionProcedure} to the RegionServer
+ * and executes the logic to refresh store files in each store of the region.
+ */
+
+@InterfaceAudience.Private
+public class RefreshHFilesCallable extends BaseRSProcedureCallable {
+  private static final Logger LOG = LoggerFactory.getLogger(RefreshHFilesCallable.class);
+
+  private RegionInfo regionInfo;
+
+  @Override
+  protected byte[] doCall() throws Exception {
+    HRegion region = rs.getRegion(regionInfo.getEncodedName());
+    LOG.debug("Starting refreshHfiles operation on region {}", region);
+
+    for (Store store : region.getStores()) {
+      store.refreshStoreFiles();
+    }
+    return null;
+  }
+
+  @Override
+  protected void initParameter(byte[] parameter) throws Exception {
+    MasterProcedureProtos.RefreshHFilesRegionParameter param =
+      MasterProcedureProtos.RefreshHFilesRegionParameter.parseFrom(parameter);
+    this.regionInfo = ProtobufUtil.toRegionInfo(param.getRegion());
+  }
+
+  @Override
+  public EventType getEventType() {
+    return EventType.RS_REFRESH_HFILES;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreEngine.java
@@ -579,4 +579,8 @@ public abstract class StoreEngine<SF extends StoreFlusher, CP extends Compaction
   public BloomFilterMetrics getBloomFilterMetrics() {
     return bloomFilterMetrics;
   }
+
+  public StoreFileTracker getStoreFileTracker() {
+    return storeFileTracker;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/FileBasedStoreFileTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/FileBasedStoreFileTracker.java
@@ -256,4 +256,12 @@ class FileBasedStoreFileTracker extends StoreFileTrackerBase {
     add(Collections.singleton(storeFileInfo));
     return reference;
   }
+
+  public void onTransitionToActive() {
+    if (backedFile != null) {
+      synchronized (storefiles) {
+        backedFile.resetWriteState();
+      }
+    }
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileListFile.java
@@ -298,4 +298,9 @@ class StoreFileListFile {
         trackFiles[nextTrackFile], e);
     }
   }
+
+  synchronized void resetWriteState() {
+    nextTrackFile = -1;
+    prevTimestamp = -1;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTracker.java
@@ -176,4 +176,8 @@ public interface StoreFileTracker {
    * @return the store context.
    */
   StoreContext getStoreContext();
+
+  default void onTransitionToActive() {
+    // no op by default
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/storefiletracker/StoreFileTrackerBase.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.HFileArchiver;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
@@ -51,6 +52,7 @@ import org.apache.hadoop.hbase.regionserver.StoreContext;
 import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
 import org.apache.hadoop.hbase.regionserver.StoreUtils;
+import org.apache.hadoop.hbase.security.access.AbstractReadOnlyController;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.HFileArchiveUtil;
@@ -84,14 +86,24 @@ abstract class StoreFileTrackerBase implements StoreFileTracker {
     this.ctx = ctx;
   }
 
+  private boolean isReadOnlyEnabled() {
+    return conf.getBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY,
+      HConstants.HBASE_GLOBAL_READONLY_ENABLED_DEFAULT);
+  }
+
+  private boolean isNonWritableTableWhenReadOnlyMode() {
+    return isReadOnlyEnabled()
+      && !AbstractReadOnlyController.isWritableInReadOnlyMode(ctx.getTableName());
+  }
+
   @Override
   public final List<StoreFileInfo> load() throws IOException {
-    return doLoadStoreFiles(!isPrimaryReplica);
+    return doLoadStoreFiles(!isPrimaryReplica || isNonWritableTableWhenReadOnlyMode());
   }
 
   @Override
   public final void add(Collection<StoreFileInfo> newFiles) throws IOException {
-    if (isPrimaryReplica) {
+    if (isPrimaryReplica && !isNonWritableTableWhenReadOnlyMode()) {
       doAddNewStoreFiles(newFiles);
     }
   }
@@ -99,14 +111,14 @@ abstract class StoreFileTrackerBase implements StoreFileTracker {
   @Override
   public final void replace(Collection<StoreFileInfo> compactedFiles,
     Collection<StoreFileInfo> newFiles) throws IOException {
-    if (isPrimaryReplica) {
+    if (isPrimaryReplica && !isNonWritableTableWhenReadOnlyMode()) {
       doAddCompactionResults(compactedFiles, newFiles);
     }
   }
 
   @Override
   public final void set(List<StoreFileInfo> files) throws IOException {
-    if (isPrimaryReplica) {
+    if (isPrimaryReplica && !isNonWritableTableWhenReadOnlyMode()) {
       doSetStoreFiles(files);
     }
   }
@@ -141,8 +153,9 @@ abstract class StoreFileTrackerBase implements StoreFileTracker {
 
   @Override
   public final StoreFileWriter createWriter(CreateStoreFileWriterParams params) throws IOException {
-    if (!isPrimaryReplica) {
-      throw new IllegalStateException("Should not call create writer on secondary replicas");
+    if (!isPrimaryReplica || isNonWritableTableWhenReadOnlyMode()) {
+      throw new IllegalStateException(
+        "Should not call create writer on secondary replicas or in read-only mode");
     }
     // creating new cache config for each new writer
     final CacheConfig cacheConf = ctx.getCacheConf();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AbstractReadOnlyController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AbstractReadOnlyController.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import java.io.FileNotFoundException;
+import java.io.IOException;
+import java.util.Set;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.ActiveClusterSuffix;
+import org.apache.hadoop.hbase.Coprocessor;
+import org.apache.hadoop.hbase.CoprocessorEnvironment;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.WriteAttemptedOnReadOnlyClusterException;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.exceptions.DeserializationException;
+import org.apache.hadoop.hbase.master.MasterFileSystem;
+import org.apache.hadoop.hbase.master.region.MasterRegionFactory;
+import org.apache.hadoop.hbase.util.FSUtils;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.CONFIG)
+public abstract class AbstractReadOnlyController implements Coprocessor {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractReadOnlyController.class);
+
+  private static final Set<TableName> writableTables =
+    Set.of(TableName.META_TABLE_NAME, MasterRegionFactory.TABLE_NAME);
+
+  public static boolean
+    isWritableInReadOnlyMode(final ObserverContext<? extends RegionCoprocessorEnvironment> c) {
+    return writableTables.contains(c.getEnvironment().getRegionInfo().getTable());
+  }
+
+  public static boolean isWritableInReadOnlyMode(final TableName tableName) {
+    return writableTables.contains(tableName);
+  }
+
+  protected void internalReadOnlyGuard() throws WriteAttemptedOnReadOnlyClusterException {
+    throw new WriteAttemptedOnReadOnlyClusterException("Operation not allowed in Read-Only Mode");
+  }
+
+  @Override
+  public void start(CoprocessorEnvironment env) throws IOException {
+  }
+
+  @Override
+  public void stop(CoprocessorEnvironment env) {
+  }
+
+  public static void manageActiveClusterIdFile(boolean readOnlyEnabled, MasterFileSystem mfs) {
+    FileSystem fs = mfs.getFileSystem();
+    Path rootDir = mfs.getRootDir();
+    Path activeClusterFile = new Path(rootDir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME);
+
+    try {
+      if (readOnlyEnabled) {
+        // ENABLING READ-ONLY (false -> true), delete the active cluster file.
+        LOG.debug("Global read-only mode is being ENABLED. Deleting active cluster file: {}",
+          activeClusterFile);
+        try (FSDataInputStream in = fs.open(activeClusterFile)) {
+          ActiveClusterSuffix actualClusterFileData =
+            ActiveClusterSuffix.parseFrom(in.readAllBytes());
+          ActiveClusterSuffix expectedClusterFileData = mfs.getActiveClusterSuffix();
+          if (expectedClusterFileData.equals(actualClusterFileData)) {
+            fs.delete(activeClusterFile, false);
+            LOG.info("Successfully deleted active cluster file: {}", activeClusterFile);
+          } else {
+            LOG.debug(
+              "Active cluster file data does not match expected data. "
+                + "Not deleting the file to avoid potential inconsistency. "
+                + "Actual data: {}, Expected data: {}",
+              actualClusterFileData, expectedClusterFileData);
+          }
+        } catch (FileNotFoundException e) {
+          LOG.debug("Active cluster file does not exist at: {}. No need to delete.",
+            activeClusterFile);
+        } catch (IOException e) {
+          LOG.error(
+            "Failed to delete active cluster file: {}. "
+              + "Read-only flag will be updated, but file system state is inconsistent.",
+            activeClusterFile, e);
+        } catch (DeserializationException e) {
+          LOG.error("Failed to deserialize ActiveClusterSuffix from file {}", activeClusterFile, e);
+        }
+      } else {
+        // DISABLING READ-ONLY (true -> false), create the active cluster file id file
+        int wait = mfs.getConfiguration().getInt(HConstants.THREAD_WAKE_FREQUENCY, 10 * 1000);
+        if (!fs.exists(activeClusterFile)) {
+          FSUtils.setClusterIdFile(fs, rootDir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME,
+            mfs.getActiveClusterSuffix(), wait);
+        } else {
+          LOG.debug("Active cluster file already exists at: {}. No need to create it again.",
+            activeClusterFile);
+        }
+      }
+    } catch (IOException e) {
+      // We still update the flag, but log that the operation failed.
+      LOG.error("Failed to perform file operation for read-only switch. "
+        + "Flag will be updated, but file system state may be inconsistent.", e);
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/BulkLoadReadOnlyController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/BulkLoadReadOnlyController.java
@@ -1,0 +1,53 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.coprocessor.BulkLoadObserver;
+import org.apache.hadoop.hbase.coprocessor.CoreCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@CoreCoprocessor
+@InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.CONFIG)
+public class BulkLoadReadOnlyController extends AbstractReadOnlyController
+  implements BulkLoadObserver, RegionCoprocessor {
+
+  @Override
+  public Optional<BulkLoadObserver> getBulkLoadObserver() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public void prePrepareBulkLoad(ObserverContext<RegionCoprocessorEnvironment> ctx)
+    throws IOException {
+    internalReadOnlyGuard();
+    BulkLoadObserver.super.prePrepareBulkLoad(ctx);
+  }
+
+  @Override
+  public void preCleanupBulkLoad(ObserverContext<RegionCoprocessorEnvironment> ctx)
+    throws IOException {
+    internalReadOnlyGuard();
+    BulkLoadObserver.super.preCleanupBulkLoad(ctx);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/EndpointReadOnlyController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/EndpointReadOnlyController.java
@@ -1,0 +1,50 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.coprocessor.CoreCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.EndpointObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hbase.thirdparty.com.google.protobuf.Message;
+import org.apache.hbase.thirdparty.com.google.protobuf.Service;
+
+@CoreCoprocessor
+@InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.CONFIG)
+public class EndpointReadOnlyController extends AbstractReadOnlyController
+  implements EndpointObserver, RegionCoprocessor {
+
+  @Override
+  public Optional<EndpointObserver> getEndpointObserver() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public Message preEndpointInvocation(ObserverContext<? extends RegionCoprocessorEnvironment> ctx,
+    Service service, String methodName, Message request) throws IOException {
+    internalReadOnlyGuard();
+    return EndpointObserver.super.preEndpointInvocation(ctx, service, methodName, request);
+  }
+
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/MasterReadOnlyController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/MasterReadOnlyController.java
@@ -1,0 +1,433 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Set;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.BalanceRequest;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.SnapshotDescription;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.coprocessor.CoreCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.MasterCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.MasterCoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.MasterObserver;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.master.MasterServices;
+import org.apache.hadoop.hbase.net.Address;
+import org.apache.hadoop.hbase.quotas.GlobalQuotaSettings;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
+import org.apache.hadoop.hbase.replication.SyncReplicationState;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@CoreCoprocessor
+@InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.CONFIG)
+public class MasterReadOnlyController extends AbstractReadOnlyController
+  implements MasterCoprocessor, MasterObserver {
+
+  private static final Logger LOG = LoggerFactory.getLogger(MasterReadOnlyController.class);
+
+  private MasterServices masterServices;
+
+  @Override
+  public Optional<MasterObserver> getMasterObserver() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public TableDescriptor preCreateTableRegionsInfos(
+    ObserverContext<MasterCoprocessorEnvironment> ctx, TableDescriptor desc) throws IOException {
+    internalReadOnlyGuard();
+    return MasterObserver.super.preCreateTableRegionsInfos(ctx, desc);
+  }
+
+  @Override
+  public void preCreateTable(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableDescriptor desc, RegionInfo[] regions) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preCreateTable(ctx, desc, regions);
+  }
+
+  @Override
+  public void preCreateTableAction(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableDescriptor desc, RegionInfo[] regions) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preCreateTableAction(ctx, desc, regions);
+  }
+
+  @Override
+  public void preDeleteTable(ObserverContext<MasterCoprocessorEnvironment> ctx, TableName tableName)
+    throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preDeleteTable(ctx, tableName);
+  }
+
+  @Override
+  public void preDeleteTableAction(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableName tableName) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preDeleteTableAction(ctx, tableName);
+  }
+
+  @Override
+  public void preTruncateTable(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableName tableName) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preTruncateTable(ctx, tableName);
+  }
+
+  @Override
+  public void preTruncateTableAction(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableName tableName) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preTruncateTableAction(ctx, tableName);
+  }
+
+  @Override
+  public TableDescriptor preModifyTable(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableName tableName, TableDescriptor currentDescriptor, TableDescriptor newDescriptor)
+    throws IOException {
+    internalReadOnlyGuard();
+    return MasterObserver.super.preModifyTable(ctx, tableName, currentDescriptor, newDescriptor);
+  }
+
+  @Override
+  public String preModifyTableStoreFileTracker(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableName tableName, String dstSFT) throws IOException {
+    internalReadOnlyGuard();
+    return MasterObserver.super.preModifyTableStoreFileTracker(ctx, tableName, dstSFT);
+  }
+
+  @Override
+  public String preModifyColumnFamilyStoreFileTracker(
+    ObserverContext<MasterCoprocessorEnvironment> ctx, TableName tableName, byte[] family,
+    String dstSFT) throws IOException {
+    internalReadOnlyGuard();
+    return MasterObserver.super.preModifyColumnFamilyStoreFileTracker(ctx, tableName, family,
+      dstSFT);
+  }
+
+  @Override
+  public void preModifyTableAction(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableName tableName, TableDescriptor currentDescriptor, TableDescriptor newDescriptor)
+    throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preModifyTableAction(ctx, tableName, currentDescriptor, newDescriptor);
+  }
+
+  @Override
+  public void preSplitRegion(ObserverContext<MasterCoprocessorEnvironment> c, TableName tableName,
+    byte[] splitRow) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSplitRegion(c, tableName, splitRow);
+  }
+
+  @Override
+  public void preSplitRegionAction(ObserverContext<MasterCoprocessorEnvironment> c,
+    TableName tableName, byte[] splitRow) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSplitRegionAction(c, tableName, splitRow);
+  }
+
+  @Override
+  public void preSplitRegionBeforeMETAAction(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    byte[] splitKey, List<Mutation> metaEntries) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSplitRegionBeforeMETAAction(ctx, splitKey, metaEntries);
+  }
+
+  @Override
+  public void preSplitRegionAfterMETAAction(ObserverContext<MasterCoprocessorEnvironment> ctx)
+    throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSplitRegionAfterMETAAction(ctx);
+  }
+
+  @Override
+  public void preTruncateRegion(ObserverContext<MasterCoprocessorEnvironment> c,
+    RegionInfo regionInfo) {
+    try {
+      internalReadOnlyGuard();
+    } catch (IOException e) {
+      LOG.info("Region truncation of region {} not allowed in read-only mode",
+        regionInfo.getRegionNameAsString());
+    }
+    MasterObserver.super.preTruncateRegion(c, regionInfo);
+  }
+
+  @Override
+  public void preTruncateRegionAction(ObserverContext<MasterCoprocessorEnvironment> c,
+    RegionInfo regionInfo) {
+    try {
+      internalReadOnlyGuard();
+    } catch (IOException e) {
+      LOG.info("Region truncation of region {} not allowed in read-only mode",
+        regionInfo.getRegionNameAsString());
+    }
+    MasterObserver.super.preTruncateRegionAction(c, regionInfo);
+  }
+
+  @Override
+  public void preMergeRegionsAction(final ObserverContext<MasterCoprocessorEnvironment> ctx,
+    final RegionInfo[] regionsToMerge) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preMergeRegionsAction(ctx, regionsToMerge);
+  }
+
+  @Override
+  public void preMergeRegionsCommitAction(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    RegionInfo[] regionsToMerge, List<Mutation> metaEntries) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preMergeRegionsCommitAction(ctx, regionsToMerge, metaEntries);
+  }
+
+  @Override
+  public void preSnapshot(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    SnapshotDescription snapshot, TableDescriptor tableDescriptor) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSnapshot(ctx, snapshot, tableDescriptor);
+  }
+
+  @Override
+  public void preCloneSnapshot(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    SnapshotDescription snapshot, TableDescriptor tableDescriptor) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preCloneSnapshot(ctx, snapshot, tableDescriptor);
+  }
+
+  @Override
+  public void preRestoreSnapshot(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    SnapshotDescription snapshot, TableDescriptor tableDescriptor) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preRestoreSnapshot(ctx, snapshot, tableDescriptor);
+  }
+
+  @Override
+  public void preDeleteSnapshot(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    SnapshotDescription snapshot) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preDeleteSnapshot(ctx, snapshot);
+  }
+
+  @Override
+  public void preCreateNamespace(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    NamespaceDescriptor ns) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preCreateNamespace(ctx, ns);
+  }
+
+  @Override
+  public void preModifyNamespace(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    NamespaceDescriptor currentNsDescriptor, NamespaceDescriptor newNsDescriptor)
+    throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preModifyNamespace(ctx, currentNsDescriptor, newNsDescriptor);
+  }
+
+  @Override
+  public void preDeleteNamespace(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String namespace) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preDeleteNamespace(ctx, namespace);
+  }
+
+  @Override
+  public void preMasterStoreFlush(ObserverContext<MasterCoprocessorEnvironment> ctx)
+    throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preMasterStoreFlush(ctx);
+  }
+
+  @Override
+  public void preSetUserQuota(ObserverContext<MasterCoprocessorEnvironment> ctx, String userName,
+    GlobalQuotaSettings quotas) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSetUserQuota(ctx, userName, quotas);
+  }
+
+  @Override
+  public void preSetUserQuota(ObserverContext<MasterCoprocessorEnvironment> ctx, String userName,
+    TableName tableName, GlobalQuotaSettings quotas) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSetUserQuota(ctx, userName, tableName, quotas);
+  }
+
+  @Override
+  public void preSetUserQuota(ObserverContext<MasterCoprocessorEnvironment> ctx, String userName,
+    String namespace, GlobalQuotaSettings quotas) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSetUserQuota(ctx, userName, namespace, quotas);
+  }
+
+  @Override
+  public void preSetTableQuota(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    TableName tableName, GlobalQuotaSettings quotas) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSetTableQuota(ctx, tableName, quotas);
+  }
+
+  @Override
+  public void preSetNamespaceQuota(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String namespace, GlobalQuotaSettings quotas) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSetNamespaceQuota(ctx, namespace, quotas);
+  }
+
+  @Override
+  public void preSetRegionServerQuota(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String regionServer, GlobalQuotaSettings quotas) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preSetRegionServerQuota(ctx, regionServer, quotas);
+  }
+
+  @Override
+  public void preMergeRegions(final ObserverContext<MasterCoprocessorEnvironment> ctx,
+    final RegionInfo[] regionsToMerge) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preMergeRegions(ctx, regionsToMerge);
+  }
+
+  @Override
+  public void preMoveServersAndTables(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    Set<Address> servers, Set<TableName> tables, String targetGroup) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preMoveServersAndTables(ctx, servers, tables, targetGroup);
+  }
+
+  @Override
+  public void preMoveServers(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    Set<Address> servers, String targetGroup) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preMoveServers(ctx, servers, targetGroup);
+  }
+
+  @Override
+  public void preMoveTables(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    Set<TableName> tables, String targetGroup) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preMoveTables(ctx, tables, targetGroup);
+  }
+
+  @Override
+  public void preAddRSGroup(ObserverContext<MasterCoprocessorEnvironment> ctx, String name)
+    throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preAddRSGroup(ctx, name);
+  }
+
+  @Override
+  public void preRemoveRSGroup(ObserverContext<MasterCoprocessorEnvironment> ctx, String name)
+    throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preRemoveRSGroup(ctx, name);
+  }
+
+  @Override
+  public void preBalanceRSGroup(ObserverContext<MasterCoprocessorEnvironment> ctx, String groupName,
+    BalanceRequest request) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preBalanceRSGroup(ctx, groupName, request);
+  }
+
+  @Override
+  public void preRemoveServers(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    Set<Address> servers) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preRemoveServers(ctx, servers);
+  }
+
+  @Override
+  public void preRenameRSGroup(ObserverContext<MasterCoprocessorEnvironment> ctx, String oldName,
+    String newName) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preRenameRSGroup(ctx, oldName, newName);
+  }
+
+  @Override
+  public void preUpdateRSGroupConfig(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String groupName, Map<String, String> configuration) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preUpdateRSGroupConfig(ctx, groupName, configuration);
+  }
+
+  @Override
+  public void preAddReplicationPeer(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String peerId, ReplicationPeerConfig peerConfig) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preAddReplicationPeer(ctx, peerId, peerConfig);
+  }
+
+  @Override
+  public void preRemoveReplicationPeer(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String peerId) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preRemoveReplicationPeer(ctx, peerId);
+  }
+
+  @Override
+  public void preEnableReplicationPeer(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String peerId) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preEnableReplicationPeer(ctx, peerId);
+  }
+
+  @Override
+  public void preDisableReplicationPeer(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String peerId) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preDisableReplicationPeer(ctx, peerId);
+  }
+
+  @Override
+  public void preUpdateReplicationPeerConfig(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    String peerId, ReplicationPeerConfig peerConfig) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preUpdateReplicationPeerConfig(ctx, peerId, peerConfig);
+  }
+
+  @Override
+  public void preTransitReplicationPeerSyncReplicationState(
+    ObserverContext<MasterCoprocessorEnvironment> ctx, String peerId, SyncReplicationState state)
+    throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preTransitReplicationPeerSyncReplicationState(ctx, peerId, state);
+  }
+
+  @Override
+  public void preGrant(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    UserPermission userPermission, boolean mergeExistingPermissions) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preGrant(ctx, userPermission, mergeExistingPermissions);
+  }
+
+  @Override
+  public void preRevoke(ObserverContext<MasterCoprocessorEnvironment> ctx,
+    UserPermission userPermission) throws IOException {
+    internalReadOnlyGuard();
+    MasterObserver.super.preRevoke(ctx, userPermission);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/RegionReadOnlyController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/RegionReadOnlyController.java
@@ -1,0 +1,367 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import java.io.IOException;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.CompareOperator;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.CheckAndMutate;
+import org.apache.hadoop.hbase.client.CheckAndMutateResult;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.coprocessor.CoreCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.RegionObserver;
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.regionserver.FlushLifeCycleTracker;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.MiniBatchOperationInProgress;
+import org.apache.hadoop.hbase.regionserver.ScanOptions;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.StoreFile;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionLifeCycleTracker;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+import org.apache.hadoop.hbase.util.Pair;
+import org.apache.hadoop.hbase.wal.WALEdit;
+import org.apache.hadoop.hbase.wal.WALKey;
+import org.apache.yetus.audience.InterfaceAudience;
+
+@CoreCoprocessor
+@InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.CONFIG)
+public class RegionReadOnlyController extends AbstractReadOnlyController
+  implements RegionCoprocessor, RegionObserver {
+
+  @Override
+  public Optional<RegionObserver> getRegionObserver() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public void preFlushScannerOpen(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Store store, ScanOptions options, FlushLifeCycleTracker tracker) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preFlushScannerOpen(c, store, options, tracker);
+  }
+
+  @Override
+  public void preFlush(final ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    FlushLifeCycleTracker tracker) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preFlush(c, tracker);
+  }
+
+  @Override
+  public InternalScanner preFlush(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Store store, InternalScanner scanner, FlushLifeCycleTracker tracker) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preFlush(c, store, scanner, tracker);
+  }
+
+  @Override
+  public void preMemStoreCompaction(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Store store) throws IOException {
+    internalReadOnlyGuard();
+    RegionObserver.super.preMemStoreCompaction(c, store);
+  }
+
+  @Override
+  public void preMemStoreCompactionCompactScannerOpen(
+    ObserverContext<? extends RegionCoprocessorEnvironment> c, Store store, ScanOptions options)
+    throws IOException {
+    internalReadOnlyGuard();
+    RegionObserver.super.preMemStoreCompactionCompactScannerOpen(c, store, options);
+  }
+
+  @Override
+  public InternalScanner preMemStoreCompactionCompact(
+    ObserverContext<? extends RegionCoprocessorEnvironment> c, Store store, InternalScanner scanner)
+    throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preMemStoreCompactionCompact(c, store, scanner);
+  }
+
+  @Override
+  public void preCompactSelection(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Store store, List<? extends StoreFile> candidates, CompactionLifeCycleTracker tracker)
+    throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preCompactSelection(c, store, candidates, tracker);
+  }
+
+  @Override
+  public void preCompactScannerOpen(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Store store, ScanType scanType, ScanOptions options, CompactionLifeCycleTracker tracker,
+    CompactionRequest request) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preCompactScannerOpen(c, store, scanType, options, tracker, request);
+  }
+
+  @Override
+  public InternalScanner preCompact(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Store store, InternalScanner scanner, ScanType scanType, CompactionLifeCycleTracker tracker,
+    CompactionRequest request) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCompact(c, store, scanner, scanType, tracker, request);
+  }
+
+  @Override
+  public void prePut(ObserverContext<? extends RegionCoprocessorEnvironment> c, Put put,
+    WALEdit edit, Durability durability) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.prePut(c, put, edit, durability);
+  }
+
+  @Override
+  public void prePut(ObserverContext<? extends RegionCoprocessorEnvironment> c, Put put,
+    WALEdit edit) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.prePut(c, put, edit);
+  }
+
+  @Override
+  public void preDelete(ObserverContext<? extends RegionCoprocessorEnvironment> c, Delete delete,
+    WALEdit edit, Durability durability) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preDelete(c, delete, edit, durability);
+  }
+
+  @Override
+  public void preDelete(ObserverContext<? extends RegionCoprocessorEnvironment> c, Delete delete,
+    WALEdit edit) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preDelete(c, delete, edit);
+  }
+
+  @Override
+  public void preBatchMutate(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    MiniBatchOperationInProgress<Mutation> miniBatchOp) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preBatchMutate(c, miniBatchOp);
+  }
+
+  @Override
+  public boolean preCheckAndPut(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    byte[] row, byte[] family, byte[] qualifier, CompareOperator op, ByteArrayComparable comparator,
+    Put put, boolean result) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCheckAndPut(c, row, family, qualifier, op, comparator, put,
+      result);
+  }
+
+  @Override
+  public boolean preCheckAndPut(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    byte[] row, Filter filter, Put put, boolean result) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCheckAndPut(c, row, filter, put, result);
+  }
+
+  @Override
+  public boolean preCheckAndPutAfterRowLock(
+    ObserverContext<? extends RegionCoprocessorEnvironment> c, byte[] row, byte[] family,
+    byte[] qualifier, CompareOperator op, ByteArrayComparable comparator, Put put, boolean result)
+    throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCheckAndPutAfterRowLock(c, row, family, qualifier, op,
+      comparator, put, result);
+  }
+
+  @Override
+  public boolean preCheckAndPutAfterRowLock(
+    ObserverContext<? extends RegionCoprocessorEnvironment> c, byte[] row, Filter filter, Put put,
+    boolean result) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCheckAndPutAfterRowLock(c, row, filter, put, result);
+  }
+
+  @Override
+  public boolean preCheckAndDelete(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    byte[] row, byte[] family, byte[] qualifier, CompareOperator op, ByteArrayComparable comparator,
+    Delete delete, boolean result) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCheckAndDelete(c, row, family, qualifier, op, comparator, delete,
+      result);
+  }
+
+  @Override
+  public boolean preCheckAndDelete(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    byte[] row, Filter filter, Delete delete, boolean result) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCheckAndDelete(c, row, filter, delete, result);
+  }
+
+  @Override
+  public boolean preCheckAndDeleteAfterRowLock(
+    ObserverContext<? extends RegionCoprocessorEnvironment> c, byte[] row, byte[] family,
+    byte[] qualifier, CompareOperator op, ByteArrayComparable comparator, Delete delete,
+    boolean result) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCheckAndDeleteAfterRowLock(c, row, family, qualifier, op,
+      comparator, delete, result);
+  }
+
+  @Override
+  public boolean preCheckAndDeleteAfterRowLock(
+    ObserverContext<? extends RegionCoprocessorEnvironment> c, byte[] row, Filter filter,
+    Delete delete, boolean result) throws IOException {
+    if (!isWritableInReadOnlyMode(c)) {
+      internalReadOnlyGuard();
+    }
+    return RegionObserver.super.preCheckAndDeleteAfterRowLock(c, row, filter, delete, result);
+  }
+
+  @Override
+  public CheckAndMutateResult preCheckAndMutate(
+    ObserverContext<? extends RegionCoprocessorEnvironment> c, CheckAndMutate checkAndMutate,
+    CheckAndMutateResult result) throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preCheckAndMutate(c, checkAndMutate, result);
+  }
+
+  @Override
+  public CheckAndMutateResult preCheckAndMutateAfterRowLock(
+    ObserverContext<? extends RegionCoprocessorEnvironment> c, CheckAndMutate checkAndMutate,
+    CheckAndMutateResult result) throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preCheckAndMutateAfterRowLock(c, checkAndMutate, result);
+  }
+
+  @Override
+  public Result preAppend(ObserverContext<? extends RegionCoprocessorEnvironment> c, Append append)
+    throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preAppend(c, append);
+  }
+
+  @Override
+  public Result preAppend(ObserverContext<? extends RegionCoprocessorEnvironment> c, Append append,
+    WALEdit edit) throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preAppend(c, append, edit);
+  }
+
+  @Override
+  public Result preAppendAfterRowLock(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Append append) throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preAppendAfterRowLock(c, append);
+  }
+
+  @Override
+  public Result preIncrement(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Increment increment) throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preIncrement(c, increment);
+  }
+
+  @Override
+  public Result preIncrement(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Increment increment, WALEdit edit) throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preIncrement(c, increment, edit);
+  }
+
+  @Override
+  public Result preIncrementAfterRowLock(ObserverContext<? extends RegionCoprocessorEnvironment> c,
+    Increment increment) throws IOException {
+    internalReadOnlyGuard();
+    return RegionObserver.super.preIncrementAfterRowLock(c, increment);
+  }
+
+  @Override
+  public void preReplayWALs(ObserverContext<? extends RegionCoprocessorEnvironment> ctx,
+    RegionInfo info, Path edits) throws IOException {
+    if (!isWritableInReadOnlyMode(ctx)) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preReplayWALs(ctx, info, edits);
+  }
+
+  @Override
+  public void preBulkLoadHFile(ObserverContext<? extends RegionCoprocessorEnvironment> ctx,
+    List<Pair<byte[], String>> familyPaths) throws IOException {
+    internalReadOnlyGuard();
+    RegionObserver.super.preBulkLoadHFile(ctx, familyPaths);
+  }
+
+  @Override
+  public void preCommitStoreFile(ObserverContext<? extends RegionCoprocessorEnvironment> ctx,
+    byte[] family, List<Pair<Path, Path>> pairs) throws IOException {
+    internalReadOnlyGuard();
+    RegionObserver.super.preCommitStoreFile(ctx, family, pairs);
+  }
+
+  @Override
+  public void preWALAppend(ObserverContext<? extends RegionCoprocessorEnvironment> ctx, WALKey key,
+    WALEdit edit) throws IOException {
+    // Only allow this operation for whitelisted table.
+    // See {@link writableTables set} for details.
+    if (!isWritableInReadOnlyMode(key.getTableName())) {
+      internalReadOnlyGuard();
+    }
+    RegionObserver.super.preWALAppend(ctx, key, edit);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/RegionServerReadOnlyController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/RegionServerReadOnlyController.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import java.io.IOException;
+import java.util.Optional;
+import org.apache.hadoop.hbase.HBaseInterfaceAudience;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.coprocessor.CoreCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionServerCoprocessor;
+import org.apache.hadoop.hbase.coprocessor.RegionServerCoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.RegionServerObserver;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos;
+
+@CoreCoprocessor
+@InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.CONFIG)
+public class RegionServerReadOnlyController extends AbstractReadOnlyController
+  implements RegionServerObserver, RegionServerCoprocessor {
+
+  @Override
+  public Optional<RegionServerObserver> getRegionServerObserver() {
+    return Optional.of(this);
+  }
+
+  @Override
+  public void preRollWALWriterRequest(ObserverContext<RegionServerCoprocessorEnvironment> ctx)
+    throws IOException {
+    internalReadOnlyGuard();
+    RegionServerObserver.super.preRollWALWriterRequest(ctx);
+  }
+
+  @Override
+  public void preReplicationSinkBatchMutate(ObserverContext<RegionServerCoprocessorEnvironment> ctx,
+    AdminProtos.WALEntry walEntry, Mutation mutation) throws IOException {
+    internalReadOnlyGuard();
+    RegionServerObserver.super.preReplicationSinkBatchMutate(ctx, walEntry, mutation);
+  }
+
+  @Override
+  public void preReplicateLogEntries(ObserverContext<RegionServerCoprocessorEnvironment> ctx)
+    throws IOException {
+    internalReadOnlyGuard();
+    RegionServerObserver.super.preReplicateLogEntries(ctx);
+  }
+
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/tool/BulkLoadHFilesTool.java
@@ -660,21 +660,21 @@ public class BulkLoadHFilesTool extends Configured implements BulkLoadHFiles, To
   private void checkRegionIndexValid(int idx, List<Pair<byte[], byte[]>> startEndKeys,
     TableName tableName) throws IOException {
     if (idx < 0) {
-      throw new IOException("The first region info for table " + tableName
-        + " can't be found in hbase:meta.Please use hbck tool to fix it first.");
+      throw new IOException("The first region info for table " + tableName + " can't be found in "
+        + TableName.META_TABLE_NAME + ". Please use hbck tool to fix it" + " first.");
     } else if (
       (idx == startEndKeys.size() - 1)
         && !Bytes.equals(startEndKeys.get(idx).getSecond(), HConstants.EMPTY_BYTE_ARRAY)
     ) {
-      throw new IOException("The last region info for table " + tableName
-        + " can't be found in hbase:meta.Please use hbck tool to fix it first.");
+      throw new IOException("The last region info for table " + tableName + " can't be found in "
+        + TableName.META_TABLE_NAME + ". Please use hbck tool to fix it" + " first.");
     } else if (
       idx + 1 < startEndKeys.size() && !(Bytes.compareTo(startEndKeys.get(idx).getSecond(),
         startEndKeys.get(idx + 1).getFirst()) == 0)
     ) {
       throw new IOException("The endkey of one region for table " + tableName
-        + " is not equal to the startkey of the next region in hbase:meta."
-        + "Please use hbck tool to fix it first.");
+        + " is not equal to the startkey of the next region in " + TableName.META_TABLE_NAME + "."
+        + " Please use hbck tool to fix it first.");
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ConfigurationUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ConfigurationUtil.java
@@ -22,6 +22,7 @@ import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.util.StringUtils;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -113,5 +114,10 @@ public final class ConfigurationUtil {
       rtn.add(new AbstractMap.SimpleImmutableEntry<>(splitKvp[0], splitKvp[1]));
     }
     return rtn;
+  }
+
+  public static boolean isReadOnlyModeEnabledInConf(Configuration conf) {
+    return conf.getBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY,
+      HConstants.HBASE_GLOBAL_READONLY_ENABLED_DEFAULT);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CoprocessorConfigurationUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/CoprocessorConfigurationUtil.java
@@ -17,28 +17,52 @@
  */
 package org.apache.hadoop.hbase.util;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Set;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorReloadTask;
+import org.apache.hadoop.hbase.security.access.BulkLoadReadOnlyController;
+import org.apache.hadoop.hbase.security.access.EndpointReadOnlyController;
+import org.apache.hadoop.hbase.security.access.MasterReadOnlyController;
+import org.apache.hadoop.hbase.security.access.RegionReadOnlyController;
+import org.apache.hadoop.hbase.security.access.RegionServerReadOnlyController;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hbase.thirdparty.com.google.common.base.Preconditions;
 import org.apache.hbase.thirdparty.com.google.common.base.Strings;
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableList;
+import org.apache.hbase.thirdparty.com.google.common.collect.ImmutableMap;
 
 /**
  * Helper class for coprocessor host when configuration changes.
  */
 @InterfaceAudience.Private
 public final class CoprocessorConfigurationUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(CoprocessorConfigurationUtil.class);
+
+  private static final ImmutableMap<String, List<String>> READONLY_COPROCESSORS =
+    ImmutableMap.of(CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY,
+      ImmutableList.of(MasterReadOnlyController.class.getName()),
+      CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY,
+      ImmutableList.of(RegionServerReadOnlyController.class.getName()),
+      CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,
+      ImmutableList.of(RegionReadOnlyController.class.getName(),
+        BulkLoadReadOnlyController.class.getName(), EndpointReadOnlyController.class.getName()));
 
   private CoprocessorConfigurationUtil() {
   }
 
   /**
    * Check configuration change by comparing current loaded coprocessors with configuration values.
-   * This method is useful when the configuration object has been updated but we need to determine
-   * if coprocessor configuration has actually changed compared to what's currently loaded.
+   * This method is useful when the configuration object has been updated, but we need to determine
+   * if the coprocessor configuration has actually changed compared to what's currently loaded.
    * <p>
    * <b>Note:</b> This method only detects changes in the set of coprocessor class names. It does
    * <b>not</b> detect changes to priority or path for coprocessors that are already loaded with the
@@ -101,5 +125,167 @@ public final class CoprocessorConfigurationUtil {
       }
     }
     return false;
+  }
+
+  private static List<String> getCoprocessorsFromConfig(Configuration conf,
+    String configurationKey) {
+    String[] existing = conf.getStrings(configurationKey);
+    return existing != null ? new ArrayList<>(Arrays.asList(existing)) : new ArrayList<>();
+  }
+
+  public static void addCoprocessors(Configuration conf, String configurationKey,
+    List<String> coprocessorsToAdd) {
+    List<String> existing = getCoprocessorsFromConfig(conf, configurationKey);
+
+    boolean isModified = false;
+
+    for (String coprocessor : coprocessorsToAdd) {
+      if (!existing.contains(coprocessor)) {
+        existing.add(coprocessor);
+        isModified = true;
+      }
+    }
+
+    if (isModified) {
+      conf.setStrings(configurationKey, existing.toArray(new String[0]));
+    }
+  }
+
+  public static void removeCoprocessors(Configuration conf, String configurationKey,
+    List<String> coprocessorsToRemove) {
+    List<String> existing = getCoprocessorsFromConfig(conf, configurationKey);
+
+    if (existing.isEmpty()) {
+      return;
+    }
+
+    boolean isModified = false;
+
+    for (String coprocessor : coprocessorsToRemove) {
+      if (existing.contains(coprocessor)) {
+        existing.remove(coprocessor);
+        isModified = true;
+      }
+    }
+
+    if (isModified) {
+      conf.setStrings(configurationKey, existing.toArray(new String[0]));
+    }
+  }
+
+  private static List<String> getReadOnlyCoprocessors(String configurationKey) {
+    return READONLY_COPROCESSORS.get(configurationKey);
+  }
+
+  /**
+   * This method adds or removes relevant ReadOnlyController coprocessors to the provided
+   * configuration based on whether read-only mode is enabled in the provided Configuration.
+   * @param conf               The up-to-date configuration used to determine how to handle
+   *                           coprocessors
+   * @param coprocessorConfKey The configuration key name
+   */
+  public static void syncReadOnlyConfigurations(Configuration conf, String coprocessorConfKey) {
+    boolean isReadOnlyModeEnabled = ConfigurationUtil.isReadOnlyModeEnabledInConf(conf);
+
+    List<String> cpList = getReadOnlyCoprocessors(coprocessorConfKey);
+    if (isReadOnlyModeEnabled) {
+      CoprocessorConfigurationUtil.addCoprocessors(conf, coprocessorConfKey, cpList);
+    } else {
+      CoprocessorConfigurationUtil.removeCoprocessors(conf, coprocessorConfKey, cpList);
+    }
+  }
+
+  /**
+   * Check whether ReadOnlyController coprocessors have been loaded in the provided configuration.
+   * @param conf               the configuration we are checking
+   * @param coprocessorConfKey configuration key used for setting master, region server, or region
+   *                           coprocessors
+   * @return true if the ReadOnlyCoprocessors are loaded in the configuration; false otherwise
+   */
+  public static boolean areReadOnlyCoprocessorsLoaded(Configuration conf,
+    String coprocessorConfKey) {
+    // Using a HashSet will improve performance when searching for read-only coprocessors
+    HashSet<String> allCoprocessors =
+      new HashSet<>(getCoprocessorsFromConfig(conf, coprocessorConfKey));
+    List<String> readOnlyCoprocessors = getReadOnlyCoprocessors(coprocessorConfKey);
+    return allCoprocessors.containsAll(readOnlyCoprocessors);
+  }
+
+  /**
+   * Takes an updated configuration and updates the coprocessors for that configuration key in the
+   * current configuration.
+   * @param currentConf        the configuration currently used by the master, region server, or
+   *                           region
+   * @param updatedConf        the updated version of the configuration whose coprocessors we want
+   *                           to copy
+   * @param coprocessorConfKey configuration key used for setting master, region server, or region
+   *                           coprocessors
+   */
+  public static void updateCoprocessorListInConf(Configuration currentConf,
+    Configuration updatedConf, String coprocessorConfKey) {
+    String[] updatedCoprocessorList = updatedConf.getStrings(coprocessorConfKey);
+    if (updatedCoprocessorList != null) {
+      currentConf.setStrings(coprocessorConfKey, updatedCoprocessorList);
+    } else {
+      currentConf.unset(coprocessorConfKey);
+    }
+  }
+
+  /**
+   * Gets the name of a component based on the provided coprocessor configuration key.
+   * @param coprocessorConfKey configuration key used for setting master, region server, or region
+   *                           coprocessors
+   * @return the component type - Master, Region Server, or Region
+   */
+  public static String getComponentName(String coprocessorConfKey) {
+    return switch (coprocessorConfKey) {
+      case CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY -> "Master";
+      case CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY -> "Region Server";
+      case CoprocessorHost.REGION_COPROCESSOR_CONF_KEY -> "Region";
+      default -> throw new IllegalArgumentException(
+        "Unsupported coprocessor configuration key: " + coprocessorConfKey);
+    };
+  }
+
+  /**
+   * This method updates the coprocessors on the master, region server, or region if a change has
+   * been detected. Detected changes include changes in coprocessors or changes in read-only mode
+   * configuration. If a change is detected, then new coprocessors are loaded using the provided
+   * reload method. The new value for the read-only config variable is updated as well.
+   * @param newConf                   an updated configuration
+   * @param originalIsReadOnlyEnabled the original value for
+   *                                  {@value HConstants#HBASE_GLOBAL_READONLY_ENABLED_KEY}
+   * @param coprocessorHost           the coprocessor host for HMaster, HRegionServer, or HRegion
+   * @param coprocessorConfKey        configuration key used for setting master, region server, or
+   *                                  region coprocessors
+   * @param isMaintenanceMode         whether maintenance mode is active (mainly for HMaster)
+   * @param instance                  string value of the instance calling this method (mainly helps
+   *                                  with tracking region logging)
+   * @param reloadTask                lambda function that reloads coprocessors on the master,
+   *                                  region server, or region
+   */
+  public static void maybeUpdateCoprocessors(Configuration newConf,
+    boolean originalIsReadOnlyEnabled, CoprocessorHost<?, ?> coprocessorHost,
+    String coprocessorConfKey, boolean isMaintenanceMode, String instance,
+    CoprocessorReloadTask reloadTask) {
+
+    boolean maybeUpdatedReadOnlyMode = ConfigurationUtil.isReadOnlyModeEnabledInConf(newConf);
+    boolean hasReadOnlyModeChanged = originalIsReadOnlyEnabled != maybeUpdatedReadOnlyMode;
+    boolean hasCoprocessorConfigChanged = CoprocessorConfigurationUtil
+      .checkConfigurationChange(coprocessorHost, newConf, coprocessorConfKey);
+
+    // update region server coprocessor if the configuration has changed.
+    if ((hasCoprocessorConfigChanged || hasReadOnlyModeChanged) && !isMaintenanceMode) {
+      LOG.info("Updating coprocessors for {} {} because the configuration has changed",
+        getComponentName(coprocessorConfKey), instance);
+      CoprocessorConfigurationUtil.syncReadOnlyConfigurations(newConf, coprocessorConfKey);
+      reloadTask.reload(newConf);
+    }
+
+    if (hasReadOnlyModeChanged) {
+      LOG.info("Config {} has been dynamically changed to {} for {} {}",
+        HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, maybeUpdatedReadOnlyMode,
+        getComponentName(coprocessorConfKey), instance);
+    }
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSTableDescriptors.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSTableDescriptors.java
@@ -153,14 +153,14 @@ public class FSTableDescriptors implements TableDescriptors {
     }
     TableDescriptorBuilder builder = createMetaTableDescriptorBuilder(conf);
     TableDescriptor td = StoreFileTrackerFactory.updateWithTrackerConfigs(conf, builder.build());
-    LOG.info("Creating new hbase:meta table descriptor {}", td);
+    LOG.info("Creating new {} table descriptor {}", TableName.META_TABLE_NAME, td);
     TableName tableName = td.getTableName();
     Path tableDir = CommonFSUtils.getTableDir(rootdir, tableName);
     Path p = writeTableDescriptor(fs, td, tableDir, null);
     if (p == null) {
-      throw new IOException("Failed update hbase:meta table descriptor");
+      throw new IOException("Failed update " + TableName.META_TABLE_NAME + " table descriptor");
     }
-    LOG.info("Updated hbase:meta table descriptor to {}", p);
+    LOG.info("Updated {} table descriptor to {}", TableName.META_TABLE_NAME, p);
     return td;
   }
 
@@ -236,7 +236,7 @@ public class FSTableDescriptors implements TableDescriptors {
         cachehits++;
         return cachedtdm;
       }
-      // we do not need to go to fs any more
+      // we do not need to go to the fs anymore
       if (fsvisited) {
         return null;
       }
@@ -270,7 +270,8 @@ public class FSTableDescriptors implements TableDescriptors {
       LOG.info("Fetching table descriptors from the filesystem.");
       final long startTime = EnvironmentEdgeManager.currentTime();
       AtomicBoolean allvisited = new AtomicBoolean(usecache);
-      List<Path> tableDirs = FSUtils.getTableDirs(fs, rootdir);
+      List<Path> tableDirs =
+        FSUtils.getTableDirs(fs, rootdir).stream().filter(FSUtils::isLocalMetaTable).toList();
       if (!tableDescriptorParallelLoadEnable) {
         for (Path dir : tableDirs) {
           internalGet(dir, tds, allvisited);
@@ -668,8 +669,8 @@ public class FSTableDescriptors implements TableDescriptors {
    * @param htd           description of the table to write
    * @param forceCreation if <tt>true</tt>,then even if previous table descriptor is present it will
    *                      be overwritten
-   * @return <tt>true</tt> if the we successfully created the file, <tt>false</tt> if the file
-   *         already exists and we weren't forcing the descriptor creation.
+   * @return <tt>true</tt> if we successfully created the file, <tt>false</tt> if the file already
+   *         exists, and we weren't forcing the descriptor creation.
    * @throws IOException if a filesystem error occurs
    */
   public boolean createTableDescriptorForTableDirectory(Path tableDir, TableDescriptor htd,
@@ -688,8 +689,8 @@ public class FSTableDescriptors implements TableDescriptors {
    * @param htd           description of the table to write
    * @param forceCreation if <tt>true</tt>,then even if previous table descriptor is present it will
    *                      be overwritten
-   * @return <tt>true</tt> if the we successfully created the file, <tt>false</tt> if the file
-   *         already exists and we weren't forcing the descriptor creation.
+   * @return <tt>true</tt> if we successfully created the file, <tt>false</tt> if the file already
+   *         exists, and we weren't forcing the descriptor creation.
    * @throws IOException if a filesystem error occurs
    */
   public static boolean createTableDescriptorForTableDirectory(FileSystem fs, Path tableDir,
@@ -705,5 +706,15 @@ public class FSTableDescriptors implements TableDescriptors {
       }
     }
     return writeTableDescriptor(fs, htd, tableDir, opt.map(Pair::getFirst).orElse(null)) != null;
+  }
+
+  /**
+   * Invalidates the table descriptor cache.
+   */
+  @Override
+  public void invalidateTableDescriptorCache() {
+    LOG.info("Invalidating table descriptor cache.");
+    this.fsvisited = false;
+    this.cache.clear();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -65,7 +65,8 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.fs.permission.FsPermission;
-import org.apache.hadoop.hbase.ClusterId;
+import org.apache.hadoop.hbase.ClusterIdFile;
+import org.apache.hadoop.hbase.ClusterIdFileParser;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HDFSBlocksDistribution;
 import org.apache.hadoop.hbase.TableName;
@@ -541,15 +542,15 @@ public final class FSUtils {
    * @return <code>true</code> if the file exists, otherwise <code>false</code>
    * @throws IOException if checking the FileSystem fails
    */
-  public static boolean checkClusterIdExists(FileSystem fs, Path rootdir, long wait)
-    throws IOException {
+  public static boolean checkFileExistsInHbaseRootDir(FileSystem fs, Path rootdir, String file,
+    long wait) throws IOException {
     while (true) {
       try {
-        Path filePath = new Path(rootdir, HConstants.CLUSTER_ID_FILE_NAME);
+        Path filePath = new Path(rootdir, file);
         return fs.exists(filePath);
       } catch (IOException ioe) {
         if (wait > 0L) {
-          LOG.warn("Unable to check cluster ID file in {}, retrying in {}ms", rootdir, wait, ioe);
+          LOG.warn("Unable to check file {} in {}, retrying in {}ms", file, rootdir, wait, ioe);
           try {
             Thread.sleep(wait);
           } catch (InterruptedException e) {
@@ -564,15 +565,13 @@ public final class FSUtils {
   }
 
   /**
-   * Returns the value of the unique cluster ID stored for this HBase instance.
-   * @param fs      the root directory FileSystem
-   * @param rootdir the path to the HBase root directory
-   * @return the unique cluster identifier
-   * @throws IOException if reading the cluster ID file fails
+   * Use the given parser object to read and parse contents of Cluster Id file. e.g. Cluster Id or
+   * Active read-replica Cluster Id
    */
-  public static ClusterId getClusterId(FileSystem fs, Path rootdir) throws IOException {
-    Path idPath = new Path(rootdir, HConstants.CLUSTER_ID_FILE_NAME);
-    ClusterId clusterId = null;
+  public static <T extends ClusterIdFile> T getClusterIdFile(FileSystem fs, Path rootdir,
+    ClusterIdFileParser<T> parser) throws IOException {
+    Path idPath = new Path(rootdir, parser.getFileName());
+    T cs = null;
     FileStatus status = fs.exists(idPath) ? fs.getFileStatus(idPath) : null;
     if (status != null) {
       int len = Ints.checkedCast(status.getLen());
@@ -581,12 +580,12 @@ public final class FSUtils {
       try {
         in.readFully(content);
       } catch (EOFException eof) {
-        LOG.warn("Cluster ID file {} is empty", idPath);
+        LOG.warn("Cluster file {} is empty", idPath);
       } finally {
         in.close();
       }
       try {
-        clusterId = ClusterId.parseFrom(content);
+        cs = parser.parseFrom(content);
       } catch (DeserializationException e) {
         throw new IOException("content=" + Bytes.toString(content), e);
       }
@@ -596,73 +595,81 @@ public final class FSUtils {
         in = fs.open(idPath);
         try {
           cid = in.readUTF();
-          clusterId = new ClusterId(cid);
+          cs = parser.readString(cid);
         } catch (EOFException eof) {
-          LOG.warn("Cluster ID file {} is empty", idPath);
+          LOG.warn("Cluster file {} is empty", idPath);
         } finally {
           in.close();
         }
-        rewriteAsPb(fs, rootdir, idPath, clusterId);
+        rewriteAsPb(fs, rootdir, idPath, parser.getFileName(), cs);
       }
-      return clusterId;
+      return cs;
     } else {
-      LOG.warn("Cluster ID file does not exist at {}", idPath);
+      LOG.warn("Cluster file does not exist at {}", idPath);
     }
-    return clusterId;
+    return cs;
   }
 
-  /**
-   *   */
-  private static void rewriteAsPb(final FileSystem fs, final Path rootdir, final Path p,
-    final ClusterId cid) throws IOException {
+  private static <T extends ClusterIdFile> void rewriteAsPb(final FileSystem fs, final Path rootdir,
+    final Path p, final String fileName, final T cs) throws IOException {
     // Rewrite the file as pb. Move aside the old one first, write new
     // then delete the moved-aside file.
     Path movedAsideName = new Path(p + "." + EnvironmentEdgeManager.currentTime());
     if (!fs.rename(p, movedAsideName)) throw new IOException("Failed rename of " + p);
-    setClusterId(fs, rootdir, cid, 100);
+    setClusterIdFile(fs, rootdir, fileName, cs, 100);
     if (!fs.delete(movedAsideName, false)) {
       throw new IOException("Failed delete of " + movedAsideName);
     }
-    LOG.debug("Rewrote the hbase.id file as pb");
+    LOG.debug("Rewrote the {} file as pb", fileName);
   }
 
   /**
-   * Writes a new unique identifier for this cluster to the "hbase.id" file in the HBase root
-   * directory. If any operations on the ID file fails, and {@code wait} is a positive value, the
-   * method will retry to produce the ID file until the thread is forcibly interrupted.
-   * @param fs        the root directory FileSystem
-   * @param rootdir   the path to the HBase root directory
-   * @param clusterId the unique identifier to store
-   * @param wait      how long (in milliseconds) to wait between retries
+   * Writes a new unique identifier for this cluster to the Cluster Id ("hbase.id" or
+   * "active.cluster.suffix.id") file in the HBase root directory. If any operations on the ID file
+   * fails, and {@code wait} is a positive value, the method will retry to produce the ID file until
+   * the thread is forcibly interrupted.
+   * @param fs       the root directory FileSystem
+   * @param rootdir  the path to the HBase root directory
+   * @param fileName name of the file to be written
+   * @param cs       the object to be written
+   * @param wait     how long (in milliseconds) to wait between retries
    * @throws IOException if writing to the FileSystem fails and no wait value
    */
-  public static void setClusterId(final FileSystem fs, final Path rootdir,
-    final ClusterId clusterId, final long wait) throws IOException {
-
-    final Path idFile = new Path(rootdir, HConstants.CLUSTER_ID_FILE_NAME);
+  public static <T extends ClusterIdFile> void setClusterIdFile(final FileSystem fs,
+    final Path rootdir, final String fileName, final T cs, final long wait) throws IOException {
+    final Path idFile = new Path(rootdir, fileName);
     final Path tempDir = new Path(rootdir, HConstants.HBASE_TEMP_DIRECTORY);
-    final Path tempIdFile = new Path(tempDir, HConstants.CLUSTER_ID_FILE_NAME);
+    final Path tempIdFile = new Path(tempDir, fileName);
 
-    LOG.debug("Create cluster ID file [{}] with ID: {}", idFile, clusterId);
+    LOG.debug("Cluster file [{}] is present and contains cluster id: {}", idFile, cs);
+    writeClusterInfo(fs, rootdir, idFile, tempIdFile, cs.toByteArray(), wait);
+  }
 
+  /**
+   * Writes information about this cluster to the specified file. For ex, it is used for writing
+   * cluster id in "hbase.id" file in the HBase root directory. Also, used for writing active
+   * cluster suffix in "active_cluster_suffix.id" file. If any operations on the ID file fails, and
+   * {@code wait} is a positive value, the method will retry to produce the ID file until the thread
+   * is forcibly interrupted.
+   */
+  private static void writeClusterInfo(final FileSystem fs, final Path rootdir, final Path idFile,
+    final Path tempIdFile, byte[] fileData, final long wait) throws IOException {
     while (true) {
       Optional<IOException> failure = Optional.empty();
 
-      LOG.debug("Write the cluster ID file to a temporary location: {}", tempIdFile);
+      LOG.debug("Write the file to a temporary location: {}", tempIdFile);
       try (FSDataOutputStream s = fs.create(tempIdFile)) {
-        s.write(clusterId.toByteArray());
+        s.write(fileData);
       } catch (IOException ioe) {
         failure = Optional.of(ioe);
       }
 
       if (!failure.isPresent()) {
         try {
-          LOG.debug("Move the temporary cluster ID file to its target location [{}]:[{}]",
-            tempIdFile, idFile);
+          LOG.debug("Move the temporary file to its target location [{}]:[{}]", tempIdFile, idFile);
 
           if (!fs.rename(tempIdFile, idFile)) {
-            failure =
-              Optional.of(new IOException("Unable to move temp cluster ID file to " + idFile));
+            failure = Optional.of(new IOException("Unable to move temp file to " + idFile));
           }
         } catch (IOException ioe) {
           failure = Optional.of(ioe);
@@ -672,8 +679,7 @@ public final class FSUtils {
       if (failure.isPresent()) {
         final IOException cause = failure.get();
         if (wait > 0L) {
-          LOG.warn("Unable to create cluster ID file in {}, retrying in {}ms", rootdir, wait,
-            cause);
+          LOG.warn("Unable to create file in {}, retrying in {}ms", rootdir, wait, cause);
           try {
             Thread.sleep(wait);
           } catch (InterruptedException e) {
@@ -1003,6 +1009,25 @@ public final class FSUtils {
       tabledirs.add(dir.getPath());
     }
     return tabledirs;
+  }
+
+  /**
+   * A filter to exclude meta tables belonging to foreign clusters. This is essential in a
+   * read-replica setup where multiple clusters share the same fs.
+   * @param tablePath The Path to the table directory.
+   * @return {@code true} if the path is a regular table or the cluster's own meta table.
+   *         {@code false} if it is a meta table belonging to a different cluster.
+   */
+  public static boolean isLocalMetaTable(Path tablePath) {
+    if (tablePath == null) {
+      return false;
+    }
+    String dirName = tablePath.getName();
+    if (dirName.startsWith(TableName.META_TABLE_NAME.getQualifierAsString())) {
+      return TableName.valueOf(TableName.META_TABLE_NAME.getNamespaceAsString(), dirName)
+        .equals(TableName.META_TABLE_NAME);
+    }
+    return true;
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/RegionMover.java
@@ -57,6 +57,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HRegionLocation;
 import org.apache.hadoop.hbase.MetaTableAccessor;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.UnknownRegionException;
 import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.Connection;
@@ -586,13 +587,13 @@ public class RegionMover extends AbstractHBaseTool implements Closeable {
           // For isolating hbase:meta, it should move explicitly in Ack mode,
           // hence the forceMoveRegionByAck = true.
           if (!metaSeverName.equals(server)) {
-            LOG.info("Region of hbase:meta " + metaRegionInfo.getEncodedName() + " is on server "
-              + metaSeverName + " moving to " + server);
+            LOG.info("Region of {} {} is on server {} moving to {}", TableName.META_TABLE_NAME,
+              metaRegionInfo.getEncodedName(), metaSeverName, server);
             submitRegionMovesWhileUnloading(metaSeverName, Collections.singletonList(server),
               movedRegions, Collections.singletonList(metaRegionInfo), true);
           } else {
-            LOG.info("Region of hbase:meta " + metaRegionInfo.getEncodedName() + " already exists"
-              + " on server : " + server);
+            LOG.info("Region of {} {} already exists on server: {}", TableName.META_TABLE_NAME,
+              metaRegionInfo.getEncodedName(), server);
           }
           isolateRegionInfoList.add(RegionInfoBuilder.FIRST_META_REGIONINFO);
         }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestMetaTableForReplica.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestMetaTableForReplica.java
@@ -1,0 +1,167 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.lang.invoke.MethodHandles;
+import java.lang.reflect.Field;
+import java.lang.reflect.Modifier;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.master.HMaster;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.MiscTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Pair;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Test {@link org.apache.hadoop.hbase.TestMetaTableForReplica}.
+ */
+@Tag(MiscTests.TAG)
+@Tag(MediumTests.TAG)
+@SuppressWarnings("deprecation")
+public class TestMetaTableForReplica {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestMetaTableForReplica.class);
+  private static final HBaseTestingUtil UTIL = new HBaseTestingUtil();
+  private static Connection connection;
+  private static Field metaTableName;
+  private static Object originalMetaTableName;
+
+  @BeforeAll
+  public static void beforeClass() throws Exception {
+    Configuration c = UTIL.getConfiguration();
+    // quicker heartbeat interval for faster DN death notification
+    c.setInt("hbase.ipc.client.connect.max.retries", 1);
+    c.setInt(HConstants.ZK_SESSION_TIMEOUT, 1000);
+    // Start cluster having non-default hbase meta table name
+    UTIL.startMiniCluster(3);
+    connection = ConnectionFactory.createConnection(c);
+    // Save the original value of META_TABLE_NAME before any test runs.x
+    metaTableName = TableName.class.getDeclaredField("META_TABLE_NAME");
+    originalMetaTableName = metaTableName.get(null);
+  }
+
+  @AfterAll
+  public static void afterClass() throws Exception {
+    connection.close();
+    UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testStateOfMetaForReplica() {
+    HMaster m = UTIL.getMiniHBaseCluster().getMaster();
+    assertTrue(m.waitForMetaOnline());
+  }
+
+  @Test
+  public void testMetaTableNameForReplicaWithoutSuffix() throws IOException {
+    testNameOfMetaForReplica();
+    testGetNonExistentRegionFromMetaFromReplica();
+    testGetExistentRegionFromMetaFromReplica();
+  }
+
+  private void testNameOfMetaForReplica() {
+    // Check the correctness of the meta table for replica
+    String metaTableName = TableName.META_TABLE_NAME.getNameWithNamespaceInclAsString();
+    assertNotNull(metaTableName);
+
+    // Check if name of the meta table for replica is same as the default meta table
+    assertEquals(0,
+      TableName.META_TABLE_NAME.compareTo(TableName.getDefaultNameOfMetaForReplica()));
+  }
+
+  private void testGetNonExistentRegionFromMetaFromReplica() throws IOException {
+    LOG.info("Started testGetNonExistentRegionFromMetaFromReplica");
+    Pair<RegionInfo, ServerName> pair =
+      MetaTableAccessor.getRegion(connection, Bytes.toBytes("nonexistent-region"));
+    assertNull(pair);
+    LOG.info("Finished testGetNonExistentRegionFromMetaFromReplica");
+  }
+
+  private void testGetExistentRegionFromMetaFromReplica() throws IOException {
+    final TableName tableName = TableName.valueOf("testMetaTableNameForReplicaWithoutSuffix");
+    LOG.info("Started " + tableName);
+    UTIL.createTable(tableName, HConstants.CATALOG_FAMILY);
+    assertEquals(1, MetaTableAccessor.getTableRegions(connection, tableName).size());
+  }
+
+  @Test
+  public void testMetaTableNameForReplicaWithSuffix() throws Exception {
+    // This test actively changes the META_TABLE_NAME to a non-default value and verifies it.
+    Configuration conf = HBaseConfiguration.create();
+    String suffix = "replica1";
+    conf.set(HConstants.HBASE_META_TABLE_SUFFIX, suffix);
+
+    // Re-initialize the static final META_TABLE_NAME for the testing to a non-default value.
+    TableName expectedMetaTableName = TableName.initializeHbaseMetaTableName(conf);
+    setStaticFinalField(metaTableName, expectedMetaTableName);
+
+    TableName currentMetaName = TableName.META_TABLE_NAME;
+    TableName defaultMetaName = TableName.getDefaultNameOfMetaForReplica();
+
+    // The current meta table name is not the default one.
+    assertNotEquals(defaultMetaName, currentMetaName,
+      "META_TABLE_NAME should not be the default. ");
+
+    // The current meta table name has the configured suffix.
+    assertEquals(expectedMetaTableName, currentMetaName,
+      "META_TABLE_NAME should have the configured suffix");
+
+    // restore default value of META_TABLE_NAME
+    setDefaultMetaTableName();
+  }
+
+  private static void setDefaultMetaTableName() throws Exception {
+    if (originalMetaTableName != null) {
+      setStaticFinalField(metaTableName, originalMetaTableName);
+    }
+  }
+
+  /**
+   * A helper method to modify a static final field using reflection. This is necessary for testing
+   * code that reads a configuration only once during class loading.
+   * @param field    The field to modify.
+   * @param newValue The new value to set.
+   * @throws Exception if reflection fails.
+   */
+  private static void setStaticFinalField(Field field, Object newValue) throws Exception {
+    field.setAccessible(true);
+    // Using MethodHandles to get a trusted lookup with the necessary permissions to modify it.
+    // NOTE: For this to work, the JVM running the test must be started with arguments like:
+    // --add-opens=java.base/java.lang.reflect=ALL-UNNAMED
+    var lookup = MethodHandles.privateLookupIn(Field.class, MethodHandles.lookup());
+    var handle = lookup.findVarHandle(Field.class, "modifiers", int.class);
+    handle.set(field, field.getModifiers() & ~Modifier.FINAL);
+    field.set(null, newValue);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestRefreshHFilesBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestRefreshHFilesBase.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import static org.apache.hadoop.hbase.HConstants.HBASE_CLIENT_RETRIES_NUMBER;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.master.HMaster;
+import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.master.procedure.RefreshHFilesTableProcedure;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.JVMClusterUtil;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class TestRefreshHFilesBase {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestRefreshHFilesBase.class);
+
+  protected static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  protected Admin admin;
+  protected HMaster master;
+  List<HRegionServer> regionServers;
+  protected SingleProcessHBaseCluster cluster;
+  protected ProcedureExecutor<MasterProcedureEnv> procExecutor;
+  protected static Configuration conf;
+  protected static final TableName TEST_TABLE = TableName.valueOf("testRefreshHFilesTable");
+  protected static final String TEST_NAMESPACE = "testRefreshHFilesNamespace";
+  protected static final byte[] TEST_FAMILY = Bytes.toBytes("testRefreshHFilesCF1");
+
+  protected void createTableAndWait(TableName table, byte[] cf)
+    throws IOException, InterruptedException {
+    TEST_UTIL.createTable(table, cf);
+    TEST_UTIL.waitTableAvailable(table);
+  }
+
+  protected void createTableInNamespaceAndWait(String namespace, TableName table, byte[] cf)
+    throws IOException, InterruptedException {
+    TableName fqTableName = TableName.valueOf(namespace + table.getNameAsString());
+    TEST_UTIL.createTable(fqTableName, cf);
+    TEST_UTIL.waitTableAvailable(fqTableName);
+  }
+
+  protected void deleteTable(TableName table) throws IOException {
+    TEST_UTIL.deleteTableIfAny(table);
+  }
+
+  protected void createNamespace(String namespace) throws RuntimeException {
+    try {
+      final NamespaceDescriptor nsd = NamespaceDescriptor.create(namespace).build();
+      // Create the namespace if it doesn’t exist
+      if (
+        Arrays.stream(admin.listNamespaceDescriptors())
+          .noneMatch(ns -> ns.getName().equals(namespace))
+      ) {
+        admin.createNamespace(nsd);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected void deleteNamespace(String namespace) {
+    try {
+      // List table in namespace
+      TableName[] tables = admin.listTableNamesByNamespace(namespace);
+      for (TableName t : tables) {
+        TEST_UTIL.deleteTableIfAny(t);
+      }
+      // Now delete the namespace
+      admin.deleteNamespace(namespace);
+    } catch (Exception e) {
+      LOG.debug(
+        "Unable to delete namespace " + namespace + " post test execution. This isn't a failure");
+    }
+  }
+
+  protected void submitProcedureAndAssertNotFailed(RefreshHFilesTableProcedure procedure) {
+    long procId = procExecutor.submitProcedure(procedure);
+    ProcedureTestingUtility.waitProcedure(procExecutor, procId);
+    ProcedureTestingUtility.assertProcNotFailed(procExecutor.getResult(procId));
+  }
+
+  protected void setReadOnlyMode(boolean isReadOnly) {
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, isReadOnly);
+    notifyConfigurationObservers();
+  }
+
+  private void notifyConfigurationObservers() {
+    master.getConfigurationManager().notifyAllObservers(TEST_UTIL.getConfiguration());
+    for (HRegionServer rs : regionServers) {
+      rs.getConfigurationManager().notifyAllObservers(TEST_UTIL.getConfiguration());
+    }
+  }
+
+  private void setupReadOnlyConf(boolean addReadOnlyConf) {
+    if (!addReadOnlyConf) return;
+    // Keep ReadOnly property to false at the beginning so that create table succeed.
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+  }
+
+  protected void baseSetup(boolean addReadOnlyConf) throws Exception {
+    conf = TEST_UTIL.getConfiguration();
+    // Shorten the run time of failed unit tests by limiting retries and the session timeout
+    // threshold
+    conf.setInt(HBASE_CLIENT_RETRIES_NUMBER, 1);
+    conf.setInt(HConstants.ZK_SESSION_TIMEOUT, 1000);
+    conf.setInt(HConstants.HBASE_RPC_TIMEOUT_KEY, 60000);
+    conf.setInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT, 120000);
+
+    setupReadOnlyConf(addReadOnlyConf);
+
+    try {
+      // Start the test cluster
+      cluster = TEST_UTIL.startMiniCluster(1);
+      admin = TEST_UTIL.getAdmin();
+      procExecutor = TEST_UTIL.getHBaseCluster().getMaster().getMasterProcedureExecutor();
+      master = TEST_UTIL.getHBaseCluster().getMaster();
+      regionServers = cluster.getRegionServerThreads().stream()
+        .map(JVMClusterUtil.RegionServerThread::getRegionServer).collect(Collectors.toList());
+    } catch (Exception e) {
+      TEST_UTIL.shutdownMiniCluster();
+      throw new RuntimeException(e);
+    }
+  }
+
+  protected void baseTearDown() throws Exception {
+    if (admin != null) {
+      admin.close();
+    }
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRefreshHFilesFromClient.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestRefreshHFilesFromClient.java
@@ -1,0 +1,136 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import org.apache.hadoop.hbase.NamespaceNotFoundException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TableNotFoundException;
+import org.apache.hadoop.hbase.TestRefreshHFilesBase;
+import org.apache.hadoop.hbase.testclassification.ClientTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(MediumTests.TAG)
+@Tag(ClientTests.TAG)
+public class TestRefreshHFilesFromClient extends TestRefreshHFilesBase {
+
+  private static final TableName TEST_NONEXISTENT_TABLE =
+    TableName.valueOf("testRefreshHFilesNonExistentTable");
+  private static final String TEST_NONEXISTENT_NAMESPACE = "testRefreshHFilesNonExistentNamespace";
+
+  @BeforeEach
+  public void setup() throws Exception {
+    baseSetup(false);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    baseTearDown();
+  }
+
+  @Test
+  public void testRefreshHFilesForTable() throws Exception {
+    try {
+      // Create table in default namespace
+      createTableAndWait(TEST_TABLE, TEST_FAMILY);
+
+      // RefreshHFiles for table
+      Long procId = admin.refreshHFiles(TEST_TABLE);
+      assertTrue(procId >= 0);
+    } catch (Exception e) {
+      fail("RefreshHFilesForTable Should Not Throw Exception: " + e);
+      throw new RuntimeException(e);
+    } finally {
+      // Delete table name post test execution
+      deleteTable(TEST_TABLE);
+    }
+  }
+
+  // Not creating table hence refresh should throw exception
+  @Test
+  public void testRefreshHFilesForNonExistentTable() {
+    assertThrows(TableNotFoundException.class, () -> admin.refreshHFiles(TEST_NONEXISTENT_TABLE));
+  }
+
+  @Test
+  public void testRefreshHFilesForNamespace() {
+    try {
+      createNamespace(TEST_NAMESPACE);
+
+      // Create table under test namespace
+      createTableInNamespaceAndWait(TEST_NAMESPACE, TEST_TABLE, TEST_FAMILY);
+
+      // RefreshHFiles for namespace
+      Long procId = admin.refreshHFiles(TEST_NAMESPACE);
+      assertTrue(procId >= 0);
+
+    } catch (Exception e) {
+      fail("RefreshHFilesForAllNamespace Should Not Throw Exception: " + e);
+      throw new RuntimeException(e);
+    } finally {
+      // Delete namespace post test execution
+      // This will delete all tables under namespace hence no explicit table
+      // deletion for table under namespace is needed.
+      deleteNamespace(TEST_NAMESPACE);
+    }
+  }
+
+  @Test
+  public void testRefreshHFilesForNonExistentNamespace() {
+    // RefreshHFiles for namespace
+    assertThrows(NamespaceNotFoundException.class,
+      () -> admin.refreshHFiles(TEST_NONEXISTENT_NAMESPACE));
+  }
+
+  @Test
+  public void testRefreshHFilesForAllTables() throws Exception {
+    try {
+      // Create table in default namespace
+      createTableAndWait(TEST_TABLE, TEST_FAMILY);
+
+      // Create test namespace
+      createNamespace(TEST_NAMESPACE);
+
+      // Create table under test namespace
+      createTableInNamespaceAndWait(TEST_NAMESPACE, TEST_TABLE, TEST_FAMILY);
+
+      // RefreshHFiles for all the tables
+      Long procId = admin.refreshHFiles();
+      assertTrue(procId >= 0);
+
+    } catch (Exception e) {
+      fail("RefreshHFilesForAllTables Should Not Throw Exception: " + e);
+      throw new RuntimeException(e);
+    } finally {
+      // Delete table name post test execution
+      deleteTable(TEST_TABLE);
+
+      // Delete namespace post test execution
+      // This will delete all tables under namespace hence no explicit table
+      // deletion for table under namespace is needed.
+      deleteNamespace(TEST_NAMESPACE);
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestMasterMetrics.java
@@ -17,21 +17,40 @@
  */
 package org.apache.hadoop.hbase.master;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
 import java.io.IOException;
+import java.io.InterruptedIOException;
 import java.io.UncheckedIOException;
+import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.ClusterMetrics;
 import org.apache.hadoop.hbase.CompatibilityFactory;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
 import org.apache.hadoop.hbase.ServerMetricsBuilder;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.SingleProcessHBaseCluster;
 import org.apache.hadoop.hbase.StartTestingClusterOption;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.YouAreDeadException;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.RegionStatesCount;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.test.MetricsAssertHelper;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hbase.util.FSTableDescriptors;
 import org.apache.zookeeper.KeeperException;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.BeforeAll;
@@ -56,6 +75,7 @@ public class TestMasterMetrics {
   private static final Logger LOG = LoggerFactory.getLogger(TestMasterMetrics.class);
   private static final MetricsAssertHelper metricsHelper =
     CompatibilityFactory.getInstance(MetricsAssertHelper.class);
+  private static final String COLUMN_FAMILY = "cf";
 
   private static SingleProcessHBaseCluster cluster;
   private static HMaster master;
@@ -183,8 +203,189 @@ public class TestMasterMetrics {
   }
 
   @Test
-  public void testDefaultMasterProcMetrics() throws Exception {
+  public void testDefaultMasterProcMetrics() {
     MetricsMasterProcSource masterSource = master.getMasterMetrics().getMetricsProcSource();
     metricsHelper.assertGauge("numMasterWALs", master.getNumWALFiles(), masterSource);
+  }
+
+  // Verifies a foreign meta table does not show up in the table regions state
+  @Test
+  public void testClusterMetricsSkippingForeignMetaTable() throws Exception {
+    TableName replicaMetaTable = TableName.valueOf("hbase", "meta_replica");
+    TableDescriptor replicaMetaDescriptor = TableDescriptorBuilder.newBuilder(replicaMetaTable)
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.of("info")).build();
+    master.getTableDescriptors().update(replicaMetaDescriptor, true);
+    try {
+      Map<TableName, RegionStatesCount> tableRegionStatesCount = getTableRegionStatesCount();
+
+      assertFalse(tableRegionStatesCount.containsKey(replicaMetaTable),
+        "Foreign meta table should not be present");
+      assertTrue(tableRegionStatesCount.containsKey(TableName.META_TABLE_NAME),
+        "Local meta should be present");
+
+    } finally {
+      master.getTableDescriptors().remove(replicaMetaTable);
+    }
+  }
+
+  // This test adds foreign file descriptors to the cluster's table descriptor cache. It then
+  // verifies the foreign tables do not show up in the table regions state.
+  @Test
+  public void testClusterMetricsSkippingCachedForeignTables() throws Exception {
+    List<TableName> allTables = new ArrayList<>();
+
+    // These tables, including the cluster's meta table, should not be foreign to the cluster.
+    // The cluster should be able to find their state.
+    allTables.add(TableName.META_TABLE_NAME);
+    List<TableName> familiarTables = new ArrayList<>();
+    familiarTables.add(TableName.valueOf(null, "familiarTable1"));
+    familiarTables.add(TableName.valueOf("", "familiarTable2"));
+    familiarTables.add(TableName.valueOf("default", "familiarTable3"));
+    familiarTables.add(TableName.valueOf("familiarNamespace", "familiarTable4"));
+    familiarTables.add(TableName.valueOf("familiarNamespace", "familiarTable5"));
+
+    // Create these "familiar" tables so their state can be found
+    TEST_UTIL.getAdmin().createNamespace(NamespaceDescriptor.create("familiarNamespace").build());
+    for (TableName familiarTable : familiarTables) {
+      TEST_UTIL.createTable(familiarTable, COLUMN_FAMILY);
+      allTables.add(familiarTable);
+    }
+
+    // hbase:meta is a familiar table that was created automatically
+    familiarTables.add(TableName.META_TABLE_NAME);
+
+    // These tables should be foreign to the cluster.
+    // The cluster should not be able to find their state.
+    allTables.add(TableName.valueOf("hbase", "meta_replica"));
+    allTables.add(TableName.valueOf(null, "defaultNamespaceTable1"));
+    allTables.add(TableName.valueOf("", "defaultNamespaceTable2"));
+    allTables.add(TableName.valueOf("default", "defaultNamespaceTable3"));
+    allTables.add(TableName.valueOf("customNamespace", "customNamespaceTable1"));
+    allTables.add(TableName.valueOf("customNamespace", "customNamespaceTable2"));
+    allTables.add(TableName.valueOf("anotherNamespace", "anotherNamespaceTable"));
+    allTables.add(TableName.valueOf("sharedNamespace", "sharedNamespaceTable1"));
+    allTables.add(TableName.valueOf("sharedNamespace", "sharedNamespaceTable2"));
+
+    // Update master's table descriptors to have all tables
+    TableDescriptor foreignTableDescriptor;
+    for (TableName tableName : allTables) {
+      foreignTableDescriptor = TableDescriptorBuilder.newBuilder(tableName)
+        .setColumnFamily(ColumnFamilyDescriptorBuilder.of(COLUMN_FAMILY)).build();
+      master.getTableDescriptors().update(foreignTableDescriptor, true);
+    }
+
+    // The state of the meta table and the familiar tables we created should exist.
+    // The other tables' state should not exist.
+    for (TableName tableName : allTables) {
+      try {
+        Map<TableName, RegionStatesCount> tableRegionStatesCount = getTableRegionStatesCount();
+
+        if (
+          tableName.equals(TableName.META_TABLE_NAME)
+            || tableName.getQualifierAsString().startsWith("familiar")
+        ) {
+          assertTrue(tableRegionStatesCount.containsKey(tableName),
+            "Expected this table's state to exist: " + tableName);
+        } else {
+          assertFalse(tableRegionStatesCount.containsKey(tableName),
+            "This foreign table's state should not exist: " + tableName);
+        }
+      } finally {
+        if (!TableName.META_TABLE_NAME.equals(tableName) && familiarTables.contains(tableName)) {
+          LOG.debug("Deleting table: {}", tableName);
+          TEST_UTIL.deleteTable(tableName);
+        } else if (!familiarTables.contains(tableName)) {
+          LOG.debug("Removing table descriptor for foreign table: {}", tableName);
+          master.getTableDescriptors().remove(tableName);
+        }
+      }
+    }
+  }
+
+  // This test creates foreign file descriptors on the filesystem in addition to updating the
+  // table descriptor cache. It then verifies the foreign tables do not show up in the
+  // table regions state.
+  @Test
+  public void testClusterMetricsSkippingForeignTablesOnFileSystem() throws IOException {
+    List<TableName> familiarTables = new ArrayList<>();
+    List<TableName> foreignTables = new ArrayList<>();
+    FileSystem fs = TEST_UTIL.getTestFileSystem();
+    Path testDir = TEST_UTIL.getDataTestDirOnTestFS();
+    LOG.info("The test dir is: {}", testDir);
+
+    // Create tables whose state are familiar to this cluster
+    familiarTables.add(TableName.valueOf("testTable1"));
+    familiarTables.add(TableName.valueOf("testTable2"));
+    TEST_UTIL.getAdmin().createNamespace(NamespaceDescriptor.create("myNamespace").build());
+    familiarTables.add(TableName.valueOf("myNamespace", "tableWithNamespace1"));
+    for (TableName tableName : familiarTables) {
+      TEST_UTIL.createTable(tableName, COLUMN_FAMILY);
+    }
+
+    // hbase:meta is a familiar table that was created automatically
+    familiarTables.add(TableName.META_TABLE_NAME);
+
+    // There should now be 4 tables, including hbase:meta
+    Map<String, TableDescriptor> tableDescriptorMap = master.getTableDescriptors().getAll();
+    assertEquals(4, tableDescriptorMap.size());
+    for (TableName tableName : familiarTables) {
+      assertTrue(
+        tableDescriptorMap
+          .containsKey(tableName.getNamespaceAsString() + ":" + tableName.getQualifierAsString()),
+        "Expected table descriptor map to contain table: " + tableName);
+    }
+
+    createTableDescriptorOnFileSystem("hbase", "meta_replica", foreignTables);
+    createTableDescriptorOnFileSystem("default", "foreignTable1", foreignTables);
+    createTableDescriptorOnFileSystem("customForeignNs", "customForeignNsTable1", foreignTables);
+
+    // Verify the table descriptors were created on the filesystem
+    for (TableName tableName : foreignTables) {
+      Path tableDescPath = new Path(testDir,
+        "data" + Path.SEPARATOR + tableName.getNamespaceAsString() + Path.SEPARATOR
+          + tableName.getQualifierAsString() + Path.SEPARATOR + FSTableDescriptors.TABLEINFO_DIR);
+      assertTrue(fs.exists(tableDescPath),
+        "Expected table descriptor directory to exist: " + tableDescPath);
+    }
+
+    Map<TableName, RegionStatesCount> tableRegionStatesCount = getTableRegionStatesCount();
+
+    // The foreign tables should not be in the table state
+    assertEquals(4, tableRegionStatesCount.size());
+    for (TableName tableName : familiarTables) {
+      assertTrue(tableRegionStatesCount.containsKey(tableName),
+        "Expected table regions state count to contain: " + tableName);
+      // Delete unneeded tables
+      if (!TableName.META_TABLE_NAME.equals(tableName)) {
+        LOG.debug("Deleting table: {}", tableName);
+        TEST_UTIL.deleteTable(tableName);
+      }
+    }
+    for (TableName tableName : foreignTables) {
+      assertFalse(tableRegionStatesCount.containsKey(tableName),
+        "Expected table regions state count to NOT contain: " + tableName);
+      // Remove unneeded table descriptors
+      LOG.debug("Removing table descriptor for foreign table: {}", tableName);
+      master.getTableDescriptors().remove(tableName);
+    }
+  }
+
+  private Map<TableName, RegionStatesCount> getTableRegionStatesCount()
+    throws InterruptedIOException {
+    ClusterMetrics metrics = master.getClusterMetricsWithoutCoprocessor(
+      EnumSet.of(ClusterMetrics.Option.TABLE_TO_REGIONS_COUNT));
+    return metrics.getTableRegionStatesCount();
+  }
+
+  private void createTableDescriptorOnFileSystem(String namespace, String qualifier,
+    List<TableName> tableNameList) throws IOException {
+    // Create a table descriptor on the filesystem that uses the provided namespace
+    TableName tableName = TableName.valueOf(namespace, qualifier);
+    TableDescriptor tableDescriptor = TableDescriptorBuilder.newBuilder(tableName)
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.of(COLUMN_FAMILY)).build();
+    // Create the table descriptor on the filesystem and update the file descriptor cache
+    master.getTableDescriptors().update(tableDescriptor, false);
+
+    tableNameList.add(tableName);
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestHbckChore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestHbckChore.java
@@ -31,19 +31,27 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.Future;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableState;
 import org.apache.hadoop.hbase.master.TableStateManager;
 import org.apache.hadoop.hbase.master.hbck.HbckChore;
 import org.apache.hadoop.hbase.master.hbck.HbckReport;
+import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.FSTableDescriptors;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.util.Pair;
 import org.junit.jupiter.api.BeforeEach;
@@ -241,5 +249,40 @@ public class TestHbckChore extends TestAssignmentManagerBase {
     HbckChore hbckChoreWithChangedConf = new HbckChore(master);
     hbckChoreWithChangedConf.choreForTesting();
     assertNull(hbckChoreWithChangedConf.getLastReport());
+  }
+
+  @Test
+  public void testChoreSkipsForeignMetaTables() throws Exception {
+    FileSystem fs = master.getMasterFileSystem().getFileSystem();
+    Path rootDir = master.getMasterFileSystem().getRootDir();
+    String[] metaTables = { "meta_replica1", "meta" };
+    Path hbaseNamespaceDir = new Path(rootDir, HConstants.BASE_NAMESPACE_DIR + "/hbase");
+    fs.mkdirs(hbaseNamespaceDir);
+
+    for (String metaTable : metaTables) {
+      TableName tableName = TableName.valueOf("hbase", metaTable);
+      Path metaTableDir = new Path(hbaseNamespaceDir, metaTable);
+      fs.mkdirs(metaTableDir);
+      fs.mkdirs(new Path(metaTableDir, FSTableDescriptors.TABLEINFO_DIR));
+      fs.mkdirs(new Path(metaTableDir, "abcdef0123456789"));
+
+      TableDescriptor tableDescriptor = TableDescriptorBuilder.newBuilder(tableName)
+        .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(HConstants.CATALOG_FAMILY)
+          .setMaxVersions(HConstants.DEFAULT_HBASE_META_VERSIONS).setInMemory(true)
+          .setBlocksize(HConstants.DEFAULT_HBASE_META_BLOCK_SIZE)
+          .setBloomFilterType(BloomType.ROWCOL).build())
+        .build();
+
+      Path tableDir = CommonFSUtils.getTableDir(rootDir, tableName);
+      FSTableDescriptors.createTableDescriptorForTableDirectory(fs, tableDir, tableDescriptor,
+        false);
+    }
+
+    assertTrue(hbckChore.runChore(), "HbckChore should run successfully");
+    HbckReport report = hbckChore.getLastReport();
+    assertNotNull(report, "HbckReport should not be null");
+    boolean hasForeignMetaOrphan = report.getOrphanRegionsOnFS().values().stream()
+      .anyMatch(path -> path.toString().contains("meta_replica1"));
+    assertFalse(hasForeignMetaOrphan, "HbckChore should not report foreign meta tables as orphans");
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestRefreshHFilesProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestRefreshHFilesProcedure.java
@@ -1,0 +1,111 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.TestRefreshHFilesBase;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(MasterTests.TAG)
+@Tag(MediumTests.TAG)
+public class TestRefreshHFilesProcedure extends TestRefreshHFilesBase {
+
+  @BeforeEach
+  public void setup() throws Exception {
+    baseSetup(false);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    baseTearDown();
+  }
+
+  @Test
+  public void testRefreshHFilesProcedureForTable() throws IOException {
+    try {
+      // Create table in default namespace
+      createTableAndWait(TEST_TABLE, TEST_FAMILY);
+
+      RefreshHFilesTableProcedure procedure =
+        new RefreshHFilesTableProcedure(procExecutor.getEnvironment(), TEST_TABLE);
+      submitProcedureAndAssertNotFailed(procedure);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      // Delete table name post test execution
+      deleteTable(TEST_TABLE);
+    }
+  }
+
+  @Test
+  public void testRefreshHFilesProcedureForNamespace() {
+    try {
+      createNamespace(TEST_NAMESPACE);
+
+      // Create table under test namespace
+      createTableInNamespaceAndWait(TEST_NAMESPACE, TEST_TABLE, TEST_FAMILY);
+
+      RefreshHFilesTableProcedure procedure =
+        new RefreshHFilesTableProcedure(procExecutor.getEnvironment(), TEST_NAMESPACE);
+      submitProcedureAndAssertNotFailed(procedure);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      // Delete namespace post test execution
+      // This will delete all tables under namespace hence no explicit table
+      // deletion for table under namespace is needed.
+      deleteNamespace(TEST_NAMESPACE);
+    }
+  }
+
+  @Test
+  public void testRefreshHFilesProcedureForAllTables() throws IOException {
+    try {
+      // Create table in default namespace
+      createTableAndWait(TEST_TABLE, TEST_FAMILY);
+
+      // Create test namespace
+      createNamespace(TEST_NAMESPACE);
+
+      // Create table under test namespace
+      createTableInNamespaceAndWait(TEST_NAMESPACE, TEST_TABLE, TEST_FAMILY);
+
+      RefreshHFilesTableProcedure procedure =
+        new RefreshHFilesTableProcedure(procExecutor.getEnvironment());
+      submitProcedureAndAssertNotFailed(procedure);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      // Delete table name post test execution
+      deleteTable(TEST_TABLE);
+
+      // Delete namespace post test execution
+      // This will delete all tables under namespace hence no explicit table
+      // deletion for table under namespace is needed.
+      deleteNamespace(TEST_NAMESPACE);
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestRefreshHFilesProcedureWithReadOnlyConf.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestRefreshHFilesProcedureWithReadOnlyConf.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.TestRefreshHFilesBase;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(MasterTests.TAG)
+@Tag(MediumTests.TAG)
+public class TestRefreshHFilesProcedureWithReadOnlyConf extends TestRefreshHFilesBase {
+
+  @BeforeEach
+  public void setup() throws Exception {
+    // When true is passed only setup for readonly property is done.
+    // The initial ReadOnly property will be false for table creation
+    baseSetup(true);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    baseTearDown();
+  }
+
+  @Test
+  public void testRefreshHFilesProcedureForTable() throws IOException {
+    try {
+      // Create table in default namespace
+      createTableAndWait(TEST_TABLE, TEST_FAMILY);
+
+      setReadOnlyMode(true);
+      RefreshHFilesTableProcedure procedure =
+        new RefreshHFilesTableProcedure(procExecutor.getEnvironment(), TEST_TABLE);
+      submitProcedureAndAssertNotFailed(procedure);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      setReadOnlyMode(false);
+      // Delete table name post test execution
+      deleteTable(TEST_TABLE);
+    }
+  }
+
+  @Test
+  public void testRefreshHFilesProcedureForNamespace() {
+    try {
+      createNamespace(TEST_NAMESPACE);
+
+      // Create table under test namespace
+      createTableInNamespaceAndWait(TEST_NAMESPACE, TEST_TABLE, TEST_FAMILY);
+
+      setReadOnlyMode(true);
+      RefreshHFilesTableProcedure procedure =
+        new RefreshHFilesTableProcedure(procExecutor.getEnvironment(), TEST_NAMESPACE);
+      submitProcedureAndAssertNotFailed(procedure);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      setReadOnlyMode(false);
+      // Delete namespace post test execution
+      // This will delete all tables under namespace hence no explicit table
+      // deletion for table under namespace is needed.
+      deleteNamespace(TEST_NAMESPACE);
+    }
+  }
+
+  @Test
+  public void testRefreshHFilesProcedureForAllTables() throws IOException {
+    try {
+      // Create table in default namespace
+      createTableAndWait(TEST_TABLE, TEST_FAMILY);
+
+      // Create test namespace
+      createNamespace(TEST_NAMESPACE);
+
+      // Create table under test namespace
+      createTableInNamespaceAndWait(TEST_NAMESPACE, TEST_TABLE, TEST_FAMILY);
+
+      setReadOnlyMode(true);
+      RefreshHFilesTableProcedure procedure =
+        new RefreshHFilesTableProcedure(procExecutor.getEnvironment());
+      submitProcedureAndAssertNotFailed(procedure);
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      setReadOnlyMode(false);
+      // Delete table name post test execution
+      deleteTable(TEST_TABLE);
+
+      // Delete namespace post test execution
+      // This will delete all tables under namespace hence no explicit table
+      // deletion for table under namespace is needed.
+      deleteNamespace(TEST_NAMESPACE);
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestRefreshMetaProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestRefreshMetaProcedure.java
@@ -1,0 +1,119 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility.assertProcNotFailed;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(MasterTests.TAG)
+@Tag(MediumTests.TAG)
+public class TestRefreshMetaProcedure {
+
+  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private ProcedureExecutor<MasterProcedureEnv> procExecutor;
+  List<RegionInfo> activeRegions;
+  TableName tableName = TableName.valueOf("testRefreshMeta");
+
+  @BeforeEach
+  public void setup() throws Exception {
+    TEST_UTIL.getConfiguration().set("USE_META_REPLICAS", "false");
+    TEST_UTIL.startMiniCluster();
+    procExecutor = TEST_UTIL.getHBaseCluster().getMaster().getMasterProcedureExecutor();
+    byte[][] splitKeys =
+      new byte[][] { Bytes.toBytes("split1"), Bytes.toBytes("split2"), Bytes.toBytes("split3") };
+    TEST_UTIL.createTable(tableName, Bytes.toBytes("cf"), splitKeys);
+    TEST_UTIL.waitTableAvailable(tableName);
+    TEST_UTIL.getAdmin().flush(tableName);
+    activeRegions = TEST_UTIL.getAdmin().getRegions(tableName);
+    assertFalse(activeRegions.isEmpty());
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testRefreshMetaProcedureExecutesSuccessfully() {
+    RefreshMetaProcedure procedure = new RefreshMetaProcedure(procExecutor.getEnvironment());
+    long procId = procExecutor.submitProcedure(procedure);
+    ProcedureTestingUtility.waitProcedure(procExecutor, procId);
+    assertProcNotFailed(procExecutor.getResult(procId));
+  }
+
+  @Test
+  public void testGetCurrentRegions() throws Exception {
+    RefreshMetaProcedure procedure = new RefreshMetaProcedure(procExecutor.getEnvironment());
+    List<RegionInfo> regions = procedure.getCurrentRegions(TEST_UTIL.getConnection());
+    assertFalse(regions.isEmpty(), "Should have found regions in meta");
+    assertTrue(
+      regions.stream().anyMatch(r -> r.getTable().getNameAsString().equals("testRefreshMeta")),
+      "Should include test table region");
+  }
+
+  @Test
+  public void testScanBackingStorage() throws Exception {
+    RefreshMetaProcedure procedure = new RefreshMetaProcedure(procExecutor.getEnvironment());
+
+    List<RegionInfo> fsRegions = procedure.scanBackingStorage(TEST_UTIL.getConnection());
+
+    assertTrue(
+      activeRegions.stream()
+        .allMatch(reg -> fsRegions.stream()
+          .anyMatch(r -> r.getRegionNameAsString().equals(reg.getRegionNameAsString()))),
+      "All regions from meta should be found in the storage");
+  }
+
+  @Test
+  public void testHasBoundaryChanged() {
+    RefreshMetaProcedure procedure = new RefreshMetaProcedure(procExecutor.getEnvironment());
+    RegionInfo region1 = RegionInfoBuilder.newBuilder(tableName)
+      .setStartKey(Bytes.toBytes("start1")).setEndKey(Bytes.toBytes("end1")).build();
+
+    RegionInfo region2 = RegionInfoBuilder.newBuilder(tableName)
+      .setStartKey(Bytes.toBytes("start2")).setEndKey(Bytes.toBytes("end1")).build();
+
+    RegionInfo region3 = RegionInfoBuilder.newBuilder(tableName)
+      .setStartKey(Bytes.toBytes("start1")).setEndKey(Bytes.toBytes("end2")).build();
+
+    assertTrue(procedure.hasBoundaryChanged(region1, region2),
+      "Different start keys should have been detected");
+
+    assertTrue(procedure.hasBoundaryChanged(region1, region3),
+      "Different end keys should have been detected");
+
+    assertFalse(procedure.hasBoundaryChanged(region1, region1),
+      "Identical boundaries should not have been identified");
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestRefreshMetaProcedureIntegration.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestRefreshMetaProcedureIntegration.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.apache.hadoop.hbase.procedure2.ProcedureTestingUtility.assertProcNotFailed;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.MetaTableAccessor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.client.TableState;
+import org.apache.hadoop.hbase.master.HMaster;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(MasterTests.TAG)
+@Tag(LargeTests.TAG)
+public class TestRefreshMetaProcedureIntegration {
+
+  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private Admin admin;
+  private ProcedureExecutor<MasterProcedureEnv> procExecutor;
+  private HMaster master;
+  private HRegionServer regionServer;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    // Start in active mode
+    TEST_UTIL.getConfiguration().setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+
+    TEST_UTIL.startMiniCluster();
+    admin = TEST_UTIL.getAdmin();
+    procExecutor = TEST_UTIL.getHBaseCluster().getMaster().getMasterProcedureExecutor();
+    master = TEST_UTIL.getHBaseCluster().getMaster();
+    regionServer = TEST_UTIL.getHBaseCluster().getRegionServerThreads().get(0).getRegionServer();
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    if (admin != null) {
+      admin.close();
+    }
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testRestoreMissingRegionInMeta() throws Exception {
+
+    TableName tableName = TableName.valueOf("replicaTestTable");
+
+    createTableWithData(tableName);
+
+    List<RegionInfo> activeRegions = admin.getRegions(tableName);
+    assertTrue(activeRegions.size() >= 2, "Should have at least 2 regions after split");
+
+    Table metaTable = TEST_UTIL.getConnection().getTable(TableName.META_TABLE_NAME);
+    RegionInfo regionToRemove = activeRegions.get(0);
+    admin.unassign(regionToRemove.getRegionName(), false);
+    Thread.sleep(1000);
+
+    org.apache.hadoop.hbase.client.Delete delete =
+      new org.apache.hadoop.hbase.client.Delete(regionToRemove.getRegionName());
+    metaTable.delete(delete);
+    metaTable.close();
+
+    List<RegionInfo> regionsAfterDrift = admin.getRegions(tableName);
+    assertEquals(activeRegions.size() - 1, regionsAfterDrift.size(),
+      "Should have one less region in meta after simulating drift");
+
+    setReadOnlyMode(true);
+
+    boolean writeBlocked = false;
+    try {
+      Table readOnlyTable = TEST_UTIL.getConnection().getTable(tableName);
+      Put testPut = new Put(Bytes.toBytes("test_readonly"));
+      testPut.addColumn(Bytes.toBytes("cf1"), Bytes.toBytes("qual"), Bytes.toBytes("should_fail"));
+      readOnlyTable.put(testPut);
+      readOnlyTable.close();
+    } catch (Exception e) {
+      if (e.getMessage().contains("Operation not allowed in Read-Only Mode")) {
+        writeBlocked = true;
+      }
+    }
+    assertTrue(writeBlocked, "Write operations should be blocked in read-only mode");
+
+    Long procId = admin.refreshMeta();
+
+    waitForProcedureCompletion(procId);
+
+    List<RegionInfo> regionsAfterRefresh = admin.getRegions(tableName);
+    assertEquals(activeRegions.size(), regionsAfterRefresh.size(),
+      "Missing regions should be restored by refresh_meta");
+
+    boolean regionRestored = regionsAfterRefresh.stream()
+      .anyMatch(r -> r.getRegionNameAsString().equals(regionToRemove.getRegionNameAsString()));
+    assertTrue(regionRestored, "Missing region should be restored by refresh_meta");
+
+    setReadOnlyMode(false);
+
+    Table activeTable = TEST_UTIL.getConnection().getTable(tableName);
+    Put testPut = new Put(Bytes.toBytes("test_active_again"));
+    testPut.addColumn(Bytes.toBytes("cf1"), Bytes.toBytes("qual"),
+      Bytes.toBytes("active_mode_again"));
+    activeTable.put(testPut);
+    activeTable.close();
+  }
+
+  @Test
+  public void testPhantomTableCleanup() throws Exception {
+    TableName table1 = TableName.valueOf("table1");
+    TableName phantomTable = TableName.valueOf("phantomTable");
+    createTableWithData(table1);
+    createTableWithData(phantomTable);
+
+    assertTrue(admin.getRegions(table1).size() >= 2, "Table1 should have multiple regions");
+    assertTrue(admin.getRegions(phantomTable).size() >= 2,
+      "phantomTable should have multiple regions");
+
+    deleteTableFromFilesystem(phantomTable);
+    List<TableName> tablesBeforeRefresh = Arrays.asList(admin.listTableNames());
+    assertTrue(tablesBeforeRefresh.contains(phantomTable),
+      "phantomTable should still be listed before refresh_meta");
+    assertTrue(tablesBeforeRefresh.contains(table1), "Table1 should still be listed");
+
+    setReadOnlyMode(true);
+    Long procId = admin.refreshMeta();
+    waitForProcedureCompletion(procId);
+
+    List<TableName> tablesAfterRefresh = Arrays.asList(admin.listTableNames());
+
+    assertFalse(tablesAfterRefresh.contains(phantomTable),
+      "phantomTable should be removed after refresh_meta");
+    assertTrue(tablesAfterRefresh.contains(table1), "Table1 should still be listed");
+    assertTrue(admin.getRegions(phantomTable).isEmpty(),
+      "phantomTable should have no regions after refresh_meta");
+    setReadOnlyMode(false);
+  }
+
+  @Test
+  public void testRestoreTableStateForOrphanRegions() throws Exception {
+    TableName tableName = TableName.valueOf("t1");
+    createTableInFilesystem(tableName);
+
+    assertEquals(0, Stream.of(admin.listTableNames()).filter(tn -> tn.equals(tableName)).count(),
+      "No tables should exist");
+
+    setReadOnlyMode(true);
+    Long procId = admin.refreshMeta();
+    waitForProcedureCompletion(procId);
+
+    TableState tableState = MetaTableAccessor.getTableState(admin.getConnection(), tableName);
+    assert tableState != null;
+    assertEquals(TableState.State.ENABLED, tableState.getState(), "Table state should be ENABLED");
+    assertEquals(1, Stream.of(admin.listTableNames()).filter(tn -> tn.equals(tableName)).count(),
+      "The list should show the new table from the FS");
+    assertFalse(admin.getRegions(tableName).isEmpty(), "Should have at least 1 region");
+    setReadOnlyMode(false);
+  }
+
+  private void createTableInFilesystem(TableName tableName) throws IOException {
+    FileSystem fs = TEST_UTIL.getTestFileSystem();
+    Path rootDir = CommonFSUtils.getRootDir(TEST_UTIL.getConfiguration());
+    Path tableDir = CommonFSUtils.getTableDir(rootDir, tableName);
+    fs.mkdirs(tableDir);
+
+    TableDescriptorBuilder builder = TableDescriptorBuilder.newBuilder(tableName);
+    TEST_UTIL.getHBaseCluster().getMaster().getTableDescriptors()
+      .update(builder.setColumnFamily(ColumnFamilyDescriptorBuilder.of("cf1")).build(), false);
+
+    Path regionDir = new Path(tableDir, "dab6d1e1c88787c13b97647f11b2c907");
+    Path regionInfoFile = new Path(regionDir, HRegionFileSystem.REGION_INFO_FILE);
+    fs.mkdirs(regionDir);
+
+    RegionInfo regionInfo = RegionInfoBuilder.newBuilder(tableName).setStartKey(new byte[0])
+      .setEndKey(new byte[0]).setRegionId(1757100253228L).build();
+    byte[] regionInfoContent = RegionInfo.toDelimitedByteArray(regionInfo);
+    try (FSDataOutputStream out = fs.create(regionInfoFile, true)) {
+      out.write(regionInfoContent);
+    }
+  }
+
+  private void deleteTableFromFilesystem(TableName tableName) throws IOException {
+    FileSystem fs = TEST_UTIL.getTestFileSystem();
+    Path rootDir = CommonFSUtils.getRootDir(TEST_UTIL.getConfiguration());
+    Path tableDir = CommonFSUtils.getTableDir(rootDir, tableName);
+    if (fs.exists(tableDir)) {
+      fs.delete(tableDir, true);
+    }
+  }
+
+  private void createTableWithData(TableName tableName) throws Exception {
+    TableDescriptorBuilder builder = TableDescriptorBuilder.newBuilder(tableName);
+    builder.setColumnFamily(ColumnFamilyDescriptorBuilder.of("cf1"));
+    byte[] splitKeyBytes = Bytes.toBytes("split_key");
+    admin.createTable(builder.build(), new byte[][] { splitKeyBytes });
+    TEST_UTIL.waitTableAvailable(tableName);
+    try (Table table = TEST_UTIL.getConnection().getTable(tableName)) {
+      for (int i = 0; i < 100; i++) {
+        Put put = new Put(Bytes.toBytes("row_" + String.format("%05d", i)));
+        put.addColumn(Bytes.toBytes("cf1"), Bytes.toBytes("qual"), Bytes.toBytes("value_" + i));
+        table.put(put);
+      }
+    }
+    admin.flush(tableName);
+  }
+
+  private void waitForProcedureCompletion(Long procId) {
+    assertTrue(procId > 0, "Procedure ID should be positive");
+    TEST_UTIL.waitFor(1000, () -> {
+      try {
+        return procExecutor.isFinished(procId);
+      } catch (Exception e) {
+        return false;
+      }
+    });
+    assertProcNotFailed(procExecutor.getResult(procId));
+  }
+
+  private void setReadOnlyMode(boolean isReadOnly) {
+    TEST_UTIL.getConfiguration().setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY,
+      isReadOnly);
+    notifyConfigurationObservers();
+  }
+
+  private void notifyConfigurationObservers() {
+    master.getConfigurationManager().notifyAllObservers(TEST_UTIL.getConfiguration());
+    regionServer.getConfigurationManager().notifyAllObservers(TEST_UTIL.getConfiguration());
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/region/TestMasterRegionInitialize.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/region/TestMasterRegionInitialize.java
@@ -24,7 +24,10 @@ import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.TableDescriptor;
@@ -108,5 +111,20 @@ public class TestMasterRegionInitialize extends MasterRegionTestBase {
 
     // but the data should have been cleaned up
     assertTrue(region.get(new Get(row)).isEmpty());
+  }
+
+  @Test
+  public void testMasterRegionDirSuffix() {
+    String currentMasterRegionDirName = MasterRegionFactory.getMasterRegionDirName();
+    assertEquals("MasterData", currentMasterRegionDirName,
+      "Default master region directory should be MasterData");
+
+    Configuration confWithSuffix = HBaseConfiguration.create();
+    String suffix = "replica1";
+    confWithSuffix.set(HConstants.HBASE_META_TABLE_SUFFIX, suffix);
+    String dirNameWithSuffix = MasterRegionFactory.initMasterRegionDirName(confWithSuffix);
+    String expectedDirName = "MasterData_" + suffix;
+    assertEquals(expectedDirName, dirNameWithSuffix,
+      "Directory name should have suffix when configured");
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestHFileProcedurePrettyPrinter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestHFileProcedurePrettyPrinter.java
@@ -97,7 +97,7 @@ public class TestHFileProcedurePrettyPrinter extends RegionProcedureStoreTestBas
     store.cleanup();
     store.region.flush(true);
     Path tableDir = CommonFSUtils.getTableDir(
-      new Path(htu.getDataTestDir(), MasterRegionFactory.MASTER_STORE_DIR),
+      new Path(htu.getDataTestDir(), MasterRegionFactory.getMasterRegionDirName()),
       MasterRegionFactory.TABLE_NAME);
     FileSystem fs = tableDir.getFileSystem(htu.getConfiguration());
     Path regionDir =

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestWALProcedurePrettyPrinter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/procedure2/store/region/TestWALProcedurePrettyPrinter.java
@@ -59,7 +59,7 @@ public class TestWALProcedurePrettyPrinter extends RegionProcedureStoreTestBase 
     }
     store.cleanup();
     Path walParentDir = new Path(htu.getDataTestDir(),
-      MasterRegionFactory.MASTER_STORE_DIR + "/" + HConstants.HREGION_LOGDIR_NAME);
+      MasterRegionFactory.getMasterRegionDirName() + "/" + HConstants.HREGION_LOGDIR_NAME);
     FileSystem fs = walParentDir.getFileSystem(htu.getConfiguration());
     Path walDir = fs.listStatus(walParentDir)[0].getPath();
     Path walFile = fs.listStatus(walDir)[0].getPath();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestActiveClusterSuffix.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestActiveClusterSuffix.java
@@ -1,0 +1,158 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.io.IOException;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.ActiveClusterSuffix;
+import org.apache.hadoop.hbase.ClusterId;
+import org.apache.hadoop.hbase.HBaseCommonTestingUtil;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.master.MasterFileSystem;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.JVMClusterUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Test Active Cluster Suffix file.
+ */
+@Tag(RegionServerTests.TAG)
+@Tag(MediumTests.TAG)
+public class TestActiveClusterSuffix {
+
+  private final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+
+  private JVMClusterUtil.RegionServerThread rst;
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    TEST_UTIL.getConfiguration().setBoolean(ShutdownHook.RUN_SHUTDOWN_HOOK, false);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+    if (rst != null && rst.getRegionServer() != null) {
+      rst.getRegionServer().stop("end of test");
+      rst.join();
+    }
+  }
+
+  @Test
+  public void testActiveClusterSuffixCreated() throws Exception {
+    TEST_UTIL.startMiniZKCluster();
+    TEST_UTIL.startMiniDFSCluster(1);
+    TEST_UTIL.startMiniHBaseCluster();
+
+    Path rootDir = CommonFSUtils.getRootDir(TEST_UTIL.getConfiguration());
+    FileSystem fs = rootDir.getFileSystem(TEST_UTIL.getConfiguration());
+    Path filePath = new Path(rootDir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME);
+
+    assertTrue(fs.exists(filePath), filePath + " should exists ");
+    assertTrue(fs.getFileStatus(filePath).getLen() > 0, filePath + " should not be empty  ");
+
+    MasterFileSystem mfs = TEST_UTIL.getHBaseCluster().getMaster().getMasterFileSystem();
+
+    try (FSDataInputStream in = fs.open(filePath)) {
+      ActiveClusterSuffix suffixFromFile = ActiveClusterSuffix.parseFrom(in.readAllBytes());
+      ActiveClusterSuffix suffixFromConfig =
+        ActiveClusterSuffix.fromConfig(TEST_UTIL.getConfiguration(), mfs.getClusterId());
+      assertEquals(suffixFromFile, suffixFromConfig,
+        "Active Cluster Suffix file content doesn't match configuration");
+    }
+  }
+
+  @Test
+  public void testSuffixFileOnRestart() throws Exception {
+    TEST_UTIL.startMiniZKCluster();
+    TEST_UTIL.startMiniDFSCluster(1);
+    TEST_UTIL.createRootDir();
+    TEST_UTIL.getConfiguration().set(HConstants.HBASE_META_TABLE_SUFFIX, "Test");
+
+    String clusterId = HBaseCommonTestingUtil.getRandomUUID().toString();
+    String cluster_suffix = clusterId + ":" + TEST_UTIL.getConfiguration()
+      .get(HConstants.HBASE_META_TABLE_SUFFIX, HConstants.HBASE_META_TABLE_SUFFIX_DEFAULT_VALUE);
+
+    writeIdFile(clusterId, HConstants.CLUSTER_ID_FILE_NAME);
+    writeIdFile(cluster_suffix, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME);
+
+    try {
+      TEST_UTIL.startMiniHBaseCluster();
+    } catch (IOException ioe) {
+      fail("Can't start mini hbase cluster.");
+    }
+
+    MasterFileSystem mfs = TEST_UTIL.getHBaseCluster().getMaster().getMasterFileSystem();
+
+    // Compute using file contents
+    ActiveClusterSuffix cluster_suffix1 = mfs.getActiveClusterSuffix();
+    // Compute using config
+    ActiveClusterSuffix cluster_suffix2 =
+      ActiveClusterSuffix.fromConfig(TEST_UTIL.getConfiguration(), new ClusterId(clusterId));
+
+    assertEquals(cluster_suffix1, cluster_suffix2);
+    assertEquals(cluster_suffix, cluster_suffix1.toString());
+  }
+
+  @Test
+  public void testVerifyErrorWhenSuffixNotMatched() throws Exception {
+    TEST_UTIL.startMiniZKCluster();
+    TEST_UTIL.startMiniDFSCluster(1);
+    TEST_UTIL.createRootDir();
+    TEST_UTIL.getConfiguration().setInt("hbase.master.start.timeout.localHBaseCluster", 10000);
+    String cluster_suffix = String.valueOf("2df92f65-d801-46e6-b892-c2bae2df3c21:test");
+    writeIdFile(cluster_suffix, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME);
+    // Exception: as config in the file and the one set by the user are not matching
+    boolean threwIOE = false;
+    try {
+      TEST_UTIL.startMiniHBaseCluster();
+    } catch (IOException ioe) {
+      threwIOE = true;
+    } finally {
+      assertTrue(threwIOE, "The master should have thrown an exception");
+    }
+  }
+
+  private void writeIdFile(String id, String fileName) throws Exception {
+    Path rootDir = CommonFSUtils.getRootDir(TEST_UTIL.getConfiguration());
+    FileSystem fs = rootDir.getFileSystem(TEST_UTIL.getConfiguration());
+    Path filePath = new Path(rootDir, fileName);
+    FSDataOutputStream s = null;
+    try {
+      s = fs.create(filePath);
+      s.writeUTF(id);
+    } finally {
+      if (s != null) {
+        s.close();
+      }
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompactSplitReadOnly.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompactSplitReadOnly.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionLifeCycleTracker;
+import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(RegionServerTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestCompactSplitReadOnly {
+
+  private CompactSplit compactSplit;
+  private Configuration conf;
+
+  @BeforeEach
+  public void setUp() {
+    conf = new Configuration();
+    // enable read-only mode
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+    // create CompactSplit with conf-only constructor (available for tests)
+    compactSplit = new CompactSplit(conf);
+  }
+
+  @AfterEach
+  public void tearDown() {
+    // ensure thread pools are shutdown to avoid leakage
+    compactSplit.interruptIfNecessary();
+  }
+
+  @Test
+  public void testRequestSystemCompactionIgnoredWhenReadOnly() throws IOException {
+    // Mock HRegion and HStore minimal behavior
+    HRegion region = mock(HRegion.class);
+    HStore store = mock(HStore.class);
+
+    // Ensure compaction queues start empty
+    assertEquals(0, compactSplit.getCompactionQueueSize());
+
+    // Call requestSystemCompaction for a single store (selectNow = false)
+    compactSplit.requestSystemCompaction(region, store, "test-readonly");
+
+    // Because read-only mode is enabled, no compaction should be queued
+    assertEquals(0, compactSplit.getCompactionQueueSize());
+  }
+
+  @Test
+  public void testSelectCompactionIgnoredWhenReadOnly() throws IOException {
+    HRegion region = mock(HRegion.class);
+    HStore store = mock(HStore.class);
+
+    // Ensure compaction queues start empty
+    assertEquals(0, compactSplit.getCompactionQueueSize());
+
+    // Call requestCompaction which uses selectNow = true and should call selectCompaction
+    compactSplit.requestCompaction(region, store, "test-select-readonly", 0,
+      CompactionLifeCycleTracker.DUMMY, (User) null);
+
+    // Because read-only mode is enabled, selectCompaction should be skipped and no task queued
+    assertEquals(0, compactSplit.getCompactionQueueSize());
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/DummyStoreFileTrackerForReadOnlyMode.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/DummyStoreFileTrackerForReadOnlyMode.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver.storefiletracker;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
+import org.apache.hadoop.hbase.regionserver.StoreContext;
+import org.apache.hadoop.hbase.regionserver.StoreFileInfo;
+import org.mockito.Mockito;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class DummyStoreFileTrackerForReadOnlyMode extends StoreFileTrackerBase {
+  private static final Logger LOG =
+    LoggerFactory.getLogger(DummyStoreFileTrackerForReadOnlyMode.class);
+
+  private boolean readOnlyUsed = false;
+  private boolean compactionExecuted = false;
+  private boolean addExecuted = false;
+  private boolean setExecuted = false;
+
+  private static StoreContext buildStoreContext(Configuration conf, TableName tableName) {
+    RegionInfo regionInfo = RegionInfoBuilder.newBuilder(tableName).build();
+    HRegionFileSystem hfs = Mockito.mock(HRegionFileSystem.class);
+    try {
+      Mockito.when(hfs.getRegionInfo()).thenReturn(regionInfo);
+      Mockito.when(hfs.getFileSystem()).thenReturn(FileSystem.get(conf));
+    } catch (IOException e) {
+      LOG.error("Failed to get FileSystem for StoreContext creation", e);
+    }
+    return StoreContext.getBuilder().withRegionFileSystem(hfs).build();
+  }
+
+  public DummyStoreFileTrackerForReadOnlyMode(Configuration conf, boolean isPrimaryReplica,
+    TableName tableName) {
+    super(conf, isPrimaryReplica, buildStoreContext(conf, tableName));
+  }
+
+  @Override
+  protected void doAddCompactionResults(Collection<StoreFileInfo> compactedFiles,
+    Collection<StoreFileInfo> newFiles) {
+    compactionExecuted = true;
+  }
+
+  @Override
+  protected void doSetStoreFiles(Collection<StoreFileInfo> files) throws IOException {
+    setExecuted = true;
+  }
+
+  @Override
+  protected List<StoreFileInfo> doLoadStoreFiles(boolean readOnly) {
+    readOnlyUsed = readOnly;
+    return Collections.emptyList();
+  }
+
+  @Override
+  protected void doAddNewStoreFiles(Collection<StoreFileInfo> newFiles) throws IOException {
+    addExecuted = true;
+  }
+
+  boolean wasReadOnlyLoad() {
+    return readOnlyUsed;
+  }
+
+  boolean wasCompactionExecuted() {
+    return compactionExecuted;
+  }
+
+  boolean wasAddExecuted() {
+    return addExecuted;
+  }
+
+  boolean wasSetExecuted() {
+    return setExecuted;
+  }
+
+  @Override
+  public boolean requireWritingToTmpDirFirst() {
+    return false;
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileListFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileListFile.java
@@ -299,4 +299,25 @@ public class TestStoreFileListFile {
       logger.setLevel(oldLevel);
     }
   }
+
+  @Test
+  public void testStoreFilesResetTracker() throws IOException {
+    storeFileListFile.update(StoreFileList.newBuilder()
+      .addStoreFile(StoreFileEntry.newBuilder().setName("h1").setSize(10).build()));
+
+    StoreFileListFile writer2 = create();
+    writer2.update(StoreFileList.newBuilder()
+      .addStoreFile(StoreFileEntry.newBuilder().setName("h1").setSize(10).build())
+      .addStoreFile(StoreFileEntry.newBuilder().setName("h2").setSize(10).build()));
+
+    storeFileListFile.resetWriteState();
+
+    storeFileListFile.update(StoreFileList.newBuilder()
+      .addStoreFile(StoreFileEntry.newBuilder().setName("h1").setSize(10).build())
+      .addStoreFile(StoreFileEntry.newBuilder().setName("h2").setSize(10).build())
+      .addStoreFile(StoreFileEntry.newBuilder().setName("h3").setSize(10).build()));
+
+    StoreFileListFile reader = create();
+    assertEquals(3, reader.load(true).getStoreFileCount());
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileTrackerBaseReadOnlyMode.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/storefiletracker/TestStoreFileTrackerBaseReadOnlyMode.java
@@ -1,0 +1,255 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver.storefiletracker;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.fail;
+
+import java.util.Collections;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.TestRefreshHFilesBase;
+import org.apache.hadoop.hbase.master.region.MasterRegionFactory;
+import org.apache.hadoop.hbase.regionserver.CreateStoreFileWriterParams;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(RegionServerTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestStoreFileTrackerBaseReadOnlyMode extends TestRefreshHFilesBase {
+  private DummyStoreFileTrackerForReadOnlyMode tracker;
+
+  TableName tableName = TableName.valueOf("TestStoreFileTrackerBaseReadOnlyMode");
+
+  @BeforeEach
+  public void setup() throws Exception {
+    // When true is passed only setup for readonly property is done.
+    // The initial ReadOnly property will be false for table creation
+    baseSetup(true);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    baseTearDown();
+  }
+
+  private void verifyLoadInReadOnlyMode(boolean readOnlyMode, TableName table,
+    boolean expectReadOnly, String msg) throws Exception {
+    try {
+      setReadOnlyMode(readOnlyMode);
+      tracker = new DummyStoreFileTrackerForReadOnlyMode(conf, true, table);
+      tracker.load();
+      assertEquals(expectReadOnly, tracker.wasReadOnlyLoad(), msg);
+    } finally {
+      setReadOnlyMode(false);
+    }
+  }
+
+  @Test
+  public void testLoadNonWritableTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifyLoadInReadOnlyMode(true, tableName, true,
+      "For non-writable tables, the doLoadStoreFiles() should get called with readOnly=true");
+  }
+
+  @Test
+  public void testLoadMetaTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifyLoadInReadOnlyMode(true, TableName.META_TABLE_NAME, false,
+      "As meta table is always writable, the doLoadStoreFiles should not get called with readOnly=false even if readonly mode is enabled");
+  }
+
+  @Test
+  public void testLoadMasterStoreTableWhenGlobalReadOnlyEnabled() throws Exception {
+    // As master:store table is always writable, the doLoadStoreFiles should not get called with
+    // readOnly=true
+    verifyLoadInReadOnlyMode(true, MasterRegionFactory.TABLE_NAME, false,
+      "As master:store table is always writable, the doLoadStoreFiles should not get called with readOnly=false even if readonly mode is enabled");
+  }
+
+  @Test
+  public void testLoadWhenGlobalReadOnlyDisabled() throws Exception {
+    // When readonly mode is disabled, then it should not interfere with normal functionality
+    verifyLoadInReadOnlyMode(false, tableName, false,
+      "As readonly mode is not set, the doLoadStoreFiles() should get called with readOnly=false");
+  }
+
+  private void verifyReplaceInReadOnlyMode(boolean readOnlyMode, TableName table,
+    boolean expectCompactionExecuted, String msg) {
+    try {
+      setReadOnlyMode(readOnlyMode);
+      tracker = new DummyStoreFileTrackerForReadOnlyMode(conf, true, table);
+      tracker.replace(Collections.emptyList(), Collections.emptyList());
+      assertEquals(expectCompactionExecuted, tracker.wasCompactionExecuted(), msg);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      setReadOnlyMode(false);
+    }
+  }
+
+  @Test
+  public void testReplaceSkippedForNonWritableTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifyReplaceInReadOnlyMode(true, tableName, false,
+      "Compaction should not be executed for non-writable table in readonly mode");
+  }
+
+  @Test
+  public void testReplaceExecutedForMetaTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifyReplaceInReadOnlyMode(true, TableName.META_TABLE_NAME, true,
+      "Compaction should be executed for meta table in readonly mode");
+  }
+
+  @Test
+  public void testReplaceExecutedForMasterStoreTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifyReplaceInReadOnlyMode(true, MasterRegionFactory.TABLE_NAME, true,
+      "Compaction should be executed for master:store table in readonly mode");
+  }
+
+  @Test
+  public void testReplaceExecutedWhenGlobalReadOnlyDisabled() throws Exception {
+    verifyReplaceInReadOnlyMode(false, tableName, true,
+      "Compaction should be executed for any table when readonly mode is disabled");
+  }
+
+  private void verifyAddInReadOnlyMode(boolean readOnlyMode, TableName table,
+    boolean expectAddExecuted, String msg) {
+    try {
+      setReadOnlyMode(readOnlyMode);
+      tracker = new DummyStoreFileTrackerForReadOnlyMode(conf, true, table);
+      tracker.add(Collections.emptyList());
+      assertEquals(expectAddExecuted, tracker.wasAddExecuted(), msg);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      setReadOnlyMode(false);
+    }
+  }
+
+  @Test
+  public void testAddSkippedForNonWritableTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifyAddInReadOnlyMode(true, tableName, false,
+      "Add should not be executed for non-writable table in readonly mode");
+  }
+
+  @Test
+  public void testAddExecutedForMetaTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifyAddInReadOnlyMode(true, TableName.META_TABLE_NAME, true,
+      "Add should be executed for meta table in readonly mode");
+  }
+
+  @Test
+  public void testAddExecutedForMasterStoreTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifyAddInReadOnlyMode(true, MasterRegionFactory.TABLE_NAME, true,
+      "Add should be executed for master:store table in readonly mode");
+  }
+
+  @Test
+  public void testAddExecutedWhenGlobalReadOnlyDisabled() throws Exception {
+    verifyAddInReadOnlyMode(false, tableName, true,
+      "Add should be executed for any table when readonly mode is disabled");
+  }
+
+  private void verifySetInReadOnlyMode(boolean readOnlyMode, TableName table,
+    boolean expectSetExecuted, String msg) {
+    try {
+      setReadOnlyMode(readOnlyMode);
+      tracker = new DummyStoreFileTrackerForReadOnlyMode(conf, true, table);
+      tracker.set(Collections.emptyList());
+      assertEquals(expectSetExecuted, tracker.wasSetExecuted(), msg);
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    } finally {
+      setReadOnlyMode(false);
+    }
+  }
+
+  @Test
+  public void testSetSkippedForNonWritableTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifySetInReadOnlyMode(true, tableName, false,
+      "Set should not be executed for non-writable table in readonly mode");
+  }
+
+  @Test
+  public void testSetExecutedForMetaTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifySetInReadOnlyMode(true, TableName.META_TABLE_NAME, true,
+      "Set should be executed for meta table in readonly mode");
+  }
+
+  @Test
+  public void testSetExecutedForMasterStoreTableWhenGlobalReadOnlyEnabled() throws Exception {
+    verifySetInReadOnlyMode(true, MasterRegionFactory.TABLE_NAME, true,
+      "Set should be executed for master:store table in readonly mode");
+  }
+
+  @Test
+  public void testSetExecutedWhenGlobalReadOnlyDisabled() throws Exception {
+    verifySetInReadOnlyMode(false, tableName, true,
+      "Set should be executed for any table when readonly mode is disabled");
+  }
+
+  private CreateStoreFileWriterParams createParams() {
+    return CreateStoreFileWriterParams.create().maxKeyCount(4).isCompaction(false)
+      .includeMVCCReadpoint(true).includesTag(false).shouldDropBehind(false);
+  }
+
+  private void assertIllegalStateThrown(TableName tableName) {
+    try {
+      setReadOnlyMode(true);
+      tracker = new DummyStoreFileTrackerForReadOnlyMode(conf, true, tableName);
+      assertThrows(IllegalStateException.class, () -> tracker.createWriter(createParams()),
+        "Expected IllegalStateException");
+    } finally {
+      setReadOnlyMode(false);
+    }
+  }
+
+  private void assertNoIllegalStateThrown(TableName tableName) {
+    try {
+      setReadOnlyMode(true);
+      tracker = new DummyStoreFileTrackerForReadOnlyMode(conf, true, tableName);
+      try {
+        tracker.createWriter(createParams());
+      } catch (IllegalStateException e) {
+        fail("Should not throw IllegalStateException for table " + tableName);
+      } catch (Exception e) {
+        // Ignore other exceptions as they are not the focus of this test
+      }
+    } finally {
+      setReadOnlyMode(false);
+    }
+  }
+
+  @Test
+  public void testCreateWriterThrowExceptionWhenGlobalReadOnlyEnabled() throws Exception {
+    assertIllegalStateThrown(tableName);
+  }
+
+  @Test
+  public void testCreateWriterNoExceptionMetaTableWhenGlobalReadOnlyEnabled() throws Exception {
+    assertNoIllegalStateThrown(TableName.META_TABLE_NAME);
+  }
+
+  @Test
+  public void testCreateWriterNoExceptionMasterStoreTableWhenGlobalReadOnlyEnabled()
+    throws Exception {
+    assertNoIllegalStateThrown(MasterRegionFactory.TABLE_NAME);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/VerifyingRSGroupAdmin.java
@@ -1011,4 +1011,23 @@ public class VerifyingRSGroupAdmin implements Admin, Closeable {
     return admin.isReplicationPeerModificationEnabled();
   }
 
+  @Override
+  public long refreshMeta() throws IOException {
+    return admin.refreshMeta();
+  }
+
+  @Override
+  public long refreshHFiles(final TableName tableName) throws IOException {
+    return admin.refreshHFiles(tableName);
+  }
+
+  @Override
+  public long refreshHFiles(final String namespace) throws IOException {
+    return admin.refreshHFiles(namespace);
+  }
+
+  @Override
+  public long refreshHFiles() throws IOException {
+    return admin.refreshHFiles();
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestCanStartHBaseInReadOnlyMode.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestCanStartHBaseInReadOnlyMode.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.apache.hadoop.hbase.HConstants.HBASE_CLIENT_RETRIES_NUMBER;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(SecurityTests.TAG)
+@Tag(LargeTests.TAG)
+@SuppressWarnings("deprecation")
+public class TestCanStartHBaseInReadOnlyMode {
+
+  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private static Configuration conf;
+
+  @BeforeAll
+  public static void beforeClass() throws Exception {
+    conf = TEST_UTIL.getConfiguration();
+
+    // Shorten the run time of failed unit tests by limiting retries and the session timeout
+    // threshold
+    conf.setInt(HBASE_CLIENT_RETRIES_NUMBER, 0);
+    conf.setInt("hbase.master.init.timeout.localHBaseCluster", 10000);
+
+    // Enable Read-Only mode to prove the cluster can be started in this state
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+  }
+
+  @AfterAll
+  public static void afterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testCanStartHBaseInReadOnlyMode() throws Exception {
+    TEST_UTIL.startMiniCluster(1);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyController.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyController.java
@@ -1,0 +1,197 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.apache.hadoop.hbase.HConstants.HBASE_CLIENT_RETRIES_NUMBER;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.SingleProcessHBaseCluster;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Row;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.master.HMaster;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.ConfigurationUtil;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag(SecurityTests.TAG)
+@Tag(LargeTests.TAG)
+@SuppressWarnings("deprecation")
+public class TestReadOnlyController {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestReadOnlyController.class);
+  private final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private static final TableName TEST_TABLE = TableName.valueOf("read_only_test_table");
+  private static final byte[] TEST_FAMILY = Bytes.toBytes("read_only_table_col_fam");
+  private static HRegionServer hRegionServer;
+  private static HMaster hMaster;
+  private static Configuration conf;
+  private static Connection connection;
+  private static SingleProcessHBaseCluster cluster;
+
+  private static Table testTable;
+
+  @BeforeEach
+  public void beforeClass() throws Exception {
+    conf = TEST_UTIL.getConfiguration();
+
+    // Shorten the run time of failed unit tests by limiting retries and the session timeout
+    // threshold
+    conf.setInt(HBASE_CLIENT_RETRIES_NUMBER, 1);
+    conf.setInt(HConstants.ZK_SESSION_TIMEOUT, 1000);
+
+    // Set up test class with Read-Only mode disabled so a table can be created
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+
+    try {
+      // Start the test cluster
+      cluster = TEST_UTIL.startMiniCluster(1);
+
+      hMaster = cluster.getMaster();
+      hRegionServer = cluster.getRegionServerThreads().get(0).getRegionServer();
+      connection = ConnectionFactory.createConnection(conf);
+
+      // Create a test table
+      testTable = TEST_UTIL.createTable(TEST_TABLE, TEST_FAMILY);
+    } catch (Exception e) {
+      // Delete the created table, and clean up the connection and cluster before throwing an
+      // exception
+      disableReadOnlyMode();
+      TEST_UTIL.deleteTable(TEST_TABLE);
+      connection.close();
+      TEST_UTIL.shutdownMiniCluster();
+      throw new RuntimeException(e);
+    }
+  }
+
+  @AfterEach
+  public void afterClass() throws Exception {
+    if (connection != null) {
+      connection.close();
+    }
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  private static void enableReadOnlyMode() {
+    // Dynamically enable Read-Only mode if it is not active
+    if (!ConfigurationUtil.isReadOnlyModeEnabledInConf(conf)) {
+      LOG.info("Dynamically enabling Read-Only mode by setting {} to true",
+        HConstants.HBASE_GLOBAL_READONLY_ENABLED_DEFAULT);
+      conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+      notifyObservers();
+    }
+  }
+
+  private static void disableReadOnlyMode() {
+    // Dynamically disable Read-Only mode if it is active
+    if (ConfigurationUtil.isReadOnlyModeEnabledInConf(conf)) {
+      LOG.info("Dynamically disabling Read-Only mode by setting {} to false",
+        HConstants.HBASE_GLOBAL_READONLY_ENABLED_DEFAULT);
+      conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+      notifyObservers();
+    }
+  }
+
+  private static void notifyObservers() {
+    LOG.info("Notifying observers about configuration changes");
+    hMaster.getConfigurationManager().notifyAllObservers(conf);
+    hRegionServer.getConfigurationManager().notifyAllObservers(conf);
+  }
+
+  // The test case for successfully creating a table with Read-Only mode disabled happens when
+  // setting up the test class, so we only need a test function for a failed table creation.
+  @Test
+  public void testCannotCreateTableWithReadOnlyEnabled() throws IOException {
+    enableReadOnlyMode();
+    TableName newTable = TableName.valueOf("bad_read_only_test_table");
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      TEST_UTIL.createTable(newTable, TEST_FAMILY);
+    });
+    assertTrue(exception.getMessage().contains("Operation not allowed in Read-Only Mode"));
+  }
+
+  @Test
+  public void testPutWithReadOnlyDisabled() throws IOException {
+    // Successfully put a row in the table since Read-Only mode is disabled
+    disableReadOnlyMode();
+    final byte[] row2 = Bytes.toBytes("row2");
+    final byte[] value = Bytes.toBytes("efgh");
+    Put put = new Put(row2);
+    put.addColumn(TEST_FAMILY, null, value);
+    testTable.put(put);
+  }
+
+  @Test
+  public void testCannotPutWithReadOnlyEnabled() throws IOException {
+    // Prepare a Put command with Read-Only mode enabled
+    enableReadOnlyMode();
+    final byte[] row1 = Bytes.toBytes("row1");
+    final byte[] value = Bytes.toBytes("abcd");
+    Put put = new Put(row1);
+    put.addColumn(TEST_FAMILY, null, value);
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      testTable.put(put);
+    });
+    assertTrue(exception.getMessage().contains("Operation not allowed in Read-Only Mode"));
+  }
+
+  @Test
+  public void testBatchPutWithReadOnlyDisabled() throws IOException, InterruptedException {
+    // Successfully create and run a batch Put operation with Read-Only mode disabled
+    disableReadOnlyMode();
+    List<Row> actions = new ArrayList<>();
+    actions.add(new Put(Bytes.toBytes("row10")).addColumn(TEST_FAMILY, null, Bytes.toBytes("10")));
+    actions.add(new Delete(Bytes.toBytes("row10")));
+    testTable.batch(actions, null);
+  }
+
+  @Test
+  public void testCannotBatchPutWithReadOnlyEnabled() throws IOException, InterruptedException {
+    // Create a batch Put operation that is expected to fail with Read-Only mode enabled
+    enableReadOnlyMode();
+    List<Row> actions = new ArrayList<>();
+    actions.add(new Put(Bytes.toBytes("row11")).addColumn(TEST_FAMILY, null, Bytes.toBytes("11")));
+    actions.add(new Delete(Bytes.toBytes("row11")));
+
+    IOException exception = assertThrows(IOException.class, () -> {
+      testTable.batch(actions, null);
+    });
+    assertTrue(exception.getMessage().contains("Operation not allowed in Read-Only Mode"));
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerBulkLoadObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerBulkLoadObserver.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.apache.hadoop.hbase.WriteAttemptedOnReadOnlyClusterException;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+// Tests methods of BulkLoad Observer which are implemented in ReadOnlyController,
+// by mocking the coprocessor environment and dependencies
+@Tag(SecurityTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestReadOnlyControllerBulkLoadObserver {
+
+  BulkLoadReadOnlyController bulkLoadReadOnlyController;
+
+  // Region Server Coprocessor mocking variables
+  ObserverContext<RegionCoprocessorEnvironment> ctx;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    bulkLoadReadOnlyController = new BulkLoadReadOnlyController();
+
+    // mocking variables initialization
+    ctx = mock(ObserverContext.class);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+
+  }
+
+  @Test
+  public void testPrePrepareBulkLoadReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      bulkLoadReadOnlyController.prePrepareBulkLoad(ctx);
+    });
+  }
+
+  @Test
+  public void testPreCleanupBulkLoadReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      bulkLoadReadOnlyController.preCleanupBulkLoad(ctx);
+    });
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerCoprocessorLoading.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerCoprocessorLoading.java
@@ -1,0 +1,257 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Stream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.master.HMaster;
+import org.apache.hadoop.hbase.master.MasterCoprocessorHost;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.regionserver.RegionCoprocessorHost;
+import org.apache.hadoop.hbase.regionserver.RegionServerCoprocessorHost;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.MethodSource;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag(SecurityTests.TAG)
+@Tag(MediumTests.TAG)
+public class TestReadOnlyControllerCoprocessorLoading {
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestReadOnlyController.class);
+  private HBaseTestingUtil TEST_UTIL;
+
+  Configuration conf;
+  TableName tableName = TableName.valueOf("test_table");
+  HMaster master;
+  HRegionServer regionServer;
+  HRegion region;
+
+  private boolean initialReadOnlyMode;
+
+  public TestReadOnlyControllerCoprocessorLoading() {
+    this.initialReadOnlyMode = false;
+  }
+
+  @BeforeEach
+  public void setup() throws Exception {
+    TEST_UTIL = new HBaseTestingUtil();
+    if (TEST_UTIL.getMiniHBaseCluster() != null) {
+      TEST_UTIL.shutdownMiniCluster();
+    }
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  private void setupMiniCluster(boolean isReadOnlyEnabled) throws Exception {
+    conf = TEST_UTIL.getConfiguration();
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, isReadOnlyEnabled);
+    TEST_UTIL.startMiniCluster(1);
+
+    master = TEST_UTIL.getMiniHBaseCluster().getMaster();
+    regionServer = TEST_UTIL.getMiniHBaseCluster().getRegionServer(0);
+  }
+
+  private void createTable() throws Exception {
+    // create a table to get at a region
+    TableDescriptor desc = TableDescriptorBuilder.newBuilder(tableName)
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.of("cf")).build();
+    TEST_UTIL.getAdmin().createTable(desc);
+
+    List<HRegion> regions = regionServer.getRegions(tableName);
+    assertFalse(regions.isEmpty());
+    region = regions.get(0);
+  }
+
+  private Configuration setReadOnlyMode(boolean isReadOnlyEnabled) {
+    // Create a new configuration to mimic client server behavior
+    // otherwise the existing conf object is shared with the cluster
+    // and can cause side effects on other tests if not reset properly.
+    // This way we can ensure that only the coprocessor loading is tested
+    // without impacting other tests.
+    HBaseTestingUtil NEW_TEST_UTIL = new HBaseTestingUtil();
+    Configuration newConf = NEW_TEST_UTIL.getConfiguration();
+    // Set the read-only enabled config dynamically after cluster startup
+    newConf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, isReadOnlyEnabled);
+    master.getConfigurationManager().notifyAllObservers(newConf);
+    regionServer.getConfigurationManager().notifyAllObservers(newConf);
+    if (region != null) {
+      region.getConfigurationManager().notifyAllObservers(newConf);
+    }
+    return newConf;
+  }
+
+  private void verifyMasterReadOnlyControllerLoading(boolean isReadOnlyEnabled) {
+    MasterCoprocessorHost masterCPHost = master.getMasterCoprocessorHost();
+    if (isReadOnlyEnabled) {
+      assertNotNull(masterCPHost.findCoprocessor(MasterReadOnlyController.class.getName()),
+        MasterReadOnlyController.class.getName()
+          + " should be loaded at startup when readonly is true.");
+    } else {
+      assertNull(masterCPHost.findCoprocessor(MasterReadOnlyController.class.getName()),
+        MasterReadOnlyController.class.getName()
+          + " should not be loaded at startup when readonly support property is false.");
+    }
+  }
+
+  private void verifyRegionServerReadOnlyControllerLoading(boolean isReadOnlyEnabled) {
+    RegionServerCoprocessorHost rsCPHost = regionServer.getRegionServerCoprocessorHost();
+    if (isReadOnlyEnabled) {
+      assertNotNull(rsCPHost.findCoprocessor(RegionServerReadOnlyController.class.getName()),
+        RegionServerReadOnlyController.class.getName()
+          + " should be loaded at startup when readonly is true.");
+    } else {
+      assertNull(rsCPHost.findCoprocessor(RegionServerReadOnlyController.class.getName()),
+        RegionServerReadOnlyController.class.getName()
+          + " should not be loaded at startup when readonly support property is false.");
+    }
+  }
+
+  private void verifyRegionReadOnlyControllerLoading(boolean isReadOnlyEnabled) {
+    RegionCoprocessorHost regionCPHost = region.getCoprocessorHost();
+
+    if (isReadOnlyEnabled) {
+      assertNotNull(regionCPHost.findCoprocessor(RegionReadOnlyController.class.getName()),
+        RegionReadOnlyController.class.getName()
+          + " should be loaded at startup when readonly is true.");
+      assertNotNull(regionCPHost.findCoprocessor(EndpointReadOnlyController.class.getName()),
+        EndpointReadOnlyController.class.getName()
+          + " should be loaded at startup when readonly is true.");
+      assertNotNull(regionCPHost.findCoprocessor(BulkLoadReadOnlyController.class.getName()),
+        BulkLoadReadOnlyController.class.getName()
+          + " should be loaded at startup when readonly is true.");
+    } else {
+      assertNull(regionCPHost.findCoprocessor(RegionReadOnlyController.class.getName()),
+        RegionReadOnlyController.class.getName()
+          + " should not be loaded at startup when readonly support property is false");
+      assertNull(regionCPHost.findCoprocessor(EndpointReadOnlyController.class.getName()),
+        EndpointReadOnlyController.class.getName()
+          + " should not be loaded at startup when readonly support property is false");
+      assertNull(regionCPHost.findCoprocessor(BulkLoadReadOnlyController.class.getName()),
+        BulkLoadReadOnlyController.class.getName()
+          + " should not be loaded at startup when readonly support property is false");
+    }
+  }
+
+  private void verifyReadOnlyState(boolean isReadOnlyEnabled) throws Exception {
+    verifyMasterReadOnlyControllerLoading(isReadOnlyEnabled);
+    verifyRegionServerReadOnlyControllerLoading(isReadOnlyEnabled);
+    verifyRegionReadOnlyControllerLoading(isReadOnlyEnabled);
+  }
+
+  @ParameterizedTest(name = "initialReadOnlyMode={0}")
+  @MethodSource("parameters")
+  public void testReadOnlyControllerStartupBehavior(boolean initialReadOnlyMode) throws Exception {
+    this.initialReadOnlyMode = initialReadOnlyMode;
+    setupMiniCluster(initialReadOnlyMode);
+    // Table creation is needed to get a region and verify region coprocessor loading hence we can't
+    // test region coprocessor loading at startup.
+    // This will get covered in the dynamic loading test where we will also verify that the
+    // coprocessors are loaded at after table creation dynamically.
+    verifyMasterReadOnlyControllerLoading(initialReadOnlyMode);
+    verifyRegionServerReadOnlyControllerLoading(initialReadOnlyMode);
+  }
+
+  @ParameterizedTest(name = "initialReadOnlyMode={0}")
+  @MethodSource("parameters")
+  public void testReadOnlyControllerLoadedWhenEnabledDynamically(boolean initialReadOnlyMode)
+    throws Exception {
+    this.initialReadOnlyMode = initialReadOnlyMode;
+    setupMiniCluster(initialReadOnlyMode);
+    if (!initialReadOnlyMode) {
+      createTable();
+    }
+    boolean isReadOnlyEnabled = true;
+    setReadOnlyMode(isReadOnlyEnabled);
+    verifyMasterReadOnlyControllerLoading(isReadOnlyEnabled);
+    verifyRegionServerReadOnlyControllerLoading(isReadOnlyEnabled);
+    if (!initialReadOnlyMode) {
+      verifyRegionReadOnlyControllerLoading(isReadOnlyEnabled);
+    }
+  }
+
+  @ParameterizedTest(name = "initialReadOnlyMode={0}")
+  @MethodSource("parameters")
+  public void testReadOnlyControllerUnloadedWhenDisabledDynamically(boolean initialReadOnlyMode)
+    throws Exception {
+    this.initialReadOnlyMode = initialReadOnlyMode;
+    setupMiniCluster(initialReadOnlyMode);
+    boolean isReadOnlyEnabled = false;
+    Configuration newConf = setReadOnlyMode(isReadOnlyEnabled);
+    createTable();
+    // The newly created table's region has a stale conf that needs to be updated
+    region.onConfigurationChange(newConf);
+    verifyMasterReadOnlyControllerLoading(isReadOnlyEnabled);
+    verifyRegionServerReadOnlyControllerLoading(isReadOnlyEnabled);
+    verifyRegionReadOnlyControllerLoading(isReadOnlyEnabled);
+  }
+
+  @ParameterizedTest(name = "initialReadOnlyMode={0}")
+  @MethodSource("parameters")
+  public void testReadOnlyControllerLoadUnloadedWhenMultipleReadOnlyToggle(
+    boolean initialReadOnlyMode) throws Exception {
+    this.initialReadOnlyMode = initialReadOnlyMode;
+    setupMiniCluster(initialReadOnlyMode);
+
+    // Ensure region exists before validation
+    Configuration newConf = setReadOnlyMode(false);
+    createTable();
+    // The newly created table's region has a stale conf that needs to be updated
+    region.onConfigurationChange(newConf);
+    verifyReadOnlyState(false);
+
+    // Define toggle sequence
+    boolean[] toggleSequence = new boolean[] { true, false, // basic toggle
+      true, true, // idempotent enable
+      false, false // idempotent disable
+    };
+
+    for (int i = 0; i < toggleSequence.length; i++) {
+      boolean state = toggleSequence[i];
+      LOG.info("Toggling read-only mode to {} (step {})", state, i);
+
+      setReadOnlyMode(state);
+      verifyReadOnlyState(state);
+    }
+  }
+
+  static Stream<Boolean> parameters() {
+    return Arrays.stream(new Boolean[] { Boolean.TRUE, Boolean.FALSE });
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerEndpointObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerEndpointObserver.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.apache.hadoop.hbase.WriteAttemptedOnReadOnlyClusterException;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hbase.thirdparty.com.google.protobuf.Message;
+import org.apache.hbase.thirdparty.com.google.protobuf.Service;
+
+// Tests methods of Endpoint Observer which are implemented in ReadOnlyController,
+// by mocking the coprocessor environment and dependencies.
+@Tag(SecurityTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestReadOnlyControllerEndpointObserver {
+
+  EndpointReadOnlyController endpointReadOnlyController;
+  // Region Server Coprocessor mocking variables.
+  ObserverContext<? extends RegionCoprocessorEnvironment> ctx;
+  Service service;
+  String methodName;
+  Message request;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    endpointReadOnlyController = new EndpointReadOnlyController();
+
+    // mocking variables initialization
+    ctx = mock(ObserverContext.class);
+    service = mock(Service.class);
+    methodName = "testMethod";
+    request = mock(Message.class);
+
+    // Linking the mocks
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+
+  }
+
+  @Test
+  public void testPreEndpointInvocationReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      endpointReadOnlyController.preEndpointInvocation(ctx, service, methodName, request);
+    });
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerMasterObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerMasterObserver.java
@@ -1,0 +1,488 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.hadoop.hbase.NamespaceDescriptor;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.WriteAttemptedOnReadOnlyClusterException;
+import org.apache.hadoop.hbase.client.BalanceRequest;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.SnapshotDescription;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.coprocessor.MasterCoprocessorEnvironment;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.net.Address;
+import org.apache.hadoop.hbase.quotas.GlobalQuotaSettings;
+import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
+import org.apache.hadoop.hbase.replication.SyncReplicationState;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+// Tests methods of Master Observer which are implemented in ReadOnlyController,
+// by mocking the coprocessor environment and dependencies
+
+@Tag(SecurityTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestReadOnlyControllerMasterObserver {
+
+  MasterReadOnlyController MasterReadOnlyController;
+
+  // Master Coprocessor mocking variables
+  ObserverContext<MasterCoprocessorEnvironment> c, ctx;
+  TableDescriptor desc;
+  RegionInfo[] regions;
+  TableName tableName;
+  TableDescriptor currentDescriptor, newDescriptor;
+  String dstSFT;
+  byte[] family;
+  byte[] splitRow;
+  byte[] splitKey;
+  List<Mutation> metaEntries;
+  RegionInfo[] regionsToMerge;
+  SnapshotDescription snapshot;
+  TableDescriptor tableDescriptor;
+  NamespaceDescriptor ns;
+  NamespaceDescriptor currentNsDescriptor, newNsDescriptor;
+  String namespace;
+  String userName;
+  GlobalQuotaSettings quotas;
+  String regionServer;
+  Set<Address> servers;
+  Set<TableName> tables;
+  String targetGroup;
+  String name;
+  String groupName;
+  BalanceRequest request;
+  String oldName, newName;
+  Map<String, String> configuration;
+  String peerId;
+  ReplicationPeerConfig peerConfig;
+  SyncReplicationState state;
+  UserPermission userPermission;
+  boolean mergeExistingPermissions;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    MasterReadOnlyController = new MasterReadOnlyController();
+
+    // mocking variables initialization
+    c = mock(ObserverContext.class);
+    // ctx is created to make naming variable in sync with the Observer interface
+    // methods where 'ctx' is used as the ObserverContext variable name instead of 'c'.
+    // otherwise both are one and the same
+    ctx = c;
+    desc = mock(TableDescriptor.class);
+    regions = new RegionInfo[] {};
+    tableName = TableName.valueOf("testTable");
+    currentDescriptor = mock(TableDescriptor.class);
+    newDescriptor = mock(TableDescriptor.class);
+    dstSFT = "dstSFT";
+    family = Bytes.toBytes("testFamily");
+    splitRow = Bytes.toBytes("splitRow");
+    splitKey = Bytes.toBytes("splitKey");
+    metaEntries = List.of();
+    regionsToMerge = new RegionInfo[] {};
+    snapshot = mock(SnapshotDescription.class);
+    tableDescriptor = mock(TableDescriptor.class);
+    ns = mock(NamespaceDescriptor.class);
+    currentNsDescriptor = mock(NamespaceDescriptor.class);
+    newNsDescriptor = mock(NamespaceDescriptor.class);
+    namespace = "testNamespace";
+    userName = "testUser";
+    quotas = mock(GlobalQuotaSettings.class);
+    regionServer = "testRegionServer";
+    servers = Set.of();
+    tables = Set.of();
+    targetGroup = "targetGroup";
+    name = "testRSGroup";
+    groupName = "testGroupName";
+    request = BalanceRequest.newBuilder().build();
+    oldName = "oldRSGroupName";
+    newName = "newRSGroupName";
+    configuration = Map.of();
+    peerId = "testPeerId";
+    peerConfig = mock(ReplicationPeerConfig.class);
+    state = SyncReplicationState.NONE;
+    userPermission = mock(UserPermission.class);
+    mergeExistingPermissions = false;
+
+    // Linking the mocks:
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+
+  }
+
+  @Test
+  public void testPreCreateTableRegionsInfosReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preCreateTableRegionsInfos(ctx, desc);
+    });
+  }
+
+  @Test
+  public void testPreCreateTableReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preCreateTable(ctx, desc, regions);
+    });
+  }
+
+  @Test
+  public void testPreCreateTableActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preCreateTableAction(ctx, desc, regions);
+    });
+  }
+
+  @Test
+  public void testPreDeleteTableReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preDeleteTable(ctx, tableName);
+    });
+  }
+
+  @Test
+  public void testPreDeleteTableActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preDeleteTableAction(ctx, tableName);
+    });
+  }
+
+  @Test
+  public void testPreTruncateTableReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preTruncateTable(ctx, tableName);
+    });
+  }
+
+  @Test
+  public void testPreTruncateTableActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preTruncateTableAction(ctx, tableName);
+    });
+  }
+
+  @Test
+  public void testPreModifyTableReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preModifyTable(ctx, tableName, currentDescriptor, newDescriptor);
+    });
+  }
+
+  @Test
+  public void testPreModifyTableStoreFileTrackerReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preModifyTableStoreFileTracker(ctx, tableName, dstSFT);
+    });
+  }
+
+  @Test
+  public void testPreModifyColumnFamilyStoreFileTrackerReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preModifyColumnFamilyStoreFileTracker(ctx, tableName, family,
+        dstSFT);
+    });
+  }
+
+  @Test
+  public void testPreModifyTableActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preModifyTableAction(ctx, tableName, currentDescriptor,
+        newDescriptor);
+    });
+  }
+
+  @Test
+  public void testPreSplitRegionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSplitRegion(c, tableName, splitRow);
+    });
+  }
+
+  @Test
+  public void testPreSplitRegionActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSplitRegionAction(c, tableName, splitRow);
+    });
+  }
+
+  @Test
+  public void testPreSplitRegionBeforeMETAActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSplitRegionBeforeMETAAction(ctx, splitKey, metaEntries);
+    });
+  }
+
+  @Test
+  public void testPreSplitRegionAfterMETAActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSplitRegionAfterMETAAction(ctx);
+    });
+  }
+
+  @Test
+  public void testPreMergeRegionsActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preMergeRegionsAction(ctx, regionsToMerge);
+    });
+  }
+
+  @Test
+  public void testPreMergeRegionsCommitActionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preMergeRegionsCommitAction(ctx, regionsToMerge, metaEntries);
+    });
+  }
+
+  @Test
+  public void testPreSnapshotReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSnapshot(ctx, snapshot, tableDescriptor);
+    });
+  }
+
+  @Test
+  public void testPreCloneSnapshotReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preCloneSnapshot(ctx, snapshot, tableDescriptor);
+    });
+  }
+
+  @Test
+  public void testPreRestoreSnapshotReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preRestoreSnapshot(ctx, snapshot, tableDescriptor);
+    });
+  }
+
+  @Test
+  public void testPreDeleteSnapshotReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preDeleteSnapshot(ctx, snapshot);
+    });
+  }
+
+  @Test
+  public void testPreCreateNamespaceReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preCreateNamespace(ctx, ns);
+    });
+  }
+
+  @Test
+  public void testPreModifyNamespaceReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preModifyNamespace(ctx, currentNsDescriptor, newNsDescriptor);
+    });
+  }
+
+  @Test
+  public void testPreDeleteNamespaceReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preDeleteNamespace(ctx, namespace);
+    });
+  }
+
+  @Test
+  public void testPreMasterStoreFlushReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preMasterStoreFlush(ctx);
+    });
+  }
+
+  @Test
+  public void testPreSetUserQuotaReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSetUserQuota(ctx, userName, quotas);
+    });
+  }
+
+  @Test
+  public void testPreSetUserQuotaOnTableReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSetUserQuota(ctx, userName, tableName, quotas);
+    });
+  }
+
+  @Test
+  public void testPreSetUserQuotaOnNamespaceReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSetUserQuota(ctx, userName, namespace, quotas);
+    });
+  }
+
+  @Test
+  public void testPreSetTableQuotaReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSetTableQuota(ctx, tableName, quotas);
+    });
+  }
+
+  @Test
+  public void testPreSetNamespaceQuotaReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSetNamespaceQuota(ctx, namespace, quotas);
+    });
+  }
+
+  @Test
+  public void testPreSetRegionServerQuotaReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preSetRegionServerQuota(ctx, regionServer, quotas);
+    });
+  }
+
+  @Test
+  public void testPreMergeRegionsReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preMergeRegions(ctx, regionsToMerge);
+    });
+  }
+
+  @Test
+  public void testPreMoveServersAndTablesReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preMoveServersAndTables(ctx, servers, tables, targetGroup);
+    });
+  }
+
+  @Test
+  public void testPreMoveServersReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preMoveServers(ctx, servers, targetGroup);
+    });
+  }
+
+  @Test
+  public void testPreMoveTablesReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preMoveTables(ctx, tables, targetGroup);
+    });
+  }
+
+  @Test
+  public void testPreAddRSGroupReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preAddRSGroup(ctx, name);
+    });
+  }
+
+  @Test
+  public void testPreRemoveRSGroupReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preRemoveRSGroup(ctx, name);
+    });
+  }
+
+  @Test
+  public void testPreBalanceRSGroupReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preBalanceRSGroup(ctx, groupName, request);
+    });
+  }
+
+  @Test
+  public void testPreRemoveServersReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preRemoveServers(ctx, servers);
+    });
+  }
+
+  @Test
+  public void testPreRenameRSGroupReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preRenameRSGroup(ctx, oldName, newName);
+    });
+  }
+
+  @Test
+  public void testPreUpdateRSGroupConfigReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preUpdateRSGroupConfig(ctx, groupName, configuration);
+    });
+  }
+
+  @Test
+  public void testPreAddReplicationPeerReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preAddReplicationPeer(ctx, peerId, peerConfig);
+    });
+  }
+
+  @Test
+  public void testPreRemoveReplicationPeerReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preRemoveReplicationPeer(ctx, peerId);
+    });
+  }
+
+  @Test
+  public void testPreEnableReplicationPeerReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preEnableReplicationPeer(ctx, peerId);
+    });
+  }
+
+  @Test
+  public void testPreDisableReplicationPeerReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preDisableReplicationPeer(ctx, peerId);
+    });
+  }
+
+  @Test
+  public void testPreUpdateReplicationPeerConfigReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preUpdateReplicationPeerConfig(ctx, peerId, peerConfig);
+    });
+  }
+
+  @Test
+  public void testPreTransitReplicationPeerSyncReplicationStateReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preTransitReplicationPeerSyncReplicationState(ctx, peerId, state);
+    });
+  }
+
+  @Test
+  public void testPreGrantReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preGrant(ctx, userPermission, mergeExistingPermissions);
+    });
+  }
+
+  @Test
+  public void testPreRevokeReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      MasterReadOnlyController.preRevoke(ctx, userPermission);
+    });
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerRegionObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerRegionObserver.java
@@ -1,0 +1,689 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.List;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.CompareOperator;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.WriteAttemptedOnReadOnlyClusterException;
+import org.apache.hadoop.hbase.client.Append;
+import org.apache.hadoop.hbase.client.CheckAndMutate;
+import org.apache.hadoop.hbase.client.CheckAndMutateResult;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Durability;
+import org.apache.hadoop.hbase.client.Increment;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
+import org.apache.hadoop.hbase.filter.Filter;
+import org.apache.hadoop.hbase.master.region.MasterRegionFactory;
+import org.apache.hadoop.hbase.regionserver.FlushLifeCycleTracker;
+import org.apache.hadoop.hbase.regionserver.InternalScanner;
+import org.apache.hadoop.hbase.regionserver.MiniBatchOperationInProgress;
+import org.apache.hadoop.hbase.regionserver.ScanOptions;
+import org.apache.hadoop.hbase.regionserver.ScanType;
+import org.apache.hadoop.hbase.regionserver.Store;
+import org.apache.hadoop.hbase.regionserver.StoreFile;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionLifeCycleTracker;
+import org.apache.hadoop.hbase.regionserver.compactions.CompactionRequest;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Pair;
+import org.apache.hadoop.hbase.wal.WALEdit;
+import org.apache.hadoop.hbase.wal.WALKey;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+// Tests methods of Region Observer interface which are implemented in ReadOnlyController,
+// by mocking the coprocessor environment and dependencies.
+// V1 and V2 means version 1 and version 2 of the coprocessor method signature.
+// For example, prePut has 2 versions:
+// V1: prePut(ObserverContext<RegionCoprocessorEnvironment> c, Put put, WALEdit edit)
+// V2: prePut(ObserverContext<RegionCoprocessorEnvironment> c, Put put, WALEdit edit, Durability durability)
+@Tag(SecurityTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestReadOnlyControllerRegionObserver {
+
+  RegionReadOnlyController regionReadOnlyController;
+
+  // Region Coprocessor mocking variables
+  ObserverContext<RegionCoprocessorEnvironment> c, ctx;
+  RegionCoprocessorEnvironment env;
+  RegionInfo regionInfo;
+  Store store;
+  InternalScanner scanner;
+  ScanOptions options;
+  FlushLifeCycleTracker flushLifeCycleTracker;
+  List<StoreFile> candidates;
+  CompactionLifeCycleTracker compactionLifeCycleTracker;
+  ScanType scanType;
+  CompactionRequest compactionRequest;
+  TableName tableName;
+  Put put;
+  WALEdit edit;
+  Durability durability;
+  Delete delete;
+  MiniBatchOperationInProgress<Mutation> miniBatchOp;
+  byte[] row;
+  byte[] family;
+  byte[] qualifier;
+  Filter filter;
+  CompareOperator op;
+  ByteArrayComparable comparator;
+  boolean result;
+  CheckAndMutate checkAndMutate;
+  CheckAndMutateResult checkAndMutateResult;
+  Append append;
+  Increment increment;
+  RegionInfo info;
+  Path edits;
+  List<Pair<byte[], String>> familyPaths;
+  List<Pair<Path, Path>> pairs;
+  WALKey key;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    regionReadOnlyController = new RegionReadOnlyController();
+
+    // mocking variables initialization
+    c = mock(ObserverContext.class);
+    // ctx is created to make naming variable in sync with the Observer interface
+    // methods where 'ctx' is used as the ObserverContext variable name instead of 'c'.
+    // otherwise both are one and the same
+    ctx = c;
+    env = mock(RegionCoprocessorEnvironment.class);
+    regionInfo = mock(RegionInfo.class);
+    store = mock(Store.class);
+    scanner = mock(InternalScanner.class);
+    options = mock(ScanOptions.class);
+    flushLifeCycleTracker = mock(FlushLifeCycleTracker.class);
+    compactionLifeCycleTracker = mock(CompactionLifeCycleTracker.class);
+    StoreFile sf1 = mock(StoreFile.class);
+    StoreFile sf2 = mock(StoreFile.class);
+    candidates = List.of(sf1, sf2);
+    scanType = ScanType.COMPACT_DROP_DELETES;
+    compactionRequest = mock(CompactionRequest.class);
+    tableName = TableName.valueOf("testTable");
+    put = mock(Put.class);
+    edit = mock(WALEdit.class);
+    durability = Durability.USE_DEFAULT;
+    delete = mock(Delete.class);
+    miniBatchOp = mock(MiniBatchOperationInProgress.class);
+    row = Bytes.toBytes("test-row");
+    family = Bytes.toBytes("test-family");
+    qualifier = Bytes.toBytes("test-qualifier");
+    filter = mock(Filter.class);
+    op = CompareOperator.NO_OP;
+    comparator = mock(ByteArrayComparable.class);
+    result = false;
+    checkAndMutate = CheckAndMutate
+      .newBuilder(Bytes.toBytes("test-row")).ifEquals(Bytes.toBytes("test-family"),
+        Bytes.toBytes("test-qualifier"), Bytes.toBytes("test-value"))
+      .build(new Put(Bytes.toBytes("test-row")));
+    checkAndMutateResult = mock(CheckAndMutateResult.class);
+    append = mock(Append.class);
+    increment = mock(Increment.class);
+    edits = mock(Path.class);
+    familyPaths = List.of(new Pair<>(Bytes.toBytes("test-family"), "/path/to/hfile1"),
+      new Pair<>(Bytes.toBytes("test-family"), "/path/to/hfile2"));
+    pairs = List.of(new Pair<>(mock(Path.class), mock(Path.class)),
+      new Pair<>(mock(Path.class), mock(Path.class)));
+    key = mock(WALKey.class);
+
+    // Linking the mocks:
+    when(c.getEnvironment()).thenReturn(env);
+    when(env.getRegionInfo()).thenReturn(regionInfo);
+    when(regionInfo.getTable()).thenReturn(tableName);
+    when(key.getTableName()).thenReturn(tableName);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+
+  }
+
+  private void mockOperationForMetaTable() {
+    when(regionInfo.getTable()).thenReturn(TableName.META_TABLE_NAME);
+  }
+
+  private void mockOperationMasterStoreTable() {
+    when(regionInfo.getTable()).thenReturn(MasterRegionFactory.TABLE_NAME);
+  }
+
+  @Test
+  public void testPreFlushV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preFlush(c, flushLifeCycleTracker);
+    });
+  }
+
+  @Test
+  public void testPreFlushV1ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preFlush(c, flushLifeCycleTracker);
+  }
+
+  @Test
+  public void testPreFlushV1ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preFlush(c, flushLifeCycleTracker);
+  }
+
+  @Test
+  public void testPreFlushV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preFlush(c, store, scanner, flushLifeCycleTracker);
+    });
+  }
+
+  @Test
+  public void testPreFlushV2ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preFlush(c, store, scanner, flushLifeCycleTracker);
+  }
+
+  @Test
+  public void testPreFlushV2ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preFlush(c, store, scanner, flushLifeCycleTracker);
+  }
+
+  @Test
+  public void testPreFlushScannerOpenReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preFlushScannerOpen(c, store, options, flushLifeCycleTracker);
+    });
+  }
+
+  @Test
+  public void testPreFlushScannerOpenReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preFlushScannerOpen(c, store, options, flushLifeCycleTracker);
+  }
+
+  @Test
+  public void testPreFlushScannerOpenReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preFlushScannerOpen(c, store, options, flushLifeCycleTracker);
+  }
+
+  @Test
+  public void testPreMemStoreCompactionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preMemStoreCompaction(c, store);
+    });
+  }
+
+  @Test
+  public void testPreMemStoreCompactionCompactScannerOpenReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preMemStoreCompactionCompactScannerOpen(c, store, options);
+    });
+  }
+
+  @Test
+  public void testPreMemStoreCompactionCompactReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preMemStoreCompactionCompact(c, store, scanner);
+    });
+  }
+
+  @Test
+  public void testPreCompactSelectionReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCompactSelection(c, store, candidates,
+        compactionLifeCycleTracker);
+    });
+  }
+
+  @Test
+  public void testPreCompactSelectionReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCompactSelection(c, store, candidates, compactionLifeCycleTracker);
+  }
+
+  @Test
+  public void testPreCompactSelectionReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCompactSelection(c, store, candidates, compactionLifeCycleTracker);
+  }
+
+  @Test
+  public void testPreCompactScannerOpenReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCompactScannerOpen(c, store, scanType, options,
+        compactionLifeCycleTracker, compactionRequest);
+    });
+  }
+
+  @Test
+  public void testPreCompactScannerOpenReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCompactScannerOpen(c, store, scanType, options,
+      compactionLifeCycleTracker, compactionRequest);
+  }
+
+  @Test
+  public void testPreCompactScannerOpenReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCompactScannerOpen(c, store, scanType, options,
+      compactionLifeCycleTracker, compactionRequest);
+  }
+
+  @Test
+  public void testPreCompactReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCompact(c, store, scanner, scanType, compactionLifeCycleTracker,
+        compactionRequest);
+    });
+  }
+
+  @Test
+  public void testPreCompactReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCompact(c, store, scanner, scanType, compactionLifeCycleTracker,
+      compactionRequest);
+  }
+
+  @Test
+  public void testPreCompactReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCompact(c, store, scanner, scanType, compactionLifeCycleTracker,
+      compactionRequest);
+  }
+
+  @Test
+  public void testPrePutV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.prePut(c, put, edit);
+    });
+  }
+
+  @Test
+  public void testPrePutV1ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.prePut(c, put, edit);
+  }
+
+  @Test
+  public void testPrePutV1ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.prePut(c, put, edit);
+  }
+
+  @Test
+  public void testPrePutV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.prePut(c, put, edit, durability);
+    });
+  }
+
+  @Test
+  public void testPrePutV2ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.prePut(c, put, edit, durability);
+  }
+
+  @Test
+  public void testPrePutV2ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.prePut(c, put, edit, durability);
+  }
+
+  @Test
+  public void testPreDeleteV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preDelete(c, delete, edit);
+    });
+  }
+
+  @Test
+  public void testPreDeleteV1ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preDelete(c, delete, edit);
+  }
+
+  @Test
+  public void testPreDeleteV1ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preDelete(c, delete, edit);
+  }
+
+  @Test
+  public void testPreDeleteV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preDelete(c, delete, edit, durability);
+    });
+  }
+
+  @Test
+  public void testPreDeleteV2ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preDelete(c, delete, edit, durability);
+  }
+
+  @Test
+  public void testPreDeleteV2ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preDelete(c, delete, edit, durability);
+  }
+
+  @Test
+  public void testPreBatchMutateReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preBatchMutate(c, miniBatchOp);
+    });
+  }
+
+  @Test
+  public void testPreBatchMutateReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preBatchMutate(c, miniBatchOp);
+  }
+
+  @Test
+  public void testPreBatchMutateReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preBatchMutate(c, miniBatchOp);
+  }
+
+  @Test
+  public void testPreCheckAndPutV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndPut(c, row, family, qualifier, op, comparator, put,
+        result);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndPutV1ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCheckAndPut(c, row, family, qualifier, op, comparator, put, result);
+  }
+
+  @Test
+  public void testPreCheckAndPutV1ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCheckAndPut(c, row, family, qualifier, op, comparator, put, result);
+  }
+
+  @Test
+  public void testPreCheckAndPutV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndPut(c, row, filter, put, result);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndPutV2ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCheckAndPut(c, row, filter, put, result);
+  }
+
+  @Test
+  public void testPreCheckAndPutV2ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCheckAndPut(c, row, filter, put, result);
+  }
+
+  @Test
+  public void testPreCheckAndPutAfterRowLockV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndPutAfterRowLock(c, row, family, qualifier, op, comparator,
+        put, result);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndPutAfterRowLockV1ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCheckAndPutAfterRowLock(c, row, family, qualifier, op, comparator,
+      put, result);
+  }
+
+  @Test
+  public void testPreCheckAndPutAfterRowLockV1ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCheckAndPutAfterRowLock(c, row, family, qualifier, op, comparator,
+      put, result);
+  }
+
+  @Test
+  public void testPreCheckAndPutAfterRowLockV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndPutAfterRowLock(c, row, filter, put, result);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndPutAfterRowLockV2ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCheckAndPutAfterRowLock(c, row, filter, put, result);
+  }
+
+  @Test
+  public void testPreCheckAndPutAfterRowLockV2ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCheckAndPutAfterRowLock(c, row, filter, put, result);
+  }
+
+  @Test
+  public void testPreCheckAndDeleteV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndDelete(c, row, family, qualifier, op, comparator, delete,
+        result);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndDeleteV1ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCheckAndDelete(c, row, family, qualifier, op, comparator, delete,
+      result);
+  }
+
+  @Test
+  public void testPreCheckAndDeleteV1ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCheckAndDelete(c, row, family, qualifier, op, comparator, delete,
+      result);
+  }
+
+  @Test
+  public void testPreCheckAndDeleteV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndDelete(c, row, filter, delete, result);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndDeleteV2ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCheckAndDelete(c, row, filter, delete, result);
+  }
+
+  @Test
+  public void testPreCheckAndDeleteV2ReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCheckAndDelete(c, row, filter, delete, result);
+  }
+
+  @Test
+  public void testPreCheckAndDeleteAfterRowLockV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndDeleteAfterRowLock(c, row, family, qualifier, op,
+        comparator, delete, result);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndDeleteAfterRowLockV1ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCheckAndDeleteAfterRowLock(c, row, family, qualifier, op,
+      comparator, delete, result);
+  }
+
+  @Test
+  public void testPreCheckAndDeleteAfterRowLockV1ReadOnlyMasterStoreNoException()
+    throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCheckAndDeleteAfterRowLock(c, row, family, qualifier, op,
+      comparator, delete, result);
+  }
+
+  @Test
+  public void testPreCheckAndDeleteAfterRowLockV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndDeleteAfterRowLock(c, row, filter, delete, result);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndDeleteAfterRowLockV2ReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preCheckAndDeleteAfterRowLock(c, row, filter, delete, result);
+  }
+
+  @Test
+  public void testPreCheckAndDeleteAfterRowLockV2ReadOnlyMasterStoreNoException()
+    throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preCheckAndDeleteAfterRowLock(c, row, filter, delete, result);
+  }
+
+  @Test
+  public void testPreCheckAndMutateReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndMutate(c, checkAndMutate, checkAndMutateResult);
+    });
+  }
+
+  @Test
+  public void testPreCheckAndMutateAfterRowLockReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCheckAndMutateAfterRowLock(c, checkAndMutate,
+        checkAndMutateResult);
+    });
+  }
+
+  @Test
+  public void testPreAppendV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preAppend(c, append);
+    });
+  }
+
+  @Test
+  public void testPreAppendV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preAppend(c, append, edit);
+    });
+  }
+
+  @Test
+  public void testPreAppendAfterRowLockReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preAppendAfterRowLock(c, append);
+    });
+  }
+
+  @Test
+  public void testPreIncrementV1ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preIncrement(c, increment);
+    });
+  }
+
+  @Test
+  public void testPreIncrementV2ReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preIncrement(c, increment, edit);
+    });
+  }
+
+  @Test
+  public void testPreIncrementAfterRowLockReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preIncrementAfterRowLock(c, increment);
+    });
+  }
+
+  @Test
+  public void testPreReplayWALsReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preReplayWALs(ctx, info, edits);
+    });
+  }
+
+  @Test
+  public void testPreReplayWALsReadOnlyMetaNoException() throws IOException {
+    mockOperationForMetaTable();
+    regionReadOnlyController.preReplayWALs(ctx, info, edits);
+  }
+
+  @Test
+  public void testPreReplayWALsReadOnlyMasterStoreNoException() throws IOException {
+    mockOperationMasterStoreTable();
+    regionReadOnlyController.preReplayWALs(ctx, info, edits);
+  }
+
+  @Test
+  public void testPreBulkLoadHFileReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preBulkLoadHFile(ctx, familyPaths);
+    });
+  }
+
+  @Test
+  public void testPreCommitStoreFileReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preCommitStoreFile(ctx, family, pairs);
+    });
+  }
+
+  @Test
+  public void testPreWALAppendReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class, () -> {
+      regionReadOnlyController.preWALAppend(ctx, key, edit);
+    });
+  }
+
+  @Test
+  public void testPreWALAppendReadOnlyMetaNoException() throws IOException {
+    when(key.getTableName()).thenReturn(TableName.META_TABLE_NAME);
+    regionReadOnlyController.preWALAppend(ctx, key, edit);
+  }
+
+  @Test
+  public void testPreWALAppendReadOnlyMasterStoreNoException() throws IOException {
+    when(key.getTableName()).thenReturn(MasterRegionFactory.TABLE_NAME);
+    regionReadOnlyController.preWALAppend(ctx, key, edit);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerRegionServerObserver.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyControllerRegionServerObserver.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.mockito.Mockito.mock;
+
+import org.apache.hadoop.hbase.WriteAttemptedOnReadOnlyClusterException;
+import org.apache.hadoop.hbase.client.Mutation;
+import org.apache.hadoop.hbase.coprocessor.ObserverContext;
+import org.apache.hadoop.hbase.coprocessor.RegionServerCoprocessorEnvironment;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hbase.thirdparty.com.google.protobuf.ByteString;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.WALProtos;
+
+// Tests methods of Region Server Observer which are implemented in ReadOnlyController,
+// by mocking the coprocessor environment and dependencies
+@Tag(SecurityTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestReadOnlyControllerRegionServerObserver {
+
+  RegionServerReadOnlyController regionServerReadOnlyController;
+
+  // Region Server Coprocessor mocking variables
+  ObserverContext<RegionServerCoprocessorEnvironment> ctx;
+  AdminProtos.WALEntry walEntry;
+  Mutation mutation;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    regionServerReadOnlyController = new RegionServerReadOnlyController();
+
+    // mocking variables initialization
+    ctx = mock(ObserverContext.class);
+    walEntry = AdminProtos.WALEntry.newBuilder()
+      .setKey(WALProtos.WALKey.newBuilder().setTableName(ByteString.copyFromUtf8("test"))
+        .setEncodedRegionName(ByteString.copyFromUtf8("regionA")).setLogSequenceNumber(100)
+        .setWriteTime(2).build())
+      .build();
+    mutation = mock(Mutation.class);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+
+  }
+
+  @Test
+  public void testPreRollWALWriterRequestReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class,
+      () -> regionServerReadOnlyController.preRollWALWriterRequest(ctx));
+  }
+
+  @Test
+  public void testPreReplicationSinkBatchMutateReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class,
+      () -> regionServerReadOnlyController.preReplicationSinkBatchMutate(ctx, walEntry, mutation));
+  }
+
+  @Test
+  public void testPreReplicateLogEntriesReadOnlyException() {
+    assertThrows(WriteAttemptedOnReadOnlyClusterException.class,
+      () -> regionServerReadOnlyController.preReplicateLogEntries(ctx));
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyManageActiveClusterFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyManageActiveClusterFile.java
@@ -1,0 +1,149 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.security.access;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.master.HMaster;
+import org.apache.hadoop.hbase.master.MasterFileSystem;
+import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@Tag(SecurityTests.TAG)
+@Tag(MediumTests.TAG)
+public class TestReadOnlyManageActiveClusterFile {
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestReadOnlyManageActiveClusterFile.class);
+  private final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private static final int NUM_RS = 1;
+  private static Configuration conf;
+  HMaster master;
+  HRegionServer regionServer;
+
+  MasterFileSystem mfs;
+  Path rootDir;
+  FileSystem fs;
+  Path activeClusterFile;
+
+  @BeforeEach
+  public void setup() throws Exception {
+    conf = TEST_UTIL.getConfiguration();
+
+    // Set up test class with Read-Only mode disabled so a table can be created
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+    // Start the test cluster
+    TEST_UTIL.startMiniCluster(NUM_RS);
+    master = TEST_UTIL.getMiniHBaseCluster().getMaster();
+    regionServer = TEST_UTIL.getMiniHBaseCluster().getRegionServer(0);
+
+    mfs = master.getMasterFileSystem();
+    rootDir = mfs.getRootDir();
+    fs = mfs.getFileSystem();
+    activeClusterFile = new Path(rootDir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME);
+  }
+
+  @AfterEach
+  public void tearDown() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  private void setReadOnlyMode(boolean enabled) {
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, enabled);
+    master.getConfigurationManager().notifyAllObservers(conf);
+    regionServer.getConfigurationManager().notifyAllObservers(conf);
+  }
+
+  private void restartCluster() throws IOException, InterruptedException {
+    TEST_UTIL.getMiniHBaseCluster().shutdown();
+    TEST_UTIL.restartHBaseCluster(NUM_RS);
+    TEST_UTIL.waitUntilNoRegionsInTransition();
+
+    master = TEST_UTIL.getMiniHBaseCluster().getMaster();
+    regionServer = TEST_UTIL.getMiniHBaseCluster().getRegionServer(0);
+
+    MasterFileSystem mfs = master.getMasterFileSystem();
+    fs = mfs.getFileSystem();
+    activeClusterFile = new Path(mfs.getRootDir(), HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME);
+  }
+
+  private void overwriteExistingFile() throws IOException {
+    try (FSDataOutputStream out = fs.create(activeClusterFile, true)) {
+      out.writeBytes("newClusterId");
+    }
+  }
+
+  private boolean activeClusterIdFileExists() throws IOException {
+    return fs.exists(activeClusterFile);
+  }
+
+  @Test
+  public void testActiveClusterIdFileCreationWhenReadOnlyDisabled()
+    throws IOException, InterruptedException {
+    setReadOnlyMode(false);
+    assertTrue(activeClusterIdFileExists());
+  }
+
+  @Test
+  public void testActiveClusterIdFileDeletionWhenReadOnlyEnabled()
+    throws IOException, InterruptedException {
+    setReadOnlyMode(true);
+    assertFalse(activeClusterIdFileExists());
+  }
+
+  @Test
+  public void testDeleteActiveClusterIdFileWhenSwitchingToReadOnlyIfOwnedByCluster()
+    throws IOException, InterruptedException {
+    // At the start cluster is in active mode hence set readonly mode and restart
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+    // Restart the cluster to trigger the deletion of the active cluster ID file
+    restartCluster();
+    // Should delete the active cluster ID file since it is owned by the cluster
+    assertFalse(activeClusterIdFileExists());
+  }
+
+  @Test
+  public void testDoNotDeleteActiveClusterIdFileWhenSwitchingToReadOnlyIfNotOwnedByCluster()
+    throws IOException, InterruptedException {
+    // Change the content of Active Cluster file to simulate the scenario where the file is not
+    // owned by the cluster and then set readonly mode and restart
+    overwriteExistingFile();
+    // At the start cluster is in active mode hence set readonly mode and restart
+    conf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+    // Restart the cluster to trigger the deletion of the active cluster ID file
+    restartCluster();
+    // As Active cluster file is not owned by the cluster, it should not be deleted even when
+    // switching to readonly mode
+    assertTrue(activeClusterIdFileExists());
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestCoprocessorConfigurationUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestCoprocessorConfigurationUtil.java
@@ -1,0 +1,205 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.util;
+
+import static org.apache.hadoop.hbase.HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY;
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.security.access.BulkLoadReadOnlyController;
+import org.apache.hadoop.hbase.security.access.EndpointReadOnlyController;
+import org.apache.hadoop.hbase.security.access.MasterReadOnlyController;
+import org.apache.hadoop.hbase.security.access.RegionReadOnlyController;
+import org.apache.hadoop.hbase.security.access.RegionServerReadOnlyController;
+import org.apache.hadoop.hbase.testclassification.CoprocessorTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(CoprocessorTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestCoprocessorConfigurationUtil {
+
+  private Configuration conf;
+  private String key;
+
+  @BeforeEach
+  public void setUp() {
+    conf = new Configuration();
+    key = "test.key";
+  }
+
+  @Test
+  public void testAddCoprocessorsEmptyCPList() {
+    CoprocessorConfigurationUtil.addCoprocessors(conf, key, List.of("cp1", "cp2"));
+    assertArrayEquals(new String[] { "cp1", "cp2" }, conf.getStrings(key));
+  }
+
+  @Test
+  public void testAddCoprocessorsNonEmptyCPList() {
+    conf.setStrings(key, "cp1");
+    CoprocessorConfigurationUtil.addCoprocessors(conf, key, List.of("cp1", "cp2"));
+    assertArrayEquals(new String[] { "cp1", "cp2" }, conf.getStrings(key));
+  }
+
+  @Test
+  public void testAddCoprocessorsNoChange() {
+    conf.setStrings(key, "cp1");
+    CoprocessorConfigurationUtil.addCoprocessors(conf, key, List.of("cp1"));
+    assertArrayEquals(new String[] { "cp1" }, conf.getStrings(key));
+  }
+
+  @Test
+  public void testAddCoprocessorsIdempotent() {
+    CoprocessorConfigurationUtil.addCoprocessors(conf, key, List.of("cp1", "cp2"));
+    // Call again
+    CoprocessorConfigurationUtil.addCoprocessors(conf, key, List.of("cp1", "cp2"));
+    assertArrayEquals(new String[] { "cp1", "cp2" }, conf.getStrings(key));
+  }
+
+  @Test
+  public void testAddCoprocessorsIdempotentWithOverlap() {
+    CoprocessorConfigurationUtil.addCoprocessors(conf, key, List.of("cp1"));
+    CoprocessorConfigurationUtil.addCoprocessors(conf, key, List.of("cp1", "cp2"));
+    CoprocessorConfigurationUtil.addCoprocessors(conf, key, List.of("cp2"));
+    assertArrayEquals(new String[] { "cp1", "cp2" }, conf.getStrings(key));
+  }
+
+  @Test
+  public void testRemoveCoprocessorsEmptyCPList() {
+    CoprocessorConfigurationUtil.removeCoprocessors(conf, key, List.of("cp1"));
+    assertNull(conf.getStrings(key));
+  }
+
+  @Test
+  public void testRemoveCoprocessorsNonEmptyCPList() {
+    conf.setStrings(key, "cp1", "cp2", "cp3");
+    CoprocessorConfigurationUtil.removeCoprocessors(conf, key, List.of("cp2"));
+    assertArrayEquals(new String[] { "cp1", "cp3" }, conf.getStrings(key));
+  }
+
+  @Test
+  public void testRemoveCoprocessorsNoChange() {
+    conf.setStrings(key, "cp1");
+    CoprocessorConfigurationUtil.removeCoprocessors(conf, key, List.of("cp2"));
+    assertArrayEquals(new String[] { "cp1" }, conf.getStrings(key));
+  }
+
+  @Test
+  public void testRemoveCoprocessorsIdempotent() {
+    conf.setStrings(key, "cp1", "cp2");
+    CoprocessorConfigurationUtil.removeCoprocessors(conf, key, List.of("cp2"));
+    // Call again
+    CoprocessorConfigurationUtil.removeCoprocessors(conf, key, List.of("cp2"));
+    assertArrayEquals(new String[] { "cp1" }, conf.getStrings(key));
+  }
+
+  @Test
+  public void testRemoveCoprocessorsIdempotentWhenNotPresent() {
+    conf.setStrings(key, "cp1");
+    CoprocessorConfigurationUtil.removeCoprocessors(conf, key, List.of("cp2"));
+    CoprocessorConfigurationUtil.removeCoprocessors(conf, key, List.of("cp2"));
+    assertArrayEquals(new String[] { "cp1" }, conf.getStrings(key));
+  }
+
+  private void assertEnableReadOnlyMode(String key, List<String> expected) {
+    conf.setBoolean(HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+    CoprocessorConfigurationUtil.syncReadOnlyConfigurations(conf, key);
+    String[] result = conf.getStrings(key);
+    assertNotNull(result);
+    assertEquals(expected.size(), result.length);
+    assertTrue(Arrays.asList(result).containsAll(expected));
+  }
+
+  @Test
+  public void testSyncReadOnlyConfigurationsReadOnlyEnableAllKeys() {
+    assertEnableReadOnlyMode(CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY,
+      List.of(MasterReadOnlyController.class.getName()));
+
+    assertEnableReadOnlyMode(CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY,
+      List.of(RegionServerReadOnlyController.class.getName()));
+    assertEnableReadOnlyMode(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,
+      List.of(RegionReadOnlyController.class.getName(), BulkLoadReadOnlyController.class.getName(),
+        EndpointReadOnlyController.class.getName()));
+  }
+
+  private void assertDisableReadOnlyMode(String key, List<String> initialCoprocs) {
+    conf.setStrings(key, initialCoprocs.toArray(new String[0]));
+    conf.setBoolean(HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+    CoprocessorConfigurationUtil.syncReadOnlyConfigurations(conf, key);
+    String[] result = conf.getStrings(key);
+    assertTrue(result == null || result.length == 0);
+  }
+
+  @Test
+  public void testSyncReadOnlyConfigurationsReadOnlyDisableAllKeys() {
+    assertDisableReadOnlyMode(CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY,
+      List.of(MasterReadOnlyController.class.getName()));
+
+    assertDisableReadOnlyMode(CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY,
+      List.of(RegionServerReadOnlyController.class.getName()));
+
+    assertDisableReadOnlyMode(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,
+      List.of(RegionReadOnlyController.class.getName(), BulkLoadReadOnlyController.class.getName(),
+        EndpointReadOnlyController.class.getName()));
+  }
+
+  @Test
+  public void testSyncReadOnlyConfigurationsReadOnlyEnablePreservesExistingCoprocessors() {
+    String key = CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY;
+    conf.setStrings(key, "existingCp");
+    conf.setBoolean(HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+    CoprocessorConfigurationUtil.syncReadOnlyConfigurations(conf, key);
+    List<String> result = Arrays.asList(conf.getStrings(key));
+    assertTrue(result.contains("existingCp"));
+    assertTrue(result.contains(MasterReadOnlyController.class.getName()));
+  }
+
+  @Test
+  public void testSyncReadOnlyConfigurationsReadOnlyDisableRemovesOnlyReadOnlyCoprocessor() {
+    Configuration conf = new Configuration(false);
+    String key = CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY;
+    String existingCp = "org.example.OtherCP";
+    conf.setStrings(key, existingCp, MasterReadOnlyController.class.getName());
+    CoprocessorConfigurationUtil.syncReadOnlyConfigurations(conf, key);
+    String[] cps = conf.getStrings(key);
+    assertNotNull(cps);
+    assertEquals(1, cps.length);
+    assertEquals(existingCp, cps[0]);
+  }
+
+  @Test
+  public void testSyncReadOnlyConfigurationsIsIdempotent() {
+    Configuration conf = new Configuration(false);
+    conf.setBoolean(HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+    String key = CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY;
+    CoprocessorConfigurationUtil.syncReadOnlyConfigurations(conf, key);
+    CoprocessorConfigurationUtil.syncReadOnlyConfigurations(conf, key);
+    String[] cps = conf.getStrings(key);
+    assertNotNull(cps);
+    assertEquals(1, cps.length);
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestFSTableDescriptors.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestFSTableDescriptors.java
@@ -40,6 +40,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.MiscTests;
 import org.junit.jupiter.api.AfterAll;
@@ -479,6 +480,38 @@ public class TestFSTableDescriptors {
     TableDescriptor getTd = fstd.get(htd.getTableName());
     assertEquals(htd, getTd);
     assertFalse(fs.exists(brokenFile));
+  }
+
+  @Test
+  public void testFSTableDescriptorsSkipsForeignMetaTables() throws Exception {
+    FileSystem fs = FileSystem.get(UTIL.getConfiguration());
+    String[] metaTables = { "meta_replica1", "meta" };
+    Path hbaseNamespaceDir = new Path(testDir, HConstants.BASE_NAMESPACE_DIR + "/hbase");
+    fs.mkdirs(hbaseNamespaceDir);
+
+    for (String metaTable : metaTables) {
+      TableName tableName = TableName.valueOf("hbase", metaTable);
+      Path metaTableDir = new Path(hbaseNamespaceDir, metaTable);
+      fs.mkdirs(metaTableDir);
+      fs.mkdirs(new Path(metaTableDir, FSTableDescriptors.TABLEINFO_DIR));
+      fs.mkdirs(new Path(metaTableDir, "abcdef0123456789"));
+
+      TableDescriptor tableDescriptor = TableDescriptorBuilder.newBuilder(tableName)
+        .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(HConstants.CATALOG_FAMILY)
+          .setMaxVersions(HConstants.DEFAULT_HBASE_META_VERSIONS).setInMemory(true)
+          .setBlocksize(HConstants.DEFAULT_HBASE_META_BLOCK_SIZE)
+          .setBloomFilterType(BloomType.ROWCOL).build())
+        .build();
+
+      Path tableDir = CommonFSUtils.getTableDir(testDir, tableName);
+      FSTableDescriptors.createTableDescriptorForTableDirectory(fs, tableDir, tableDescriptor,
+        false);
+    }
+    FSTableDescriptors tableDescriptors = new FSTableDescriptors(fs, testDir);
+    Map<String, TableDescriptor> allTables = tableDescriptors.getAll();
+
+    assertFalse(allTables.containsKey("hbase:meta_replica1"), "Should not contain meta_replica1");
+    assertTrue(allTables.containsKey("hbase:meta"), "Should include the local hbase:meta");
   }
 
   private static class FSTableDescriptorsTest extends FSTableDescriptors {

--- a/hbase-shell/src/main/ruby/hbase/admin.rb
+++ b/hbase-shell/src/main/ruby/hbase/admin.rb
@@ -1955,6 +1955,32 @@ module Hbase
     def list_tables_by_state(isEnabled)
       @admin.listTableNamesByState(isEnabled).map(&:getNameAsString)
     end
+
+    #----------------------------------------------------------------------------------------------
+    # Refresh hbase:meta table by syncing with the backing storage
+    def refresh_meta()
+      @admin.refreshMeta()
+    end
+
+    #----------------------------------------------------------------------------------------------
+    # Refresh HFiles for the table
+    def refresh_hfiles(args = {})
+      table_name = args.fetch(TABLE_NAME, nil)
+      namespace = args.fetch(NAMESPACE, nil)
+      if namespace && table_name
+        raise ArgumentError, "Specify either a TABLE_NAME or a NAMESPACE, not both"
+      elsif namespace == "" || table_name == ""
+        raise ArgumentError, "TABLE_NAME or NAMESPACE cannot be empty string"
+      elsif namespace.is_a?(Array) || table_name.is_a?(Array)
+        raise ArgumentError, "TABLE_NAME or NAMESPACE must be a single string, not an array"
+      elsif namespace
+        @admin.refreshHFiles(namespace)
+      elsif table_name
+        @admin.refreshHFiles(org.apache.hadoop.hbase.TableName.valueOf(table_name))
+      else
+        @admin.refreshHFiles()
+      end
+    end
   end
   # rubocop:enable Metrics/ClassLength
 end

--- a/hbase-shell/src/main/ruby/shell.rb
+++ b/hbase-shell/src/main/ruby/shell.rb
@@ -493,6 +493,8 @@ Shell.load_command_group(
     decommission_regionservers
     recommission_regionserver
     truncate_region
+    refresh_meta
+    refresh_hfiles
   ],
   # TODO: remove older hlog_roll command
   aliases: {

--- a/hbase-shell/src/main/ruby/shell/commands/refresh_hfiles.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/refresh_hfiles.rb
@@ -1,0 +1,64 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Shell
+  module Commands
+    class RefreshHfiles < Command
+      def help
+        return <<-EOF
+Refresh HFiles/storefiles for table(s) or namespaces.
+
+Allowed Syntax:
+hbase> refresh_hfiles
+hbase> refresh_hfiles 'TABLE_NAME' => 'test_table'
+hbase> refresh_hfiles 'TABLE_NAME' => 'namespace:test_table'
+hbase> refresh_hfiles 'NAMESPACE' => 'test_namespace'
+
+Behavior:
+- Without any argument, it refreshes HFiles for all user tables in HBase.
+- If 'TABLE_NAME' is provided: Refreshes HFiles for that specific table.
+   - If provided without a namespace qualifier (e.g., 'TABLE_NAME' => 'test_table'),
+    it refreshes HFiles for that table in the default namespace.
+   - If provided with a namespace qualifier (e.g., 'TABLE_NAME' => 'namespace:test_table'),
+    it refreshes HFiles for the table in the specified namespace.
+- With 'NAMESPACE', it refreshes HFiles for all tables in the given namespace.
+On successful submission, it returns the procedure ID (procId). Otherwise, it throws an exception.
+
+Important Note:
+This command should ideally be run on a read-replica cluster,
+ and only after successfully executing refresh_meta.
+
+Not Allowed:
+hbase> refresh_hfiles 'TABLE_NAME' => 'test_table', 'NAMESPACE' => 'test_namespace'
+
+Passing both 'TABLE_NAME' and 'NAMESPACE' is not allowed to avoid ambiguity.
+Otherwise, it is unclear whether the user intends to:
+1. Refresh HFiles for 'test_table' under 'test_namespace',
+or
+2. Refresh HFiles for 'test_table' under the default namespace and
+   all tables under 'test_namespace'.
+To prevent such confusion, only one argument should be provided per command.
+
+EOF
+      end
+      def command(args = {})
+        admin.refresh_hfiles(args)
+      end
+    end
+  end
+end

--- a/hbase-shell/src/main/ruby/shell/commands/refresh_meta.rb
+++ b/hbase-shell/src/main/ruby/shell/commands/refresh_meta.rb
@@ -1,0 +1,43 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+module Shell
+  module Commands
+    class RefreshMeta < Command
+      def help
+        <<-EOF
+Refresh the hbase:meta table by syncing with backing storage.
+This command is used in Read Replica clusters to pick up new
+tables and regions from the shared storage.
+Examples:
+
+  hbase> refresh_meta
+
+The command returns a procedure ID that can be used to track the progress
+of the meta table refresh operation.
+EOF
+      end
+
+      def command
+        proc_id = admin.refresh_meta
+        formatter.row(["Refresh meta procedure submitted. Procedure ID: #{proc_id}"])
+        proc_id
+      end
+    end
+  end
+end

--- a/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
+++ b/hbase-thrift/src/main/java/org/apache/hadoop/hbase/thrift2/client/ThriftAdmin.java
@@ -1375,6 +1375,11 @@ public class ThriftAdmin implements Admin {
   }
 
   @Override
+  public long refreshMeta() throws IOException {
+    throw new NotImplementedException("refreshMeta not supported in ThriftAdmin");
+  }
+
+  @Override
   public boolean replicationPeerModificationSwitch(boolean on, boolean drainProcedures)
     throws IOException {
     throw new NotImplementedException(
@@ -1385,5 +1390,20 @@ public class ThriftAdmin implements Admin {
   public boolean isReplicationPeerModificationEnabled() throws IOException {
     throw new NotImplementedException(
       "isReplicationPeerModificationEnabled not supported in ThriftAdmin");
+  }
+
+  @Override
+  public long refreshHFiles(final TableName tableName) throws IOException {
+    throw new NotImplementedException("refreshHFiles not supported in ThriftAdmin");
+  }
+
+  @Override
+  public long refreshHFiles(final String namespace) throws IOException {
+    throw new NotImplementedException("refreshHFiles not supported in ThriftAdmin");
+  }
+
+  @Override
+  public long refreshHFiles() throws IOException {
+    throw new NotImplementedException("refreshHFiles not supported in ThriftAdmin");
   }
 }

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MetaTableLocator.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/MetaTableLocator.java
@@ -21,6 +21,7 @@ import com.google.errorprone.annotations.RestrictedApi;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.NotAllMetaRegionsOnlineException;
 import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.exceptions.DeserializationException;
 import org.apache.hadoop.hbase.master.RegionState;
@@ -165,11 +166,12 @@ public final class MetaTableLocator {
   public static void setMetaLocation(ZKWatcher zookeeper, ServerName serverName, int replicaId,
     RegionState.State state) throws KeeperException {
     if (serverName == null) {
-      LOG.warn("Tried to set null ServerName in hbase:meta; skipping -- ServerName required");
+      LOG.warn("Tried to set null ServerName in {}; skipping -- ServerName required",
+        TableName.META_TABLE_NAME);
       return;
     }
-    LOG.info("Setting hbase:meta replicaId={} location in ZooKeeper as {}, state={}", replicaId,
-      serverName, state);
+    LOG.info("Setting {} replicaId={} location in ZooKeeper as {}, state={}",
+      TableName.META_TABLE_NAME, replicaId, serverName, state);
     // Make the MetaRegionServer pb and then get its bytes and save this as
     // the znode content.
     MetaRegionServer pbrsr =
@@ -180,10 +182,10 @@ public final class MetaTableLocator {
       ZKUtil.setData(zookeeper, zookeeper.getZNodePaths().getZNodeForReplica(replicaId), data);
     } catch (KeeperException.NoNodeException nne) {
       if (replicaId == RegionInfo.DEFAULT_REPLICA_ID) {
-        LOG.debug("hbase:meta region location doesn't exist, create it");
+        LOG.debug("{} region location doesn't exist, create it", TableName.META_TABLE_NAME);
       } else {
-        LOG.debug(
-          "hbase:meta region location doesn't exist for replicaId=" + replicaId + ", create it");
+        LOG.debug("{} region location doesn't exist for replicaId={}, create it",
+          TableName.META_TABLE_NAME, replicaId);
       }
       ZKUtil.createAndWatch(zookeeper, zookeeper.getZNodePaths().getZNodeForReplica(replicaId),
         data);
@@ -233,9 +235,10 @@ public final class MetaTableLocator {
 
   public static void deleteMetaLocation(ZKWatcher zookeeper, int replicaId) throws KeeperException {
     if (replicaId == RegionInfo.DEFAULT_REPLICA_ID) {
-      LOG.info("Deleting hbase:meta region location in ZooKeeper");
+      LOG.info("Deleting {} region location in ZooKeeper", TableName.META_TABLE_NAME);
     } else {
-      LOG.info("Deleting hbase:meta for {} region location in ZooKeeper", replicaId);
+      LOG.info("Deleting {} for {} region location in ZooKeeper", TableName.META_TABLE_NAME,
+        replicaId);
     }
     try {
       // Just delete the node. Don't need any watches.

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKClusterId.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKClusterId.java
@@ -66,7 +66,7 @@ public class ZKClusterId {
       }
       if (data != null) {
         try {
-          return ClusterId.parseFrom(data).toString();
+          return new ClusterId.Parser().parseFrom(data).toString();
         } catch (DeserializationException e) {
           throw ZKUtil.convert(e);
         }

--- a/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKDump.java
+++ b/hbase-zookeeper/src/main/java/org/apache/hadoop/hbase/zookeeper/ZKDump.java
@@ -32,6 +32,7 @@ import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.exceptions.DeserializationException;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.zookeeper.KeeperException;
@@ -74,7 +75,7 @@ public final class ZKDump {
           sb.append("\n ").append(child);
         }
       }
-      sb.append("\nRegion server holding hbase:meta:");
+      sb.append("\nRegion server holding ").append(TableName.META_TABLE_NAME).append(":");
       sb.append("\n ").append(MetaTableLocator.getMetaRegionLocation(zkWatcher));
       int numMetaReplicas = zkWatcher.getMetaReplicaNodes().size();
       for (int i = 1; i < numMetaReplicas; i++) {


### PR DESCRIPTION
Hi all,

We would like to propose merging the feature “Read Replica Cluster” into 
the main branch.

**Background**

We’d like to implement the open source version of Amazon’s [Read Replica 
Cluster on S3](https://aws.amazon.com/blogs/big-data/setting-up-read-replica-clusters-with-hbase-on-amazon-s3/) feature for Apache HBase. It adds the ability of running 
another HBase cluster on the same cloud storage location in read-only mode, 
allowing users to share the read workload between multiple clusters. Due 
to the characteristics of the implementation and the lack of automated 
synchronization between the active and read-replica clusters, read replicas 
are eventually consistent, hence they’re not suitable for reading most 
recent data. However we still believe that users of open source Apache HBase 
could take advantage of this feature and there are use cases out there which 
read replicas could help with. Please find more information about the 
feature in the linked blog post.

**Pros**

- Running multiple clusters in different Availability Zones adds HA to the 
entire workload,
- No need for data movement or duplication (active-active replication setup) 
which is cost and time efficient,
- No limit for the number of read replica clusters

**Cons**

- Read Replica clusters are eventually consistent: in memory data is not 
visible from read replicas,
- Read Replica clusters must be manually refreshed: flush on active cluster, 
refresh hfiles/meta on read replicas

A detailed description of the design and implementation can be found in the
following document.

[Apache HBase Read Replica Cluster Feature](https://docs.google.com/document/d/1EI0lsURX1BZhv3DYgMvZCl4EUy-ADJRkHUc1PjzZtj0/edit?usp=sharing)

Please review and share your feedback or comments.

Best regards,
Andor