### PR TITLE
Backport "HBASE-30101 Move login() before RpcServer construction (#8122)" to branch-2.5

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -225,6 +225,7 @@ import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.Addressing;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
+import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSTableDescriptors;
 import org.apache.hadoop.hbase.util.HBaseFsck;
@@ -558,6 +559,11 @@ public class HMaster extends HRegionServer implements MasterServices {
   @Override
   protected String getUseThisHostnameInstead(Configuration conf) {
     return conf.get(MASTER_HOSTNAME_KEY);
+  }
+
+  @Override
+  protected DNS.ServerType getDNSServerType() {
+    return DNS.ServerType.MASTER;
   }
 
   private void registerConfigurationObservers() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -174,6 +174,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.CompressionTest;
 import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
+import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSTableDescriptors;
 import org.apache.hadoop.hbase.util.FSUtils;
@@ -640,22 +641,23 @@ public class HRegionServer extends Thread
       this.stopped = false;
 
       initNamedQueueRecorder(conf);
-      rpcServices = createRpcServices();
       useThisHostnameInstead = getUseThisHostnameInstead(conf);
-      String hostName = StringUtils.isBlank(useThisHostnameInstead)
-        ? this.rpcServices.isa.getHostName()
-        : this.useThisHostnameInstead;
-      serverName = ServerName.valueOf(hostName, this.rpcServices.isa.getPort(), this.startcode);
-
-      rpcControllerFactory = RpcControllerFactory.instantiate(this.conf);
-      rpcRetryingCallerFactory = RpcRetryingCallerFactory.instantiate(this.conf,
-        clusterConnection == null ? null : clusterConnection.getConnectionMetrics());
-
+      // Resolve the hostname up-front and log in before creating the RpcServer. The RpcServer
+      // constructor reads UserGroupInformation.getCurrentUser() (HBASE-28321); if the server
+      // has not logged in yet, UGI bootstraps from the ticket cache and spawns a TGT renewer
+      // for whichever principal happens to be there.
+      String hostName = resolveHostName(conf, useThisHostnameInstead);
       // login the zookeeper client principal (if using security)
       ZKAuthentication.loginClient(this.conf, HConstants.ZK_CLIENT_KEYTAB_FILE,
         HConstants.ZK_CLIENT_KERBEROS_PRINCIPAL, hostName);
       // login the server principal (if using secure Hadoop)
       login(userProvider, hostName);
+      rpcServices = createRpcServices();
+      serverName = ServerName.valueOf(hostName, this.rpcServices.isa.getPort(), this.startcode);
+
+      rpcControllerFactory = RpcControllerFactory.instantiate(this.conf);
+      rpcRetryingCallerFactory = RpcRetryingCallerFactory.instantiate(this.conf,
+        clusterConnection == null ? null : clusterConnection.getConnectionMetrics());
       // init superusers and add the server principal (if using security)
       // or process owner as default super user.
       Superusers.initialize(conf);
@@ -760,7 +762,7 @@ public class HRegionServer extends Thread
           + UNSAFE_RS_HOSTNAME_KEY + " is used";
         throw new IOException(msg);
       } else {
-        return rpcServices.isa.getHostName();
+        return DNS.getHostname(conf, DNS.ServerType.REGIONSERVER);
       }
     } else {
       return hostname;
@@ -813,6 +815,18 @@ public class HRegionServer extends Thread
     this.dataRootDir = CommonFSUtils.getRootDir(this.conf);
     this.tableDescriptors = new FSTableDescriptors(this.dataFs, this.dataRootDir,
       !canUpdateTableDescriptor(), cacheTableDescriptor());
+  }
+
+  protected DNS.ServerType getDNSServerType() {
+    return DNS.ServerType.REGIONSERVER;
+  }
+
+  private String resolveHostName(Configuration conf, String useThisHostnameInstead)
+    throws IOException {
+    if (!StringUtils.isBlank(useThisHostnameInstead)) {
+      return useThisHostnameInstead;
+    }
+    return DNS.getHostname(conf, getDNSServerType());
   }
 
   protected void login(UserProvider user, String host) throws IOException {


### PR DESCRIPTION
Conflict in `HRegionServer.java` constructor. Two adaptations needed:

1. **Kept branch-2.5's `initNamedQueueRecorder(conf)` helper** instead of the inline `namedQueueRecorder = NamedQueueRecorder.getInstance(...)` from the upstream commit.
2. **Stripped the HBASE-27304 useIp branch from `resolveHostName()`.** `HConstants.HBASE_SERVER_USEIP_ENABLED_KEY`/`DEFAULT` don't exist in branch-2.5, so `resolveHostName` falls back to `DNS.getHostname(conf, getDNSServerType())` directly.
