### PR TITLE
HBASE-30101 Move login() before RpcServer construction

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -73,6 +73,7 @@ import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.unsafe.HBasePlatformDependent;
 import org.apache.hadoop.hbase.util.Addressing;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSTableDescriptors;
 import org.apache.hadoop.hbase.util.NettyEventLoopGroupConfig;
@@ -258,24 +259,20 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
       this.msgInterval = conf.getInt("hbase.regionserver.msginterval", 3 * 1000);
       this.sleeper = new Sleeper(this.msgInterval, this);
       this.namedQueueRecorder = createNamedQueueRecord();
-      this.rpcServices = createRpcServices();
       useThisHostnameInstead = getUseThisHostnameInstead(conf);
-      InetSocketAddress addr = rpcServices.getSocketAddress();
-
-      // if use-ip is enabled, we will use ip to expose Master/RS service for client,
-      // see HBASE-27304 for details.
-      boolean useIp = conf.getBoolean(HConstants.HBASE_SERVER_USEIP_ENABLED_KEY,
-        HConstants.HBASE_SERVER_USEIP_ENABLED_DEFAULT);
-      String isaHostName =
-        useIp ? addr.getAddress().getHostAddress() : addr.getAddress().getHostName();
-      String hostName =
-        StringUtils.isBlank(useThisHostnameInstead) ? isaHostName : useThisHostnameInstead;
-      serverName = ServerName.valueOf(hostName, addr.getPort(), this.startcode);
+      // Resolve the hostname up-front and log in before creating the RpcServer. The RpcServer
+      // constructor reads UserGroupInformation.getCurrentUser() (HBASE-28321); if the server
+      // has not logged in yet, UGI bootstraps from the ticket cache and spawns a TGT renewer
+      // for whichever principal happens to be there.
+      String hostName = resolveHostName(conf, useThisHostnameInstead);
       // login the zookeeper client principal (if using security)
       ZKAuthentication.loginClient(this.conf, HConstants.ZK_CLIENT_KEYTAB_FILE,
         HConstants.ZK_CLIENT_KERBEROS_PRINCIPAL, hostName);
       // login the server principal (if using secure Hadoop)
       login(userProvider, hostName);
+      this.rpcServices = createRpcServices();
+      InetSocketAddress addr = rpcServices.getSocketAddress();
+      serverName = ServerName.valueOf(hostName, addr.getPort(), this.startcode);
       // init superusers and add the server principal (if using security)
       // or process owner as default super user.
       Superusers.initialize(conf);
@@ -686,6 +683,21 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
   protected abstract String getUseThisHostnameInstead(Configuration conf) throws IOException;
 
   protected abstract void login(UserProvider user, String host) throws IOException;
+
+  protected abstract DNS.ServerType getDNSServerType();
+
+  private String resolveHostName(Configuration conf, String useThisHostnameInstead)
+    throws IOException {
+    if (!StringUtils.isBlank(useThisHostnameInstead)) {
+      return useThisHostnameInstead;
+    }
+    // if use-ip is enabled, we will use ip to expose Master/RS service for client,
+    // see HBASE-27304 for details.
+    boolean useIp = conf.getBoolean(HConstants.HBASE_SERVER_USEIP_ENABLED_KEY,
+      HConstants.HBASE_SERVER_USEIP_ENABLED_DEFAULT);
+    InetAddress addr = InetAddress.getByName(DNS.getHostname(conf, getDNSServerType()));
+    return useIp ? addr.getHostAddress() : addr.getHostName();
+  }
 
   protected abstract NamedQueueRecorder createNamedQueueRecord();
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -253,6 +253,7 @@ import org.apache.hadoop.hbase.util.Addressing;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
+import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSTableDescriptors;
 import org.apache.hadoop.hbase.util.FutureUtils;
@@ -606,6 +607,11 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
   @Override
   protected String getUseThisHostnameInstead(Configuration conf) {
     return conf.get(MASTER_HOSTNAME_KEY);
+  }
+
+  @Override
+  protected DNS.ServerType getDNSServerType() {
+    return DNS.ServerType.MASTER;
   }
 
   private void registerConfigurationObservers() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -162,6 +162,7 @@ import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CompressionTest;
 import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
+import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.util.FutureUtils;
@@ -577,11 +578,16 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
           + UNSAFE_RS_HOSTNAME_KEY + " is used";
         throw new IOException(msg);
       } else {
-        return rpcServices.getSocketAddress().getHostName();
+        return DNS.getHostname(conf, DNS.ServerType.REGIONSERVER);
       }
     } else {
       return hostname;
     }
+  }
+
+  @Override
+  protected DNS.ServerType getDNSServerType() {
+    return DNS.ServerType.REGIONSERVER;
   }
 
   @Override


### PR DESCRIPTION
Login before creating the RPC services to prevent a stray TGT Renewer thread in HBase 2.6+.

Description:
- https://issues.apache.org/jira/browse/HBASE-30101?focusedCommentId=18075865&page=com.atlassian.jira.plugin.system.issuetabpanels%3Acomment-tabpanel#comment-18075865

Related:
- https://github.com/apache/hbase/pull/8110

