### PR TITLE
Revert "HBASE-30068 Bump cryptography from 46.0.6 to 46.0.7 in /dev-support/git-jira-release-audit"

### DIFF
--- a/dev-support/git-jira-release-audit/requirements.txt
+++ b/dev-support/git-jira-release-audit/requirements.txt
@@ -19,7 +19,7 @@ blessed==1.17.0
 certifi==2024.7.4
 cffi==1.13.2
 chardet==3.0.4
-cryptography==46.0.7
+cryptography==46.0.6
 defusedxml==0.6.0
 enlighten==1.4.0
 gitdb2==2.0.6


### PR DESCRIPTION
Reverts apache/hbase#8045