### PR TITLE
HBASE-29588: New HFile Design For Multi-Tenant Support (cherry-pick of  PR #7296 onto branch-2)

### DIFF
--- a/hbase-common/src/main/resources/hbase-default.xml
+++ b/hbase-common/src/main/resources/hbase-default.xml
@@ -1089,10 +1089,12 @@ possible configurations would overwhelm and obscure the important.
   </property>
   <property>
       <name>hfile.format.version</name>
-      <value>3</value>
+      <value>4</value>
       <description>The HFile format version to use for new files.
       Version 3 adds support for tags in hfiles (See
       https://hbase.apache.org/docs/security/data-access#tags).
+      Version 4 introduces the multi-tenant HFile layout while remaining backward compatible
+      with older readers.
       Also see the configuration 'hbase.replication.rpc.codec'.
       </description>
   </property>

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestIngestWithACL.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestIngestWithACL.java
@@ -56,7 +56,7 @@ public class IntegrationTestIngestWithACL extends IntegrationTestIngest {
   public void setUpCluster() throws Exception {
     util = getTestingUtil(null);
     Configuration conf = util.getConfiguration();
-    conf.setInt(HFile.FORMAT_VERSION_KEY, 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     conf.set("hbase.coprocessor.master.classes", AccessController.class.getName());
     conf.set("hbase.coprocessor.region.classes", AccessController.class.getName());
     conf.setBoolean("hbase.security.access.early_out", false);

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestIngestWithEncryption.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestIngestWithEncryption.java
@@ -47,7 +47,7 @@ public class IntegrationTestIngestWithEncryption extends IntegrationTestIngest {
     Configuration conf = util.getConfiguration();
     if (!util.isDistributedCluster()) {
       // Inject required configuration if we are not running in distributed mode
-      conf.setInt(HFile.FORMAT_VERSION_KEY, 3);
+      conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
       conf.set(HConstants.CRYPTO_KEYPROVIDER_CONF_KEY, KeyProviderForTesting.class.getName());
       conf.set(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, "hbase");
       conf.setBoolean(HConstants.ENABLE_WAL_ENCRYPTION, true);

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestIngestWithTags.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestIngestWithTags.java
@@ -36,7 +36,8 @@ public class IntegrationTestIngestWithTags extends IntegrationTestIngest {
 
   @Override
   public void setUpCluster() throws Exception {
-    getTestingUtil(conf).getConfiguration().setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
+    getTestingUtil(conf).getConfiguration().setInt(HFile.FORMAT_VERSION_KEY,
+      HFile.MAX_FORMAT_VERSION);
     super.setUpCluster();
   }
 

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestIngestWithTags.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestIngestWithTags.java
@@ -36,7 +36,7 @@ public class IntegrationTestIngestWithTags extends IntegrationTestIngest {
 
   @Override
   public void setUpCluster() throws Exception {
-    getTestingUtil(conf).getConfiguration().setInt(HFile.FORMAT_VERSION_KEY, 3);
+    getTestingUtil(conf).getConfiguration().setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     super.setUpCluster();
   }
 

--- a/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestMobCompaction.java
+++ b/hbase-it/src/test/java/org/apache/hadoop/hbase/IntegrationTestMobCompaction.java
@@ -209,7 +209,7 @@ public class IntegrationTestMobCompaction extends IntegrationTestBase {
 
   private static void initConf(Configuration conf) {
 
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt("hfile.format.version", 4);
     conf.setLong(TimeToLiveHFileCleaner.TTL_CONF_KEY, 0);
     conf.setInt("hbase.client.retries.number", 100);
     conf.setInt("hbase.hregion.max.filesize", 200000000);

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTSVWithTTLs.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestImportTSVWithTTLs.java
@@ -88,7 +88,7 @@ public class TestImportTSVWithTTLs implements Configurable {
     conf = util.getConfiguration();
     // We don't check persistence in HFiles in this test, but if we ever do we will
     // need this where the default hfile version is not 3 (i.e. 0.98)
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt("hfile.format.version", 4);
     conf.set("hbase.coprocessor.region.classes", TTLCheckingObserver.class.getName());
     util.startMiniCluster();
   }

--- a/hbase-protocol-shaded/src/main/protobuf/HFile.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/HFile.proto
@@ -51,8 +51,8 @@ message FileTrailerProto {
   optional string comparator_class_name = 11;
   optional uint32 compression_codec = 12;
   optional bytes encryption_key = 13;
-  optional bool multiTenant = 14;
-  optional int32 tenantPrefixLength = 15;
+  optional bool multi_tenant = 14;
+  optional int32 tenant_prefix_length = 15;
   optional uint64 section_index_offset = 16;
   optional string key_namespace = 17;
   optional string kek_metadata = 18;

--- a/hbase-protocol-shaded/src/main/protobuf/HFile.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/HFile.proto
@@ -51,4 +51,10 @@ message FileTrailerProto {
   optional string comparator_class_name = 11;
   optional uint32 compression_codec = 12;
   optional bytes encryption_key = 13;
+  optional bool multiTenant = 14;
+  optional int32 tenantPrefixLength = 15;
+  optional uint64 section_index_offset = 16;
+  optional string key_namespace = 17;
+  optional string kek_metadata = 18;
+  optional uint64 kek_checksum = 19;
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -28,7 +28,10 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.PrivateCellUtil;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.io.hfile.BlockWithScanInfo;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.io.hfile.HFileBlockIndex;
 import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.io.hfile.HFileReaderImpl;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
@@ -370,31 +373,59 @@ public class HalfStoreFileReader extends StoreFileReader {
   public void close(boolean evictOnClose) throws IOException {
     if (closed.compareAndSet(false, true)) {
       if (evictOnClose) {
-        final HFileReaderImpl.HFileScannerImpl s =
-          (HFileReaderImpl.HFileScannerImpl) super.getScanner(false, true, false);
+        long splitBlockOffset = findSplitBlockOffset();
         final String reference = this.reader.getHFileInfo().getHFileContext().getHFileName();
         final String referred = StoreFileInfo.getReferredToRegionAndFile(reference).getSecond();
-        s.seekTo(splitCell);
-        if (s.getCurBlock() != null) {
-          long offset = s.getCurBlock().getOffset();
+        if (splitBlockOffset >= 0) {
           LOG.trace("Seeking to split cell in reader: {} for file: {} top: {}, split offset: {}",
-            this, reference, top, offset);
+            this, reference, top, splitBlockOffset);
           ((HFileReaderImpl) reader).getCacheConf().getBlockCache().ifPresent(cache -> {
             int numEvictedReferred = top
-              ? cache.evictBlocksRangeByHfileName(referred, offset, Long.MAX_VALUE)
-              : cache.evictBlocksRangeByHfileName(referred, 0, offset);
+              ? cache.evictBlocksRangeByHfileName(referred, splitBlockOffset, Long.MAX_VALUE)
+              : cache.evictBlocksRangeByHfileName(referred, 0, splitBlockOffset);
             int numEvictedReference = cache.evictBlocksByHfileName(reference);
             LOG.trace(
               "Closing reference: {}; referred file: {}; was top? {}; evicted for referred: {};"
                 + "evicted for reference: {}",
               reference, referred, top, numEvictedReferred, numEvictedReference);
           });
+        } else {
+          LOG.debug("Unable to determine split block offset for reference {} (top? {})", reference,
+            top);
         }
-        s.close();
         reader.close(false);
       } else {
         reader.close(evictOnClose);
       }
     }
+  }
+
+  private long findSplitBlockOffset() throws IOException {
+    HFileBlockIndex.BlockIndexReader indexReader = reader.getDataBlockIndexReader();
+    if (indexReader != null) {
+      BlockWithScanInfo blockWithScanInfo = indexReader.loadDataBlockWithScanInfo(splitCell, null,
+        false, true, false, reader.getEffectiveEncodingInCache(false), reader);
+      if (blockWithScanInfo != null) {
+        HFileBlock block = blockWithScanInfo.getHFileBlock();
+        if (block != null) {
+          try {
+            return block.getOffset();
+          } finally {
+            block.release();
+          }
+        }
+      }
+    }
+
+    try (HFileScanner scanner = super.getScanner(false, true, false)) {
+      if (scanner instanceof HFileReaderImpl.HFileScannerImpl) {
+        HFileReaderImpl.HFileScannerImpl delegate = (HFileReaderImpl.HFileScannerImpl) scanner;
+        delegate.seekTo(splitCell);
+        if (delegate.getCurBlock() != null) {
+          return delegate.getCurBlock().getOffset();
+        }
+      }
+    }
+    return -1L;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hbase.PrivateCellUtil;
 import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.io.hfile.BlockWithScanInfo;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.FixedFileTrailer;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
 import org.apache.hadoop.hbase.io.hfile.HFileBlockIndex;
 import org.apache.hadoop.hbase.io.hfile.HFileInfo;
@@ -373,30 +374,68 @@ public class HalfStoreFileReader extends StoreFileReader {
   public void close(boolean evictOnClose) throws IOException {
     if (closed.compareAndSet(false, true)) {
       if (evictOnClose) {
-        long splitBlockOffset = findSplitBlockOffset();
         final String reference = this.reader.getHFileInfo().getHFileContext().getHFileName();
         final String referred = StoreFileInfo.getReferredToRegionAndFile(reference).getSecond();
-        if (splitBlockOffset >= 0) {
-          LOG.trace("Seeking to split cell in reader: {} for file: {} top: {}, split offset: {}",
-            this, reference, top, splitBlockOffset);
-          ((HFileReaderImpl) reader).getCacheConf().getBlockCache().ifPresent(cache -> {
-            int numEvictedReferred = top
-              ? cache.evictBlocksRangeByHfileName(referred, splitBlockOffset, Long.MAX_VALUE)
-              : cache.evictBlocksRangeByHfileName(referred, 0, splitBlockOffset);
-            int numEvictedReference = cache.evictBlocksByHfileName(reference);
+        // For v4 multi-tenant referred files, findSplitBlockOffset() reports a section-relative
+        // offset (the data block index reader is null at the file level for multi-tenant files,
+        // so we fall back to a section scanner whose getCurBlock() offset is local to that
+        // section). Using that as a file-level eviction range mis-targets blocks. Until we have
+        // a section-aware eviction range, fall back to evicting all blocks for the referred file
+        // when this reader is over a multi-tenant container — correctness over surgical eviction.
+        boolean referredIsMultiTenant = isReferredMultiTenant();
+        ((HFileReaderImpl) reader).getCacheConf().getBlockCache().ifPresent(cache -> {
+          int numEvictedReferred;
+          if (referredIsMultiTenant) {
+            numEvictedReferred = cache.evictBlocksByHfileName(referred);
             LOG.trace(
-              "Closing reference: {}; referred file: {}; was top? {}; evicted for referred: {};"
-                + "evicted for reference: {}",
-              reference, referred, top, numEvictedReferred, numEvictedReference);
-          });
-        } else {
-          LOG.debug("Unable to determine split block offset for reference {} (top? {})", reference,
-            top);
-        }
+              "Multi-tenant referred file {}: doing full-file eviction (range eviction is not"
+                + " section-aware). evictedReferred={}",
+              referred, numEvictedReferred);
+          } else {
+            long splitBlockOffset = -1L;
+            try {
+              splitBlockOffset = findSplitBlockOffset();
+            } catch (IOException e) {
+              LOG.warn("Failed to determine split block offset for reference {} (top? {});"
+                + " falling back to full-file eviction", reference, top, e);
+            }
+            if (splitBlockOffset >= 0) {
+              LOG.trace("Seeking to split cell in reader: {} for file: {} top: {}, split: {}", this,
+                reference, top, splitBlockOffset);
+              numEvictedReferred = top
+                ? cache.evictBlocksRangeByHfileName(referred, splitBlockOffset, Long.MAX_VALUE)
+                : cache.evictBlocksRangeByHfileName(referred, 0, splitBlockOffset);
+            } else {
+              LOG.debug("Unable to determine split block offset for reference {} (top? {});"
+                + " falling back to full-file eviction", reference, top);
+              numEvictedReferred = cache.evictBlocksByHfileName(referred);
+            }
+          }
+          int numEvictedReference = cache.evictBlocksByHfileName(reference);
+          LOG.trace(
+            "Closing reference: {}; referred file: {}; was top? {}; evicted for referred: {};"
+              + " evicted for reference: {}",
+            reference, referred, top, numEvictedReferred, numEvictedReference);
+        });
         reader.close(false);
       } else {
         reader.close(evictOnClose);
       }
+    }
+  }
+
+  /**
+   * Returns true if the underlying referred reader is a v4 multi-tenant container. Used to decide
+   * whether {@link #findSplitBlockOffset()} can produce a meaningful file-level offset for
+   * block-range eviction.
+   */
+  private boolean isReferredMultiTenant() {
+    try {
+      FixedFileTrailer trailer = reader.getTrailer();
+      return trailer != null && trailer.isMultiTenant();
+    } catch (Exception e) {
+      // Defensive: if anything is off (no trailer, wrong type), treat as multi-tenant=false.
+      return false;
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/MultiTenantFSDataInputStreamWrapper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/MultiTenantFSDataInputStreamWrapper.java
@@ -1,0 +1,565 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.ByteBuffer;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.fs.PositionedReadable;
+import org.apache.hadoop.fs.Seekable;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Implementation of {@link FSDataInputStreamWrapper} that adds offset translation capability for
+ * multi-tenant HFiles. This allows each tenant section to have its own coordinate system starting
+ * from 0, while the actual file positions are calculated by adding the section offset.
+ * <p>
+ * The class transparently handles all position-related operations including:
+ * <ul>
+ * <li>Converting relative positions (0-based within section) to absolute file positions</li>
+ * <li>Maintaining correct logical position tracking for the section reader</li>
+ * <li>Seeking and position reporting that is section-relative</li>
+ * </ul>
+ */
+@InterfaceAudience.Private
+public class MultiTenantFSDataInputStreamWrapper extends FSDataInputStreamWrapper {
+  private static final Logger LOG =
+    LoggerFactory.getLogger(MultiTenantFSDataInputStreamWrapper.class);
+
+  /** The offset where this section starts in the parent file */
+  private final long sectionOffset;
+  /** The size of this section in bytes; used for boundary enforcement */
+  private final long sectionSize;
+  /** The original input stream wrapper to delegate to */
+  private final FSDataInputStreamWrapper parent;
+  /** Whether this wrapper owns the parent and must close it */
+  private final boolean ownsParent;
+  /** Cached translating wrappers to avoid per-call allocation (one per checksum mode) */
+  private volatile TranslatingFSStream cachedStreamWithChecksum;
+  private volatile TranslatingFSStream cachedStreamWithoutChecksum;
+
+  /**
+   * Constructor that creates a wrapper with offset translation and boundary enforcement. The parent
+   * stream is shared (not owned) — it will NOT be closed when this wrapper is closed.
+   * @param parent      the original input stream wrapper to delegate to
+   * @param offset      the offset where the section starts in the parent file
+   * @param sectionSize the size of the section in bytes
+   */
+  public MultiTenantFSDataInputStreamWrapper(FSDataInputStreamWrapper parent, long offset,
+    long sectionSize) {
+    this(parent, offset, sectionSize, false);
+  }
+
+  /**
+   * Constructor that creates a wrapper with offset translation and boundary enforcement.
+   * @param parent      the original input stream wrapper to delegate to
+   * @param offset      the offset where the section starts in the parent file
+   * @param sectionSize the size of the section in bytes
+   * @param ownsParent  if true, closing this wrapper also closes the parent stream. Use true when
+   *                    the parent was opened exclusively for this section (e.g., stream readers).
+   */
+  public MultiTenantFSDataInputStreamWrapper(FSDataInputStreamWrapper parent, long offset,
+    long sectionSize, boolean ownsParent) {
+    super(java.util.Objects.requireNonNull(parent, "parent stream wrapper").getStream(false),
+      parent.getStream(true));
+    if (offset < 0) {
+      throw new IllegalArgumentException("Section offset must be non-negative, got: " + offset);
+    }
+    if (sectionSize <= 0) {
+      throw new IllegalArgumentException("Section size must be positive, got: " + sectionSize);
+    }
+    this.parent = parent;
+    this.sectionOffset = offset;
+    this.sectionSize = sectionSize;
+    this.ownsParent = ownsParent;
+
+    LOG.debug("Created section wrapper at offset {}, size {} (ownsParent={}, translation: {})",
+      offset, sectionSize, ownsParent, offset == 0 ? "none" : "enabled");
+  }
+
+  /**
+   * Converts a position relative to the section to an absolute file position.
+   * @param relativePosition the position relative to the section start
+   * @return the absolute position in the file
+   */
+  public long toAbsolutePosition(long relativePosition) {
+    return relativePosition + sectionOffset;
+  }
+
+  /**
+   * Converts an absolute file position to a position relative to the section.
+   * @param absolutePosition the absolute position in the file
+   * @return the position relative to the section start
+   */
+  public long toRelativePosition(long absolutePosition) {
+    return absolutePosition - sectionOffset;
+  }
+
+  /**
+   * Validates that a section-relative position is within the section bounds.
+   * @param position the section-relative position to validate
+   * @throws IOException if the position is outside the section
+   */
+  private void checkSeekBounds(long position) throws IOException {
+    if (position < 0 || position > sectionSize) {
+      throw new IOException("Seek position " + position + " is outside section bounds [0, "
+        + sectionSize + "], sectionOffset=" + sectionOffset);
+    }
+  }
+
+  /**
+   * Validates that a positioned read stays within the section and returns the clamped length.
+   * @param position the section-relative start position
+   * @param length   the requested read length
+   * @return the clamped length that stays within the section
+   * @throws IOException if the position is outside the section
+   */
+  private int clampReadLength(long position, int length) throws IOException {
+    if (position < 0 || position >= sectionSize) {
+      throw new IOException("Read position " + position + " is outside section bounds [0, "
+        + sectionSize + "), sectionOffset=" + sectionOffset);
+    }
+    long remaining = sectionSize - position;
+    return (int) Math.min(length, remaining);
+  }
+
+  @Override
+  public FSDataInputStream getStream(boolean useHBaseChecksum) {
+    FSDataInputStream rawStream = parent.getStream(useHBaseChecksum);
+    if (useHBaseChecksum) {
+      TranslatingFSStream cached = cachedStreamWithChecksum;
+      if (cached == null || cached.rawStream != rawStream) {
+        cached = new TranslatingFSStream(rawStream);
+        cachedStreamWithChecksum = cached;
+      }
+      return cached;
+    } else {
+      TranslatingFSStream cached = cachedStreamWithoutChecksum;
+      if (cached == null || cached.rawStream != rawStream) {
+        cached = new TranslatingFSStream(rawStream);
+        cachedStreamWithoutChecksum = cached;
+      }
+      return cached;
+    }
+  }
+
+  @Override
+  public Path getReaderPath() {
+    return parent.getReaderPath();
+  }
+
+  @Override
+  public boolean shouldUseHBaseChecksum() {
+    return parent.shouldUseHBaseChecksum();
+  }
+
+  @Override
+  public void prepareForBlockReader(boolean forceNoHBaseChecksum) throws IOException {
+    // Since we're using test constructor with hfs=null, prepareForBlockReader should return early
+    // and never hit the assertion. Call super instead of parent to avoid multiple calls on parent.
+    super.prepareForBlockReader(forceNoHBaseChecksum);
+  }
+
+  @Override
+  public FSDataInputStream fallbackToFsChecksum(int offCount) throws IOException {
+    return new TranslatingFSStream(parent.fallbackToFsChecksum(offCount));
+  }
+
+  @Override
+  public void checksumOk() {
+    parent.checksumOk();
+  }
+
+  @Override
+  public void unbuffer() {
+    parent.unbuffer();
+  }
+
+  @Override
+  public void close() {
+    if (ownsParent) {
+      parent.close();
+    }
+  }
+
+  /**
+   * Custom implementation to translate seek position.
+   * @param seekPosition the position to seek to (section-relative)
+   * @throws IOException if an I/O error occurs
+   */
+  public void seek(long seekPosition) throws IOException {
+    checkSeekBounds(seekPosition);
+    FSDataInputStream stream = parent.getStream(shouldUseHBaseChecksum());
+
+    // Convert section-relative position to absolute file position
+    long absolutePosition = toAbsolutePosition(seekPosition);
+    stream.seek(absolutePosition);
+  }
+
+  /**
+   * Custom implementation to translate position.
+   * @return the current position (section-relative)
+   * @throws IOException if an I/O error occurs
+   */
+  public long getPos() throws IOException {
+    FSDataInputStream stream = parent.getStream(shouldUseHBaseChecksum());
+    long absolutePosition = stream.getPos();
+
+    // Get the absolute position and convert to section-relative position
+    return toRelativePosition(absolutePosition);
+  }
+
+  /**
+   * Read method that translates position.
+   * @param buffer the buffer to read into
+   * @param offset the offset in the buffer
+   * @param length the number of bytes to read
+   * @return the number of bytes read
+   * @throws IOException if an I/O error occurs
+   */
+  public int read(byte[] buffer, int offset, int length) throws IOException {
+    FSDataInputStream stream = parent.getStream(shouldUseHBaseChecksum());
+    return stream.read(buffer, offset, length);
+  }
+
+  /**
+   * Custom implementation to read at position with offset translation.
+   * @param position the position to read from (section-relative)
+   * @param buffer   the buffer to read into
+   * @param offset   the offset in the buffer
+   * @param length   the number of bytes to read
+   * @return the number of bytes read
+   * @throws IOException if an I/O error occurs
+   */
+  public int read(long position, byte[] buffer, int offset, int length) throws IOException {
+    int clampedLength = clampReadLength(position, length);
+    FSDataInputStream stream = parent.getStream(shouldUseHBaseChecksum());
+
+    // Convert section-relative position to absolute file position
+    long absolutePosition = toAbsolutePosition(position);
+    return stream.read(absolutePosition, buffer, offset, clampedLength);
+  }
+
+  /**
+   * Get the positioned readable interface.
+   * @return the positioned readable interface
+   */
+  public PositionedReadable getPositionedReadable() {
+    FSDataInputStream stream = parent.getStream(shouldUseHBaseChecksum());
+    return stream;
+  }
+
+  /**
+   * Get the seekable interface.
+   * @return the seekable interface
+   */
+  public Seekable getSeekable() {
+    FSDataInputStream stream = parent.getStream(shouldUseHBaseChecksum());
+    return stream;
+  }
+
+  /**
+   * Get the input stream.
+   * @return the input stream
+   */
+  public InputStream getStream() {
+    FSDataInputStream stream = parent.getStream(shouldUseHBaseChecksum());
+    return stream;
+  }
+
+  /**
+   * Check if an input stream is available.
+   * @return true if an input stream is available
+   */
+  public boolean hasInputStream() {
+    return true;
+  }
+
+  /**
+   * Check if positioned readable interface is available.
+   * @return true if positioned readable is available
+   */
+  public boolean hasPositionedReadable() {
+    return true;
+  }
+
+  /**
+   * Check if seekable interface is available.
+   * @return true if seekable is available
+   */
+  public boolean hasSeekable() {
+    return true;
+  }
+
+  /**
+   * Read a single byte.
+   * @return the byte read, or -1 if end of stream
+   * @throws IOException if an I/O error occurs
+   */
+  public int read() throws IOException {
+    FSDataInputStream stream = parent.getStream(shouldUseHBaseChecksum());
+    return stream.read();
+  }
+
+  /**
+   * Get the stream wrapper for the given stream.
+   * @param stream the stream to wrap
+   * @return the wrapped stream
+   */
+  public FSDataInputStream getStream(FSDataInputStream stream) {
+    return stream;
+  }
+
+  /**
+   * Translates section-relative seeks/reads into absolute file positions.
+   */
+  private class TranslatingFSStream extends FSDataInputStream {
+    /** The raw underlying stream */
+    private final FSDataInputStream rawStream;
+
+    /**
+     * Constructor for TranslatingFSStream.
+     * @param rawStream the raw stream to wrap
+     */
+    TranslatingFSStream(FSDataInputStream rawStream) {
+      super(new OffsetTranslatingInputStream(rawStream, sectionOffset, sectionSize));
+      this.rawStream = rawStream;
+      // DO NOT automatically seek to sectionOffset here!
+      // This interferes with normal HFile reading patterns.
+      // The HFileReaderImpl will seek to specific positions as needed,
+      // and our translator will handle the offset translation.
+      LOG.debug("Created section stream wrapper for section starting at offset {}", sectionOffset);
+    }
+
+    @Override
+    public void seek(long position) throws IOException {
+      checkSeekBounds(position);
+      long absolutePosition = toAbsolutePosition(position);
+      LOG.debug("Section seek: relative pos {} -> absolute pos {}, sectionOffset={}", position,
+        absolutePosition, sectionOffset);
+      rawStream.seek(absolutePosition);
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      long absolutePosition = rawStream.getPos();
+
+      // Convert absolute position to section-relative position
+      long relativePosition = toRelativePosition(absolutePosition);
+      LOG.trace("Section getPos: absolute {} -> relative {}, sectionOffset={}", absolutePosition,
+        relativePosition, sectionOffset);
+      if (relativePosition < 0) {
+        throw new IOException(
+          "Position translation resulted in negative relative position: absolute="
+            + absolutePosition + ", sectionOffset=" + sectionOffset);
+      }
+      return relativePosition;
+    }
+
+    @Override
+    public int read(long position, byte[] buffer, int offset, int length) throws IOException {
+      int clampedLength = clampReadLength(position, length);
+      long absolutePosition = toAbsolutePosition(position);
+      LOG.trace("Section pread: relative pos {} -> absolute pos {}, len={}, sectionOffset={}",
+        position, absolutePosition, clampedLength, sectionOffset);
+      return rawStream.read(absolutePosition, buffer, offset, clampedLength);
+    }
+
+    @Override
+    public boolean seekToNewSource(long targetPosition) throws IOException {
+      checkSeekBounds(targetPosition);
+      return rawStream.seekToNewSource(toAbsolutePosition(targetPosition));
+    }
+
+    @Override
+    public boolean hasCapability(String capability) {
+      return rawStream.hasCapability(capability);
+    }
+
+    @Override
+    public int read(long position, ByteBuffer buf) throws IOException {
+      int clampedLimit = clampReadLength(position, buf.remaining());
+      long absolutePosition = toAbsolutePosition(position);
+      if (clampedLimit < buf.remaining()) {
+        ByteBuffer limited = buf.duplicate();
+        limited.limit(limited.position() + clampedLimit);
+        return rawStream.read(absolutePosition, limited);
+      }
+      return rawStream.read(absolutePosition, buf);
+    }
+  }
+
+  /**
+   * Custom InputStream that translates all read operations by adding the section offset. This
+   * ensures that when DataInputStream's final methods call read(), they go through our offset
+   * translation logic.
+   */
+  private static class OffsetTranslatingInputStream extends InputStream
+    implements Seekable, PositionedReadable {
+    /** The raw underlying stream */
+    private final FSDataInputStream rawStream;
+    /** The section offset for translation */
+    private final long sectionOffset;
+    /** The section size for boundary enforcement */
+    private final long sectionSize;
+    /** Absolute end boundary: reads must not go beyond this position */
+    private final long sectionEndAbsolute;
+
+    /**
+     * Constructor for OffsetTranslatingInputStream.
+     * @param rawStream     the raw stream to wrap
+     * @param sectionOffset the section offset for translation
+     * @param sectionSize   the section size for boundary enforcement
+     */
+    OffsetTranslatingInputStream(FSDataInputStream rawStream, long sectionOffset,
+      long sectionSize) {
+      this.rawStream = rawStream;
+      this.sectionOffset = sectionOffset;
+      this.sectionSize = sectionSize;
+      this.sectionEndAbsolute = sectionOffset + sectionSize;
+    }
+
+    private long remainingInSection() throws IOException {
+      return sectionEndAbsolute - rawStream.getPos();
+    }
+
+    @Override
+    public int read() throws IOException {
+      if (remainingInSection() <= 0) {
+        return -1;
+      }
+      return rawStream.read();
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+      long remaining = remainingInSection();
+      if (remaining <= 0) {
+        return -1;
+      }
+      int clampedLength = (int) Math.min(length, remaining);
+      return rawStream.read(buffer, offset, clampedLength);
+    }
+
+    @Override
+    public long skip(long bytesToSkip) throws IOException {
+      long remaining = remainingInSection();
+      if (remaining <= 0) {
+        return 0;
+      }
+      long clampedSkip = Math.min(bytesToSkip, remaining);
+      return rawStream.skip(clampedSkip);
+    }
+
+    @Override
+    public int available() throws IOException {
+      return rawStream.available();
+    }
+
+    @Override
+    public void close() throws IOException {
+      // Do not close the shared raw stream. Section readers are lightweight views that
+      // should not own the lifecycle of the underlying stream.
+    }
+
+    @Override
+    public void mark(int readLimit) {
+      rawStream.mark(readLimit);
+    }
+
+    @Override
+    public void reset() throws IOException {
+      rawStream.reset();
+    }
+
+    @Override
+    public boolean markSupported() {
+      return rawStream.markSupported();
+    }
+
+    // Seekable interface implementation
+    @Override
+    public void seek(long position) throws IOException {
+      if (position < 0 || position > sectionSize) {
+        throw new IOException("Seek position " + position + " is outside section bounds [0, "
+          + sectionSize + "], sectionOffset=" + sectionOffset);
+      }
+      long absolutePosition = sectionOffset + position;
+      LOG.trace("OffsetTranslatingInputStream seek: relative pos {} -> absolute pos {}, "
+        + "sectionOffset={}", position, absolutePosition, sectionOffset);
+      rawStream.seek(absolutePosition);
+    }
+
+    @Override
+    public long getPos() throws IOException {
+      // Translate absolute file position back to section-relative position
+      long absolutePosition = rawStream.getPos();
+      long relativePosition = absolutePosition - sectionOffset;
+      LOG.trace("OffsetTranslatingInputStream getPos: absolute pos {} -> relative pos {}, "
+        + "sectionOffset={}", absolutePosition, relativePosition, sectionOffset);
+      return relativePosition;
+    }
+
+    @Override
+    public boolean seekToNewSource(long targetPosition) throws IOException {
+      if (targetPosition < 0 || targetPosition > sectionSize) {
+        throw new IOException("seekToNewSource position " + targetPosition
+          + " is outside section bounds [0, " + sectionSize + "], sectionOffset=" + sectionOffset);
+      }
+      long absolutePosition = sectionOffset + targetPosition;
+      LOG.trace("OffsetTranslatingInputStream seekToNewSource: relative pos {} -> "
+        + "absolute pos {}, sectionOffset={}", targetPosition, absolutePosition, sectionOffset);
+      return rawStream.seekToNewSource(absolutePosition);
+    }
+
+    // PositionedReadable interface implementation
+    @Override
+    public int read(long position, byte[] buffer, int offset, int length) throws IOException {
+      if (position < 0 || position >= sectionSize) {
+        throw new IOException("Read position " + position + " is outside section bounds [0, "
+          + sectionSize + "), sectionOffset=" + sectionOffset);
+      }
+      int clampedLength = (int) Math.min(length, sectionSize - position);
+      long absolutePosition = sectionOffset + position;
+      LOG.trace("OffsetTranslatingInputStream pread: relative pos {} -> absolute pos {}, "
+        + "len={}, sectionOffset={}", position, absolutePosition, clampedLength, sectionOffset);
+      return rawStream.read(absolutePosition, buffer, offset, clampedLength);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer, int offset, int length) throws IOException {
+      if (position < 0 || position + length > sectionSize) {
+        throw new IOException("readFully range [" + position + ", " + (position + length)
+          + ") is outside section bounds [0, " + sectionSize + "), sectionOffset=" + sectionOffset);
+      }
+      long absolutePosition = sectionOffset + position;
+      LOG.trace("OffsetTranslatingInputStream readFully: relative pos {} -> absolute pos {}, "
+        + "len={}, sectionOffset={}", position, absolutePosition, length, sectionOffset);
+      rawStream.readFully(absolutePosition, buffer, offset, length);
+    }
+
+    @Override
+    public void readFully(long position, byte[] buffer) throws IOException {
+      readFully(position, buffer, 0, buffer.length);
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/MultiTenantFSDataInputStreamWrapper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/MultiTenantFSDataInputStreamWrapper.java
@@ -353,15 +353,15 @@ public class MultiTenantFSDataInputStreamWrapper extends FSDataInputStreamWrappe
     /**
      * Translates a section-relative seek into an absolute file seek on the parent stream.
      * <p>
-     * <b>Concurrency hazard:</b> when {@code ownsParent} is {@code false} (PREAD mode), this
-     * method mutates the position of a stream shared with other section readers and the parent
-     * file. Concurrent positional reads ({@code read(position, ...)}) are themselves safe, but
-     * a {@code seek()} interleaved with them races and produces mis-targeted reads. Callers in
-     * the steady-state read path must rely on positional reads exclusively; {@code seek()} here
-     * remains usable because section reader initialization (notably
+     * <b>Concurrency hazard:</b> when {@code ownsParent} is {@code false} (PREAD mode), this method
+     * mutates the position of a stream shared with other section readers and the parent file.
+     * Concurrent positional reads ({@code read(position, ...)}) are themselves safe, but a
+     * {@code seek()} interleaved with them races and produces mis-targeted reads. Callers in the
+     * steady-state read path must rely on positional reads exclusively; {@code seek()} here remains
+     * usable because section reader initialization (notably
      * {@link org.apache.hadoop.hbase.io.hfile.FixedFileTrailer#readFromStream}) seeks before any
-     * other reader has a handle on the stream. A more durable fix is to open per-section streams
-     * in PREAD mode (see HBASE-29588 review item #7 / #19).
+     * other reader has a handle on the stream. A more durable fix is to open per-section streams in
+     * PREAD mode (see HBASE-29588 review item #7 / #19).
      */
     @Override
     public void seek(long position) throws IOException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/MultiTenantFSDataInputStreamWrapper.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/MultiTenantFSDataInputStreamWrapper.java
@@ -350,6 +350,19 @@ public class MultiTenantFSDataInputStreamWrapper extends FSDataInputStreamWrappe
       LOG.debug("Created section stream wrapper for section starting at offset {}", sectionOffset);
     }
 
+    /**
+     * Translates a section-relative seek into an absolute file seek on the parent stream.
+     * <p>
+     * <b>Concurrency hazard:</b> when {@code ownsParent} is {@code false} (PREAD mode), this
+     * method mutates the position of a stream shared with other section readers and the parent
+     * file. Concurrent positional reads ({@code read(position, ...)}) are themselves safe, but
+     * a {@code seek()} interleaved with them races and produces mis-targeted reads. Callers in
+     * the steady-state read path must rely on positional reads exclusively; {@code seek()} here
+     * remains usable because section reader initialization (notably
+     * {@link org.apache.hadoop.hbase.io.hfile.FixedFileTrailer#readFromStream}) seeks before any
+     * other reader has a handle on the stream. A more durable fix is to open per-section streams
+     * in PREAD mode (see HBASE-29588 review item #7 / #19).
+     */
     @Override
     public void seek(long position) throws IOException {
       checkSeekBounds(position);
@@ -386,6 +399,8 @@ public class MultiTenantFSDataInputStreamWrapper extends FSDataInputStreamWrappe
 
     @Override
     public boolean seekToNewSource(long targetPosition) throws IOException {
+      // Same shared-stream caveat as seek(); see javadoc above. Retained for initialization-time
+      // callers; concurrent steady-state callers should use positional reads.
       checkSeekBounds(targetPosition);
       return rawStream.seekToNewSource(toAbsolutePosition(targetPosition));
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/AbstractMultiTenantReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/AbstractMultiTenantReader.java
@@ -1514,9 +1514,16 @@ public abstract class AbstractMultiTenantReader extends HFileReaderImpl
       // Extract tenant section ID
       byte[] tenantSectionId = tenantExtractor.extractTenantSectionId(key);
 
-      // If tenant section changed, check direction before seeking
+      // If tenant section changed, check direction before seeking.
       if (!Bytes.equals(tenantSectionId, currentTenantSectionId)) {
         if (Bytes.compareTo(tenantSectionId, currentTenantSectionId) < 0) {
+          // Requested key sorts in a tenant section strictly before the current section.
+          // reseekTo is forward-only by contract, so the scanner stays at its current cell.
+          // Per HFileReaderImpl.reseekTo, the return value follows compareKey semantics:
+          // a positive value means "scanner cell is greater than requested key, no movement
+          // needed". The HFileScanner javadoc enumerates -1/0/1 as canonical returns; we use 1
+          // here so callers using the canonical interpretation (== 1 → past requested key) work
+          // correctly. See TestMultiTenantScannerReseekTo for the contract on backward reseek.
           return 1;
         }
         return seekTo(key);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/AbstractMultiTenantReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/AbstractMultiTenantReader.java
@@ -2707,6 +2707,10 @@ public abstract class AbstractMultiTenantReader extends HFileReaderImpl
         try (DataInputStream dis = new DataInputStream(blockToRead.getByteStream())) {
           fileInfo.read(dis);
         }
+        // Mirror HFileInfo.initMetaAndIndex: FILE_SIZE and FILE_PATH are runtime-only
+        // entries populated from the ReaderContext, not read from disk.
+        fileInfo.put(HFileInfo.FILE_SIZE, Bytes.toBytes(context.getFileSize()));
+        fileInfo.put(HFileInfo.FILE_PATH, Bytes.toBytes(context.getFilePath().toString()));
         applyFileInfoMetadataToContext();
       } finally {
         if (blockToRead != null) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/AbstractMultiTenantReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/AbstractMultiTenantReader.java
@@ -1,0 +1,2769 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import java.io.DataInput;
+import java.io.DataInputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.NavigableMap;
+import java.util.Optional;
+import java.util.TreeMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellComparator;
+import org.apache.hadoop.hbase.ExtendedCell;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.io.MultiTenantFSDataInputStreamWrapper;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.regionserver.HStoreFile;
+import org.apache.hadoop.hbase.util.BloomFilter;
+import org.apache.hadoop.hbase.util.BloomFilterFactory;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.com.google.common.cache.Cache;
+import org.apache.hbase.thirdparty.com.google.common.cache.CacheBuilder;
+import org.apache.hbase.thirdparty.com.google.common.cache.RemovalNotification;
+
+/**
+ * Abstract base class for multi-tenant HFile readers. This class handles the common functionality
+ * for both pread and stream access modes, delegating specific reader creation to subclasses.
+ * <p>
+ * The multi-tenant reader acts as a router that:
+ * <ol>
+ * <li>Extracts tenant information from cell keys</li>
+ * <li>Locates the appropriate section in the HFile for that tenant</li>
+ * <li>Delegates reading operations to a standard v3 reader for that section</li>
+ * </ol>
+ * <p>
+ * Key features:
+ * <ul>
+ * <li>Multi-level tenant index support for efficient section lookup</li>
+ * <li>Prefetching for sequential access optimization</li>
+ * <li>Configuration-driven tenant settings recorded in the trailer</li>
+ * <li>Transparent delegation to HFile v3 readers for each section</li>
+ * </ul>
+ */
+@InterfaceAudience.Private
+public abstract class AbstractMultiTenantReader extends HFileReaderImpl
+  implements MultiTenantBloomSupport {
+  private static final Logger LOG = LoggerFactory.getLogger(AbstractMultiTenantReader.class);
+
+  /** Tenant extractor for identifying tenant information from cells */
+  protected final TenantExtractor tenantExtractor;
+  /** Section index reader for locating tenant sections */
+  protected final SectionIndexManager.Reader sectionIndexReader;
+
+  /** Configuration key for section prefetch enablement */
+  private static final String SECTION_PREFETCH_ENABLED =
+    "hbase.multi.tenant.reader.prefetch.enabled";
+  /** Default prefetch enabled flag */
+  private static final boolean DEFAULT_SECTION_PREFETCH_ENABLED = true;
+
+  /** Configuration key controlling meta block lookup caching */
+  private static final String META_BLOCK_CACHE_ENABLED =
+    "hbase.multi.tenant.reader.meta.cache.enabled";
+  /** Default flag enabling meta block cache */
+  private static final boolean DEFAULT_META_BLOCK_CACHE_ENABLED = true;
+  /** Configuration key controlling cache size */
+  private static final String META_BLOCK_CACHE_MAX_SIZE =
+    "hbase.multi.tenant.reader.meta.cache.max";
+  /** Default maximum cache entries */
+  private static final int DEFAULT_META_BLOCK_CACHE_MAX_SIZE = 256;
+
+  /** Configuration key controlling data block index lookup caching */
+  private static final String DATA_BLOCK_INDEX_CACHE_ENABLED =
+    "hbase.multi.tenant.reader.data.index.cache.enabled";
+  /** Default flag enabling data block index cache */
+  private static final boolean DEFAULT_DATA_BLOCK_INDEX_CACHE_ENABLED = true;
+
+  /** Configuration key for the maximum number of cached section readers */
+  private static final String SECTION_READER_CACHE_MAX_SIZE =
+    "hbase.multi.tenant.reader.section.cache.max";
+  /** Default maximum number of cached section readers */
+  private static final int DEFAULT_SECTION_READER_CACHE_MAX_SIZE = 8;
+  /** Configuration key for section reader cache idle eviction (ms) */
+  private static final String SECTION_READER_CACHE_EXPIRE_MS =
+    "hbase.multi.tenant.reader.section.cache.expire.ms";
+  /** Default idle eviction (1 minute) */
+  private static final long DEFAULT_SECTION_READER_CACHE_EXPIRE_MS = TimeUnit.MINUTES.toMillis(1);
+
+  /** Private map to store section metadata */
+  private final Map<ImmutableBytesWritable, SectionMetadata> sectionLocations =
+    new LinkedHashMap<ImmutableBytesWritable, SectionMetadata>();
+
+  /** O(log n) index from section start offset to section key for fast offset-based lookup */
+  private final NavigableMap<Long, ImmutableBytesWritable> sectionOffsetIndex = new TreeMap<>();
+
+  /** List for section navigation */
+  private List<ImmutableBytesWritable> sectionIds;
+
+  /** Number of levels in the tenant index structure */
+  private int tenantIndexLevels = 1;
+  /** Maximum chunk size used in the tenant index */
+  private int tenantIndexMaxChunkSize = SectionIndexManager.DEFAULT_MAX_CHUNK_SIZE;
+  /** Whether prefetch is enabled for sequential access */
+  private final boolean prefetchEnabled;
+  /**
+   * Track block-prefetch-on-open for v4 containers.
+   * <p>
+   * For v4 multi-tenant HFiles, block prefetching is executed by section readers (which are v3
+   * {@link HFilePreadReader}s) and scheduled via {@link PrefetchExecutor} using a section-specific
+   * Path. For single-section v4 containers we eagerly instantiate the single section reader so the
+   * standard prefetch-on-open path runs and we can report status via {@link #prefetchComplete()}.
+   */
+  private volatile Path prefetchOnOpenPath;
+  /** Guards lazy loading of the file-level FileInfo block (see {@link #getHFileInfo()}) */
+  private volatile boolean fileInfoBlockLoaded;
+  /** Cache of section readers keyed by tenant section ID */
+  private final Cache<ImmutableBytesWritable, SectionReaderHolder> sectionReaderCache;
+  /** Cached Bloom filter state per section */
+  private final Cache<ImmutableBytesWritable, SectionBloomState> sectionBloomCache;
+  private final AtomicReference<BloomType> generalBloomTypeCache = new AtomicReference<>();
+  /** Whether we cache meta block to section mappings */
+  private final boolean metaBlockCacheEnabled;
+  /** Cache for meta block name to section mapping */
+  private final Cache<String, ImmutableBytesWritable> metaBlockSectionCache;
+  /** Whether we cache data block index section hints */
+  private final boolean dataBlockIndexCacheEnabled;
+  /** Cached section hint for data block index lookup */
+  private final AtomicReference<byte[]> dataBlockIndexSectionHint;
+  /** Thread-safe cache for the last resolved data block index reader (avoids parent field race) */
+  private final AtomicReference<
+    HFileBlockIndex.CellBasedKeyBlockIndexReader> cachedDataBlockIndexReader =
+      new AtomicReference<>();
+
+  /**
+   * Constructor for multi-tenant reader.
+   * @param context   Reader context info
+   * @param fileInfo  HFile info
+   * @param cacheConf Cache configuration values
+   * @param conf      Configuration
+   * @throws IOException If an error occurs during initialization
+   */
+  public AbstractMultiTenantReader(ReaderContext context, HFileInfo fileInfo, CacheConfig cacheConf,
+    Configuration conf) throws IOException {
+    super(context, fileInfo, cacheConf, conf);
+
+    // Initialize section index reader
+    this.sectionIndexReader = new SectionIndexManager.Reader();
+
+    // Load tenant index metadata before accessing the section index so we know how to interpret it
+    loadTenantIndexMetadata();
+
+    // Initialize section index using dataBlockIndexReader from parent
+    initializeSectionIndex();
+
+    // Log tenant index structure information once sections are available
+    logTenantIndexStructureInfo();
+
+    // Create tenant extractor with consistent configuration
+    this.tenantExtractor =
+      java.util.Objects.requireNonNull(TenantExtractorFactory.createFromReader(this),
+        "TenantExtractorFactory.createFromReader returned null for " + context.getFilePath());
+
+    // Initialize prefetch configuration
+    this.prefetchEnabled =
+      conf.getBoolean(SECTION_PREFETCH_ENABLED, DEFAULT_SECTION_PREFETCH_ENABLED);
+
+    // Initialize cache for section readers
+    this.sectionReaderCache = createSectionReaderCache(conf);
+    this.sectionBloomCache = createSectionBloomCache(conf);
+
+    this.metaBlockCacheEnabled =
+      conf.getBoolean(META_BLOCK_CACHE_ENABLED, DEFAULT_META_BLOCK_CACHE_ENABLED);
+    if (metaBlockCacheEnabled) {
+      int maxEntries = conf.getInt(META_BLOCK_CACHE_MAX_SIZE, DEFAULT_META_BLOCK_CACHE_MAX_SIZE);
+      this.metaBlockSectionCache = CacheBuilder.newBuilder().maximumSize(maxEntries).build();
+    } else {
+      this.metaBlockSectionCache = null;
+    }
+
+    this.dataBlockIndexCacheEnabled =
+      conf.getBoolean(DATA_BLOCK_INDEX_CACHE_ENABLED, DEFAULT_DATA_BLOCK_INDEX_CACHE_ENABLED);
+    this.dataBlockIndexSectionHint = new AtomicReference<>();
+
+    LOG.info("Initialized multi-tenant reader for {}", context.getFilePath());
+  }
+
+  /**
+   * Best-effort initiation of block-prefetch-on-open for v4 containers.
+   * <p>
+   * In the v4 multi-tenant reader implementation, actual block prefetching is performed by the
+   * delegated per-section v3 readers. Those section readers are typically created lazily. However,
+   * the prefetch-on-open feature is expected to be scheduled at open time (honoring
+   * {@link PrefetchExecutor#PREFETCH_DELAY}) so that callers/tests can observe prefetch start and
+   * completion.
+   * <p>
+   * To preserve v3 semantics for the common v4 single-section case, we eagerly create the only
+   * section reader when prefetch-on-open is enabled. For multi-section files we do not eagerly
+   * create all section readers to avoid potentially heavy fan-out.
+   */
+  protected final void prefetchBlocksOnOpenIfRequested() {
+    if (prefetchOnOpenPath != null) {
+      return;
+    }
+    if (!cacheConf.getBlockCache().isPresent() || !cacheConf.shouldPrefetchOnOpen()) {
+      return;
+    }
+    if (sectionIds == null || sectionIds.size() != 1) {
+      if (LOG.isDebugEnabled()) {
+        int count = sectionIds == null ? 0 : sectionIds.size();
+        LOG.debug(
+          "Skipping eager prefetch-on-open for v4 multi-tenant file {} because sectionCount={}",
+          getPath(), count);
+      }
+      return;
+    }
+
+    byte[] firstSectionId = sectionIds.get(0).get();
+    try {
+      SectionReaderLease lease = getSectionReader(firstSectionId);
+      if (lease == null) {
+        return;
+      }
+      // Avoid nullable resource in try-with-resources (SpotBugs false-positive for NP/RCN).
+      try (SectionReaderLease ignored = lease) {
+        HFileReaderImpl sectionReader = ignored.getReader();
+        if (sectionReader != null) {
+          prefetchOnOpenPath = sectionReader.getPath();
+        }
+      }
+    } catch (IOException e) {
+      // Best-effort: failure to prefetch must not prevent reads.
+      LOG.debug("Failed to initiate prefetch-on-open for v4 multi-tenant file {}", getPath(), e);
+    }
+  }
+
+  /**
+   * Initialize the section index from the file.
+   * @throws IOException If an error occurs loading the section index
+   */
+  protected void initializeSectionIndex() throws IOException {
+    // Get the trailer directly
+    FixedFileTrailer trailer = fileInfo.getTrailer();
+
+    // Access the input stream through the context
+    FSDataInputStreamWrapper fsWrapper = context.getInputStreamWrapper();
+    FSDataInputStream fsdis = fsWrapper.getStream(fsWrapper.shouldUseHBaseChecksum());
+    long originalPosition = fsdis.getPos();
+
+    long sectionIndexOffset = getSectionIndexOffset();
+    try {
+      LOG.debug("Seeking to load-on-open section at offset {}", sectionIndexOffset);
+
+      // Fall back to trailer-provided level count when metadata has not been loaded yet
+      int trailerLevels = trailer.getNumDataIndexLevels();
+      if (trailerLevels >= 1 && trailerLevels > tenantIndexLevels) {
+        tenantIndexLevels = trailerLevels;
+      }
+
+      // In HFile v4, the tenant index is stored at the recorded section index offset
+      HFileBlock rootIndexBlock =
+        getUncachedBlockReader().readBlockData(sectionIndexOffset, -1, true, false, false);
+
+      // Validate this is a root index block
+      if (rootIndexBlock.getBlockType() != BlockType.ROOT_INDEX) {
+        throw new IOException("Expected ROOT_INDEX block for tenant index in HFile v4, found "
+          + rootIndexBlock.getBlockType() + " at offset " + sectionIndexOffset);
+      }
+
+      HFileBlock blockToRead = null;
+      try {
+        blockToRead = rootIndexBlock.unpack(getFileContext(), getUncachedBlockReader());
+
+        // Load the section index from the root block (support multi-level traversal)
+        if (tenantIndexLevels <= 1) {
+          sectionIndexReader.loadSectionIndex(blockToRead);
+        } else {
+          sectionIndexReader.loadSectionIndex(blockToRead, tenantIndexLevels,
+            getUncachedBlockReader());
+        }
+
+        // Copy section info to our internal data structures
+        initSectionLocations();
+
+        LOG.debug("Initialized tenant section index with {} entries", getSectionCount());
+      } finally {
+        if (blockToRead != null) {
+          blockToRead.release();
+          if (blockToRead != rootIndexBlock) {
+            rootIndexBlock.release();
+          }
+        } else {
+          rootIndexBlock.release();
+        }
+      }
+    } finally {
+      fsdis.seek(originalPosition);
+    }
+  }
+
+  private long getSectionIndexOffset() {
+    long offset = trailer.getSectionIndexOffset();
+    return offset >= 0 ? offset : trailer.getLoadOnOpenDataOffset();
+  }
+
+  /**
+   * Load information about the tenant index structure from file info.
+   * <p>
+   * Extracts tenant index levels and chunk size configuration from the HFile metadata to optimize
+   * section lookup performance.
+   */
+  private void logTenantIndexStructureInfo() {
+    int numSections = getSectionCount();
+    if (tenantIndexLevels > 1) {
+      LOG.info("Multi-tenant HFile loaded with {} sections using {}-level tenant index "
+        + "(maxChunkSize={})", numSections, tenantIndexLevels, tenantIndexMaxChunkSize);
+    } else {
+      LOG.info("Multi-tenant HFile loaded with {} sections using single-level tenant index",
+        numSections);
+    }
+
+    LOG.debug("Tenant index details: levels={}, chunkSize={}, sections={}", tenantIndexLevels,
+      tenantIndexMaxChunkSize, numSections);
+  }
+
+  private Cache<ImmutableBytesWritable, SectionReaderHolder>
+    createSectionReaderCache(Configuration conf) {
+    int maxSize = Math.max(1,
+      conf.getInt(SECTION_READER_CACHE_MAX_SIZE, DEFAULT_SECTION_READER_CACHE_MAX_SIZE));
+    long expireMs =
+      conf.getLong(SECTION_READER_CACHE_EXPIRE_MS, DEFAULT_SECTION_READER_CACHE_EXPIRE_MS);
+
+    CacheBuilder<Object, Object> builder = CacheBuilder.newBuilder().maximumSize(maxSize);
+    if (expireMs > 0) {
+      builder.expireAfterAccess(expireMs, TimeUnit.MILLISECONDS);
+    }
+
+    Cache<ImmutableBytesWritable, SectionReaderHolder> cache = builder.removalListener(
+      (RemovalNotification<ImmutableBytesWritable, SectionReaderHolder> notification) -> {
+        SectionReaderHolder holder = notification.getValue();
+        if (holder != null) {
+          holder.markEvicted(true);
+        }
+      }).build();
+    LOG.debug("Initialized section reader cache with maxSize={}, expireMs={}", maxSize, expireMs);
+    return cache;
+  }
+
+  private Cache<ImmutableBytesWritable, SectionBloomState>
+    createSectionBloomCache(Configuration conf) {
+    int maxSize = Math.max(1,
+      conf.getInt(SECTION_READER_CACHE_MAX_SIZE, DEFAULT_SECTION_READER_CACHE_MAX_SIZE));
+    Cache<ImmutableBytesWritable, SectionBloomState> cache =
+      CacheBuilder.newBuilder().maximumSize(maxSize).build();
+    LOG.debug("Initialized section bloom cache with maxSize={}", maxSize);
+    return cache;
+  }
+
+  private static final int MAX_TENANT_INDEX_LEVELS = 16;
+
+  private void loadTenantIndexMetadata() {
+    byte[] tenantIndexLevelsBytes =
+      fileInfo.get(Bytes.toBytes(MultiTenantHFileWriter.FILEINFO_TENANT_INDEX_LEVELS));
+    if (tenantIndexLevelsBytes != null) {
+      if (tenantIndexLevelsBytes.length != Bytes.SIZEOF_INT) {
+        LOG.warn("Corrupt tenant index levels byte array (length={}) in file info for {}, "
+          + "using default", tenantIndexLevelsBytes.length, context.getFilePath());
+      } else {
+        int parsedLevels = Bytes.toInt(tenantIndexLevelsBytes);
+        if (parsedLevels >= 1 && parsedLevels <= MAX_TENANT_INDEX_LEVELS) {
+          tenantIndexLevels = parsedLevels;
+        } else {
+          LOG.warn(
+            "Ignoring invalid tenant index level count {} in file info for {} "
+              + "(valid range: [1, {}])",
+            parsedLevels, context.getFilePath(), MAX_TENANT_INDEX_LEVELS);
+          tenantIndexLevels = 1;
+        }
+      }
+    }
+
+    byte[] chunkSizeBytes =
+      fileInfo.get(Bytes.toBytes(MultiTenantHFileWriter.FILEINFO_TENANT_INDEX_MAX_CHUNK));
+    if (chunkSizeBytes != null) {
+      if (chunkSizeBytes.length != Bytes.SIZEOF_INT) {
+        LOG.warn("Corrupt tenant index chunk size byte array (length={}) in file info for {}, "
+          + "using default", chunkSizeBytes.length, context.getFilePath());
+      } else {
+        int parsedChunkSize = Bytes.toInt(chunkSizeBytes);
+        if (parsedChunkSize > 0) {
+          tenantIndexMaxChunkSize = parsedChunkSize;
+        } else {
+          LOG.warn("Ignoring invalid tenant index chunk size {} in file info for {}",
+            parsedChunkSize, context.getFilePath());
+        }
+      }
+    }
+  }
+
+  /**
+   * Get the number of levels in the tenant index.
+   * @return The number of levels (1 for single-level, 2+ for multi-level)
+   */
+  public int getTenantIndexLevels() {
+    return tenantIndexLevels;
+  }
+
+  /**
+   * Get the maximum chunk size used in the tenant index.
+   * @return The maximum entries per index block
+   */
+  public int getTenantIndexMaxChunkSize() {
+    return tenantIndexMaxChunkSize;
+  }
+
+  /**
+   * Initialize our section location map from the index reader.
+   * <p>
+   * Populates the internal section metadata map and creates the section ID list for efficient
+   * navigation during scanning operations.
+   */
+  private void initSectionLocations() {
+    for (SectionIndexManager.SectionIndexEntry entry : sectionIndexReader.getSections()) {
+      ImmutableBytesWritable key = new ImmutableBytesWritable(entry.getTenantPrefix());
+      SectionMetadata metadata = new SectionMetadata(entry.getOffset(), entry.getSectionSize());
+
+      SectionMetadata previous = sectionLocations.put(key, metadata);
+      if (previous != null) {
+        sectionOffsetIndex.remove(previous.getOffset());
+        LOG.warn("Duplicate tenant prefix {} in section index: replacing offset {} with {}",
+          Bytes.toStringBinary(entry.getTenantPrefix()), previous.getOffset(), entry.getOffset());
+      }
+      sectionOffsetIndex.put(entry.getOffset(), key);
+    }
+
+    if (sectionLocations.isEmpty()) {
+      LOG.warn("Multi-tenant HFile {} contains zero sections", context.getFilePath());
+    }
+
+    // Create list for section navigation
+    sectionIds = new ArrayList<>(sectionLocations.keySet());
+    // Sort by tenant prefix to ensure lexicographic order
+    sectionIds.sort((a, b) -> Bytes.compareTo(a.get(), b.get()));
+    LOG.debug("Initialized {} section IDs for navigation", sectionIds.size());
+  }
+
+  /**
+   * Get the number of sections in this file.
+   * @return The number of sections in this file
+   */
+  private int getSectionCount() {
+    return sectionLocations.size();
+  }
+
+  /**
+   * Get the total number of tenant sections in this file.
+   * @return The number of sections
+   */
+  public int getTotalSectionCount() {
+    return sectionLocations.size();
+  }
+
+  @Override
+  public boolean passesGeneralRowBloomFilter(byte[] row, int rowOffset, int rowLen)
+    throws IOException {
+    byte[] sectionId = extractTenantSectionId(row, rowOffset, rowLen);
+    if (sectionId == null) {
+      return true;
+    }
+    ImmutableBytesWritable cacheKey = new ImmutableBytesWritable(sectionId);
+    SectionReaderLease lease = getSectionReader(sectionId);
+    if (lease == null) {
+      // No section for this tenant prefix → key definitively cannot exist in this file
+      return false;
+    }
+    try (SectionReaderLease ignored = lease) {
+      SectionBloomState bloomState = getOrLoadSectionBloomState(cacheKey, lease);
+      if (bloomState == null || !bloomState.hasGeneralBloom()) {
+        return true;
+      }
+      return bloomState.passesGeneralRowBloom(row, rowOffset, rowLen, lease.getReader());
+    }
+  }
+
+  @Override
+  public boolean passesGeneralRowColBloomFilter(ExtendedCell cell) throws IOException {
+    // Gracefully handle short row keys (same as the byte[] path)
+    int prefixLength = tenantExtractor.getPrefixLength();
+    if (prefixLength > 0 && cell.getRowLength() < prefixLength) {
+      return true;
+    }
+    byte[] sectionId = tenantExtractor.extractTenantSectionId(cell);
+    if (sectionId == null) {
+      return true;
+    }
+    ImmutableBytesWritable cacheKey = new ImmutableBytesWritable(sectionId);
+    SectionReaderLease lease = getSectionReader(sectionId);
+    if (lease == null) {
+      return false;
+    }
+    try (SectionReaderLease ignored = lease) {
+      SectionBloomState bloomState = getOrLoadSectionBloomState(cacheKey, lease);
+      if (bloomState == null || !bloomState.hasGeneralBloom()) {
+        return true;
+      }
+      return bloomState.passesGeneralRowColBloom(cell, lease.getReader());
+    }
+  }
+
+  @Override
+  public boolean passesGeneralRowPrefixBloomFilter(byte[] rowPrefix, int offset, int length)
+    throws IOException {
+    byte[] sectionId = extractTenantSectionId(rowPrefix, offset, length);
+    if (sectionId == null) {
+      return true;
+    }
+    ImmutableBytesWritable cacheKey = new ImmutableBytesWritable(sectionId);
+    SectionReaderLease lease = getSectionReader(sectionId);
+    if (lease == null) {
+      return false;
+    }
+    try (SectionReaderLease ignored = lease) {
+      SectionBloomState bloomState = getOrLoadSectionBloomState(cacheKey, lease);
+      if (bloomState == null) {
+        return true;
+      }
+      return bloomState.passesRowPrefixBloom(rowPrefix, offset, length, lease.getReader());
+    }
+  }
+
+  @Override
+  public boolean passesDeleteFamilyBloomFilter(byte[] row, int rowOffset, int rowLen)
+    throws IOException {
+    byte[] sectionId = extractTenantSectionId(row, rowOffset, rowLen);
+    if (sectionId == null) {
+      return true;
+    }
+    ImmutableBytesWritable cacheKey = new ImmutableBytesWritable(sectionId);
+    SectionReaderLease lease = getSectionReader(sectionId);
+    if (lease == null) {
+      return false;
+    }
+    try (SectionReaderLease ignored = lease) {
+      SectionBloomState bloomState = getOrLoadSectionBloomState(cacheKey, lease);
+      if (bloomState == null) {
+        return true;
+      }
+      if (bloomState.getDeleteFamilyCnt() == 0) {
+        return false;
+      }
+      if (!bloomState.hasDeleteFamilyBloom()) {
+        return true;
+      }
+      return bloomState.passesDeleteFamilyBloom(row, rowOffset, rowLen);
+    }
+  }
+
+  private byte[] extractTenantSectionId(byte[] row, int rowOffset, int rowLen) {
+    if (row == null) {
+      return null;
+    }
+    if (rowLen > Short.MAX_VALUE) {
+      throw new IllegalArgumentException(
+        "Row length " + rowLen + " exceeds maximum (" + Short.MAX_VALUE + ")");
+    }
+    int prefixLength = tenantExtractor.getPrefixLength();
+    if (prefixLength > 0 && rowLen < prefixLength) {
+      return null;
+    }
+    ExtendedCell lookupCell = PrivateCellUtil.createFirstOnRow(row, rowOffset, (short) rowLen);
+    return tenantExtractor.extractTenantSectionId(lookupCell);
+  }
+
+  private SectionBloomState getOrLoadSectionBloomState(ImmutableBytesWritable cacheKey,
+    SectionReaderLease lease) throws IOException {
+    try {
+      return sectionBloomCache.get(cacheKey, () -> loadSectionBloomState(cacheKey, lease));
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      throw new IOException(
+        "Failed to load bloom state for section "
+          + Bytes.toStringBinary(cacheKey.get(), cacheKey.getOffset(), cacheKey.getLength()),
+        cause);
+    }
+  }
+
+  private SectionBloomState loadSectionBloomState(ImmutableBytesWritable sectionKey,
+    SectionReaderLease lease) throws IOException {
+    HFileReaderImpl reader = lease.getReader();
+    Map<byte[], byte[]> fileInfoMap = reader.getHFileInfo();
+
+    BloomType bloomType = BloomType.NONE;
+    byte[] bloomTypeBytes = fileInfoMap.get(HStoreFile.BLOOM_FILTER_TYPE_KEY);
+    if (bloomTypeBytes != null) {
+      bloomType = BloomType.valueOf(Bytes.toString(bloomTypeBytes));
+    }
+
+    BloomFilter generalBloom = null;
+    DataInput generalMeta = reader.getGeneralBloomFilterMetadata();
+    if (generalMeta != null) {
+      generalBloom = BloomFilterFactory.createFromMeta(generalMeta, reader, null);
+    }
+
+    BloomFilter deleteBloom = null;
+    DataInput deleteMeta = reader.getDeleteBloomFilterMetadata();
+    if (deleteMeta != null) {
+      deleteBloom = BloomFilterFactory.createFromMeta(deleteMeta, reader, null);
+    }
+
+    byte[] lastBloomKey = fileInfoMap.get(HStoreFile.LAST_BLOOM_KEY);
+    KeyValue.KeyOnlyKeyValue lastBloomKeyKV = null;
+    if (lastBloomKey != null && bloomType == BloomType.ROWCOL) {
+      lastBloomKeyKV = new KeyValue.KeyOnlyKeyValue(lastBloomKey, 0, lastBloomKey.length);
+    }
+
+    int prefixLength = 0;
+    byte[] bloomParam = fileInfoMap.get(HStoreFile.BLOOM_FILTER_PARAM_KEY);
+    if (bloomParam != null) {
+      prefixLength = Bytes.toInt(bloomParam);
+    }
+
+    long deleteFamilyCnt = 0L;
+    byte[] deleteFamilyCntBytes = fileInfoMap.get(HStoreFile.DELETE_FAMILY_COUNT);
+    if (deleteFamilyCntBytes != null) {
+      deleteFamilyCnt = Bytes.toLong(deleteFamilyCntBytes);
+    }
+
+    long entries = reader.getTrailer().getEntryCount();
+
+    return new SectionBloomState(sectionKey.copyBytes(), bloomType, generalBloom, deleteBloom,
+      lastBloomKey, lastBloomKeyKV, prefixLength, deleteFamilyCnt, entries, reader.getComparator());
+  }
+
+  private SectionBloomState findSectionBloomState(boolean needGeneral, boolean needDelete)
+    throws IOException {
+    if (sectionIds == null || sectionIds.isEmpty()) {
+      return null;
+    }
+    for (ImmutableBytesWritable sectionId : sectionIds) {
+      byte[] key = sectionId.copyBytes();
+      SectionReaderLease lease = getSectionReader(key);
+      if (lease == null) {
+        continue;
+      }
+      try (SectionReaderLease ignored = lease) {
+        SectionBloomState state = getOrLoadSectionBloomState(sectionId, lease);
+        if (state == null) {
+          continue;
+        }
+        if (needGeneral && !state.hasGeneralBloom()) {
+          continue;
+        }
+        if (needDelete && !state.hasDeleteFamilyBloom()) {
+          continue;
+        }
+        return state;
+      }
+    }
+    return null;
+  }
+
+  @Override
+  public BloomType getGeneralBloomFilterType() {
+    BloomType cached = generalBloomTypeCache.get();
+    if (cached != null) {
+      return cached;
+    }
+
+    BloomType computed = BloomType.NONE;
+    try {
+      SectionBloomState state = findSectionBloomState(true, false);
+      if (state != null && state.hasGeneralBloom()) {
+        computed = state.getBloomType();
+      }
+    } catch (IOException e) {
+      LOG.debug("Failed to inspect bloom type", e);
+    }
+
+    generalBloomTypeCache.compareAndSet(null, computed);
+    BloomType result = generalBloomTypeCache.get();
+    return result != null ? result : computed;
+  }
+
+  @Override
+  public int getGeneralBloomPrefixLength() throws IOException {
+    SectionBloomState state = findSectionBloomState(true, false);
+    return state != null ? state.getPrefixLength() : 0;
+  }
+
+  @Override
+  public byte[] getLastBloomKey() throws IOException {
+    if (sectionIds == null || sectionIds.isEmpty()) {
+      return null;
+    }
+    byte[] maxKey = null;
+    for (ImmutableBytesWritable sectionId : sectionIds) {
+      byte[] key = sectionId.copyBytes();
+      SectionReaderLease lease = getSectionReader(key);
+      if (lease == null) {
+        continue;
+      }
+      try (SectionReaderLease ignored = lease) {
+        SectionBloomState state = getOrLoadSectionBloomState(sectionId, lease);
+        if (state == null || !state.hasGeneralBloom()) {
+          continue;
+        }
+        byte[] sectionLastKey = state.getLastBloomKey();
+        if (sectionLastKey != null) {
+          if (maxKey == null || Bytes.compareTo(sectionLastKey, maxKey) > 0) {
+            maxKey = sectionLastKey;
+          }
+        }
+      }
+    }
+    return maxKey;
+  }
+
+  @Override
+  public long getDeleteFamilyBloomCount() throws IOException {
+    SectionBloomState state = findSectionBloomState(false, true);
+    return state != null ? state.getDeleteFamilyCnt() : 0L;
+  }
+
+  @Override
+  public BloomFilter getGeneralBloomFilterInstance() throws IOException {
+    if (getSectionCount() != 1) {
+      return null;
+    }
+    SectionBloomState state = findSectionBloomState(true, false);
+    return state != null ? state.getGeneralBloom() : null;
+  }
+
+  @Override
+  public BloomFilter getDeleteFamilyBloomFilterInstance() throws IOException {
+    if (getSectionCount() != 1) {
+      return null;
+    }
+    SectionBloomState state = findSectionBloomState(false, true);
+    return state != null ? state.getDeleteBloom() : null;
+  }
+
+  /**
+   * Metadata for a tenant section within the HFile.
+   */
+  protected static class SectionMetadata {
+    /** The offset where the section starts */
+    private final long offset;
+    /** The size of the section in bytes */
+    private final int size;
+
+    /**
+     * Constructor for SectionMetadata.
+     * @param offset the file offset where the section starts
+     * @param size   the size of the section in bytes
+     */
+    SectionMetadata(long offset, int size) {
+      if (offset < 0) {
+        throw new IllegalArgumentException("Section offset must be non-negative, got: " + offset);
+      }
+      if (size <= 0) {
+        throw new IllegalArgumentException("Section size must be positive, got: " + size);
+      }
+      this.offset = offset;
+      this.size = size;
+    }
+
+    /**
+     * Get the offset where the section starts.
+     * @return the section offset
+     */
+    long getOffset() {
+      return offset;
+    }
+
+    /**
+     * Get the size of the section.
+     * @return the section size in bytes
+     */
+    int getSize() {
+      return size;
+    }
+  }
+
+  /**
+   * Get metadata for a tenant section.
+   * @param tenantSectionId The tenant section ID to look up
+   * @return Section metadata or null if not found
+   * @throws IOException If an error occurs during lookup
+   */
+  protected SectionMetadata getSectionMetadata(byte[] tenantSectionId) throws IOException {
+    if (tenantSectionId == null) {
+      return null;
+    }
+    return sectionLocations.get(new ImmutableBytesWritable(tenantSectionId));
+  }
+
+  /**
+   * Create a reader for a tenant section on demand.
+   * @param tenantSectionId The tenant section ID for the section
+   * @return A section reader or null if the section doesn't exist
+   * @throws IOException If an error occurs creating the reader
+   */
+  protected SectionReaderLease getSectionReader(byte[] tenantSectionId) throws IOException {
+    SectionMetadata metadata = getSectionMetadata(tenantSectionId);
+    if (metadata == null) {
+      return null;
+    }
+
+    final ImmutableBytesWritable cacheKey =
+      new ImmutableBytesWritable(tenantSectionId, 0, tenantSectionId.length);
+    final SectionMetadata sectionMetadata = metadata;
+    final int maxRetries = 3;
+    try {
+      for (int attempt = 1; attempt <= maxRetries; attempt++) {
+        SectionReaderHolder holder = sectionReaderCache.get(cacheKey, () -> {
+          byte[] sectionIdCopy = Bytes.copy(tenantSectionId);
+          SectionReader sectionReader = createSectionReader(sectionIdCopy, sectionMetadata);
+          return new SectionReaderHolder(sectionReader);
+        });
+        if (holder.retain()) {
+          return new SectionReaderLease(cacheKey, holder);
+        }
+        sectionReaderCache.invalidate(cacheKey);
+        LOG.debug("Section reader for tenant {} was closed by concurrent eviction (attempt {}/{})",
+          Bytes.toStringBinary(tenantSectionId), attempt, maxRetries);
+      }
+      throw new IOException(
+        "Failed to obtain section reader for tenant " + Bytes.toStringBinary(tenantSectionId)
+          + " after " + maxRetries + " attempts due to concurrent eviction");
+    } catch (ExecutionException e) {
+      Throwable cause = e.getCause();
+      if (cause instanceof IOException) {
+        throw (IOException) cause;
+      }
+      throw new IOException(
+        "Failed to create section reader for tenant " + Bytes.toStringBinary(tenantSectionId),
+        cause);
+    }
+  }
+
+  /**
+   * Create appropriate section reader based on type (to be implemented by subclasses).
+   * @param tenantSectionId The tenant section ID
+   * @param metadata        The section metadata
+   * @return A section reader
+   * @throws IOException If an error occurs creating the reader
+   */
+  protected abstract SectionReader createSectionReader(byte[] tenantSectionId,
+    SectionMetadata metadata) throws IOException;
+
+  /**
+   * Get a scanner for this file.
+   * @param conf         Configuration to use
+   * @param cacheBlocks  Whether to cache blocks
+   * @param pread        Whether to use positional read
+   * @param isCompaction Whether this is for a compaction
+   * @return A scanner for this file
+   */
+  @Override
+  public HFileScanner getScanner(Configuration conf, boolean cacheBlocks, boolean pread,
+    boolean isCompaction) {
+    return new MultiTenantScanner(conf, cacheBlocks, pread, isCompaction);
+  }
+
+  /**
+   * Simpler scanner method that delegates to the full method.
+   * @param conf        Configuration to use
+   * @param cacheBlocks Whether to cache blocks
+   * @param pread       Whether to use positional read
+   * @return A scanner for this file
+   */
+  @Override
+  public HFileScanner getScanner(Configuration conf, boolean cacheBlocks, boolean pread) {
+    return getScanner(conf, cacheBlocks, pread, false);
+  }
+
+  /**
+   * Abstract base class for section readers.
+   * <p>
+   * Each section reader manages access to a specific tenant section within the HFile, providing
+   * transparent delegation to standard HFile v3 readers with proper offset translation and resource
+   * management.
+   */
+  protected abstract class SectionReader {
+    /** The tenant section ID for this reader */
+    protected final byte[] tenantSectionId;
+    /** The section metadata */
+    protected final SectionMetadata metadata;
+    /** The underlying HFile reader; volatile for safe double-checked locking in subclasses */
+    protected volatile HFileReaderImpl reader;
+    /** The base offset for this section */
+    protected long sectionBaseOffset;
+
+    /**
+     * Constructor for SectionReader.
+     * @param tenantSectionId The tenant section ID
+     * @param metadata        The section metadata
+     */
+    public SectionReader(byte[] tenantSectionId, SectionMetadata metadata) {
+      this.tenantSectionId = tenantSectionId.clone(); // Make defensive copy
+      this.metadata = metadata;
+      this.sectionBaseOffset = metadata.getOffset();
+    }
+
+    /**
+     * Get or initialize the underlying reader.
+     * @return The underlying HFile reader
+     * @throws IOException If an error occurs initializing the reader
+     */
+    public abstract HFileReaderImpl getReader() throws IOException;
+
+    /**
+     * Get a scanner for this section.
+     * @param conf         Configuration to use
+     * @param cacheBlocks  Whether to cache blocks
+     * @param pread        Whether to use positional read
+     * @param isCompaction Whether this is for a compaction
+     * @return A scanner for this section
+     * @throws IOException If an error occurs creating the scanner
+     */
+    public abstract HFileScanner getScanner(Configuration conf, boolean cacheBlocks, boolean pread,
+      boolean isCompaction) throws IOException;
+
+    /**
+     * Close the section reader.
+     * @throws IOException If an error occurs closing the reader
+     */
+    public void close() throws IOException {
+      close(false);
+    }
+
+    /**
+     * Close the section reader.
+     * @param evictOnClose whether to evict blocks on close
+     * @throws IOException If an error occurs closing the reader
+     */
+    public abstract void close(boolean evictOnClose) throws IOException;
+  }
+
+  private static final class SectionBloomState {
+    private final byte[] sectionId;
+    private final BloomType bloomType;
+    private final BloomFilter generalBloom;
+    private final BloomFilter deleteBloom;
+    private final byte[] lastBloomKey;
+    private final KeyValue.KeyOnlyKeyValue lastBloomKeyOnlyKV;
+    private final int prefixLength;
+    private final long deleteFamilyCnt;
+    private final long entryCount;
+    private final CellComparator comparator;
+
+    SectionBloomState(byte[] sectionId, BloomType bloomType, BloomFilter generalBloom,
+      BloomFilter deleteBloom, byte[] lastBloomKey, KeyValue.KeyOnlyKeyValue lastBloomKeyOnlyKV,
+      int prefixLength, long deleteFamilyCnt, long entryCount, CellComparator comparator) {
+      this.sectionId = sectionId;
+      this.bloomType = bloomType == null ? BloomType.NONE : bloomType;
+      this.generalBloom = generalBloom;
+      this.deleteBloom = deleteBloom;
+      this.lastBloomKey = lastBloomKey;
+      this.lastBloomKeyOnlyKV = lastBloomKeyOnlyKV;
+      this.prefixLength = prefixLength;
+      this.deleteFamilyCnt = deleteFamilyCnt;
+      this.entryCount = entryCount;
+      this.comparator = comparator;
+    }
+
+    boolean hasGeneralBloom() {
+      return generalBloom != null && bloomType != BloomType.NONE;
+    }
+
+    BloomType getBloomType() {
+      return bloomType;
+    }
+
+    boolean hasDeleteFamilyBloom() {
+      return deleteBloom != null;
+    }
+
+    boolean passesGeneralRowBloom(byte[] row, int rowOffset, int rowLen, HFileReaderImpl reader)
+      throws IOException {
+      if (!hasGeneralBloom()) {
+        return true;
+      }
+      if (entryCount == 0) {
+        return false;
+      }
+      if (bloomType == BloomType.ROWCOL) {
+        // Without column information we cannot make a definitive call.
+        return true;
+      }
+      int keyOffset = rowOffset;
+      int keyLen = rowLen;
+      if (bloomType == BloomType.ROWPREFIX_FIXED_LENGTH) {
+        if (prefixLength <= 0 || rowLen < prefixLength) {
+          return true;
+        }
+        keyLen = prefixLength;
+      }
+      return checkGeneralBloomFilter(row, keyOffset, keyLen, null, reader);
+    }
+
+    boolean passesGeneralRowColBloom(ExtendedCell cell, HFileReaderImpl reader) throws IOException {
+      if (!hasGeneralBloom()) {
+        return true;
+      }
+      if (entryCount == 0) {
+        return false;
+      }
+      if (bloomType != BloomType.ROWCOL) {
+        // When the Bloom filter is not a ROWCOL type, fall back to row-based filtering.
+        ExtendedCell rowCell = PrivateCellUtil.createFirstOnRow(cell);
+        byte[] rowKey = rowCell.getRowArray();
+        return checkGeneralBloomFilter(rowKey, rowCell.getRowOffset(), rowCell.getRowLength(), null,
+          reader);
+      }
+      ExtendedCell kvKey = PrivateCellUtil.createFirstOnRowCol(cell);
+      return checkGeneralBloomFilter(null, 0, 0, kvKey, reader);
+    }
+
+    boolean passesRowPrefixBloom(byte[] rowPrefix, int offset, int length, HFileReaderImpl reader)
+      throws IOException {
+      if (!hasGeneralBloom()) {
+        return true;
+      }
+      if (entryCount == 0) {
+        return false;
+      }
+      return checkGeneralBloomFilter(rowPrefix, offset, length, null, reader);
+    }
+
+    boolean passesDeleteFamilyBloom(byte[] row, int rowOffset, int rowLen) {
+      if (deleteFamilyCnt == 0) {
+        return false;
+      }
+      if (deleteBloom == null) {
+        return true;
+      }
+      try {
+        return deleteBloom.contains(row, rowOffset, rowLen, null);
+      } catch (IllegalArgumentException e) {
+        LOG.error("Bad delete family bloom filter data in section {} -- proceeding without",
+          Bytes.toStringBinary(sectionId), e);
+        return true;
+      }
+    }
+
+    int getPrefixLength() {
+      return prefixLength;
+    }
+
+    byte[] getLastBloomKey() {
+      return lastBloomKey != null ? lastBloomKey.clone() : null;
+    }
+
+    long getDeleteFamilyCnt() {
+      return deleteFamilyCnt;
+    }
+
+    BloomFilter getGeneralBloom() {
+      return generalBloom;
+    }
+
+    BloomFilter getDeleteBloom() {
+      return deleteBloom;
+    }
+
+    private boolean checkGeneralBloomFilter(byte[] key, int keyOffset, int keyLen, Cell kvKey,
+      HFileReaderImpl reader) throws IOException {
+      ByteBuff bloomData = null;
+      HFileBlock bloomBlock = null;
+      try {
+        if (!generalBloom.supportsAutoLoading()) {
+          bloomBlock = reader.getMetaBlock(HFile.BLOOM_FILTER_DATA_KEY, true);
+          if (bloomBlock == null) {
+            return true;
+          }
+          bloomData = bloomBlock.getBufferWithoutHeader();
+        }
+
+        boolean keyIsAfterLast = false;
+        if (lastBloomKey != null) {
+          if (bloomType == BloomType.ROWCOL && kvKey != null && comparator != null) {
+            keyIsAfterLast = comparator.compare(kvKey, lastBloomKeyOnlyKV) > 0;
+          } else if (key != null) {
+            keyIsAfterLast =
+              Bytes.compareTo(key, keyOffset, keyLen, lastBloomKey, 0, lastBloomKey.length) > 0;
+          }
+        }
+
+        if (bloomType == BloomType.ROWCOL && kvKey != null) {
+          ExtendedCell rowBloomKey = PrivateCellUtil.createFirstOnRow(kvKey);
+          if (
+            keyIsAfterLast && comparator != null
+              && comparator.compare(rowBloomKey, lastBloomKeyOnlyKV) > 0
+          ) {
+            return false;
+          }
+          return generalBloom.contains(kvKey, bloomData, BloomType.ROWCOL)
+            || generalBloom.contains(rowBloomKey, bloomData, BloomType.ROWCOL);
+        } else {
+          if (keyIsAfterLast) {
+            return false;
+          }
+          return generalBloom.contains(key, keyOffset, keyLen, bloomData);
+        }
+      } catch (IllegalArgumentException e) {
+        LOG.error("Bad bloom filter data in section {} -- proceeding without",
+          Bytes.toStringBinary(sectionId), e);
+        return true;
+      } finally {
+        if (bloomBlock != null) {
+          bloomBlock.release();
+        }
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "SectionBloomState{" + Bytes.toStringBinary(sectionId) + ", type=" + bloomType + '}';
+    }
+  }
+
+  /**
+   * Cache entry wrapper managing lifecycle and reference counting for section readers.
+   */
+  private static final class SectionReaderHolder {
+    private final SectionReader sectionReader;
+    private final AtomicInteger refCount = new AtomicInteger(0);
+    private final AtomicBoolean evicted = new AtomicBoolean(false);
+    private final AtomicBoolean closed = new AtomicBoolean(false);
+
+    SectionReaderHolder(SectionReader sectionReader) {
+      this.sectionReader = sectionReader;
+    }
+
+    SectionReader getSectionReader() {
+      return sectionReader;
+    }
+
+    /**
+     * Increment the reference count if the holder is not already closed. Synchronized with
+     * {@link #markEvicted} to prevent a race where eviction closes this holder between
+     * {@code cache.get()} returning and the caller retaining.
+     * @return true if the retain succeeded; false if the holder was already closed
+     */
+    synchronized boolean retain() {
+      if (closed.get()) {
+        return false;
+      }
+      int refs = refCount.incrementAndGet();
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Retained section reader {} (refCount={})",
+          Bytes.toStringBinary(sectionReader.tenantSectionId), refs);
+      }
+      return true;
+    }
+
+    synchronized void release(boolean evictOnClose) {
+      int refs = refCount.decrementAndGet();
+      if (refs < 0) {
+        LOG.error("Section reader {} released too many times (refCount={}), forcing close",
+          Bytes.toStringBinary(sectionReader.tenantSectionId), refs);
+        refCount.incrementAndGet();
+        closeInternal(evictOnClose);
+        return;
+      }
+      if (refs == 0 && (evicted.get() || evictOnClose)) {
+        closeInternal(evictOnClose);
+      }
+    }
+
+    /**
+     * Mark this holder as evicted. If no references are held, close immediately. Synchronized with
+     * {@link #retain} to prevent a TOCTOU race on refCount.
+     */
+    synchronized void markEvicted(boolean evictOnClose) {
+      evicted.set(true);
+      if (refCount.get() == 0) {
+        closeInternal(evictOnClose);
+      }
+    }
+
+    synchronized void forceClose(boolean evictOnClose) {
+      evicted.set(true);
+      closeInternal(evictOnClose);
+    }
+
+    private void closeInternal(boolean evictOnClose) {
+      if (closed.compareAndSet(false, true)) {
+        try {
+          sectionReader.close(evictOnClose);
+        } catch (IOException e) {
+          LOG.warn("Failed to close section reader {}",
+            Bytes.toStringBinary(sectionReader.tenantSectionId), e);
+        }
+      }
+    }
+
+    @Override
+    public String toString() {
+      return "SectionReaderHolder{" + "tenant="
+        + Bytes.toStringBinary(sectionReader.tenantSectionId) + ", refCount=" + refCount.get()
+        + ", evicted=" + evicted.get() + ", closed=" + closed.get() + '}';
+    }
+  }
+
+  /**
+   * Lease handle giving callers access to a cached section reader while ensuring proper release.
+   */
+  protected static final class SectionReaderLease implements AutoCloseable {
+    private final ImmutableBytesWritable cacheKey;
+    private final SectionReaderHolder holder;
+    private final SectionReader sectionReader;
+    private boolean closed;
+
+    SectionReaderLease(ImmutableBytesWritable cacheKey, SectionReaderHolder holder) {
+      this.cacheKey = cacheKey;
+      this.holder = holder;
+      this.sectionReader = holder.getSectionReader();
+    }
+
+    public SectionReader getSectionReader() {
+      return sectionReader;
+    }
+
+    public HFileReaderImpl getReader() throws IOException {
+      return sectionReader.getReader();
+    }
+
+    @Override
+    public void close() {
+      release(false);
+    }
+
+    public void close(boolean evictOnClose) {
+      release(evictOnClose);
+    }
+
+    private void release(boolean evictOnClose) {
+      if (closed) {
+        return;
+      }
+      closed = true;
+      holder.release(evictOnClose);
+      if (LOG.isTraceEnabled()) {
+        LOG.trace("Released lease for tenant {} (cacheKey={})",
+          Bytes.toStringBinary(sectionReader.tenantSectionId), cacheKey);
+      }
+    }
+  }
+
+  /**
+   * Scanner implementation for multi-tenant HFiles.
+   * <p>
+   * This scanner provides transparent access across multiple tenant sections by:
+   * <ul>
+   * <li>Extracting tenant information from seek keys</li>
+   * <li>Routing operations to the appropriate section reader</li>
+   * <li>Managing section transitions during sequential scans</li>
+   * <li>Optimizing performance through section prefetching</li>
+   * </ul>
+   */
+  protected class MultiTenantScanner implements HFileScanner {
+    /** Configuration to use */
+    protected final Configuration conf;
+    /** Whether to cache blocks */
+    protected final boolean cacheBlocks;
+    /** Whether to use positional read */
+    protected final boolean pread;
+    /** Whether this is for a compaction */
+    protected final boolean isCompaction;
+
+    /** Current tenant section ID */
+    protected byte[] currentTenantSectionId;
+    /** Index of the current section in sectionIds for O(1) next-section lookup */
+    protected int currentSectionIndex = -1;
+    /** Current scanner instance */
+    protected HFileScanner currentScanner;
+    /** Current section reader lease */
+    protected SectionReaderLease currentSectionLease;
+    /** Current section reader */
+    protected SectionReader currentSectionReader;
+    /** Whether we have successfully seeked */
+    protected boolean seeked = false;
+
+    /**
+     * Constructor for MultiTenantScanner.
+     * @param conf         Configuration to use
+     * @param cacheBlocks  Whether to cache blocks
+     * @param pread        Whether to use positional read
+     * @param isCompaction Whether this is for a compaction
+     */
+    public MultiTenantScanner(Configuration conf, boolean cacheBlocks, boolean pread,
+      boolean isCompaction) {
+      this.conf = conf;
+      this.cacheBlocks = cacheBlocks;
+      this.pread = pread;
+      this.isCompaction = isCompaction;
+    }
+
+    /**
+     * Switch to a new section reader, properly managing resource cleanup.
+     * @param newReader The new section reader to switch to
+     * @param sectionId The section ID for the new reader
+     * @throws IOException If an error occurs during the switch
+     */
+    private void switchToSectionReader(SectionReaderLease newLease, byte[] sectionId)
+      throws IOException {
+      if (currentScanner != null) {
+        currentScanner.close();
+        currentScanner = null;
+      }
+      if (currentSectionLease != null) {
+        currentSectionLease.close();
+        currentSectionLease = null;
+      }
+
+      currentSectionReader = null;
+      currentTenantSectionId = null;
+      currentSectionIndex = -1;
+
+      if (newLease != null) {
+        currentSectionLease = newLease;
+        currentSectionReader = newLease.getSectionReader();
+        currentTenantSectionId = sectionId;
+        currentSectionIndex = resolveCurrentSectionIndex(sectionId);
+        try {
+          currentScanner = currentSectionReader.getScanner(conf, cacheBlocks, pread, isCompaction);
+        } catch (IOException | RuntimeException e) {
+          currentSectionLease.close();
+          currentSectionLease = null;
+          currentSectionReader = null;
+          currentTenantSectionId = null;
+          currentSectionIndex = -1;
+          throw e;
+        }
+      }
+    }
+
+    @Override
+    public boolean isSeeked() {
+      return seeked && currentScanner != null && currentScanner.isSeeked();
+    }
+
+    @Override
+    public boolean seekTo() throws IOException {
+      // Get the first section from the section index
+      if (!sectionIds.isEmpty()) {
+        // Get the first section ID from the list
+        byte[] firstSectionId = sectionIds.get(0).get();
+
+        if (switchToSection(firstSectionId)) {
+          boolean result = currentScanner.seekTo();
+          seeked = result;
+          return result;
+        } else {
+          LOG.debug("No section reader available for first section {}",
+            Bytes.toStringBinary(firstSectionId));
+        }
+      }
+
+      // If we reach here, no sections were found or seeking failed
+      seeked = false;
+      return false;
+    }
+
+    private boolean switchToSection(byte[] sectionId) throws IOException {
+      if (
+        currentTenantSectionId != null && currentScanner != null && currentSectionLease != null
+          && Bytes.equals(currentTenantSectionId, sectionId)
+      ) {
+        return true;
+      }
+      SectionReaderLease lease = getSectionReader(sectionId);
+      if (lease == null) {
+        return false;
+      }
+      switchToSectionReader(lease, sectionId);
+      return true;
+    }
+
+    @Override
+    public int seekTo(ExtendedCell key) throws IOException {
+      // Handle empty or null keys by falling back to seekTo() without parameters
+      if (key == null || key.getRowLength() == 0) {
+        if (seekTo()) {
+          return 0; // Successfully seeked to first position
+        } else {
+          return -1; // No data found
+        }
+      }
+
+      // Extract tenant section ID for the target key
+      byte[] targetSectionId = tenantExtractor.extractTenantSectionId(key);
+
+      // Find insertion point for the target section in the sorted sectionIds list
+      int n = sectionIds.size();
+      int insertionIndex = n; // default: after last
+      boolean exactSectionMatch = false;
+      for (int i = 0; i < n; i++) {
+        byte[] sid = sectionIds.get(i).get();
+        int cmp = Bytes.compareTo(sid, targetSectionId);
+        if (cmp == 0) {
+          insertionIndex = i;
+          exactSectionMatch = true;
+          break;
+        }
+        if (cmp > 0) {
+          insertionIndex = i;
+          break;
+        }
+      }
+
+      // If there is no exact section for this tenant prefix
+      if (!exactSectionMatch) {
+        if (insertionIndex == 0) {
+          // Key sorts before first section => before first key of entire file
+          seeked = false;
+          return -1;
+        }
+        return positionToPreviousSection(insertionIndex - 1);
+      }
+
+      // Exact section exists. Seek within that section first.
+      byte[] matchedSectionId = sectionIds.get(insertionIndex).get();
+      if (!switchToSection(matchedSectionId)) {
+        if (insertionIndex == 0) {
+          seeked = false;
+          return -1;
+        }
+        return positionToPreviousSection(insertionIndex - 1);
+      }
+
+      int result = currentScanner.seekTo(key);
+      if (result == -1) {
+        // Key sorts before first key in this section. If this is the first section overall,
+        // then the key is before the first key in the entire file.
+        if (insertionIndex == 0) {
+          seeked = false;
+          return -1;
+        }
+        return positionToPreviousSection(insertionIndex - 1);
+      }
+      seeked = true;
+      return result;
+    }
+
+    private int positionToPreviousSection(int startIndex) throws IOException {
+      for (int i = startIndex; i >= 0; i--) {
+        byte[] prevSectionId = sectionIds.get(i).get();
+        if (!switchToSection(prevSectionId)) {
+          continue;
+        }
+        try {
+          Optional<ExtendedCell> lastKeyOpt = currentSectionReader.getReader().getLastKey();
+          if (lastKeyOpt.isPresent()) {
+            currentScanner.seekTo(lastKeyOpt.get());
+            seeked = true;
+            return 1;
+          }
+        } catch (IOException e) {
+          LOG.warn("Failed to retrieve last key from section {}",
+            Bytes.toStringBinary(prevSectionId), e);
+        }
+      }
+      seeked = false;
+      return -1;
+    }
+
+    @Override
+    public int reseekTo(ExtendedCell key) throws IOException {
+      if (!isSeeked()) {
+        return seekTo(key);
+      }
+
+      // Extract tenant section ID
+      byte[] tenantSectionId = tenantExtractor.extractTenantSectionId(key);
+
+      // If tenant section changed, check direction before seeking
+      if (!Bytes.equals(tenantSectionId, currentTenantSectionId)) {
+        if (Bytes.compareTo(tenantSectionId, currentTenantSectionId) < 0) {
+          return 1;
+        }
+        return seekTo(key);
+      }
+
+      // Reuse existing scanner for same tenant section
+      int result = currentScanner.reseekTo(key);
+      if (result == -1) {
+        seeked = false;
+      }
+      return result;
+    }
+
+    @Override
+    public boolean seekBefore(ExtendedCell key) throws IOException {
+      byte[] targetSectionId = tenantExtractor.extractTenantSectionId(key);
+
+      // Find the section index for this tenant (same lookup as seekTo)
+      int n = sectionIds.size();
+      int insertionIndex = n;
+      boolean exactSectionMatch = false;
+      for (int i = 0; i < n; i++) {
+        byte[] sid = sectionIds.get(i).get();
+        int cmp = Bytes.compareTo(sid, targetSectionId);
+        if (cmp == 0) {
+          insertionIndex = i;
+          exactSectionMatch = true;
+          break;
+        }
+        if (cmp > 0) {
+          insertionIndex = i;
+          break;
+        }
+      }
+
+      // No exact section match — fall back to last key of the preceding section
+      if (!exactSectionMatch) {
+        if (insertionIndex == 0) {
+          seeked = false;
+          return false;
+        }
+        return seekBeforePreviousSection(insertionIndex - 1);
+      }
+
+      // Exact section found — try seekBefore within it
+      byte[] matchedSectionId = sectionIds.get(insertionIndex).get();
+      if (!switchToSection(matchedSectionId)) {
+        if (insertionIndex == 0) {
+          seeked = false;
+          return false;
+        }
+        return seekBeforePreviousSection(insertionIndex - 1);
+      }
+
+      boolean result = currentScanner.seekBefore(key);
+      if (result) {
+        seeked = true;
+        return true;
+      }
+
+      // Key is at or before first key of this section — fall back to previous section
+      if (insertionIndex == 0) {
+        seeked = false;
+        return false;
+      }
+      return seekBeforePreviousSection(insertionIndex - 1);
+    }
+
+    /**
+     * Positions the scanner at the last key of the section at startIndex (or an earlier section if
+     * that one is unavailable). Mirrors {@link #positionToPreviousSection} but returns boolean.
+     */
+    private boolean seekBeforePreviousSection(int startIndex) throws IOException {
+      int result = positionToPreviousSection(startIndex);
+      return result != -1;
+    }
+
+    @Override
+    public ExtendedCell getCell() {
+      if (!isSeeked()) {
+        return null;
+      }
+      return currentScanner.getCell();
+    }
+
+    @Override
+    public ExtendedCell getKey() {
+      assertSeeked();
+      return currentScanner.getKey();
+    }
+
+    @Override
+    public java.nio.ByteBuffer getValue() {
+      assertSeeked();
+      return currentScanner.getValue();
+    }
+
+    @Override
+    public boolean next() throws IOException {
+      assertSeeked();
+
+      boolean hasNext = currentScanner.next();
+      if (!hasNext) {
+        // Try subsequent sections until we find one with data or exhaust all sections
+        while (true) {
+          byte[] nextTenantSectionId = findNextTenantSectionId(currentTenantSectionId);
+          if (nextTenantSectionId == null) {
+            seeked = false;
+            return false;
+          }
+
+          if (!switchToSection(nextTenantSectionId)) {
+            // Section unavailable; advance currentSectionIndex so we skip past it
+            currentTenantSectionId = nextTenantSectionId;
+            currentSectionIndex = resolveCurrentSectionIndex(nextTenantSectionId);
+            continue;
+          }
+
+          if (prefetchEnabled) {
+            prefetchNextSection(nextTenantSectionId);
+          }
+
+          boolean result = currentScanner.seekTo();
+          if (result) {
+            seeked = true;
+            return true;
+          }
+          // Empty section — continue to next
+        }
+      }
+
+      return true;
+    }
+
+    /**
+     * Prefetch the next section after the given one for sequential access optimization.
+     * @param currentSectionId The current section ID
+     */
+    private void prefetchNextSection(byte[] currentSectionId) {
+      try {
+        byte[] nextSectionId = findNextTenantSectionId(currentSectionId);
+        if (nextSectionId != null) {
+          // Trigger async load by creating the reader
+          SectionReaderLease lease = getSectionReader(nextSectionId);
+          if (lease != null) {
+            lease.close();
+          }
+        }
+      } catch (Exception e) {
+        // Prefetch is best-effort, don't fail the operation
+        LOG.debug("Failed to prefetch next section", e);
+      }
+    }
+
+    private int resolveCurrentSectionIndex(byte[] sectionId) {
+      for (int i = 0; i < sectionIds.size(); i++) {
+        if (Bytes.equals(sectionIds.get(i).get(), sectionId)) {
+          return i;
+        }
+      }
+      return -1;
+    }
+
+    /**
+     * Find the next tenant section ID after the current one.
+     * @param currentSectionId The current section ID (unused, kept for call-site clarity)
+     * @return The next section ID, or null if this is the last section
+     */
+    private byte[] findNextTenantSectionId(byte[] currentSectionId) {
+      int nextIndex = currentSectionIndex + 1;
+      if (nextIndex >= 0 && nextIndex < sectionIds.size()) {
+        return sectionIds.get(nextIndex).get();
+      }
+      return null;
+    }
+
+    /**
+     * Assert that we have successfully seeked.
+     * @throws NotSeekedException if not seeked
+     */
+    private void assertSeeked() {
+      if (!isSeeked()) {
+        throw new NotSeekedException(getPath());
+      }
+    }
+
+    @Override
+    public ExtendedCell getNextIndexedKey() {
+      if (!isSeeked()) {
+        return null;
+      }
+      return currentScanner.getNextIndexedKey();
+    }
+
+    @Override
+    public void close() {
+      try {
+        if (currentScanner != null) {
+          currentScanner.close();
+          currentScanner = null;
+        }
+      } finally {
+        if (currentSectionLease != null) {
+          currentSectionLease.close();
+          currentSectionLease = null;
+        }
+      }
+      currentSectionReader = null;
+      currentTenantSectionId = null;
+      seeked = false;
+    }
+
+    @Override
+    public void shipped() throws IOException {
+      if (currentScanner != null) {
+        currentScanner.shipped();
+      }
+    }
+
+    @Override
+    public void recordBlockSize(java.util.function.IntConsumer blockSizeConsumer) {
+      if (currentScanner != null) {
+        currentScanner.recordBlockSize(blockSizeConsumer);
+      }
+    }
+
+    @Override
+    public HFile.Reader getReader() {
+      return AbstractMultiTenantReader.this;
+    }
+
+    @Override
+    public String getKeyString() {
+      return currentScanner != null ? currentScanner.getKeyString() : "";
+    }
+
+    @Override
+    public String getValueString() {
+      return currentScanner != null ? currentScanner.getValueString() : "";
+    }
+  }
+
+  /**
+   * Close all section readers and release resources.
+   * @throws IOException If an error occurs during close
+   */
+  @Override
+  public void close() throws IOException {
+    close(cacheConf.shouldEvictOnClose());
+  }
+
+  /**
+   * Close underlying resources, with optional block eviction.
+   * @param evictOnClose Whether to evict blocks on close
+   * @throws IOException If an error occurs during close
+   */
+  private final AtomicBoolean readerClosed = new AtomicBoolean(false);
+
+  @Override
+  public void close(boolean evictOnClose) throws IOException {
+    if (!readerClosed.compareAndSet(false, true)) {
+      return;
+    }
+
+    try {
+      sectionReaderCache.asMap().forEach((key, holder) -> {
+        if (holder != null) {
+          holder.forceClose(evictOnClose);
+        }
+      });
+      sectionReaderCache.invalidateAll();
+      sectionReaderCache.cleanUp();
+      sectionBloomCache.invalidateAll();
+      sectionBloomCache.cleanUp();
+    } finally {
+      try {
+        if (fileInfo != null) {
+          fileInfo.close();
+        }
+      } finally {
+        try {
+          if (fsBlockReader != null) {
+            fsBlockReader.closeStreams();
+          }
+        } finally {
+          context.getInputStreamWrapper().unbuffer();
+        }
+      }
+    }
+  }
+
+  /**
+   * Get HFile version.
+   * @return The major version number
+   */
+  @Override
+  public int getMajorVersion() {
+    return HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT;
+  }
+
+  /**
+   * Build a section context with the appropriate offset translation wrapper.
+   * <p>
+   * Creates a specialized reader context for a tenant section that handles:
+   * <ul>
+   * <li>Offset translation from section-relative to file-absolute positions</li>
+   * <li>Proper trailer positioning for HFile v3 section format</li>
+   * <li>Block boundary validation and alignment</li>
+   * <li>File size calculation for section boundaries</li>
+   * </ul>
+   * @param metadata   The section metadata containing offset and size
+   * @param readerType The type of reader (PREAD or STREAM)
+   * @return A reader context for the section, or null if section is invalid
+   * @throws IOException If an error occurs building the context
+   */
+  protected ReaderContext buildSectionContext(SectionMetadata metadata,
+    ReaderContext.ReaderType readerType) throws IOException {
+    int sectionSize = metadata.getSize();
+    int trailerSize = FixedFileTrailer.getTrailerSize(3); // HFile v3 sections use v3 format
+
+    if (sectionSize < trailerSize) {
+      LOG.warn("Section size {} for offset {} is smaller than minimum trailer size {}", sectionSize,
+        metadata.getOffset(), trailerSize);
+      return null;
+    }
+
+    // For STREAM readers, open a dedicated file handle per section so that concurrent
+    // seek+read sequences from different sections don't interleave on a shared stream.
+    // PREAD readers use positioned reads which are thread-safe on a shared handle.
+    FSDataInputStreamWrapper streamWrapper;
+    boolean ownsStream;
+    if (readerType == ReaderContext.ReaderType.STREAM) {
+      // Use the resolved data file path, not context.getFilePath() which may be a reference path
+      Path dataFilePath = context.getInputStreamWrapper().getReaderPath();
+      streamWrapper = new FSDataInputStreamWrapper(context.getFileSystem(), dataFilePath);
+      ownsStream = true;
+    } else {
+      streamWrapper = context.getInputStreamWrapper();
+      ownsStream = false;
+    }
+
+    MultiTenantFSDataInputStreamWrapper sectionWrapper = new MultiTenantFSDataInputStreamWrapper(
+      streamWrapper, metadata.getOffset(), sectionSize, ownsStream);
+
+    // Build the reader context with proper file size calculation
+    // Use section size; wrapper handles offset translation
+    ReaderContext sectionContext =
+      ReaderContextBuilder.newBuilder(context).withInputStreamWrapper(sectionWrapper)
+        .withFilePath(context.getFilePath()).withReaderType(readerType)
+        .withFileSystem(context.getFileSystem()).withFileSize(sectionSize).build();
+
+    LOG.debug("Created section reader context for offset {}, size {}, readerType={}",
+      metadata.getOffset(), sectionSize, readerType);
+    return sectionContext;
+  }
+
+  /**
+   * Get all tenant section IDs present in the file.
+   * <p>
+   * Returns a defensive copy of all section IDs for external iteration without exposing internal
+   * data structures.
+   * @return An array of all tenant section IDs
+   */
+  public byte[][] getAllTenantSectionIds() {
+    byte[][] allIds = new byte[sectionLocations.size()][];
+    int i = 0;
+    for (ImmutableBytesWritable key : sectionLocations.keySet()) {
+      allIds[i++] = key.copyBytes();
+    }
+    return allIds;
+  }
+
+  /**
+   * For multi-tenant HFiles, get the first key from the first available section. This overrides the
+   * HFileReaderImpl implementation that requires dataBlockIndexReader.
+   * @return The first key if available
+   */
+  @Override
+  public Optional<ExtendedCell> getFirstKey() {
+    try {
+      // Get the first section and try to read its first key
+      for (ImmutableBytesWritable sectionKey : sectionLocations.keySet()) {
+        byte[] sectionId = sectionKey.get();
+        SectionReaderLease lease = getSectionReader(sectionId);
+        if (lease == null) {
+          continue;
+        }
+        try (SectionReaderLease ignored = lease) {
+          HFileReaderImpl reader = lease.getReader();
+          Optional<ExtendedCell> firstKey = reader.getFirstKey();
+          if (firstKey.isPresent()) {
+            return firstKey;
+          }
+        } catch (IOException e) {
+          LOG.warn("Failed to get first key from section {}, trying next section",
+            Bytes.toString(sectionId), e);
+          // Continue to next section
+        }
+      }
+
+      return Optional.empty();
+    } catch (IOException e) {
+      LOG.error("Failed to get first key from multi-tenant HFile {}", getPath(), e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * For multi-tenant HFiles, get the last key from the last available section. This overrides the
+   * HFileReaderImpl implementation that requires dataBlockIndexReader.
+   * @return The last key if available
+   */
+  @Override
+  public Optional<ExtendedCell> getLastKey() {
+    try {
+      // Get the last section and try to read its last key
+      // Since LinkedHashMap maintains insertion order, iterate in reverse to get the last section
+      // first
+      List<ImmutableBytesWritable> sectionKeys = new ArrayList<>(sectionLocations.keySet());
+      for (int i = sectionKeys.size() - 1; i >= 0; i--) {
+        byte[] sectionId = sectionKeys.get(i).get();
+        SectionReaderLease lease = getSectionReader(sectionId);
+        if (lease == null) {
+          continue;
+        }
+        try (SectionReaderLease ignored = lease) {
+          HFileReaderImpl reader = lease.getReader();
+          Optional<ExtendedCell> lastKey = reader.getLastKey();
+          if (lastKey.isPresent()) {
+            return lastKey;
+          }
+        } catch (IOException e) {
+          LOG.warn("Failed to get last key from section {}, trying previous section",
+            Bytes.toString(sectionId), e);
+          // Continue to previous section
+        }
+      }
+
+      return Optional.empty();
+    } catch (IOException e) {
+      LOG.error("Failed to get last key from multi-tenant HFile {}", getPath(), e);
+      return Optional.empty();
+    }
+  }
+
+  /**
+   * For HFile v4 multi-tenant files, meta blocks don't exist at the file level. They exist within
+   * individual sections. This method is not supported.
+   * @param metaBlockName the name of the meta block to retrieve
+   * @param cacheBlock    whether to cache the block
+   * @return always null for multi-tenant HFiles
+   * @throws IOException if an error occurs
+   */
+  @Override
+  public HFileBlock getMetaBlock(String metaBlockName, boolean cacheBlock) throws IOException {
+    byte[] cachedSectionId = null;
+    if (metaBlockCacheEnabled && metaBlockSectionCache != null) {
+      ImmutableBytesWritable cached = metaBlockSectionCache.getIfPresent(metaBlockName);
+      if (cached != null) {
+        cachedSectionId = copySectionId(cached);
+      }
+    }
+
+    if (cachedSectionId != null) {
+      HFileBlock cachedBlock = loadMetaBlockFromSection(cachedSectionId, metaBlockName, cacheBlock);
+      if (cachedBlock != null) {
+        return cachedBlock;
+      }
+      if (metaBlockCacheEnabled && metaBlockSectionCache != null) {
+        metaBlockSectionCache.invalidate(metaBlockName);
+      }
+    }
+
+    if (sectionIds == null || sectionIds.isEmpty()) {
+      return null;
+    }
+
+    for (ImmutableBytesWritable sectionId : sectionIds) {
+      byte[] candidateSectionId = copySectionId(sectionId);
+      if (cachedSectionId != null && Bytes.equals(candidateSectionId, cachedSectionId)) {
+        continue;
+      }
+      HFileBlock sectionBlock =
+        loadMetaBlockFromSection(candidateSectionId, metaBlockName, cacheBlock);
+      if (sectionBlock != null) {
+        if (metaBlockCacheEnabled && metaBlockSectionCache != null) {
+          metaBlockSectionCache.put(metaBlockName, new ImmutableBytesWritable(candidateSectionId));
+        }
+        return sectionBlock;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * For HFile v4 multi-tenant files, bloom filter metadata doesn't exist at the file level. It
+   * exists within individual sections. This method is not supported.
+   * @return always null for multi-tenant HFiles
+   * @throws IOException if an error occurs
+   */
+  @Override
+  public DataInput getGeneralBloomFilterMetadata() throws IOException {
+    // HFile v4 multi-tenant files don't have file-level bloom filters
+    // Bloom filters exist within individual sections
+    LOG.debug(
+      "General bloom filter metadata not supported at file level for HFile v4 multi-tenant files");
+    return null;
+  }
+
+  /**
+   * For HFile v4 multi-tenant files, delete bloom filter metadata doesn't exist at the file level.
+   * It exists within individual sections. This method is not supported.
+   * @return always null for multi-tenant HFiles
+   * @throws IOException if an error occurs
+   */
+  @Override
+  public DataInput getDeleteBloomFilterMetadata() throws IOException {
+    // HFile v4 multi-tenant files don't have file-level delete bloom filters
+    // Delete bloom filters exist within individual sections
+    LOG.debug(
+      "Delete bloom filter metadata not supported at file level for HFile v4 multi-tenant files");
+    return null;
+  }
+
+  private HFileBlockIndex.CellBasedKeyBlockIndexReader
+    loadDataBlockIndexFromSection(byte[] sectionId) {
+    SectionReaderLease lease;
+    try {
+      lease = getSectionReader(sectionId);
+    } catch (IOException e) {
+      LOG.debug("Failed to get section reader for section {}", Bytes.toStringBinary(sectionId), e);
+      return null;
+    }
+    if (lease == null) {
+      return null;
+    }
+    try (SectionReaderLease ignored = lease) {
+      HFileReaderImpl reader = lease.getReader();
+      HFileBlockIndex.CellBasedKeyBlockIndexReader delegate = reader.getDataBlockIndexReader();
+      if (delegate != null) {
+        cachedDataBlockIndexReader.set(delegate);
+        return delegate;
+      }
+    } catch (IOException e) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Failed to load data block index from section {}",
+          Bytes.toStringBinary(sectionId), e);
+      } else {
+        LOG.warn("Failed to load data block index from section", e);
+      }
+    }
+    return null;
+  }
+
+  private HFileBlock loadMetaBlockFromSection(byte[] sectionId, String metaBlockName,
+    boolean cacheBlock) throws IOException {
+    SectionReaderLease lease = getSectionReader(sectionId);
+    if (lease == null) {
+      return null;
+    }
+    try (SectionReaderLease ignored = lease) {
+      HFileReaderImpl reader = lease.getReader();
+      return reader.getMetaBlock(metaBlockName, cacheBlock);
+    }
+  }
+
+  private byte[] copySectionId(ImmutableBytesWritable sectionId) {
+    return Bytes.copy(sectionId.get(), sectionId.getOffset(), sectionId.getLength());
+  }
+
+  /**
+   * For HFile v4 multi-tenant files, index size is just the section index size.
+   * @return the heap size of the section index
+   */
+  @Override
+  public long indexSize() {
+    if (sectionIndexReader != null) {
+      int numSections = sectionIndexReader.getNumSections();
+      // Estimate: each section entry is approximately 64 bytes (prefix + offset + size)
+      return numSections * 64L;
+    }
+    return 0;
+  }
+
+  /**
+   * Find a key at approximately the given position within a section.
+   * @param reader         The section reader
+   * @param targetProgress The target position as a percentage (0.0 to 1.0) within the section
+   * @return A key near the target position, or empty if not found
+   */
+
+  /**
+   * Override mid-key calculation to find the middle key that respects tenant boundaries. For single
+   * tenant files, returns the midkey from the section. For multi-tenant files, finds the optimal
+   * tenant boundary that best balances the split.
+   * @return the middle key of the file
+   * @throws IOException if an error occurs
+   */
+  @Override
+  public Optional<ExtendedCell> midKey() throws IOException {
+    // Handle empty file case
+    if (sectionLocations.isEmpty()) {
+      LOG.debug("No sections in file, returning empty midkey");
+      return Optional.empty();
+    }
+
+    // If there's only one section (single tenant), use that section's midkey
+    if (sectionLocations.size() == 1) {
+      byte[] sectionId = sectionLocations.keySet().iterator().next().get();
+      try (SectionReaderLease lease = getSectionReader(sectionId)) {
+        if (lease == null) {
+          throw new IOException("Unable to create section reader for single tenant section: "
+            + Bytes.toStringBinary(sectionId));
+        }
+
+        HFileReaderImpl reader = lease.getReader();
+        Optional<ExtendedCell> midKey = reader.midKey();
+        LOG.debug("Single tenant midkey: {}", midKey.orElse(null));
+        return midKey;
+      }
+    }
+
+    // For multiple tenants, find the optimal tenant boundary for splitting
+    // This ensures we never split within a tenant's data range
+    return findOptimalTenantBoundaryForSplit();
+  }
+
+  /**
+   * Find the optimal tenant boundary that best balances the region split. This method ensures that
+   * splits always occur at tenant boundaries, preserving tenant isolation and maintaining proper
+   * key ordering.
+   * @return the optimal boundary key for splitting
+   * @throws IOException if an error occurs
+   */
+  private Optional<ExtendedCell> findOptimalTenantBoundaryForSplit() throws IOException {
+    // Calculate total data volume and ideal split point
+    long totalFileSize = 0;
+    List<TenantSectionInfo> tenantSections = new ArrayList<>();
+
+    for (Map.Entry<ImmutableBytesWritable, SectionMetadata> entry : sectionLocations.entrySet()) {
+      SectionMetadata metadata = entry.getValue();
+      totalFileSize += metadata.getSize();
+
+      // cumulative size up to this point
+      tenantSections
+        .add(new TenantSectionInfo(entry.getKey().get(), metadata.getSize(), totalFileSize));
+    }
+
+    if (totalFileSize == 0) {
+      LOG.debug("No data in file, returning empty midkey");
+      return Optional.empty();
+    }
+
+    long idealSplitSize = totalFileSize / 2;
+
+    // Find the tenant boundary that best approximates the ideal split
+    TenantSectionInfo bestBoundary = findBestTenantBoundary(tenantSections, idealSplitSize);
+
+    if (bestBoundary == null) {
+      // Fallback: use the middle tenant if we can't find an optimal boundary
+      int middleTenantIndex = tenantSections.size() / 2;
+      bestBoundary = tenantSections.get(middleTenantIndex);
+      LOG.debug("Using middle tenant as fallback boundary: {}",
+        Bytes.toStringBinary(bestBoundary.tenantSectionId));
+    }
+
+    // Get the first key of the selected tenant section as the split point
+    // This ensures the split happens exactly at the tenant boundary
+    try (SectionReaderLease lease = getSectionReader(bestBoundary.tenantSectionId)) {
+      if (lease == null) {
+        throw new IOException("Unable to create section reader for boundary tenant: "
+          + Bytes.toStringBinary(bestBoundary.tenantSectionId));
+      }
+
+      HFileReaderImpl reader = lease.getReader();
+      Optional<ExtendedCell> firstKey = reader.getFirstKey();
+
+      if (firstKey.isPresent()) {
+        LOG.info("Selected tenant boundary midkey: {} (tenant: {}, split balance: {}/{})",
+          firstKey.get(), Bytes.toStringBinary(bestBoundary.tenantSectionId),
+          bestBoundary.cumulativeSize - bestBoundary.sectionSize, totalFileSize);
+        return firstKey;
+      }
+
+      // If we can't get the first key, try the section's lastkey as fallback
+      Optional<ExtendedCell> sectionLastKey = reader.getLastKey();
+      if (sectionLastKey.isPresent()) {
+        LOG.warn(
+          "Using section last key as fallback (tenant boundary not available): {} (tenant: {})",
+          sectionLastKey.get(), Bytes.toStringBinary(bestBoundary.tenantSectionId));
+        return sectionLastKey;
+      }
+
+      throw new IOException("Unable to get any key from selected boundary tenant: "
+        + Bytes.toStringBinary(bestBoundary.tenantSectionId));
+    }
+  }
+
+  /**
+   * Find the tenant boundary that provides the most balanced split. This uses a heuristic to find
+   * the boundary that gets closest to a 50/50 split while maintaining tenant isolation.
+   * @param tenantSections List of tenant sections with cumulative sizes
+   * @param idealSplitSize The ideal size for the first region after split
+   * @return The best tenant boundary, or null if none suitable
+   */
+  private TenantSectionInfo findBestTenantBoundary(List<TenantSectionInfo> tenantSections,
+    long idealSplitSize) {
+    TenantSectionInfo bestBoundary = null;
+    long bestDeviation = Long.MAX_VALUE;
+
+    // Evaluate each potential tenant boundary
+    for (int i = 1; i < tenantSections.size(); i++) { // Start from 1 to exclude first tenant
+      TenantSectionInfo boundary = tenantSections.get(i);
+
+      // Calculate how balanced this split would be
+      long leftSideSize = boundary.cumulativeSize - boundary.sectionSize; // Size before this tenant
+      long deviation = Math.abs(leftSideSize - idealSplitSize);
+
+      // Prefer boundaries that create more balanced splits
+      if (deviation < bestDeviation) {
+        bestDeviation = deviation;
+        bestBoundary = boundary;
+      }
+
+      LOG.debug("Evaluating tenant boundary: {} (left: {}, deviation: {})",
+        Bytes.toStringBinary(boundary.tenantSectionId), leftSideSize, deviation);
+    }
+
+    // Only use a boundary if it's reasonably balanced (within 30% of ideal)
+    if (bestBoundary != null) {
+      long leftSideSize = bestBoundary.cumulativeSize - bestBoundary.sectionSize;
+      double balanceRatio = Math.abs((double) leftSideSize / idealSplitSize - 1.0);
+
+      if (balanceRatio > 0.3) { // More than 30% deviation
+        LOG.warn("Best tenant boundary has poor balance ratio: {}% (tenant: {})",
+          String.format("%.1f", balanceRatio * 100),
+          Bytes.toStringBinary(bestBoundary.tenantSectionId));
+        // Still return it - tenant boundary is more important than perfect balance
+      }
+    }
+
+    return bestBoundary;
+  }
+
+  /**
+   * Helper class to track tenant section information for split analysis.
+   */
+  private static class TenantSectionInfo {
+    final byte[] tenantSectionId;
+    final long sectionSize;
+    final long cumulativeSize;
+
+    TenantSectionInfo(byte[] tenantSectionId, long sectionSize, long cumulativeSize) {
+      this.tenantSectionId = tenantSectionId;
+      this.sectionSize = sectionSize;
+      this.cumulativeSize = cumulativeSize;
+    }
+  }
+
+  /**
+   * Override block reading to support tenant-aware block access. Routes block reads to the
+   * appropriate section based on offset.
+   * @param dataBlockOffset           the offset of the block to read
+   * @param onDiskBlockSize           the on-disk size of the block
+   * @param cacheBlock                whether to cache the block
+   * @param pread                     whether to use positional read
+   * @param isCompaction              whether this is for a compaction
+   * @param updateCacheMetrics        whether to update cache metrics
+   * @param expectedBlockType         the expected block type
+   * @param expectedDataBlockEncoding the expected data block encoding
+   * @return the read block
+   * @throws IOException if an error occurs reading the block
+   */
+  @Override
+  public HFileBlock readBlock(long dataBlockOffset, long onDiskBlockSize, boolean cacheBlock,
+    boolean pread, boolean isCompaction, boolean updateCacheMetrics, BlockType expectedBlockType,
+    DataBlockEncoding expectedDataBlockEncoding) throws IOException {
+
+    try (SectionReaderLease lease = findSectionForOffset(dataBlockOffset)) {
+      if (lease == null) {
+        throw new IOException(
+          "No section found for offset: " + dataBlockOffset + ", path=" + getPath());
+      }
+
+      SectionReader targetSectionReader = lease.getSectionReader();
+      HFileReaderImpl sectionReader = lease.getReader();
+
+      // Convert absolute offset to section-relative offset
+      long sectionRelativeOffset = dataBlockOffset - targetSectionReader.sectionBaseOffset;
+
+      return sectionReader.readBlock(sectionRelativeOffset, onDiskBlockSize, cacheBlock, pread,
+        isCompaction, updateCacheMetrics, expectedBlockType, expectedDataBlockEncoding);
+    } catch (IOException e) {
+      LOG.error("Failed to read block at offset {} from section", dataBlockOffset, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Override block reading with section routing.
+   * @param dataBlockOffset           the offset of the block to read
+   * @param onDiskBlockSize           the on-disk size of the block
+   * @param cacheBlock                whether to cache the block
+   * @param pread                     whether to use positional read
+   * @param isCompaction              whether this is for a compaction
+   * @param updateCacheMetrics        whether to update cache metrics
+   * @param expectedBlockType         the expected block type
+   * @param expectedDataBlockEncoding the expected data block encoding
+   * @param cacheOnly                 whether to only read from cache
+   * @return the read block
+   * @throws IOException if an error occurs reading the block
+   */
+  @Override
+  public HFileBlock readBlock(long dataBlockOffset, long onDiskBlockSize, boolean cacheBlock,
+    boolean pread, boolean isCompaction, boolean updateCacheMetrics, BlockType expectedBlockType,
+    DataBlockEncoding expectedDataBlockEncoding, boolean cacheOnly) throws IOException {
+
+    try (SectionReaderLease lease = findSectionForOffset(dataBlockOffset)) {
+      if (lease == null) {
+        throw new IOException(
+          "No section found for offset: " + dataBlockOffset + ", path=" + getPath());
+      }
+
+      SectionReader targetSectionReader = lease.getSectionReader();
+      HFileReaderImpl sectionReader = lease.getReader();
+
+      // Convert absolute offset to section-relative offset
+      long sectionRelativeOffset = dataBlockOffset - targetSectionReader.sectionBaseOffset;
+
+      return sectionReader.readBlock(sectionRelativeOffset, onDiskBlockSize, cacheBlock, pread,
+        isCompaction, updateCacheMetrics, expectedBlockType, expectedDataBlockEncoding, cacheOnly);
+    } catch (IOException e) {
+      LOG.error("Failed to read block at offset {} from section", dataBlockOffset, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Find the section reader that contains the given absolute file offset.
+   * @param absoluteOffset the absolute offset in the file
+   * @return the section reader containing this offset, or null if not found
+   */
+  private SectionReaderLease findSectionForOffset(long absoluteOffset) throws IOException {
+    Map.Entry<Long, ImmutableBytesWritable> floor = sectionOffsetIndex.floorEntry(absoluteOffset);
+    if (floor == null) {
+      return null;
+    }
+    SectionMetadata metadata = sectionLocations.get(floor.getValue());
+    if (metadata != null && absoluteOffset < metadata.getOffset() + metadata.getSize()) {
+      return getSectionReader(floor.getValue().get());
+    }
+    return null;
+  }
+
+  @Override
+  public boolean hasMVCCInfo() {
+    return getFileContext().isIncludesMvcc();
+  }
+
+  /**
+   * For HFile v4 multi-tenant files, entry count is determined from trailer only.
+   * @return the entry count from the trailer
+   */
+  @Override
+  public long getEntries() {
+    // HFile v4 multi-tenant files get entry count from trailer only
+    if (trailer != null) {
+      return trailer.getEntryCount();
+    }
+    return 0;
+  }
+
+  /**
+   * Override unbuffer stream to handle main context.
+   */
+  @Override
+  public void unbufferStream() {
+    // Unbuffer the main context
+    super.unbufferStream();
+
+    // Section readers are created on demand and managed by scanner
+  }
+
+  /**
+   * Expose effective data block encoding using a representative section reader.
+   * <p>
+   * This preserves legacy reader semantics for v4 containers by delegating to one section's
+   * underlying v3 reader.
+   */
+  @Override
+  public DataBlockEncoding getEffectiveEncodingInCache(boolean isCompaction) {
+    return resolveSectionDataBlockEncoding(isCompaction);
+  }
+
+  /**
+   * Get section-specific statistics for monitoring and debugging.
+   * @return a map of section statistics
+   */
+  public Map<String, Object> getSectionStatistics() {
+    Map<String, Object> stats = new HashMap<>();
+
+    stats.put("totalSections", sectionLocations.size());
+    stats.put("tenantIndexLevels", tenantIndexLevels);
+    stats.put("tenantIndexMaxChunkSize", tenantIndexMaxChunkSize);
+    stats.put("prefetchEnabled", prefetchEnabled);
+    stats.put("cachedSectionReaders", sectionReaderCache.size());
+
+    // Section size distribution
+    List<Integer> sectionSizes = new ArrayList<>();
+    for (SectionMetadata metadata : sectionLocations.values()) {
+      sectionSizes.add(metadata.getSize());
+    }
+    if (!sectionSizes.isEmpty()) {
+      stats.put("avgSectionSize",
+        sectionSizes.stream().mapToInt(Integer::intValue).average().orElse(0.0));
+      stats.put("minSectionSize",
+        sectionSizes.stream().mapToInt(Integer::intValue).min().orElse(0));
+      stats.put("maxSectionSize",
+        sectionSizes.stream().mapToInt(Integer::intValue).max().orElse(0));
+    }
+
+    return stats;
+  }
+
+  /**
+   * Get metadata for a specific tenant section by section ID.
+   * @param tenantSectionId The tenant section ID to look up
+   * @return Detailed metadata about the section
+   */
+  public Map<String, Object> getSectionInfo(byte[] tenantSectionId) {
+    Map<String, Object> info = new HashMap<>();
+
+    ImmutableBytesWritable key = new ImmutableBytesWritable(tenantSectionId);
+    SectionMetadata metadata = sectionLocations.get(key);
+
+    if (metadata != null) {
+      info.put("exists", true);
+      info.put("offset", metadata.getOffset());
+      info.put("size", metadata.getSize());
+    } else {
+      info.put("exists", false);
+    }
+
+    return info;
+  }
+
+  /**
+   * Backward-compatibility shim for v3 expectations.
+   * <p>
+   * Some existing code paths and unit tests (e.g. TestSeekTo) expect that a reader exposes a
+   * non-null data block index at the file level. For HFile v4 multi-tenant containers there is no
+   * global data index. When the container holds exactly one tenant section (the common case when
+   * multi-tenant writing is disabled), we can safely delegate to that section's v3 reader and
+   * expose its data block index to preserve v3 semantics.
+   */
+  @Override
+  public HFileBlockIndex.CellBasedKeyBlockIndexReader getDataBlockIndexReader() {
+    HFileBlockIndex.CellBasedKeyBlockIndexReader existing = cachedDataBlockIndexReader.get();
+    if (existing != null) {
+      return existing;
+    }
+
+    byte[] hint = dataBlockIndexSectionHint.get();
+    if (hint != null) {
+      HFileBlockIndex.CellBasedKeyBlockIndexReader delegate = loadDataBlockIndexFromSection(hint);
+      if (delegate != null) {
+        return delegate;
+      }
+      dataBlockIndexSectionHint.compareAndSet(hint, null);
+    }
+
+    if (sectionIds == null || sectionIds.isEmpty()) {
+      return null;
+    }
+
+    for (ImmutableBytesWritable sectionId : sectionIds) {
+      byte[] candidateSectionId = copySectionId(sectionId);
+      if (hint != null && Bytes.equals(candidateSectionId, hint)) {
+        continue;
+      }
+      HFileBlockIndex.CellBasedKeyBlockIndexReader delegate =
+        loadDataBlockIndexFromSection(candidateSectionId);
+      if (delegate != null) {
+        if (dataBlockIndexCacheEnabled) {
+          dataBlockIndexSectionHint.compareAndSet(null, candidateSectionId);
+        }
+        return delegate;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Expose data block encoding using a representative section reader.
+   * <p>
+   * This preserves v3-style expectations for callers that read encoding from the top-level reader.
+   */
+  @Override
+  public DataBlockEncoding getDataBlockEncoding() {
+    return resolveSectionDataBlockEncoding(false);
+  }
+
+  private DataBlockEncoding resolveSectionDataBlockEncoding(boolean isCompaction) {
+    byte[] hint = dataBlockIndexSectionHint.get();
+    DataBlockEncoding hintedEncoding = loadDataBlockEncodingFromSection(hint, isCompaction);
+    if (hintedEncoding != null) {
+      return hintedEncoding;
+    }
+    if (hint != null) {
+      dataBlockIndexSectionHint.compareAndSet(hint, null);
+    }
+
+    if (sectionIds == null || sectionIds.isEmpty()) {
+      return DataBlockEncoding.NONE;
+    }
+
+    for (ImmutableBytesWritable sectionId : sectionIds) {
+      byte[] candidateSectionId = copySectionId(sectionId);
+      if (hint != null && Bytes.equals(candidateSectionId, hint)) {
+        continue;
+      }
+      DataBlockEncoding encoding =
+        loadDataBlockEncodingFromSection(candidateSectionId, isCompaction);
+      if (encoding != null) {
+        if (dataBlockIndexCacheEnabled) {
+          dataBlockIndexSectionHint.compareAndSet(null, candidateSectionId);
+        }
+        return encoding;
+      }
+    }
+
+    return DataBlockEncoding.NONE;
+  }
+
+  private DataBlockEncoding loadDataBlockEncodingFromSection(byte[] sectionId,
+    boolean isCompaction) {
+    if (sectionId == null) {
+      return null;
+    }
+    SectionReaderLease lease;
+    try {
+      lease = getSectionReader(sectionId);
+    } catch (IOException e) {
+      LOG.debug("Failed to get section reader for encoding in section {}",
+        Bytes.toStringBinary(sectionId), e);
+      return null;
+    }
+    if (lease == null) {
+      return null;
+    }
+    try (SectionReaderLease ignored = lease) {
+      HFileReaderImpl sectionReader = lease.getReader();
+      if (sectionReader == null) {
+        return null;
+      }
+      return isCompaction
+        ? sectionReader.getEffectiveEncodingInCache(isCompaction)
+        : sectionReader.getDataBlockEncoding();
+    } catch (IOException e) {
+      LOG.debug("Failed to load data block encoding from section {}",
+        Bytes.toStringBinary(sectionId), e);
+      return null;
+    }
+  }
+
+  /**
+   * For v4 multi-tenant readers (including refs/links), align {@link #getName()} with the name used
+   * for block cache keys.
+   * <p>
+   * The underlying {@link FSDataInputStreamWrapper} may resolve a {@code readerPath} different from
+   * {@link #getPath()} (e.g. for HFileLinks/Refs). Internally we use
+   * {@link HFileReaderImpl#getPathForCaching()} for cache keys; exposing the same name here keeps
+   * behavior consistent for callers/tests that use {@link #getName()} to build
+   * {@link BlockCacheKey} instances.
+   */
+  @Override
+  public String getName() {
+    return getNameForCaching();
+  }
+
+  /**
+   * Check if prefetch is complete for this multi-tenant file.
+   * @return true if prefetching is complete for all sections
+   */
+  @Override
+  public boolean prefetchComplete() {
+    prefetchBlocksOnOpenIfRequested();
+    Path p = prefetchOnOpenPath;
+    return p == null || PrefetchExecutor.isCompleted(p);
+  }
+
+  /**
+   * Check if prefetch has started for this multi-tenant file.
+   * @return true if prefetching has started
+   */
+  @Override
+  public boolean prefetchStarted() {
+    prefetchBlocksOnOpenIfRequested();
+    return PrefetchExecutor.isPrefetchStarted();
+  }
+
+  /**
+   * Get file length from the context.
+   * @return the file length in bytes
+   */
+  @Override
+  public long length() {
+    return context.getFileSize();
+  }
+
+  /**
+   * Check if file info is loaded (always true for multi-tenant readers).
+   * @return true as file info is always loaded during construction
+   */
+  public boolean isFileInfoLoaded() {
+    return true;
+  }
+
+  /**
+   * Override getHFileInfo to properly load FileInfo metadata for v4 files.
+   * <p>
+   * Since initMetaAndIndex() is skipped for v4 files, we need to manually load the FileInfo block
+   * to expose the metadata written during file creation.
+   * <p>
+   * This method ensures that the FileInfo block is loaded on-demand when HFilePrettyPrinter or
+   * other tools request the file metadata.
+   * @return The HFileInfo object with loaded metadata
+   */
+  @Override
+  public HFileInfo getHFileInfo() {
+    if (!fileInfoBlockLoaded) {
+      synchronized (this) {
+        if (!fileInfoBlockLoaded) {
+          try {
+            loadFileInfoBlock();
+            fileInfoBlockLoaded = true;
+          } catch (IOException e) {
+            LOG.error("Failed to load FileInfo block for multi-tenant HFile; "
+              + "will retry on next access", e);
+          }
+        }
+      }
+    }
+    return fileInfo;
+  }
+
+  /**
+   * Manually load the FileInfo block for multi-tenant HFiles.
+   * <p>
+   * This method replicates the FileInfo loading logic from HFileInfo.loadMetaInfo() but adapted for
+   * the multi-tenant file structure.
+   * @throws IOException if an error occurs loading the FileInfo block
+   */
+  private void loadFileInfoBlock() throws IOException {
+    FixedFileTrailer trailer = getTrailer();
+
+    // Get the FileInfo block offset from the trailer
+    long fileInfoOffset = trailer.getFileInfoOffset();
+    if (fileInfoOffset == 0) {
+      LOG.debug("No FileInfo block found in multi-tenant HFile");
+      return;
+    }
+
+    // Access the input stream through the context
+    FSDataInputStreamWrapper fsWrapper = context.getInputStreamWrapper();
+    FSDataInputStream fsdis = fsWrapper.getStream(fsWrapper.shouldUseHBaseChecksum());
+    long originalPosition = fsdis.getPos();
+
+    try {
+      LOG.debug("Loading FileInfo block from offset {}", fileInfoOffset);
+
+      // Read the FileInfo block
+      HFileBlock fileInfoBlock =
+        getUncachedBlockReader().readBlockData(fileInfoOffset, -1, true, false, false);
+      HFileBlock blockToRead = null;
+
+      // Validate this is a FileInfo block
+      if (fileInfoBlock.getBlockType() != BlockType.FILE_INFO) {
+        throw new IOException("Expected FILE_INFO block at offset " + fileInfoOffset + ", found "
+          + fileInfoBlock.getBlockType());
+      }
+
+      // Parse the FileInfo data using the HFileInfo.read() method
+      try {
+        blockToRead = fileInfoBlock.unpack(getFileContext(), getUncachedBlockReader());
+        try (DataInputStream dis = new DataInputStream(blockToRead.getByteStream())) {
+          fileInfo.read(dis);
+        }
+        applyFileInfoMetadataToContext();
+      } finally {
+        if (blockToRead != null) {
+          blockToRead.release();
+          if (blockToRead != fileInfoBlock) {
+            fileInfoBlock.release();
+          }
+        } else {
+          fileInfoBlock.release();
+        }
+      }
+
+      LOG.debug("Successfully loaded FileInfo with {} entries", fileInfo.size());
+    } catch (IOException e) {
+      LOG.error("Failed to load FileInfo block from offset {}", fileInfoOffset, e);
+      throw e;
+    } finally {
+      // Restore original position
+      try {
+        fsdis.seek(originalPosition);
+      } catch (IOException e) {
+        LOG.warn("Failed to restore stream position", e);
+      }
+    }
+  }
+
+  private void applyFileInfoMetadataToContext() {
+    HFileContext fileContext = getFileContext();
+
+    byte[] creationTimeBytes = fileInfo.get(HFileInfo.CREATE_TIME_TS);
+    if (creationTimeBytes != null) {
+      fileContext.setFileCreateTime(Bytes.toLong(creationTimeBytes));
+    }
+
+    byte[] maxTagsLenBytes = fileInfo.get(HFileInfo.MAX_TAGS_LEN);
+    boolean includesTags = maxTagsLenBytes != null;
+    fileContext.setIncludesTags(includesTags);
+    if (includesTags) {
+      byte[] tagsCompressedBytes = fileInfo.get(HFileInfo.TAGS_COMPRESSED);
+      boolean tagsCompressed = tagsCompressedBytes != null && Bytes.toBoolean(tagsCompressedBytes);
+      fileContext.setCompressTags(tagsCompressed);
+    }
+
+    byte[] keyValueVersionBytes = fileInfo.get(HFileWriterImpl.KEY_VALUE_VERSION);
+    boolean includesMvcc = keyValueVersionBytes != null
+      && Bytes.toInt(keyValueVersionBytes) == HFileWriterImpl.KEY_VALUE_VER_WITH_MEMSTORE;
+    fileContext.setIncludesMvcc(includesMvcc);
+  }
+
+  /**
+   * Enhanced toString with multi-tenant specific information.
+   * @return detailed string representation of this reader
+   */
+  @Override
+  public String toString() {
+    return "MultiTenantReader{path=" + getPath() + ", majorVersion=" + getMajorVersion()
+      + ", sections=" + sectionLocations.size() + ", tenantIndexLevels=" + tenantIndexLevels
+      + ", fileSize=" + length() + "}";
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheUtil.java
@@ -57,6 +57,49 @@ public class BlockCacheUtil {
   public static final long NANOS_PER_SECOND = 1000000000;
 
   /**
+   * Multi-tenant HFile readers may decorate the underlying HFile name with a section suffix in the
+   * form {@code <hfileName>#<tenantSectionId>} to avoid cache key collisions across sections.
+   */
+  public static final char MULTI_TENANT_HFILE_NAME_DELIMITER = '#';
+
+  /**
+   * Return the base HFile name, stripping any multi-tenant section suffix ({@code #...}).
+   */
+  public static String getBaseHFileName(String hfileName) {
+    if (hfileName == null) {
+      return null;
+    }
+    int idx = hfileName.indexOf(MULTI_TENANT_HFILE_NAME_DELIMITER);
+    return idx >= 0 ? hfileName.substring(0, idx) : hfileName;
+  }
+
+  /** Returns true if the given HFile name contains a multi-tenant section suffix ({@code #...}). */
+  public static boolean isMultiTenantSectionHFileName(String hfileName) {
+    return hfileName != null && hfileName.indexOf(MULTI_TENANT_HFILE_NAME_DELIMITER) >= 0;
+  }
+
+  /**
+   * Match an HFile name for operations where callers use the base storefile name while the cache
+   * may contain multi-tenant section-decorated names.
+   * <p>
+   * If {@code requestedHFileName} already includes a section suffix ({@code #...}), this performs
+   * an exact match. Otherwise it matches either the exact base name or any section-decorated name
+   * that starts with {@code <requestedHFileName>#}.
+   */
+  public static boolean matchesHFileName(String cachedHFileName, String requestedHFileName) {
+    if (cachedHFileName == null || requestedHFileName == null) {
+      return false;
+    }
+    if (cachedHFileName.equals(requestedHFileName)) {
+      return true;
+    }
+    if (isMultiTenantSectionHFileName(requestedHFileName)) {
+      return false;
+    }
+    return cachedHFileName.startsWith(requestedHFileName + MULTI_TENANT_HFILE_NAME_DELIMITER);
+  }
+
+  /**
    * Needed generating JSON.
    */
   private static final Gson GSON =

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/BlockCacheUtil.java
@@ -57,8 +57,16 @@ public class BlockCacheUtil {
   public static final long NANOS_PER_SECOND = 1000000000;
 
   /**
-   * Multi-tenant HFile readers may decorate the underlying HFile name with a section suffix in the
-   * form {@code <hfileName>#<tenantSectionId>} to avoid cache key collisions across sections.
+   * Delimiter used to decorate cache keys for multi-tenant HFile sections. The cache stores blocks
+   * under the synthetic name {@code <hfileName>#<tenantSectionId>} so blocks belonging to different
+   * tenant sections of the same physical file do not collide on identical block offsets.
+   * <p>
+   * <b>Invariant:</b> the character {@code '#'} is reserved across the cache key space and MUST NOT
+   * appear in any underlying HFile name. {@link #getBaseHFileName} strips everything from the first
+   * {@code '#'} onward, so any out-of-tree producer that writes HFile names containing {@code '#'}
+   * will silently lose part of the name and confuse the cache. Standard HBase HFile names (32-char
+   * hex) cannot contain this character; if you build files outside the standard factory pipeline,
+   * validate names against this invariant.
    */
   public static final char MULTI_TENANT_HFILE_NAME_DELIMITER = '#';
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/DefaultTenantExtractor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/DefaultTenantExtractor.java
@@ -1,0 +1,101 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import java.util.Objects;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Default implementation of TenantExtractor that extracts tenant information based on configurable
+ * prefix length at the beginning of row keys.
+ */
+@InterfaceAudience.Private
+public class DefaultTenantExtractor implements TenantExtractor {
+  /** The length of the tenant prefix to extract */
+  private final int prefixLength;
+
+  /**
+   * Constructor for DefaultTenantExtractor.
+   * @param prefixLength the length of the tenant prefix to extract from row keys
+   */
+  private static final int MAX_PREFIX_LENGTH = Short.MAX_VALUE;
+
+  public DefaultTenantExtractor(int prefixLength) {
+    if (prefixLength <= 0 || prefixLength > MAX_PREFIX_LENGTH) {
+      throw new IllegalArgumentException(
+        "Tenant prefix length must be in [1, " + MAX_PREFIX_LENGTH + "], got: " + prefixLength);
+    }
+    this.prefixLength = prefixLength;
+  }
+
+  @Override
+  public byte[] extractTenantId(Cell cell) {
+    return extractPrefix(cell);
+  }
+
+  @Override
+  public byte[] extractTenantSectionId(Cell cell) {
+    // Tenant section ID is same as tenant ID
+    return extractPrefix(cell);
+  }
+
+  /**
+   * Extract tenant prefix from a cell.
+   * @param cell The cell to extract tenant information from
+   * @return The tenant prefix as a byte array, or null if the row key is shorter than the
+   *         configured prefix length (e.g., synthetic seek keys, bloom filter probes)
+   */
+  private byte[] extractPrefix(Cell cell) {
+    Objects.requireNonNull(cell, "cell must not be null");
+    int rowLength = cell.getRowLength();
+    if (rowLength < prefixLength) {
+      return null;
+    }
+
+    byte[] prefix = new byte[prefixLength];
+    System.arraycopy(cell.getRowArray(), cell.getRowOffset(), prefix, 0, prefixLength);
+    return prefix;
+  }
+
+  /**
+   * Get the tenant prefix length.
+   * @return The configured tenant prefix length
+   */
+  @Override
+  public int getPrefixLength() {
+    return prefixLength;
+  }
+
+  /**
+   * Zero-allocation comparison: checks whether the cell's row prefix matches the given section ID
+   * by comparing directly from the cell's backing byte array.
+   */
+  @Override
+  public boolean matchesTenantSectionId(Cell cell, byte[] currentSectionId) {
+    if (cell == null || currentSectionId == null) {
+      return false;
+    }
+    int rowLength = cell.getRowLength();
+    if (rowLength < prefixLength || currentSectionId.length != prefixLength) {
+      return false;
+    }
+    return org.apache.hadoop.hbase.util.Bytes.equals(cell.getRowArray(), cell.getRowOffset(),
+      prefixLength, currentSectionId, 0, prefixLength);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/FixedFileTrailer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/FixedFileTrailer.java
@@ -133,6 +133,34 @@ public class FixedFileTrailer {
   private byte[] encryptionKey;
 
   /**
+   * Flag indicating if this file is a multi-tenant HFile
+   */
+  private boolean isMultiTenant = false;
+
+  /**
+   * The tenant prefix length for multi-tenant HFiles
+   */
+  private int tenantPrefixLength = 0;
+
+  /** Offset of the multi-tenant section index root block */
+  private long sectionIndexOffset = -1L;
+
+  /**
+   * The key namespace
+   */
+  private String keyNamespace;
+
+  /**
+   * The KEK checksum
+   */
+  private long kekChecksum;
+
+  /**
+   * The KEK metadata
+   */
+  private String kekMetadata;
+
+  /**
    * The {@link HFile} format major version.
    */
   private final int majorVersion;
@@ -213,6 +241,23 @@ public class FixedFileTrailer {
       .setCompressionCodec(compressionCodec.ordinal());
     if (encryptionKey != null) {
       builder.setEncryptionKey(UnsafeByteOperations.unsafeWrap(encryptionKey));
+    }
+    // Set multi-tenant fields for v4 files
+    if (isMultiTenant) {
+      builder.setMultiTenant(isMultiTenant);
+      builder.setTenantPrefixLength(tenantPrefixLength);
+      if (sectionIndexOffset >= 0) {
+        builder.setSectionIndexOffset(sectionIndexOffset);
+      }
+    }
+    if (keyNamespace != null) {
+      builder.setKeyNamespace(keyNamespace);
+    }
+    if (kekMetadata != null) {
+      builder.setKekMetadata(kekMetadata);
+    }
+    if (kekChecksum != 0) {
+      builder.setKekChecksum(kekChecksum);
     }
     return builder.build();
   }
@@ -317,6 +362,25 @@ public class FixedFileTrailer {
     if (trailerProto.hasEncryptionKey()) {
       encryptionKey = trailerProto.getEncryptionKey().toByteArray();
     }
+
+    if (trailerProto.hasMultiTenant()) {
+      isMultiTenant = trailerProto.getMultiTenant();
+    }
+    if (trailerProto.hasTenantPrefixLength()) {
+      tenantPrefixLength = trailerProto.getTenantPrefixLength();
+    }
+    if (trailerProto.hasSectionIndexOffset()) {
+      sectionIndexOffset = trailerProto.getSectionIndexOffset();
+    }
+    if (trailerProto.hasKeyNamespace()) {
+      keyNamespace = trailerProto.getKeyNamespace();
+    }
+    if (trailerProto.hasKekMetadata()) {
+      kekMetadata = trailerProto.getKekMetadata();
+    }
+    if (trailerProto.hasKekChecksum()) {
+      kekChecksum = trailerProto.getKekChecksum();
+    }
   }
 
   /**
@@ -365,6 +429,18 @@ public class FixedFileTrailer {
     append(sb, "comparatorClassName=" + comparatorClassName);
     if (majorVersion >= 3) {
       append(sb, "encryptionKey=" + (encryptionKey != null ? "PRESENT" : "NONE"));
+    }
+
+    if (majorVersion >= 4) {
+      append(sb, "isMultiTenant=" + isMultiTenant);
+      if (isMultiTenant) {
+        append(sb, "tenantPrefixLength=" + tenantPrefixLength);
+        append(sb, "sectionIndexOffset=" + sectionIndexOffset);
+      }
+    }
+
+    if (keyNamespace != null) {
+      append(sb, "keyNamespace=" + keyNamespace);
     }
     append(sb, "majorVersion=" + majorVersion);
     append(sb, "minorVersion=" + minorVersion);
@@ -455,6 +531,16 @@ public class FixedFileTrailer {
 
   public void setLoadOnOpenOffset(long loadOnOpenDataOffset) {
     this.loadOnOpenDataOffset = loadOnOpenDataOffset;
+  }
+
+  public long getSectionIndexOffset() {
+    expectAtLeastMajorVersion(4);
+    return sectionIndexOffset;
+  }
+
+  public void setSectionIndexOffset(long sectionIndexOffset) {
+    expectAtLeastMajorVersion(4);
+    this.sectionIndexOffset = sectionIndexOffset;
   }
 
   public int getDataIndexCount() {
@@ -702,5 +788,25 @@ public class FixedFileTrailer {
    */
   static int materializeVersion(int majorVersion, int minorVersion) {
     return ((majorVersion & 0x00ffffff) | (minorVersion << 24));
+  }
+
+  public boolean isMultiTenant() {
+    expectAtLeastMajorVersion(4);
+    return isMultiTenant;
+  }
+
+  public void setMultiTenant(boolean multiTenant) {
+    expectAtLeastMajorVersion(4);
+    isMultiTenant = multiTenant;
+  }
+
+  public int getTenantPrefixLength() {
+    expectAtLeastMajorVersion(4);
+    return tenantPrefixLength;
+  }
+
+  public void setTenantPrefixLength(int tenantPrefixLength) {
+    expectAtLeastMajorVersion(4);
+    this.tenantPrefixLength = tenantPrefixLength;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -138,12 +138,15 @@ public final class HFile {
   /**
    * Maximum supported HFile format version
    */
-  public static final int MAX_FORMAT_VERSION = 3;
+  public static final int MAX_FORMAT_VERSION = 4;
 
   /**
    * Minimum HFile format version with support for persisting cell tags
    */
   public static final int MIN_FORMAT_VERSION_WITH_TAGS = 3;
+
+  /** Version for HFiles that support multi-tenant workloads */
+  public static final int MIN_FORMAT_VERSION_WITH_MULTI_TENANT = 4;
 
   /** Default compression name: none. */
   public final static String DEFAULT_COMPRESSION = DEFAULT_COMPRESSION_ALGORITHM.getName();
@@ -224,6 +227,11 @@ public final class HFile {
     public void appendCustomCellTimestampsToMetadata(TimeRangeTracker timeRangeTracker)
       throws IOException;
 
+    /**
+     * Returns the current write position.
+     */
+    long getPos() throws IOException;
+
     /** Returns the path to this {@link HFile} */
     Path getPath();
 
@@ -256,6 +264,24 @@ public final class HFile {
      * Return the file context for the HFile this writer belongs to
      */
     HFileContext getFileContext();
+
+    /**
+     * Whether this writer manages general Bloom filters internally. Writers that handle Bloom
+     * filter lifecycle (creation, per-cell updates, and serialization) return {@code true} so that
+     * callers do not create a redundant external Bloom filter.
+     * @return {@code true} if the writer owns the general Bloom filter lifecycle
+     */
+    default boolean hasGeneralBloom() {
+      return false;
+    }
+
+    /**
+     * Return the writer's internally-managed general Bloom filter, or {@code null} when Bloom
+     * filters are managed externally (the default).
+     */
+    default BloomFilterWriter getGeneralBloomWriter() {
+      return null;
+    }
   }
 
   /**
@@ -354,6 +380,8 @@ public final class HFile {
           + "in hbase-site.xml)");
       case 3:
         return new HFile.WriterFactory(conf, cacheConf);
+      case 4:
+        return new MultiTenantHFileWriter.WriterFactory(conf, cacheConf);
       default:
         throw new IllegalArgumentException(
           "Cannot create writer for HFile " + "format version " + version);
@@ -499,19 +527,29 @@ public final class HFile {
   public static Reader createReader(ReaderContext context, HFileInfo fileInfo,
     CacheConfig cacheConf, Configuration conf) throws IOException {
     try {
+      FixedFileTrailer trailer = fileInfo.getTrailer();
+      int majorVersion = trailer.getMajorVersion();
+
+      // Handle HFile V4 (multi-tenant) separately for both stream and pread modes
+      if (majorVersion == MIN_FORMAT_VERSION_WITH_MULTI_TENANT) {
+        LOG.debug("Opening MultiTenant HFile v4");
+        return MultiTenantReaderFactory.create(context, fileInfo, cacheConf, conf);
+      }
+
+      // For non-multi-tenant files, continue with existing approach
       if (context.getReaderType() == ReaderType.STREAM) {
         // stream reader will share trailer with pread reader, see HFileStreamReader#copyFields
         return new HFileStreamReader(context, fileInfo, cacheConf, conf);
       }
-      FixedFileTrailer trailer = fileInfo.getTrailer();
-      switch (trailer.getMajorVersion()) {
+
+      switch (majorVersion) {
         case 2:
           LOG.debug("Opening HFile v2 with v3 reader");
           // Fall through. FindBugs: SF_SWITCH_FALLTHROUGH
         case 3:
           return new HFilePreadReader(context, fileInfo, cacheConf, conf);
         default:
-          throw new IllegalArgumentException("Invalid HFile version " + trailer.getMajorVersion());
+          throw new IllegalArgumentException("Invalid HFile version " + majorVersion);
       }
     } catch (Throwable t) {
       IOUtils.closeQuietly(context.getInputStreamWrapper(),
@@ -560,7 +598,10 @@ public final class HFile {
         .withPrimaryReplicaReader(primaryReplicaReader).withReaderType(ReaderType.PREAD).build();
     HFileInfo fileInfo = new HFileInfo(context, conf);
     Reader reader = createReader(context, fileInfo, cacheConf, conf);
-    fileInfo.initMetaAndIndex(reader);
+    if (fileInfo.getTrailer().getMajorVersion() != HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT) {
+      // Only initialize meta and index for non-multi-tenant files
+      fileInfo.initMetaAndIndex(reader);
+    }
     return reader;
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFile.java
@@ -704,10 +704,10 @@ public final class HFile {
 
   public static void checkHFileVersion(final Configuration c) {
     int version = c.getInt(FORMAT_VERSION_KEY, MAX_FORMAT_VERSION);
-    if (version < MAX_FORMAT_VERSION || version > MAX_FORMAT_VERSION) {
+    if (version < MIN_FORMAT_VERSION || version > MAX_FORMAT_VERSION) {
       throw new IllegalArgumentException(
         "The setting for " + FORMAT_VERSION_KEY + " (in your hbase-*.xml files) is " + version
-          + " which does not match " + MAX_FORMAT_VERSION
+          + " which is not between " + MIN_FORMAT_VERSION + " and " + MAX_FORMAT_VERSION
           + "; are you running with a configuration from an older or newer hbase install (an "
           + "incompatible hbase-default.xml or hbase-site.xml on your CLASSPATH)?");
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileInfo.java
@@ -372,25 +372,46 @@ public class HFileInfo implements SortedMap<byte[], byte[]> {
     ReaderContext context = reader.getContext();
     try {
       HFileBlock.FSReader blockReader = reader.getUncachedBlockReader();
-      // Initialize an block iterator, and parse load-on-open blocks in the following.
-      blockIter = blockReader.blockRange(trailer.getLoadOnOpenDataOffset(),
-        context.getFileSize() - trailer.getTrailerSize());
-      // Data index. We also read statistics about the block index written after
-      // the root level.
-      HFileBlock dataBlockRootIndex = blockIter.nextBlockWithBlockType(BlockType.ROOT_INDEX);
-      HFileBlock metaBlockIndex = blockIter.nextBlockWithBlockType(BlockType.ROOT_INDEX);
-      loadMetaInfo(blockIter, hfileContext);
+      long loadOnOpenOffset = trailer.getLoadOnOpenDataOffset();
+      boolean isMultiTenantFile =
+        trailer.getMajorVersion() == HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT
+          && trailer.getSectionIndexOffset() >= 0;
+      if (isMultiTenantFile) {
+        loadOnOpenOffset = trailer.getSectionIndexOffset();
+      }
 
-      HFileIndexBlockEncoder indexBlockEncoder =
-        HFileIndexBlockEncoderImpl.createFromFileInfo(this);
-      this.dataIndexReader = new HFileBlockIndex.CellBasedKeyBlockIndexReaderV2(
-        trailer.createComparator(), trailer.getNumDataIndexLevels(), indexBlockEncoder);
-      dataIndexReader.readMultiLevelIndexRoot(dataBlockRootIndex, trailer.getDataIndexCount());
-      reader.setDataBlockIndexReader(dataIndexReader);
-      // Meta index.
-      this.metaIndexReader = new HFileBlockIndex.ByteArrayKeyBlockIndexReader(1);
-      metaIndexReader.readRootIndex(metaBlockIndex, trailer.getMetaIndexCount());
-      reader.setMetaBlockIndexReader(metaIndexReader);
+      // Initialize an block iterator, and parse load-on-open blocks in the following.
+      blockIter =
+        blockReader.blockRange(loadOnOpenOffset, context.getFileSize() - trailer.getTrailerSize());
+      if (isMultiTenantFile) {
+        HFileBlock sectionIndexRoot = blockIter.nextBlockWithBlockType(BlockType.ROOT_INDEX);
+        try {
+          loadMetaInfo(blockIter, hfileContext);
+        } finally {
+          sectionIndexRoot.release();
+        }
+        this.dataIndexReader = null;
+        this.metaIndexReader = null;
+        reader.setDataBlockIndexReader(null);
+        reader.setMetaBlockIndexReader(null);
+      } else {
+        // Data index. We also read statistics about the block index written after
+        // the root level.
+        HFileBlock dataBlockRootIndex = blockIter.nextBlockWithBlockType(BlockType.ROOT_INDEX);
+        HFileBlock metaBlockIndex = blockIter.nextBlockWithBlockType(BlockType.ROOT_INDEX);
+        loadMetaInfo(blockIter, hfileContext);
+
+        HFileIndexBlockEncoder indexBlockEncoder =
+          HFileIndexBlockEncoderImpl.createFromFileInfo(this);
+        this.dataIndexReader = new HFileBlockIndex.CellBasedKeyBlockIndexReaderV2(
+          trailer.createComparator(), trailer.getNumDataIndexLevels(), indexBlockEncoder);
+        dataIndexReader.readMultiLevelIndexRoot(dataBlockRootIndex, trailer.getDataIndexCount());
+        reader.setDataBlockIndexReader(dataIndexReader);
+        // Meta index.
+        this.metaIndexReader = new HFileBlockIndex.ByteArrayKeyBlockIndexReader(1);
+        metaIndexReader.readRootIndex(metaBlockIndex, trailer.getMetaIndexCount());
+        reader.setMetaBlockIndexReader(metaIndexReader);
+      }
 
       reader.setDataBlockEncoder(HFileDataBlockEncoderImpl.createFromFileInfo(this));
       // Load-On-Open info
@@ -472,12 +493,15 @@ public class HFileInfo implements SortedMap<byte[], byte[]> {
   }
 
   /**
-   * File version check is a little sloppy. We read v3 files but can also read v2 files if their
-   * content has been pb'd; files written with 0.98.
+   * File version check is a little sloppy. We read v4 and v3 files but can also read v2 files if
+   * their content has been pb'd; files written with 0.98.
    */
   private void checkFileVersion(Path path) {
     int majorVersion = trailer.getMajorVersion();
     if (majorVersion == getMajorVersion()) {
+      return;
+    }
+    if (majorVersion == HFile.MIN_FORMAT_VERSION_WITH_TAGS) {
       return;
     }
     int minorVersion = trailer.getMinorVersion();
@@ -497,7 +521,7 @@ public class HFileInfo implements SortedMap<byte[], byte[]> {
   }
 
   public int getMajorVersion() {
-    return 3;
+    return 4;
   }
 
   public void setTrailer(FixedFileTrailer trailer) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileInfo.java
@@ -520,8 +520,13 @@ public class HFileInfo implements SortedMap<byte[], byte[]> {
     }
   }
 
+  /**
+   * Returns the major HFile format version of *this* file (read from its trailer), not the max
+   * supported by the current binary. Phoenix and other downstream consumers branch on this to
+   * distinguish v2/v3/v4 files; returning a constant breaks that classification.
+   */
   public int getMajorVersion() {
-    return 4;
+    return trailer != null ? trailer.getMajorVersion() : HFile.MAX_FORMAT_VERSION;
   }
 
   public void setTrailer(FixedFileTrailer trailer) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -77,7 +77,8 @@ public class HFilePreadReader extends HFileReaderImpl {
               // so we check first if the block exists on its in-memory index, if so, we just
               // update the offset and move on to the next block without actually going read all
               // the way to the cache.
-              BlockCacheKey cacheKey = new BlockCacheKey(name, offset);
+              BlockCacheKey cacheKey =
+                new BlockCacheKey(getNameForCaching(), getOffsetForCaching(offset));
               if (cache.isAlreadyCached(cacheKey).orElse(false)) {
                 // Right now, isAlreadyCached is only supported by BucketCache, which should
                 // always cache data blocks.
@@ -165,17 +166,20 @@ public class HFilePreadReader extends HFileReaderImpl {
     }
   }
 
+  private static String getPathOffsetEndStr(final Path path, final long offset, final long end) {
+    return "path=" + path.toString() + ", offset=" + offset + ", end=" + end;
+  }
+
   /*
    * Get the region name for the given file path. A HFile is always kept under the <region>/<column
    * family>/<hfile>. To find the region for a given hFile, just find the name of the grandparent
    * directory.
    */
   private static String getRegionName(Path path) {
+    if (path == null || path.getParent() == null || path.getParent().getParent() == null) {
+      return "";
+    }
     return path.getParent().getParent().getName();
-  }
-
-  private static String getPathOffsetEndStr(final Path path, final long offset, final long end) {
-    return "path=" + path.toString() + ", offset=" + offset + ", end=" + end;
   }
 
   public void close(boolean evictOnClose) throws IOException {
@@ -185,9 +189,10 @@ public class HFilePreadReader extends HFileReaderImpl {
     // Deallocate data blocks
     cacheConf.getBlockCache().ifPresent(cache -> {
       if (evictOnClose) {
-        int numEvicted = cache.evictBlocksByHfileName(name);
+        int numEvicted = cache.evictBlocksByHfileName(getNameForCaching());
         if (LOG.isTraceEnabled()) {
-          LOG.trace("On close, file= {} evicted= {} block(s)", name, numEvicted);
+          LOG.trace("On close, file= {}, region= {}, evicted= {} block(s)", getNameForCaching(),
+            getRegionName(getPathForCaching()), numEvicted);
         }
       }
     });

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePrettyPrinter.java
@@ -48,6 +48,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.ExtendedCell;
 import org.apache.hadoop.hbase.HBaseConfiguration;
 import org.apache.hadoop.hbase.HBaseInterfaceAudience;
 import org.apache.hadoop.hbase.HConstants;
@@ -85,6 +86,37 @@ import org.apache.hbase.thirdparty.org.apache.commons.cli.PosixParser;
 
 /**
  * Implements pretty-printing functionality for {@link HFile}s.
+ * <p>
+ * This tool supports all HFile versions (v2, v3, and v4) with version-specific enhancements:
+ * <ul>
+ * <li><b>HFile v2:</b> Basic file inspection, metadata, block headers, and key/value display</li>
+ * <li><b>HFile v3:</b> All v2 features plus tag support and encryption metadata</li>
+ * <li><b>HFile v4:</b> All v3 features plus multi-tenant support, tenant section display, and
+ * enhanced metadata for tenant isolation</li>
+ * </ul>
+ * <p>
+ * Key improvements for HFile v4 multi-tenant support:
+ * <ul>
+ * <li>Version-aware block index handling (graceful fallback for v4)</li>
+ * <li>Enhanced block header display with tenant-aware error handling</li>
+ * <li>Tenant-specific information display with -t option</li>
+ * <li>Tenant boundary detection in key/value output</li>
+ * <li>V4-specific trailer field display (multi-tenant flags, tenant prefix length)</li>
+ * <li>Tenant isolation considerations (suppressed last key)</li>
+ * </ul>
+ * <p>
+ * Usage examples:
+ *
+ * <pre>
+ * # Basic metadata for any HFile version
+ * hbase hfile -m -f /path/to/hfile
+ *
+ * # Key/value pairs with tenant information (v4 files)
+ * hbase hfile -p -v -t -f /path/to/v4/hfile
+ *
+ * # Block analysis (works across all versions)
+ * hbase hfile -b -h -f /path/to/hfile
+ * </pre>
  */
 @InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.TOOLS)
 @InterfaceStability.Evolving
@@ -106,11 +138,16 @@ public class HFilePrettyPrinter extends Configured implements Tool {
   private boolean checkFamily;
   private boolean isSeekToRow = false;
   private boolean checkMobIntegrity = false;
+  private boolean printTenantInfo = false;
   private Map<String, List<Path>> mobFileLocations;
   private static final int FOUND_MOB_FILES_CACHE_CAPACITY = 50;
   private static final int MISSING_MOB_FILES_CACHE_CAPACITY = 20;
   private PrintStream out = System.out;
   private PrintStream err = System.err;
+
+  // Configurable block display limits
+  private int maxBlocksToShow;
+  private static final int DEFAULT_MAX_BLOCKS = 50;
 
   /**
    * The row which the user wants to specify and print all the KeyValues for.
@@ -121,6 +158,7 @@ public class HFilePrettyPrinter extends Configured implements Tool {
   private int count;
 
   private static final String FOUR_SPACES = "    ";
+  private static final int BLOCK_READ_ERROR_SKIP_BYTES = 64;
 
   public HFilePrettyPrinter() {
     super();
@@ -149,6 +187,9 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       "Print detailed statistics, including counts by range");
     options.addOption("i", "checkMobIntegrity", false,
       "Print all cells whose mob files are missing");
+    options.addOption("t", "tenantinfo", false,
+      "Print tenant information for multi-tenant HFiles (v4+)");
+    options.addOption("l", "blocklimit", true, "Maximum number of blocks to display (default: 50)");
 
     OptionGroup files = new OptionGroup();
     files.addOption(new Option("f", "file", true,
@@ -183,6 +224,22 @@ public class HFilePrettyPrinter extends Configured implements Tool {
     checkRow = cmd.hasOption("k");
     checkFamily = cmd.hasOption("a");
     checkMobIntegrity = cmd.hasOption("i");
+    printTenantInfo = cmd.hasOption("t");
+
+    if (cmd.hasOption("l")) {
+      try {
+        int limit = Integer.parseInt(cmd.getOptionValue("l"));
+        if (limit > 0) {
+          maxBlocksToShow = limit;
+        } else {
+          err.println("Invalid block limit: " + limit + ". Must be a positive number.");
+          System.exit(-1);
+        }
+      } catch (NumberFormatException e) {
+        err.println("Invalid block limit format: " + cmd.getOptionValue("l"));
+        System.exit(-1);
+      }
+    }
 
     if (cmd.hasOption("f")) {
       files.add(new Path(cmd.getOptionValue("f")));
@@ -305,6 +362,9 @@ public class HFilePrettyPrinter extends Configured implements Tool {
     HFile.Reader reader = HFile.createReader(fs, file, CacheConfig.DISABLED, true, getConf());
 
     Map<byte[], byte[]> fileInfo = reader.getHFileInfo();
+    FixedFileTrailer trailer = reader.getTrailer();
+    int majorVersion = trailer.getMajorVersion();
+    boolean isV4 = majorVersion == HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT;
 
     KeyValueStatsCollector fileStats = null;
 
@@ -326,31 +386,20 @@ public class HFilePrettyPrinter extends Configured implements Tool {
 
     // print meta data
     if (shouldPrintMeta) {
-      printMeta(reader, fileInfo);
+      printMeta(reader, fileInfo, isV4);
+    }
+
+    // print tenant information for v4 files
+    if (printTenantInfo && isV4) {
+      printTenantInformation(reader);
     }
 
     if (printBlockIndex) {
-      out.println("Block Index:");
-      out.println(reader.getDataBlockIndexReader());
+      printBlockIndex(reader, isV4);
     }
 
     if (printBlockHeaders) {
-      out.println("Block Headers:");
-      /*
-       * TODO: this same/similar block iteration logic is used in HFileBlock#blockRange and
-       * TestLazyDataBlockDecompression. Refactor?
-       */
-      FSDataInputStreamWrapper fsdis = new FSDataInputStreamWrapper(fs, file);
-      long fileSize = fs.getFileStatus(file).getLen();
-      FixedFileTrailer trailer = FixedFileTrailer.readFromStream(fsdis.getStream(false), fileSize);
-      long offset = trailer.getFirstDataBlockOffset(), max = trailer.getLastDataBlockOffset();
-      HFileBlock block;
-      while (offset <= max) {
-        block = reader.readBlock(offset, -1, /* cacheBlock */ false, /* pread */ false,
-          /* isCompaction */ false, /* updateCacheMetrics */ false, null, null);
-        offset += block.getOnDiskSizeWithHeader();
-        out.println(block);
-      }
+      printBlockHeaders(reader, file, fs, isV4);
     }
 
     if (printStats) {
@@ -362,14 +411,47 @@ public class HFilePrettyPrinter extends Configured implements Tool {
     return 0;
   }
 
+  /**
+   * Get the effective block limit based on user configuration.
+   * @return the effective block limit to use
+   */
+  private int getEffectiveBlockLimit() {
+    // If user specified a custom limit (> 0), use it
+    if (maxBlocksToShow > 0) {
+      return maxBlocksToShow;
+    }
+    // Otherwise use default
+    return DEFAULT_MAX_BLOCKS;
+  }
+
   private void scanKeysValues(Path file, KeyValueStatsCollector fileStats, HFileScanner scanner,
     byte[] row) throws IOException {
     Cell pCell = null;
     FileSystem fs = FileSystem.get(getConf());
     Set<String> foundMobFiles = new LinkedHashSet<>(FOUND_MOB_FILES_CACHE_CAPACITY);
     Set<String> missingMobFiles = new LinkedHashSet<>(MISSING_MOB_FILES_CACHE_CAPACITY);
+
+    // Check if this is a v4 file for enhanced output
+    boolean isV4 = false;
+    String currentTenantId = null;
+    try {
+      HFile.Reader reader = scanner.getReader();
+      if (
+        reader != null
+          && reader.getTrailer().getMajorVersion() == HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT
+      ) {
+        isV4 = true;
+        if (verbose) {
+          out.println("Scanning HFile v4 - tenant boundaries may be shown");
+        }
+      }
+    } catch (RuntimeException e) {
+      LOG.debug("Could not determine HFile version; continuing without tenant-specific processing",
+        e);
+    }
+
     do {
-      Cell cell = scanner.getCell();
+      ExtendedCell cell = scanner.getCell();
       if (row != null && row.length != 0) {
         int result = CellComparator.getInstance().compareRows(cell, row, 0, row.length);
         if (result > 0) {
@@ -378,6 +460,19 @@ public class HFilePrettyPrinter extends Configured implements Tool {
           continue;
         }
       }
+
+      // For multi-tenant v4 files, try to extract tenant information
+      if (isV4 && printKey) {
+        String extractedTenantId = extractTenantIdFromCell(cell, scanner.getReader());
+        if (extractedTenantId != null && !extractedTenantId.equals(currentTenantId)) {
+          if (currentTenantId != null) {
+            out.println("--- End of tenant section: " + currentTenantId + " ---");
+          }
+          currentTenantId = extractedTenantId;
+          out.println("--- Start of tenant section: " + currentTenantId + " ---");
+        }
+      }
+
       // collect stats
       if (printStats) {
         fileStats.collect(cell, printStatRanges);
@@ -393,6 +488,10 @@ public class HFilePrettyPrinter extends Configured implements Tool {
           for (Tag tag : tags) {
             out.print(String.format(" T[%d]: %s", i++, tag.toString()));
           }
+        }
+        // Show tenant ID if available and verbose mode is on
+        if (isV4 && verbose && currentTenantId != null) {
+          out.print(" [Tenant: " + currentTenantId + "]");
         }
         out.println();
       }
@@ -442,6 +541,43 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       pCell = cell;
       ++count;
     } while (scanner.next());
+
+    // Close final tenant section if we were tracking it
+    if (isV4 && printKey && currentTenantId != null) {
+      out.println("--- End of tenant section: " + currentTenantId + " ---");
+    }
+  }
+
+  /**
+   * Enhanced tenant ID extraction that uses trailer information when available.
+   */
+  private String extractTenantIdFromCell(ExtendedCell cell, HFile.Reader reader) {
+    try {
+      FixedFileTrailer trailer = reader.getTrailer();
+      int tenantPrefixLength = 4; // fallback default
+
+      // For v4 files, always try to get the actual tenant prefix length from trailer
+      if (trailer.getMajorVersion() == HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT) {
+        tenantPrefixLength = trailer.getTenantPrefixLength();
+      }
+
+      byte[] rowKey = CellUtil.cloneRow(cell);
+      if (rowKey.length >= tenantPrefixLength) {
+        return Bytes.toStringBinary(rowKey, 0, tenantPrefixLength);
+      } else {
+        // Row key is shorter than expected tenant prefix
+        if (verbose && rowKey.length > 0) {
+          err.println("Warning: Row key length (" + rowKey.length
+            + ") is shorter than tenant prefix length (" + tenantPrefixLength + ")");
+        }
+        return rowKey.length > 0 ? Bytes.toStringBinary(rowKey) : null;
+      }
+    } catch (Exception e) {
+      if (verbose) {
+        err.println("Warning: Error extracting tenant ID from cell: " + e.getMessage());
+      }
+    }
+    return null;
   }
 
   /**
@@ -507,10 +643,19 @@ public class HFilePrettyPrinter extends Configured implements Tool {
     return keyValueStr.replaceAll(", ([a-zA-Z]+=)", ",\n" + FOUR_SPACES + "$1");
   }
 
-  private void printMeta(HFile.Reader reader, Map<byte[], byte[]> fileInfo) throws IOException {
+  private void printMeta(HFile.Reader reader, Map<byte[], byte[]> fileInfo, boolean isV4)
+    throws IOException {
     out.println("Block index size as per heapsize: " + reader.indexSize());
     out.println(asSeparateLines(reader.toString()));
-    out.println("Trailer:\n    " + asSeparateLines(reader.getTrailer().toString()));
+
+    FixedFileTrailer trailer = reader.getTrailer();
+    out.println("Trailer:\n    " + asSeparateLines(trailer.toString()));
+
+    // Print v4-specific trailer information if available
+    if (isV4) {
+      printV4SpecificTrailerInfo(trailer);
+    }
+
     out.println("Fileinfo:");
     for (Map.Entry<byte[], byte[]> e : fileInfo.entrySet()) {
       out.print(FOUR_SPACES + Bytes.toString(e.getKey()) + " = ");
@@ -531,6 +676,11 @@ public class HFilePrettyPrinter extends Configured implements Tool {
           || Bytes.equals(e.getKey(), HFileInfo.AVG_VALUE_LEN)
           || Bytes.equals(e.getKey(), HFileWriterImpl.KEY_VALUE_VERSION)
           || Bytes.equals(e.getKey(), HFileInfo.MAX_TAGS_LEN)
+          || Bytes.equals(e.getKey(), Bytes.toBytes(MultiTenantHFileWriter.FILEINFO_SECTION_COUNT))
+          || Bytes.equals(e.getKey(),
+            Bytes.toBytes(MultiTenantHFileWriter.FILEINFO_TENANT_INDEX_LEVELS))
+          || Bytes.equals(e.getKey(),
+            Bytes.toBytes(MultiTenantHFileWriter.FILEINFO_TENANT_INDEX_MAX_CHUNK))
       ) {
         out.println(Bytes.toInt(e.getValue()));
       } else if (
@@ -547,6 +697,13 @@ public class HFilePrettyPrinter extends Configured implements Tool {
       }
     }
 
+    // For v4 files, also print section-level trailers and FileInfo
+    if (isV4 && reader instanceof AbstractMultiTenantReader) {
+      printSectionTrailers((AbstractMultiTenantReader) reader);
+      printSectionFileInfo((AbstractMultiTenantReader) reader);
+    }
+
+    // Mid-key handling for different versions
     try {
       out.println("Mid-key: " + reader.midKey().map(CellUtil::getCellKeyAsString));
     } catch (Exception e) {
@@ -577,6 +734,583 @@ public class HFilePrettyPrinter extends Configured implements Tool {
         + bloomFilter.toString().replaceAll(BloomFilterUtil.STATS_RECORD_SEP, "\n" + FOUR_SPACES));
     } else {
       out.println(FOUR_SPACES + "Not present");
+    }
+
+    // For v4 files, also print section-level bloom filter information
+    if (isV4 && reader instanceof AbstractMultiTenantReader) {
+      printSectionBloomFilters((AbstractMultiTenantReader) reader);
+    }
+  }
+
+  /**
+   * Print trailer information for each section in a multi-tenant HFile v4. Each section is
+   * essentially an HFile v3 with its own trailer.
+   * @param mtReader the multi-tenant reader to get section information from
+   */
+  private void printSectionTrailers(AbstractMultiTenantReader mtReader) {
+    byte[][] tenantSectionIds = mtReader.getAllTenantSectionIds();
+
+    if (tenantSectionIds == null || tenantSectionIds.length == 0) {
+      out.println("Section-level Trailers: No sections found");
+      return;
+    }
+
+    out.println("Section-level Trailers:");
+
+    for (int i = 0; i < tenantSectionIds.length; i++) {
+      byte[] sectionId = tenantSectionIds[i];
+      out.println(
+        FOUR_SPACES + "--- Section " + i + ": " + Bytes.toStringBinary(sectionId) + " ---");
+
+      try (
+        AbstractMultiTenantReader.SectionReaderLease lease = mtReader.getSectionReader(sectionId)) {
+        if (lease != null) {
+          HFileReaderImpl sectionHFileReader = lease.getReader();
+          if (sectionHFileReader != null) {
+            FixedFileTrailer sectionTrailer = sectionHFileReader.getTrailer();
+            if (sectionTrailer != null) {
+              out.println(FOUR_SPACES + FOUR_SPACES + "Section Trailer:");
+              String trailerStr = sectionTrailer.toString();
+              String[] lines = trailerStr.split("\n");
+              for (String line : lines) {
+                out.println(FOUR_SPACES + FOUR_SPACES + FOUR_SPACES + line);
+              }
+            } else {
+              out.println(FOUR_SPACES + FOUR_SPACES + "Section trailer not available");
+            }
+          } else {
+            out.println(FOUR_SPACES + FOUR_SPACES + "Section reader not initialized");
+          }
+        } else {
+          out.println(FOUR_SPACES + FOUR_SPACES + "Could not create section reader");
+        }
+      } catch (IllegalArgumentException | IOException sectionException) {
+        out.println(FOUR_SPACES + FOUR_SPACES + "Error accessing section trailer: "
+          + sectionException.getMessage());
+      }
+
+      if (i < tenantSectionIds.length - 1) {
+        out.println(); // Add spacing between sections
+      }
+    }
+  }
+
+  /**
+   * Print FileInfo for each section in a multi-tenant HFile v4. Each section is essentially an
+   * HFile v3 with its own FileInfo block.
+   * @param mtReader the multi-tenant reader to get section information from
+   */
+  private void printSectionFileInfo(AbstractMultiTenantReader mtReader) {
+    byte[][] tenantSectionIds = mtReader.getAllTenantSectionIds();
+
+    if (tenantSectionIds == null || tenantSectionIds.length == 0) {
+      out.println("Section-level FileInfo: No sections found");
+      return;
+    }
+
+    out.println("Section-level FileInfo:");
+
+    for (int i = 0; i < tenantSectionIds.length; i++) {
+      byte[] sectionId = tenantSectionIds[i];
+      out.println(
+        FOUR_SPACES + "--- Section " + i + ": " + Bytes.toStringBinary(sectionId) + " ---");
+
+      try (
+        AbstractMultiTenantReader.SectionReaderLease lease = mtReader.getSectionReader(sectionId)) {
+        if (lease != null) {
+          HFileReaderImpl sectionHFileReader = lease.getReader();
+          if (sectionHFileReader != null) {
+            Map<byte[], byte[]> sectionFileInfo = sectionHFileReader.getHFileInfo();
+            if (sectionFileInfo != null && !sectionFileInfo.isEmpty()) {
+              out.println(FOUR_SPACES + FOUR_SPACES + "Section FileInfo:");
+              for (Map.Entry<byte[], byte[]> e : sectionFileInfo.entrySet()) {
+                out.print(
+                  FOUR_SPACES + FOUR_SPACES + FOUR_SPACES + Bytes.toString(e.getKey()) + " = ");
+                if (
+                  Bytes.equals(e.getKey(), HStoreFile.MAX_SEQ_ID_KEY)
+                    || Bytes.equals(e.getKey(), HStoreFile.DELETE_FAMILY_COUNT)
+                    || Bytes.equals(e.getKey(), HStoreFile.EARLIEST_PUT_TS)
+                    || Bytes.equals(e.getKey(), HFileWriterImpl.MAX_MEMSTORE_TS_KEY)
+                    || Bytes.equals(e.getKey(), HFileInfo.CREATE_TIME_TS)
+                    || Bytes.equals(e.getKey(), HStoreFile.BULKLOAD_TIME_KEY)
+                ) {
+                  out.println(Bytes.toLong(e.getValue()));
+                } else if (Bytes.equals(e.getKey(), HStoreFile.TIMERANGE_KEY)) {
+                  TimeRangeTracker timeRangeTracker = TimeRangeTracker.parseFrom(e.getValue());
+                  out.println(timeRangeTracker.getMin() + "...." + timeRangeTracker.getMax());
+                } else if (
+                  Bytes.equals(e.getKey(), HFileInfo.AVG_KEY_LEN)
+                    || Bytes.equals(e.getKey(), HFileInfo.AVG_VALUE_LEN)
+                    || Bytes.equals(e.getKey(), HFileWriterImpl.KEY_VALUE_VERSION)
+                    || Bytes.equals(e.getKey(), HFileInfo.MAX_TAGS_LEN)
+                ) {
+                  out.println(Bytes.toInt(e.getValue()));
+                } else if (
+                  Bytes.equals(e.getKey(), HStoreFile.MAJOR_COMPACTION_KEY)
+                    || Bytes.equals(e.getKey(), HFileInfo.TAGS_COMPRESSED)
+                    || Bytes.equals(e.getKey(), HStoreFile.EXCLUDE_FROM_MINOR_COMPACTION_KEY)
+                    || Bytes.equals(e.getKey(), HStoreFile.HISTORICAL_KEY)
+                ) {
+                  out.println(Bytes.toBoolean(e.getValue()));
+                } else if (Bytes.equals(e.getKey(), HFileInfo.LASTKEY)) {
+                  out.println(new KeyValue.KeyOnlyKeyValue(e.getValue()).toString());
+                } else {
+                  out.println(Bytes.toStringBinary(e.getValue()));
+                }
+              }
+            } else {
+              out.println(FOUR_SPACES + FOUR_SPACES + "Section FileInfo not available or empty");
+            }
+          } else {
+            out.println(FOUR_SPACES + FOUR_SPACES + "Section reader not initialized");
+          }
+        } else {
+          out.println(FOUR_SPACES + FOUR_SPACES + "Could not create section reader");
+        }
+      } catch (IllegalArgumentException | IOException sectionException) {
+        out.println(FOUR_SPACES + FOUR_SPACES + "Error accessing section FileInfo: "
+          + sectionException.getMessage());
+      }
+
+      if (i < tenantSectionIds.length - 1) {
+        out.println(); // Add spacing between sections
+      }
+    }
+  }
+
+  /**
+   * Print bloom filter information for each section in a multi-tenant HFile v4.
+   * @param mtReader the multi-tenant reader to get section information from
+   */
+  private void printSectionBloomFilters(AbstractMultiTenantReader mtReader) {
+    byte[][] tenantSectionIds = mtReader.getAllTenantSectionIds();
+
+    if (tenantSectionIds == null || tenantSectionIds.length == 0) {
+      out.println("Section-level Bloom filters: No sections found");
+      return;
+    }
+
+    out.println("Section-level Bloom filters:");
+
+    for (int i = 0; i < tenantSectionIds.length; i++) {
+      byte[] sectionId = tenantSectionIds[i];
+      out.println(
+        FOUR_SPACES + "--- Section " + i + ": " + Bytes.toStringBinary(sectionId) + " ---");
+
+      try (
+        AbstractMultiTenantReader.SectionReaderLease lease = mtReader.getSectionReader(sectionId)) {
+        if (lease != null) {
+          HFileReaderImpl sectionHFileReader = lease.getReader();
+          if (sectionHFileReader != null) {
+
+            // Print general bloom filter for this section
+            DataInput bloomMeta = sectionHFileReader.getGeneralBloomFilterMetadata();
+            BloomFilter bloomFilter = null;
+            if (bloomMeta != null) {
+              bloomFilter = BloomFilterFactory.createFromMeta(bloomMeta, sectionHFileReader);
+            }
+
+            out.println(FOUR_SPACES + FOUR_SPACES + FOUR_SPACES + "General Bloom filter:");
+            if (bloomFilter != null) {
+              String bloomDetails = bloomFilter.toString().replaceAll(
+                BloomFilterUtil.STATS_RECORD_SEP, "\n" + FOUR_SPACES + FOUR_SPACES + FOUR_SPACES);
+              out.println(FOUR_SPACES + FOUR_SPACES + FOUR_SPACES + bloomDetails);
+            } else {
+              out.println(FOUR_SPACES + FOUR_SPACES + FOUR_SPACES + "Not present");
+            }
+
+            // Print delete bloom filter for this section
+            bloomMeta = sectionHFileReader.getDeleteBloomFilterMetadata();
+            bloomFilter = null;
+            if (bloomMeta != null) {
+              bloomFilter = BloomFilterFactory.createFromMeta(bloomMeta, sectionHFileReader);
+            }
+
+            out.println(FOUR_SPACES + FOUR_SPACES + "Delete Family Bloom filter:");
+            if (bloomFilter != null) {
+              String bloomDetails = bloomFilter.toString().replaceAll(
+                BloomFilterUtil.STATS_RECORD_SEP, "\n" + FOUR_SPACES + FOUR_SPACES + FOUR_SPACES);
+              out.println(FOUR_SPACES + FOUR_SPACES + FOUR_SPACES + bloomDetails);
+            } else {
+              out.println(FOUR_SPACES + FOUR_SPACES + FOUR_SPACES + "Not present");
+            }
+
+          } else {
+            out.println(FOUR_SPACES + FOUR_SPACES + "Section reader not initialized");
+          }
+        } else {
+          out.println(FOUR_SPACES + FOUR_SPACES + "Could not create section reader");
+        }
+      } catch (IllegalArgumentException | IOException sectionException) {
+        out.println(FOUR_SPACES + FOUR_SPACES + "Error accessing section bloom filters: "
+          + sectionException.getMessage());
+      }
+
+      if (i < tenantSectionIds.length - 1) {
+        out.println(); // Add spacing between sections
+      }
+    }
+  }
+
+  private void printV4SpecificTrailerInfo(FixedFileTrailer trailer) {
+    out.println("HFile v4 Specific Information:");
+    try {
+      // Access v4-specific trailer fields directly (no reflection needed)
+      boolean isMultiTenant = trailer.isMultiTenant();
+      out.println(FOUR_SPACES + "Multi-tenant enabled: " + isMultiTenant);
+
+      if (isMultiTenant) {
+        int tenantPrefixLength = trailer.getTenantPrefixLength();
+        out.println(FOUR_SPACES + "Tenant prefix length: " + tenantPrefixLength);
+      }
+
+    } catch (Exception e) {
+      out.println(
+        FOUR_SPACES + "Unable to retrieve v4-specific trailer information: " + e.getMessage());
+    }
+  }
+
+  private void printTenantInformation(HFile.Reader reader) throws IOException {
+    out.println("Tenant Information:");
+
+    FixedFileTrailer trailer = reader.getTrailer();
+    if (trailer.getMajorVersion() == HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT) {
+      // Check if this is actually a multi-tenant file in the trailer
+      try {
+        // Access multi-tenant specific fields directly from trailer (no reflection needed)
+        boolean isMultiTenant = trailer.isMultiTenant();
+
+        if (isMultiTenant) {
+          out.println(FOUR_SPACES + "Multi-tenant: true");
+
+          int tenantPrefixLength = trailer.getTenantPrefixLength();
+          out.println(FOUR_SPACES + "Tenant prefix length: " + tenantPrefixLength);
+
+          // Try to access tenant section information if available
+          if (reader instanceof AbstractMultiTenantReader) {
+            AbstractMultiTenantReader mtReader = (AbstractMultiTenantReader) reader;
+            out.println(FOUR_SPACES + "Reader type: " + reader.getClass().getSimpleName());
+            try {
+              byte[][] tenantSectionIds = mtReader.getAllTenantSectionIds();
+              if (tenantSectionIds != null && tenantSectionIds.length > 0) {
+                out.println(FOUR_SPACES + "Number of tenant sections: " + tenantSectionIds.length);
+                for (int i = 0; i < Math.min(tenantSectionIds.length, 10); i++) {
+                  out.println(FOUR_SPACES + "Tenant section " + i + ": "
+                    + Bytes.toStringBinary(tenantSectionIds[i]));
+                }
+                if (tenantSectionIds.length > 10) {
+                  out.println(
+                    FOUR_SPACES + "... and " + (tenantSectionIds.length - 10) + " more sections");
+                }
+              }
+            } catch (Exception e) {
+              out.println(
+                FOUR_SPACES + "Unable to retrieve tenant section information: " + e.getMessage());
+            }
+          }
+        } else {
+          out.println(FOUR_SPACES + "Multi-tenant: false (HFile v4 format but single tenant)");
+        }
+      } catch (Exception e) {
+        out.println(FOUR_SPACES + "Unable to retrieve multi-tenant information: " + e.getMessage());
+      }
+    } else {
+      out.println(
+        FOUR_SPACES + "Not a multi-tenant HFile (version " + trailer.getMajorVersion() + ")");
+    }
+  }
+
+  private void printBlockIndex(HFile.Reader reader, boolean isV4) throws IOException {
+    out.println("Block Index:");
+
+    if (isV4) {
+      // For v4 files, show block index for each tenant section
+      if (reader instanceof AbstractMultiTenantReader) {
+        AbstractMultiTenantReader mtReader = (AbstractMultiTenantReader) reader;
+        byte[][] tenantSectionIds = mtReader.getAllTenantSectionIds();
+
+        if (tenantSectionIds != null && tenantSectionIds.length > 0) {
+          out.println(
+            FOUR_SPACES + "HFile v4 contains " + tenantSectionIds.length + " tenant sections:");
+
+          for (int i = 0; i < tenantSectionIds.length; i++) {
+            byte[] sectionId = tenantSectionIds[i];
+            out.println(FOUR_SPACES + "--- Tenant Section " + i + ": "
+              + Bytes.toStringBinary(sectionId) + " ---");
+
+            try {
+              // Always show basic section information first
+              java.util.Map<String, Object> sectionInfo = mtReader.getSectionInfo(sectionId);
+              if (sectionInfo != null && (Boolean) sectionInfo.get("exists")) {
+                out.println(
+                  FOUR_SPACES + FOUR_SPACES + "Section offset: " + sectionInfo.get("offset"));
+                out.println(FOUR_SPACES + FOUR_SPACES + "Section size: " + sectionInfo.get("size")
+                  + " bytes");
+              } else {
+                out.println(FOUR_SPACES + FOUR_SPACES + "Section metadata not available");
+                continue;
+              }
+
+              // Get the actual block index from the section reader
+              try (AbstractMultiTenantReader.SectionReaderLease lease =
+                mtReader.getSectionReader(sectionId)) {
+                if (lease != null) {
+                  HFileReaderImpl sectionHFileReader = lease.getReader();
+                  if (sectionHFileReader != null) {
+                    HFileBlockIndex.CellBasedKeyBlockIndexReader indexReader =
+                      sectionHFileReader.getDataBlockIndexReader();
+                    if (indexReader != null) {
+                      out.println(FOUR_SPACES + FOUR_SPACES + "Block index details:");
+                      String indexDetails = indexReader.toString();
+                      // Indent the index details for better readability
+                      String[] lines = indexDetails.split("\n");
+                      for (String line : lines) {
+                        out.println(FOUR_SPACES + FOUR_SPACES + FOUR_SPACES + line);
+                      }
+                    } else {
+                      out.println(
+                        FOUR_SPACES + FOUR_SPACES + "Block index not available for this section");
+                    }
+                  } else {
+                    out.println(FOUR_SPACES + FOUR_SPACES + "Section reader not initialized");
+                  }
+                } else {
+                  out.println(FOUR_SPACES + FOUR_SPACES + "Could not create section reader");
+                }
+              } catch (Exception sectionException) {
+                out.println(FOUR_SPACES + FOUR_SPACES + "Error accessing section reader: "
+                  + sectionException.getMessage());
+              }
+
+            } catch (Exception e) {
+              out.println(
+                FOUR_SPACES + FOUR_SPACES + "Error reading section block index: " + e.getMessage());
+            }
+
+            if (i < tenantSectionIds.length - 1) {
+              out.println(); // Add spacing between sections
+            }
+          }
+        } else {
+          out.println(FOUR_SPACES + "No tenant sections found in HFile v4");
+        }
+      } else {
+        out.println(FOUR_SPACES + "Reader is not a multi-tenant reader for v4 file");
+      }
+    } else {
+      // For v2/v3 files, use standard approach
+      HFileBlockIndex.CellBasedKeyBlockIndexReader indexReader = reader.getDataBlockIndexReader();
+      if (indexReader != null) {
+        out.println(indexReader);
+      } else {
+        out.println(FOUR_SPACES + "Block index not available");
+      }
+    }
+  }
+
+  private void printBlockHeaders(HFile.Reader reader, Path file, FileSystem fs, boolean isV4)
+    throws IOException {
+    out.println("Block Headers:");
+
+    if (isV4) {
+      // For v4 files, show block headers for each tenant section
+      if (reader instanceof AbstractMultiTenantReader) {
+        AbstractMultiTenantReader mtReader = (AbstractMultiTenantReader) reader;
+        byte[][] tenantSectionIds = mtReader.getAllTenantSectionIds();
+
+        if (tenantSectionIds != null && tenantSectionIds.length > 0) {
+          out.println(
+            FOUR_SPACES + "HFile v4 contains " + tenantSectionIds.length + " tenant sections:");
+
+          for (int i = 0; i < tenantSectionIds.length; i++) {
+            byte[] sectionId = tenantSectionIds[i];
+            out.println(FOUR_SPACES + "--- Tenant Section " + i + ": "
+              + Bytes.toStringBinary(sectionId) + " ---");
+
+            try {
+              // Always show basic section information first
+              java.util.Map<String, Object> sectionInfo = mtReader.getSectionInfo(sectionId);
+              if (sectionInfo != null && (Boolean) sectionInfo.get("exists")) {
+                out.println(
+                  FOUR_SPACES + FOUR_SPACES + "Section offset: " + sectionInfo.get("offset"));
+                out.println(FOUR_SPACES + FOUR_SPACES + "Section size: " + sectionInfo.get("size")
+                  + " bytes");
+              } else {
+                out.println(FOUR_SPACES + FOUR_SPACES + "Section metadata not available");
+                continue;
+              }
+
+              // Get the actual block headers from the section reader
+              try (AbstractMultiTenantReader.SectionReaderLease lease =
+                mtReader.getSectionReader(sectionId)) {
+                if (lease != null) {
+                  HFileReaderImpl sectionHFileReader = lease.getReader();
+                  if (sectionHFileReader != null) {
+                    out.println(FOUR_SPACES + FOUR_SPACES + "Block headers:");
+                    // Create a section-specific path for block header reading
+                    // Use the original file path since block reading handles section offsets
+                    // internally
+                    printSectionBlockHeaders(sectionHFileReader, file, fs,
+                      FOUR_SPACES + FOUR_SPACES + FOUR_SPACES);
+                  } else {
+                    out.println(FOUR_SPACES + FOUR_SPACES + "Section reader not initialized");
+                  }
+                } else {
+                  out.println(FOUR_SPACES + FOUR_SPACES + "Could not create section reader");
+                }
+              } catch (Exception sectionException) {
+                out.println(FOUR_SPACES + FOUR_SPACES + "Error accessing section reader: "
+                  + sectionException.getMessage());
+              }
+
+            } catch (Exception e) {
+              out.println(FOUR_SPACES + FOUR_SPACES + "Error reading section block headers: "
+                + e.getMessage());
+            }
+
+            if (i < tenantSectionIds.length - 1) {
+              out.println(); // Add spacing between sections
+            }
+          }
+        } else {
+          out.println(FOUR_SPACES + "No tenant sections found in HFile v4");
+        }
+      } else {
+        out.println(FOUR_SPACES + "Reader is not a multi-tenant reader for v4 file");
+      }
+    } else {
+      // For v2/v3 files, use standard approach
+      printStandardBlockHeaders(reader, file, fs);
+    }
+  }
+
+  /**
+   * Print block headers using the standard approach for v2/v3 files.
+   */
+  private void printStandardBlockHeaders(HFile.Reader reader, Path file, FileSystem fs)
+    throws IOException {
+    try {
+      FSDataInputStreamWrapper fsdis = new FSDataInputStreamWrapper(fs, file);
+      long fileSize = fs.getFileStatus(file).getLen();
+      FixedFileTrailer trailer = FixedFileTrailer.readFromStream(fsdis.getStream(false), fileSize);
+      long offset = trailer.getFirstDataBlockOffset();
+      long max = trailer.getLastDataBlockOffset();
+
+      if (offset > max || offset < 0 || max < 0) {
+        out.println(FOUR_SPACES + "Invalid block offset range: " + offset + " to " + max);
+        return;
+      }
+
+      int blockCount = 0;
+      final int effectiveLimit = getEffectiveBlockLimit();
+
+      HFileBlock block;
+      while (offset <= max && blockCount < effectiveLimit) {
+        try {
+          block = reader.readBlock(offset, -1, /* cacheBlock */ false, /* pread */ false,
+            /* isCompaction */ false, /* updateCacheMetrics */ false, null, null);
+
+          if (block == null) {
+            out.println(FOUR_SPACES + "Warning: null block at offset " + offset);
+            break;
+          }
+
+          out.println(block);
+          offset += block.getOnDiskSizeWithHeader();
+          blockCount++;
+
+        } catch (Exception e) {
+          out.println(
+            FOUR_SPACES + "Error reading block at offset " + offset + ": " + e.getMessage());
+          offset += BLOCK_READ_ERROR_SKIP_BYTES;
+          if (offset > max) {
+            break;
+          }
+        }
+      }
+
+      if (blockCount >= effectiveLimit) {
+        out.println(FOUR_SPACES + "... (truncated after " + effectiveLimit + " blocks)");
+      }
+
+      out.println(FOUR_SPACES + "Total blocks shown: " + blockCount);
+
+    } catch (Exception e) {
+      out.println(FOUR_SPACES + "Unable to read block headers: " + e.getMessage());
+    }
+  }
+
+  /**
+   * Print block headers for a specific section reader with custom indentation.
+   * @param sectionReader the section reader to get block headers from
+   * @param file          the original file path (for context)
+   * @param fs            the file system
+   * @param indent        the indentation string to use for output
+   * @throws IOException if an error occurs reading block headers
+   */
+  private void printSectionBlockHeaders(HFileReaderImpl sectionReader, Path file, FileSystem fs,
+    String indent) throws IOException {
+    try {
+      FixedFileTrailer sectionTrailer = sectionReader.getTrailer();
+      long firstDataBlockOffset = sectionTrailer.getFirstDataBlockOffset();
+      long lastDataBlockOffset = sectionTrailer.getLastDataBlockOffset();
+
+      if (firstDataBlockOffset == -1 || lastDataBlockOffset == -1) {
+        out.println(indent + "No data blocks in this section");
+        return;
+      }
+
+      if (
+        firstDataBlockOffset > lastDataBlockOffset || firstDataBlockOffset < 0
+          || lastDataBlockOffset < 0
+      ) {
+        out.println(indent + "Invalid block offset range: " + firstDataBlockOffset + " to "
+          + lastDataBlockOffset);
+        return;
+      }
+
+      int blockCount = 0;
+      final int effectiveLimit = getEffectiveBlockLimit();
+      long offset = firstDataBlockOffset;
+
+      while (offset <= lastDataBlockOffset && blockCount < effectiveLimit) {
+        try {
+          HFileBlock block =
+            sectionReader.readBlock(offset, -1, /* cacheBlock */ false, /* pread */ false,
+              /* isCompaction */ false, /* updateCacheMetrics */ false, null, null);
+
+          if (block == null) {
+            out.println(indent + "Warning: null block at offset " + offset);
+            break;
+          }
+
+          // Print block header with proper indentation
+          String blockHeader = block.toString();
+          String[] lines = blockHeader.split("\n");
+          for (String line : lines) {
+            out.println(indent + line);
+          }
+
+          offset += block.getOnDiskSizeWithHeader();
+          blockCount++;
+
+        } catch (Exception e) {
+          out.println(indent + "Error reading block at offset " + offset + ": " + e.getMessage());
+          offset += BLOCK_READ_ERROR_SKIP_BYTES;
+          if (offset > lastDataBlockOffset) {
+            break;
+          }
+        }
+      }
+
+      if (blockCount >= effectiveLimit) {
+        out.println(indent + "... (truncated after " + effectiveLimit + " blocks)");
+      }
+
+      out.println(indent + "Total blocks shown: " + blockCount);
+
+    } catch (Exception e) {
+      out.println(indent + "Unable to read section block headers: " + e.getMessage());
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -43,6 +43,8 @@ import org.apache.hadoop.hbase.SizeCachedByteBufferKeyValue;
 import org.apache.hadoop.hbase.SizeCachedKeyValue;
 import org.apache.hadoop.hbase.SizeCachedNoTagsByteBufferKeyValue;
 import org.apache.hadoop.hbase.SizeCachedNoTagsKeyValue;
+import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
+import org.apache.hadoop.hbase.io.MultiTenantFSDataInputStreamWrapper;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoder;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
@@ -1230,6 +1232,31 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
   }
 
   /**
+   * For multi-tenant HFiles, a section reader uses an offset-translating stream wrapper so that
+   * section-internal offsets start at 0. For block cache keys we must always use container-file
+   * coordinates (container file name + absolute file offset), otherwise we will cache the same
+   * physical block under multiple names/offsets (e.g. with/without section suffixes), which breaks
+   * ref-counting/eviction and wastes cache space.
+   */
+  protected Path getPathForCaching() {
+    FSDataInputStreamWrapper wrapper = context.getInputStreamWrapper();
+    Path readerPath = wrapper.getReaderPath();
+    return readerPath != null ? readerPath : path;
+  }
+
+  protected String getNameForCaching() {
+    return getPathForCaching().getName();
+  }
+
+  protected long getOffsetForCaching(long relativeOffset) {
+    FSDataInputStreamWrapper wrapper = context.getInputStreamWrapper();
+    if (wrapper instanceof MultiTenantFSDataInputStreamWrapper) {
+      return ((MultiTenantFSDataInputStreamWrapper) wrapper).toAbsolutePosition(relativeOffset);
+    }
+    return relativeOffset;
+  }
+
+  /**
    * @param cacheBlock Add block to cache, if found
    * @return block wrapped in a ByteBuffer, with header skipped
    */
@@ -1255,8 +1282,8 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     synchronized (metaBlockIndexReader.getRootBlockKey(block)) {
       // Check cache for block. If found return.
       long metaBlockOffset = metaBlockIndexReader.getRootBlockOffset(block);
-      BlockCacheKey cacheKey =
-        new BlockCacheKey(path, metaBlockOffset, this.isPrimaryReplicaReader(), BlockType.META);
+      BlockCacheKey cacheKey = new BlockCacheKey(getPathForCaching(),
+        getOffsetForCaching(metaBlockOffset), this.isPrimaryReplicaReader(), BlockType.META);
 
       cacheBlock &=
         cacheConf.shouldCacheBlockOnRead(BlockType.META.getCategory(), getHFileInfo(), conf);
@@ -1345,8 +1372,9 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     // the other choice is to duplicate work (which the cache would prevent you
     // from doing).
 
-    BlockCacheKey cacheKey =
-      new BlockCacheKey(path, dataBlockOffset, this.isPrimaryReplicaReader(), expectedBlockType);
+    long cacheKeyOffset = getOffsetForCaching(dataBlockOffset);
+    BlockCacheKey cacheKey = new BlockCacheKey(getPathForCaching(), cacheKeyOffset,
+      this.isPrimaryReplicaReader(), expectedBlockType);
 
     boolean useLock = false;
     IdLock.Entry lockEntry = null;
@@ -1361,7 +1389,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
         // Check cache for block. If found return.
         if (cacheConf.shouldReadBlockFromCache(expectedBlockType) && !cacheOnly) {
           if (useLock) {
-            lockEntry = offsetLock.getLockEntry(dataBlockOffset);
+            lockEntry = offsetLock.getLockEntry(cacheKeyOffset);
           }
           // Try and get the block from the block cache. If the useLock variable is true then this
           // is the second time through the loop and it should not be counted as a block cache miss.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -69,7 +69,7 @@ import org.slf4j.LoggerFactory;
  * Common functionality needed by all versions of {@link HFile} writers.
  */
 @InterfaceAudience.Private
-public class HFileWriterImpl implements HFile.Writer {
+public class HFileWriterImpl implements HFile.Writer, LastCellAwareWriter {
   private static final Logger LOG = LoggerFactory.getLogger(HFileWriterImpl.class);
 
   private static final long UNSET = -1;
@@ -250,6 +250,7 @@ public class HFileWriterImpl implements HFile.Writer {
     HFile.updateWriteLatency(EnvironmentEdgeManager.currentTime() - startTime);
   }
 
+  @Override
   public long getPos() throws IOException {
     return outputStream.getPos();
 
@@ -590,7 +591,13 @@ public class HFileWriterImpl implements HFile.Writer {
     });
   }
 
-  private BlockCacheKey buildCacheBlockKey(long offset, BlockType blockType) {
+  /**
+   * Builds a cache key for a block written at the given offset.
+   * <p>
+   * Subclasses that write into virtualized sections should override this to translate section
+   * offsets into container-file offsets.
+   */
+  protected BlockCacheKey buildCacheBlockKey(long offset, BlockType blockType) {
     if (path != null) {
       return new BlockCacheKey(path, offset, true, blockType);
     }
@@ -824,6 +831,7 @@ public class HFileWriterImpl implements HFile.Writer {
     }
   }
 
+  @Override
   public Cell getLastCell() {
     return lastCell;
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LastCellAwareWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LastCellAwareWriter.java
@@ -1,0 +1,29 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Capability marker for HFile writers that can expose the last appended cell.
+ */
+@InterfaceAudience.Private
+public interface LastCellAwareWriter {
+  Cell getLastCell();
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruAdaptiveBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruAdaptiveBlockCache.java
@@ -674,7 +674,8 @@ public class LruAdaptiveBlockCache implements FirstLevelBlockCache {
    */
   @Override
   public int evictBlocksByHfileName(String hfileName) {
-    int numEvicted = (int) map.keySet().stream().filter(key -> key.getHfileName().equals(hfileName))
+    int numEvicted = (int) map.keySet().stream()
+      .filter(key -> BlockCacheUtil.matchesHFileName(key.getHfileName(), hfileName))
       .filter(this::evictBlock).count();
     if (victimHandler != null) {
       numEvicted += victimHandler.evictBlocksByHfileName(hfileName);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
@@ -578,7 +578,7 @@ public class LruBlockCache implements FirstLevelBlockCache {
   public int evictBlocksByHfileName(String hfileName) {
     int numEvicted = 0;
     for (BlockCacheKey key : map.keySet()) {
-      if (key.getHfileName().equals(hfileName)) {
+      if (BlockCacheUtil.matchesHFileName(key.getHfileName(), hfileName)) {
         if (evictBlock(key)) {
           ++numEvicted;
         }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantBloomSupport.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantBloomSupport.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import java.io.IOException;
+import org.apache.hadoop.hbase.ExtendedCell;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.util.BloomFilter;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Internal contract that enables multi-tenant HFile readers to participate in Bloom filter
+ * decisions while staying transparent to existing StoreFileReader callers.
+ */
+@InterfaceAudience.Private
+public interface MultiTenantBloomSupport {
+
+  boolean passesGeneralRowBloomFilter(byte[] row, int rowOffset, int rowLen) throws IOException;
+
+  /**
+   * Checks whether the given pre-extracted row prefix passes the general bloom filter in the
+   * appropriate tenant section. Unlike {@link #passesGeneralRowBloomFilter}, the caller has already
+   * extracted the prefix bytes so the bloom is checked directly without ROWPREFIX length gating.
+   * @param rowPrefix the already-extracted prefix bytes
+   * @param offset    offset into the prefix array
+   * @param length    number of prefix bytes to use
+   * @return true if the prefix may exist (or bloom is unavailable), false if definitely absent
+   */
+  boolean passesGeneralRowPrefixBloomFilter(byte[] rowPrefix, int offset, int length)
+    throws IOException;
+
+  boolean passesGeneralRowColBloomFilter(ExtendedCell cell) throws IOException;
+
+  boolean passesDeleteFamilyBloomFilter(byte[] row, int rowOffset, int rowLen) throws IOException;
+
+  BloomType getGeneralBloomFilterType();
+
+  int getGeneralBloomPrefixLength() throws IOException;
+
+  byte[] getLastBloomKey() throws IOException;
+
+  long getDeleteFamilyBloomCount() throws IOException;
+
+  BloomFilter getGeneralBloomFilterInstance() throws IOException;
+
+  BloomFilter getDeleteFamilyBloomFilterInstance() throws IOException;
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileWriter.java
@@ -1,0 +1,1674 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.apache.hadoop.hbase.io.hfile.BlockCompressedSizePredicator.MAX_BLOCK_SIZE_UNCOMPRESSED;
+import static org.apache.hadoop.hbase.io.hfile.HFileWriterImpl.KEY_VALUE_VERSION;
+import static org.apache.hadoop.hbase.io.hfile.HFileWriterImpl.KEY_VALUE_VER_WITH_MEMSTORE;
+
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.io.UncheckedIOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.ExtendedCell;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.KeyValueUtil;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.io.crypto.Encryption;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoding;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.regionserver.HStoreFile;
+import org.apache.hadoop.hbase.security.EncryptionUtil;
+import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.util.BloomFilterFactory;
+import org.apache.hadoop.hbase.util.BloomFilterWriter;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.io.Writable;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * An HFile writer that supports multiple tenants by sectioning the data within a single file.
+ * <p>
+ * This implementation takes advantage of the fact that HBase data is always written in sorted
+ * order, so once we move to a new tenant, we'll never go back to a previous one.
+ * <p>
+ * Instead of creating separate physical files for each tenant, this writer creates a single HFile
+ * with internal sections that are indexed by tenant prefix.
+ * <p>
+ * Key features:
+ * <ul>
+ * <li>Single HFile v4 format with multiple tenant sections</li>
+ * <li>Each section contains complete HFile v3 structure</li>
+ * <li>Section-level bloom filters for efficient tenant-specific queries</li>
+ * <li>Multi-level tenant indexing for fast section lookup</li>
+ * <li>Configurable tenant prefix extraction</li>
+ * </ul>
+ */
+@InterfaceAudience.Private
+public class MultiTenantHFileWriter implements HFile.Writer, LastCellAwareWriter {
+  private static final Logger LOG = LoggerFactory.getLogger(MultiTenantHFileWriter.class);
+
+  /** Tenant identification configuration at cluster level */
+  public static final String TENANT_PREFIX_LENGTH = "hbase.multi.tenant.prefix.length";
+
+  /** Tenant identification configuration at table level (higher precedence) */
+  public static final String TABLE_TENANT_PREFIX_LENGTH = "TENANT_PREFIX_LENGTH";
+
+  /** Table-level property to enable/disable multi-tenant sectioning */
+  public static final String TABLE_MULTI_TENANT_ENABLED = "MULTI_TENANT_HFILE";
+
+  /** FileInfo keys for multi-tenant HFile metadata */
+  public static final String FILEINFO_SECTION_COUNT = "SECTION_COUNT";
+  public static final String FILEINFO_TENANT_INDEX_LEVELS = "TENANT_INDEX_LEVELS";
+  public static final String FILEINFO_TENANT_INDEX_MAX_CHUNK = "TENANT_INDEX_MAX_CHUNK";
+  public static final String FILEINFO_TENANT_ID = "TENANT_ID";
+  public static final String FILEINFO_TENANT_SECTION_ID = "TENANT_SECTION_ID";
+  /** Empty prefix for default tenant */
+  private static final byte[] DEFAULT_TENANT_PREFIX = new byte[0];
+
+  /**
+   * Class that manages tenant configuration with proper precedence:
+   * <ol>
+   * <li>Table level settings have highest precedence</li>
+   * <li>Cluster level settings are used as fallback</li>
+   * <li>Default values are used if neither is specified</li>
+   * </ol>
+   */
+  // TenantConfiguration class removed - use TenantExtractorFactory instead
+
+  /** Extractor for tenant information */
+  private final TenantExtractor tenantExtractor;
+  /** Path for the HFile */
+  private final Path path;
+  /** Configuration settings */
+  private final Configuration conf;
+  /** Cache configuration */
+  private final CacheConfig cacheConf;
+  /** HFile context */
+  private final HFileContext fileContext;
+  /** Name used for logging/caching when path is not available */
+  private final String streamName;
+
+  /** Main file writer components - Output stream */
+  private final FSDataOutputStream outputStream;
+  /** Whether this writer owns the underlying output stream */
+  private final boolean closeOutputStream;
+  /** Tracks whether close has already run */
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+  /** Block writer for HFile blocks */
+  private HFileBlock.Writer blockWriter;
+  /** Section index writer for tenant indexing */
+  private SectionIndexManager.Writer sectionIndexWriter;
+
+  /** Section tracking - Current section writer */
+  private SectionWriter currentSectionWriter;
+  /** Current tenant section ID */
+  private byte[] currentTenantSectionId;
+  /** Start offset of current section */
+  private long sectionStartOffset;
+  /** Number of sections written */
+  private int sectionCount = 0;
+
+  /** Stats for the entire file - Last cell written (internal tracking only) */
+  private Cell lastCell = null;
+  /** Total number of entries */
+  private long entryCount = 0;
+  /** Total key length across all entries */
+  private long totalKeyLength = 0;
+  /** Total value length across all entries */
+  private long totalValueLength = 0;
+  /** Length of the biggest cell */
+  private long lenOfBiggestCell = 0;
+  /** Maximum memstore timestamp */
+  private long maxMemstoreTS = 0;
+  /** Maximum tags length encountered */
+  private int maxTagsLength = 0;
+  /** Aggregated time range across all sections */
+  private final org.apache.hadoop.hbase.regionserver.TimeRangeTracker globalTimeRangeTracker =
+    org.apache.hadoop.hbase.regionserver.TimeRangeTracker
+      .create(org.apache.hadoop.hbase.regionserver.TimeRangeTracker.Type.NON_SYNC);
+  /** Aggregated custom tiering min timestamp */
+  private long globalCustomMinTimestamp =
+    org.apache.hadoop.hbase.regionserver.TimeRangeTracker.INITIAL_MIN_TIMESTAMP;
+  /** Aggregated custom tiering max timestamp */
+  private long globalCustomMaxTimestamp =
+    org.apache.hadoop.hbase.regionserver.TimeRangeTracker.INITIAL_MAX_TIMESTAMP;
+  /** Whether we have seen any custom time range metadata */
+  private boolean globalCustomTimeRangePresent = false;
+  /** Supplier that exposes compaction-specific custom tiering time range tracking */
+  private Supplier<org.apache.hadoop.hbase.regionserver.TimeRangeTracker> customTieringSupplier;
+  /** Earliest put timestamp across the file */
+  private long globalEarliestPutTs = org.apache.hadoop.hbase.HConstants.LATEST_TIMESTAMP;
+
+  /** Total uncompressed bytes */
+  private long totalUncompressedBytes = 0;
+  /** Global maximum sequence id across sections */
+  private long globalMaxSeqId = Long.MIN_VALUE;
+
+  /** Absolute offset where each section's load-on-open data begins (max across sections) */
+  private long maxSectionDataEndOffset = 0;
+  /**
+   * Absolute offset of the first data block across all sections, if any. Compatibility envelope for
+   * legacy trailer consumers that expect a single global data range.
+   */
+  private long globalFirstDataBlockOffset = -1L;
+  /**
+   * Absolute offset of the last data block across all sections, if any. Compatibility envelope for
+   * legacy trailer consumers that expect a single global data range.
+   */
+  private long globalLastDataBlockOffset = -1L;
+  /** Absolute offset where the global section index root block starts */
+  private long sectionIndexRootOffset = -1;
+  /** HFile v4 trailer */
+  private FixedFileTrailer trailer;
+  /** File info for metadata */
+  private HFileInfo fileInfo = new HFileInfo();
+  /** Defaults to apply to each new section's FileInfo (e.g., compaction context) */
+  private final HFileInfo sectionDefaultFileInfo = new HFileInfo();
+  /**
+   * Metadata keys that belong in the global (v4-level) FileInfo block. Only these keys are
+   * propagated from external {@link #appendFileInfo} calls to the global file info; all other keys
+   * are section-local. Keys that require global aggregation (e.g. {@code TIMERANGE_KEY},
+   * {@code EARLIEST_PUT_TS}) are handled separately in {@link #finishFileInfo()} and do not need to
+   * appear here.
+   */
+  private static final byte[][] GLOBAL_FILE_INFO_KEYS = new byte[][] {
+    // Bulk-load identifiers
+    HStoreFile.BULKLOAD_TIME_KEY, HStoreFile.BULKLOAD_TASK_KEY,
+    // Compaction & lifecycle markers
+    HStoreFile.MAJOR_COMPACTION_KEY, HStoreFile.EXCLUDE_FROM_MINOR_COMPACTION_KEY,
+    HStoreFile.COMPACTION_EVENT_KEY, HStoreFile.HISTORICAL_KEY,
+    // Sequence & version metadata
+    HStoreFile.MAX_SEQ_ID_KEY, HFile.Writer.MAX_MEMSTORE_TS_KEY, HFileWriterImpl.KEY_VALUE_VERSION,
+    // Encoding metadata
+    HFileDataBlockEncoder.DATA_BLOCK_ENCODING, HFileIndexBlockEncoder.INDEX_BLOCK_ENCODING,
+    // MOB metadata
+    HStoreFile.MOB_CELLS_COUNT, HStoreFile.MOB_FILE_REFS,
+    // Stripe store boundaries — file-level properties that describe how the HFile
+    // maps to stripes; required by StripeStoreFileManager for stripe assignment.
+    org.apache.hadoop.hbase.regionserver.StripeStoreFileManager.STRIPE_START_KEY,
+    org.apache.hadoop.hbase.regionserver.StripeStoreFileManager.STRIPE_END_KEY,
+    // Custom tiering
+    org.apache.hadoop.hbase.regionserver.CustomTieringMultiFileWriter.CUSTOM_TIERING_TIME_RANGE };
+
+  /** Current bloom filter writer — one per section */
+  private BloomFilterWriter currentBloomFilterWriter;
+  /** Whether bloom filter is enabled */
+  private boolean bloomFilterEnabled;
+  /** Type of bloom filter to use */
+  private BloomType bloomFilterType;
+  /** Per-section delete family bloom filter writer */
+  private BloomFilterWriter currentDeleteFamilyBloomFilterWriter;
+  /** Per-section general bloom context for dedupe and LAST_BLOOM_KEY */
+  private org.apache.hadoop.hbase.util.BloomContext currentGeneralBloomContext;
+  /** Per-section delete family bloom context */
+  private org.apache.hadoop.hbase.util.BloomContext currentDeleteFamilyBloomContext;
+  /**
+   * Inline block writers buffered before the first section is created. Flushed to the first section
+   * writer during {@link #createNewSection}.
+   */
+  private final java.util.List<InlineBlockWriter> pendingInlineBlockWriters =
+    new java.util.ArrayList<>();
+  /** Per-section time range tracker */
+  private org.apache.hadoop.hbase.regionserver.TimeRangeTracker currentSectionTimeRangeTracker;
+  /** Per-section earliest put timestamp */
+  private long currentSectionEarliestPutTs = org.apache.hadoop.hbase.HConstants.LATEST_TIMESTAMP;
+  /** Per-section delete family counter */
+  private long currentSectionDeleteFamilyCnt = 0;
+  /** Per-section max sequence id */
+  private long currentSectionMaxSeqId = 0;
+  /** Bloom param (e.g., rowprefix length) for the section */
+  private byte[] currentGeneralBloomParam;
+
+  /**
+   * Only these FileInfo keys are propagated as per-section defaults across tenant sections. This
+   * avoids unintentionally overriding section-local metadata.
+   */
+  private static boolean isPropagatedDefaultKey(byte[] key) {
+    return Bytes.equals(key, org.apache.hadoop.hbase.regionserver.HStoreFile.MAJOR_COMPACTION_KEY)
+      || Bytes.equals(key, org.apache.hadoop.hbase.regionserver.HStoreFile.COMPACTION_EVENT_KEY)
+      || Bytes.equals(key, org.apache.hadoop.hbase.regionserver.HStoreFile.HISTORICAL_KEY);
+  }
+
+  /**
+   * Creates a multi-tenant HFile writer that writes sections to a single file.
+   * @param fs              Filesystem to write to
+   * @param path            Path for the HFile (final destination)
+   * @param conf            Configuration settings
+   * @param cacheConf       Cache configuration
+   * @param tenantExtractor Extractor for tenant information
+   * @param fileContext     HFile context
+   * @param bloomType       Type of bloom filter to use
+   * @throws IOException If an error occurs during initialization
+   */
+  public MultiTenantHFileWriter(Path path, Configuration conf, CacheConfig cacheConf,
+    TenantExtractor tenantExtractor, HFileContext fileContext, BloomType bloomType,
+    FSDataOutputStream outputStream, boolean closeOutputStream) throws IOException {
+    this.path = path;
+    this.conf = Objects.requireNonNull(conf, "conf");
+    this.cacheConf = Objects.requireNonNull(cacheConf, "cacheConf");
+    this.tenantExtractor = Objects.requireNonNull(tenantExtractor, "tenantExtractor");
+    this.fileContext = Objects.requireNonNull(fileContext, "fileContext");
+
+    BloomType effectiveBloomType = bloomType != null ? bloomType : BloomType.NONE;
+    this.bloomFilterEnabled =
+      effectiveBloomType != BloomType.NONE && BloomFilterFactory.isGeneralBloomEnabled(conf);
+    this.bloomFilterType = effectiveBloomType;
+
+    this.outputStream = Objects.requireNonNull(outputStream, "outputStream");
+    this.closeOutputStream = closeOutputStream;
+    this.streamName = path != null ? path.toString() : this.outputStream.toString();
+
+    // initialize blockWriter and sectionIndexWriter after creating stream
+    initialize();
+  }
+
+  /**
+   * Factory method to create a MultiTenantHFileWriter with configuration from both table and
+   * cluster levels.
+   * <p>
+   * This method applies configuration precedence:
+   * <ol>
+   * <li>Table-level properties have highest precedence</li>
+   * <li>Cluster-level configuration used as fallback</li>
+   * <li>Default values used if neither specified</li>
+   * </ol>
+   * @param fs              Filesystem to write to
+   * @param path            Path for the HFile
+   * @param conf            Configuration settings that include cluster-level tenant configuration
+   * @param cacheConf       Cache configuration
+   * @param tableProperties Table properties that may include table-level tenant configuration
+   * @param fileContext     HFile context
+   * @return A configured MultiTenantHFileWriter
+   * @throws IOException if writer creation fails
+   */
+  public static MultiTenantHFileWriter create(FileSystem fs, Path path, Configuration conf,
+    CacheConfig cacheConf, Map<String, String> tableProperties, HFileContext fileContext,
+    BloomType columnFamilyBloomType, BloomType defaultBloomType, FSDataOutputStream outputStream,
+    boolean closeOutputStream) throws IOException {
+
+    FSDataOutputStream writerStream = outputStream;
+    boolean shouldCloseStream = closeOutputStream;
+    if (writerStream == null) {
+      Objects.requireNonNull(path, "path must be provided when outputStream is null");
+      Objects.requireNonNull(fs, "filesystem must be provided when outputStream is null");
+      writerStream = HFileWriterImpl.createOutputStream(conf, fs, path, null);
+      shouldCloseStream = true;
+    }
+
+    boolean success = false;
+    try {
+      // Create tenant extractor using factory - it will decide whether to use
+      // DefaultTenantExtractor or SingleTenantExtractor based on table properties
+      TenantExtractor tenantExtractor =
+        TenantExtractorFactory.createTenantExtractor(conf, tableProperties);
+
+      // Determine bloom configuration with precedence: column family > table property > builder >
+      // default ROW
+      BloomType bloomType = columnFamilyBloomType;
+      if (
+        tableProperties != null
+          && tableProperties.containsKey(ColumnFamilyDescriptorBuilder.BLOOMFILTER)
+      ) {
+        try {
+          bloomType = BloomType
+            .valueOf(tableProperties.get(ColumnFamilyDescriptorBuilder.BLOOMFILTER).toUpperCase());
+        } catch (IllegalArgumentException e) {
+          LOG.warn("Invalid bloom filter type in table properties: {}, ignoring override",
+            tableProperties.get(ColumnFamilyDescriptorBuilder.BLOOMFILTER));
+        }
+      }
+      if (bloomType == null) {
+        bloomType = defaultBloomType;
+      }
+      if (bloomType == null) {
+        bloomType = BloomType.ROW;
+      }
+
+      LOG.info(
+        "Creating MultiTenantHFileWriter with tenant extractor: {}, bloom type: {} "
+          + "(cf override: {}, default: {}) and target {}",
+        tenantExtractor.getClass().getSimpleName(), bloomType,
+        columnFamilyBloomType != null ? columnFamilyBloomType : "<not-set>",
+        defaultBloomType != null ? defaultBloomType : "<none>", path != null ? path : writerStream);
+
+      // HFile version 4 inherently implies multi-tenant
+      MultiTenantHFileWriter writer = new MultiTenantHFileWriter(path, conf, cacheConf,
+        tenantExtractor, fileContext, bloomType, writerStream, shouldCloseStream);
+      success = true;
+      return writer;
+    } finally {
+      if (!success && shouldCloseStream && writerStream != outputStream) {
+        try {
+          writerStream.close();
+        } catch (IOException e) {
+          LOG.warn("Failed to close output stream after factory method failure for {}", path, e);
+        }
+      }
+    }
+  }
+
+  /**
+   * Initialize the writer components including block writer and section index writer.
+   * <p>
+   * Sets up multi-level tenant indexing with configurable chunk sizes and index parameters.
+   * @throws IOException if initialization fails
+   */
+  private void initialize() throws IOException {
+    // Initialize the block writer
+    blockWriter = new HFileBlock.Writer(conf, NoOpDataBlockEncoder.INSTANCE, fileContext,
+      cacheConf.getByteBuffAllocator(),
+      conf.getInt(MAX_BLOCK_SIZE_UNCOMPRESSED, fileContext.getBlocksize() * 10));
+
+    // Initialize the section index using SectionIndexManager
+    boolean cacheIndexesOnWrite = cacheConf.shouldCacheIndexesOnWrite();
+    String nameForCaching = null;
+    if (cacheIndexesOnWrite) {
+      nameForCaching = path != null ? path.getName() : streamName;
+    }
+
+    sectionIndexWriter = new SectionIndexManager.Writer(blockWriter,
+      cacheIndexesOnWrite ? cacheConf : null, nameForCaching);
+
+    // Configure multi-level tenant indexing based on configuration
+    int maxChunkSize = conf.getInt(SectionIndexManager.SECTION_INDEX_MAX_CHUNK_SIZE,
+      SectionIndexManager.DEFAULT_MAX_CHUNK_SIZE);
+    int minIndexNumEntries = conf.getInt(SectionIndexManager.SECTION_INDEX_MIN_NUM_ENTRIES,
+      SectionIndexManager.DEFAULT_MIN_INDEX_NUM_ENTRIES);
+
+    sectionIndexWriter.setMaxChunkSize(maxChunkSize);
+    sectionIndexWriter.setMinIndexNumEntries(minIndexNumEntries);
+
+    LOG.info("Initialized MultiTenantHFileWriter with multi-level section indexing for {} "
+      + "(maxChunkSize={}, minIndexNumEntries={})", streamName, maxChunkSize, minIndexNumEntries);
+
+    initializeEagerBloom();
+  }
+
+  /**
+   * Eagerly create the first Bloom filter writer so that {@link #hasGeneralBloom()} /
+   * {@link #getGeneralBloomWriter()} return valid state before the first section is created. The
+   * writer and its context are attached to the first section when {@link #createNewSection} runs.
+   */
+  private void initializeEagerBloom() {
+    if (!bloomFilterEnabled || bloomFilterType == BloomType.NONE) {
+      return;
+    }
+    currentBloomFilterWriter =
+      BloomFilterFactory.createGeneralBloomAtWrite(conf, cacheConf, bloomFilterType, 0, this);
+    if (currentBloomFilterWriter != null) {
+      currentGeneralBloomContext =
+        createBloomContext(currentBloomFilterWriter, bloomFilterType, fileContext);
+      currentGeneralBloomParam =
+        org.apache.hadoop.hbase.util.BloomFilterUtil.getBloomFilterParam(bloomFilterType, conf);
+    }
+  }
+
+  private org.apache.hadoop.hbase.util.BloomContext
+    createBloomContext(BloomFilterWriter bloomWriter, BloomType type, HFileContext ctx) {
+    switch (type) {
+      case ROW:
+        return new org.apache.hadoop.hbase.util.RowBloomContext(bloomWriter,
+          ctx.getCellComparator());
+      case ROWCOL:
+        return new org.apache.hadoop.hbase.util.RowColBloomContext(bloomWriter,
+          ctx.getCellComparator());
+      case ROWPREFIX_FIXED_LENGTH:
+        byte[] param = org.apache.hadoop.hbase.util.BloomFilterUtil.getBloomFilterParam(type, conf);
+        return new org.apache.hadoop.hbase.util.RowPrefixFixedLengthBloomContext(bloomWriter,
+          ctx.getCellComparator(), org.apache.hadoop.hbase.util.Bytes.toInt(param));
+      default:
+        return null;
+    }
+  }
+
+  @Override
+  public void append(ExtendedCell cell) throws IOException {
+    if (closed.get()) {
+      throw new IOException("Cannot append to a closed writer: " + streamName);
+    }
+    if (cell == null) {
+      throw new IOException("Cannot append null cell");
+    }
+
+    // Fast path: check if the cell belongs to the current section without allocation
+    boolean sameSection = currentSectionWriter != null
+      && tenantExtractor.matchesTenantSectionId(cell, currentTenantSectionId);
+
+    if (!sameSection) {
+      // Allocate only on section transitions (rare) or first cell
+      byte[] tenantSectionId = tenantExtractor.extractTenantSectionId(cell);
+      if (tenantSectionId == null) {
+        throw new IOException("Row key too short for configured tenant prefix length ("
+          + tenantExtractor.getPrefixLength() + "). Row length: " + cell.getRowLength()
+          + ". Check hbase.multi.tenant.prefix.length or TENANT_PREFIX_LENGTH configuration.");
+      }
+
+      // Validate cross-section sort order: the first cell of the new section must
+      // sort strictly after the last cell of the previous section.
+      if (lastCell != null) {
+        int cmp = fileContext.getCellComparator().compare(cell, (ExtendedCell) lastCell);
+        if (cmp <= 0) {
+          throw new IOException("Cross-section sort order violation: new section cell "
+            + CellUtil.getCellKeyAsString(cell) + " does not sort after previous section's last "
+            + "cell " + CellUtil.getCellKeyAsString(lastCell) + ". Section transition from "
+            + Bytes.toStringBinary(currentTenantSectionId) + " to "
+            + Bytes.toStringBinary(tenantSectionId));
+        }
+      }
+
+      if (currentSectionWriter != null) {
+        closeCurrentSection();
+      }
+      byte[] tenantId = tenantExtractor.extractTenantId(cell);
+      createNewSection(tenantSectionId, tenantId);
+    }
+
+    // Write the cell to the current section
+    currentSectionWriter.append(cell);
+
+    // Update per-section metadata
+    // 1) General bloom (deduped by context)
+    if (bloomFilterEnabled && currentGeneralBloomContext != null) {
+      currentGeneralBloomContext.writeBloom(cell);
+    }
+    // 2) Delete family bloom and counter
+    if (
+      org.apache.hadoop.hbase.PrivateCellUtil.isDeleteFamily(cell)
+        || org.apache.hadoop.hbase.PrivateCellUtil.isDeleteFamilyVersion(cell)
+    ) {
+      currentSectionDeleteFamilyCnt++;
+      if (currentDeleteFamilyBloomContext != null) {
+        currentDeleteFamilyBloomContext.writeBloom(cell);
+      }
+    }
+    // 3) Time range and earliest put ts
+    if (currentSectionTimeRangeTracker != null) {
+      currentSectionTimeRangeTracker.includeTimestamp(cell);
+    }
+    globalTimeRangeTracker.includeTimestamp(cell);
+    // Do not call cell.getType() here. Some internal/test-only cells (e.g. KeyValue.Type.Maximum)
+    // use type codes which are not valid Cell.Type values and would throw on conversion.
+    // HFile writers historically tolerate these and treat them as non-Put for put-specific
+    // bookkeeping.
+    if (CellUtil.isPut(cell)) {
+      long ts = cell.getTimestamp();
+      currentSectionEarliestPutTs = Math.min(currentSectionEarliestPutTs, ts);
+      globalEarliestPutTs = Math.min(globalEarliestPutTs, ts);
+    }
+    // 4) Max seq id
+    if (cell.getSequenceId() > currentSectionMaxSeqId) {
+      currentSectionMaxSeqId = cell.getSequenceId();
+    }
+
+    // Track statistics for the entire file
+    lastCell = cell;
+    entryCount++;
+    totalKeyLength += PrivateCellUtil.estimatedSerializedSizeOfKey(cell);
+    totalValueLength += cell.getValueLength();
+
+    int cellSize = PrivateCellUtil.estimatedSerializedSizeOf(cell);
+    if (lenOfBiggestCell < cellSize) {
+      lenOfBiggestCell = cellSize;
+    }
+
+    // Track maximum memstore timestamp across all cells
+    long cellMemstoreTS = cell.getSequenceId();
+    if (cellMemstoreTS > maxMemstoreTS) {
+      maxMemstoreTS = cellMemstoreTS;
+    }
+
+    int tagsLength = cell.getTagsLength();
+    if (tagsLength > this.maxTagsLength) {
+      this.maxTagsLength = tagsLength;
+    }
+  }
+
+  private void closeCurrentSection() throws IOException {
+    LOG.info("Closing section for tenant section ID: {}",
+      currentTenantSectionId == null ? "null" : Bytes.toStringBinary(currentTenantSectionId));
+
+    if (currentSectionWriter == null) {
+      LOG.warn("Attempted to close null section writer");
+      return;
+    }
+
+    try {
+      // Record the section start position
+      long sectionStartOffset = currentSectionWriter.getSectionStartOffset();
+
+      // Validate section has data
+      long entryCount = currentSectionWriter.getEntryCount();
+      if (entryCount == 0) {
+        LOG.warn("Closing empty section for tenant: {}",
+          Bytes.toStringBinary(currentTenantSectionId));
+      }
+
+      // Add general bloom filter and metadata to the section if enabled
+      if (bloomFilterEnabled && currentBloomFilterWriter != null) {
+        long keyCount = currentBloomFilterWriter.getKeyCount();
+        if (keyCount > 0) {
+          LOG.debug("Adding section-specific bloom filter with {} keys for section: {}", keyCount,
+            Bytes.toStringBinary(currentTenantSectionId));
+          currentSectionWriter.addGeneralBloomFilter(currentBloomFilterWriter);
+          // Append bloom metadata similar to StoreFileWriter
+          currentSectionWriter.appendFileInfo(
+            org.apache.hadoop.hbase.regionserver.HStoreFile.BLOOM_FILTER_TYPE_KEY,
+            Bytes.toBytes(bloomFilterType.toString()));
+          if (currentGeneralBloomParam != null) {
+            currentSectionWriter.appendFileInfo(
+              org.apache.hadoop.hbase.regionserver.HStoreFile.BLOOM_FILTER_PARAM_KEY,
+              currentGeneralBloomParam);
+          }
+          // LAST_BLOOM_KEY
+          if (currentGeneralBloomContext != null) {
+            try {
+              currentGeneralBloomContext.addLastBloomKey(currentSectionWriter);
+            } catch (IOException e) {
+              LOG.warn("Failed to append LAST_BLOOM_KEY for section: {}",
+                Bytes.toStringBinary(currentTenantSectionId), e);
+            }
+          }
+        } else {
+          LOG.debug("No keys to add to general bloom filter for section: {}",
+            Bytes.toStringBinary(currentTenantSectionId));
+        }
+      }
+      // Add delete family bloom filter and count
+      if (currentDeleteFamilyBloomFilterWriter != null) {
+        boolean hasDeleteFamilyBloom = currentDeleteFamilyBloomFilterWriter.getKeyCount() > 0;
+        if (hasDeleteFamilyBloom) {
+          currentDeleteFamilyBloomFilterWriter.compactBloom();
+          currentSectionWriter.addDeleteFamilyBloomFilter(currentDeleteFamilyBloomFilterWriter);
+        }
+      }
+      // Always append delete family count
+      currentSectionWriter.appendFileInfo(
+        org.apache.hadoop.hbase.regionserver.HStoreFile.DELETE_FAMILY_COUNT,
+        Bytes.toBytes(this.currentSectionDeleteFamilyCnt));
+
+      // Append per-section time range and earliest put ts
+      if (currentSectionTimeRangeTracker != null) {
+        currentSectionWriter.appendFileInfo(
+          org.apache.hadoop.hbase.regionserver.HStoreFile.TIMERANGE_KEY,
+          org.apache.hadoop.hbase.regionserver.TimeRangeTracker
+            .toByteArray(currentSectionTimeRangeTracker));
+      }
+      currentSectionWriter.appendFileInfo(
+        org.apache.hadoop.hbase.regionserver.HStoreFile.EARLIEST_PUT_TS,
+        Bytes.toBytes(this.currentSectionEarliestPutTs));
+
+      // Append per-section MAX_SEQ_ID_KEY
+      currentSectionWriter.appendFileInfo(
+        org.apache.hadoop.hbase.regionserver.HStoreFile.MAX_SEQ_ID_KEY,
+        Bytes.toBytes(this.currentSectionMaxSeqId));
+
+      // Finish writing the current section
+      currentSectionWriter.close();
+      outputStream.flush();
+
+      long sectionDataEnd = currentSectionWriter.getSectionDataEndOffset();
+      if (sectionDataEnd >= 0) {
+        maxSectionDataEndOffset = Math.max(maxSectionDataEndOffset, sectionDataEnd);
+      }
+      // Aggregate section-local data bounds into a global compatibility envelope.
+      long sectionFirstDataOffset = currentSectionWriter.getSectionFirstDataBlockOffset();
+      if (
+        sectionFirstDataOffset >= 0
+          && (globalFirstDataBlockOffset < 0 || sectionFirstDataOffset < globalFirstDataBlockOffset)
+      ) {
+        globalFirstDataBlockOffset = sectionFirstDataOffset;
+      }
+      long sectionLastDataOffset = currentSectionWriter.getSectionLastDataBlockOffset();
+      if (sectionLastDataOffset >= 0 && sectionLastDataOffset > globalLastDataBlockOffset) {
+        globalLastDataBlockOffset = sectionLastDataOffset;
+      }
+
+      // Get current position to calculate section size
+      long sectionEndOffset = outputStream.getPos();
+      long sectionSize = sectionEndOffset - sectionStartOffset;
+
+      // Validate section size
+      if (sectionSize <= 0) {
+        throw new IOException("Invalid section size: " + sectionSize + " for tenant: "
+          + Bytes.toStringBinary(currentTenantSectionId));
+      }
+
+      // Validate section doesn't exceed max size (2GB limit for int)
+      if (sectionSize > Integer.MAX_VALUE) {
+        throw new IOException("Section size exceeds maximum: " + sectionSize + " for tenant: "
+          + Bytes.toStringBinary(currentTenantSectionId));
+      }
+
+      // Record section in the index
+      sectionIndexWriter.addEntry(currentTenantSectionId, sectionStartOffset, (int) sectionSize);
+
+      // Add to total uncompressed bytes
+      totalUncompressedBytes += currentSectionWriter.getTotalUncompressedBytes();
+
+      globalMaxSeqId = Math.max(globalMaxSeqId, currentSectionMaxSeqId);
+
+      LOG.info("Section closed: start={}, size={}, entries={}", sectionStartOffset, sectionSize,
+        currentSectionWriter.getEntryCount());
+    } catch (IOException e) {
+      LOG.error("Error closing section for tenant section ID: {}",
+        currentTenantSectionId == null ? "null" : Bytes.toStringBinary(currentTenantSectionId), e);
+      throw e;
+    } finally {
+      currentSectionWriter = null;
+      // Clear per-section trackers
+      currentBloomFilterWriter = null;
+      currentDeleteFamilyBloomFilterWriter = null;
+      currentGeneralBloomContext = null;
+      currentDeleteFamilyBloomContext = null;
+      currentSectionTimeRangeTracker = null;
+      currentSectionEarliestPutTs = org.apache.hadoop.hbase.HConstants.LATEST_TIMESTAMP;
+      currentSectionDeleteFamilyCnt = 0;
+      currentSectionMaxSeqId = 0;
+      currentGeneralBloomParam = null;
+    }
+  }
+
+  /**
+   * Create a new section for a tenant with its own writer and bloom filter.
+   * <p>
+   * Each section is a complete HFile v3 structure within the larger v4 file.
+   * @param tenantSectionId The tenant section identifier for indexing
+   * @param tenantId        The tenant identifier for metadata
+   * @throws IOException if section creation fails
+   */
+  private void createNewSection(byte[] tenantSectionId, byte[] tenantId) throws IOException {
+    // Set the start offset for this section
+    sectionStartOffset = outputStream.getPos();
+
+    // Create a new virtual section writer. If post-construction init fails,
+    // clean up the partially-initialized writer to avoid resource leaks.
+    SectionWriter newSection = new SectionWriter(conf, cacheConf, outputStream, fileContext,
+      tenantSectionId, tenantId, sectionStartOffset);
+    try {
+      if (customTieringSupplier != null) {
+        newSection.setTimeRangeTrackerForTiering(customTieringSupplier);
+      }
+    } catch (RuntimeException e) {
+      try {
+        newSection.close();
+      } catch (IOException closeEx) {
+        e.addSuppressed(closeEx);
+      }
+      throw new IOException(e);
+    }
+    currentSectionWriter = newSection;
+
+    // Initialize per-section trackers
+    this.currentSectionTimeRangeTracker = org.apache.hadoop.hbase.regionserver.TimeRangeTracker
+      .create(org.apache.hadoop.hbase.regionserver.TimeRangeTracker.Type.NON_SYNC);
+    this.currentSectionEarliestPutTs = org.apache.hadoop.hbase.HConstants.LATEST_TIMESTAMP;
+    this.currentSectionDeleteFamilyCnt = 0;
+    this.currentSectionMaxSeqId = 0;
+
+    // Default per-section flags to ensure consistent presence across sections
+    currentSectionWriter.appendFileInfo(
+      org.apache.hadoop.hbase.regionserver.HStoreFile.MAJOR_COMPACTION_KEY, Bytes.toBytes(false));
+    currentSectionWriter.appendFileInfo(
+      org.apache.hadoop.hbase.regionserver.HStoreFile.HISTORICAL_KEY, Bytes.toBytes(false));
+    try {
+      byte[] emptyEvent = org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil
+        .toCompactionEventTrackerBytes(java.util.Collections.emptySet());
+      currentSectionWriter.appendFileInfo(
+        org.apache.hadoop.hbase.regionserver.HStoreFile.COMPACTION_EVENT_KEY, emptyEvent);
+    } catch (Exception e) {
+      LOG.debug("Unable to append default COMPACTION_EVENT_KEY for section: {}",
+        tenantSectionId == null ? "null" : Bytes.toStringBinary(tenantSectionId), e);
+    }
+
+    // Apply only whitelisted section defaults (e.g., compaction context). Values here override
+    // above
+    for (java.util.Map.Entry<byte[], byte[]> e : sectionDefaultFileInfo.entrySet()) {
+      currentSectionWriter.appendFileInfo(e.getKey(), e.getValue());
+    }
+
+    // Flush any inline block writers that were buffered before the first section existed.
+    // This covers the eagerly-created Bloom filter writer added by initializeEagerBloom().
+    if (!pendingInlineBlockWriters.isEmpty()) {
+      for (InlineBlockWriter ibw : pendingInlineBlockWriters) {
+        currentSectionWriter.addInlineBlockWriter(ibw);
+      }
+      pendingInlineBlockWriters.clear();
+    }
+
+    // Initialize bloom filters for this section.
+    // The first section reuses the eagerly-created bloom writer (created in initializeEagerBloom);
+    // subsequent sections get fresh bloom writers attached to their section writer.
+    if (bloomFilterEnabled) {
+      boolean firstSection = (sectionCount == 0);
+      if (firstSection && currentBloomFilterWriter != null) {
+        LOG.debug("Reusing eagerly-created bloom for first section: {}",
+          tenantSectionId == null ? "null" : Bytes.toStringBinary(tenantSectionId));
+      } else {
+        currentBloomFilterWriter = BloomFilterFactory.createGeneralBloomAtWrite(conf, cacheConf,
+          bloomFilterType, 0, currentSectionWriter);
+        if (currentBloomFilterWriter != null) {
+          currentGeneralBloomContext =
+            createBloomContext(currentBloomFilterWriter, bloomFilterType, fileContext);
+          if (currentGeneralBloomParam == null) {
+            currentGeneralBloomParam = org.apache.hadoop.hbase.util.BloomFilterUtil
+              .getBloomFilterParam(bloomFilterType, conf);
+          }
+        }
+      }
+      // Initialize delete family bloom filter unless ROWCOL per StoreFileWriter semantics
+      if (bloomFilterType != BloomType.ROWCOL) {
+        currentDeleteFamilyBloomFilterWriter =
+          BloomFilterFactory.createDeleteBloomAtWrite(conf, cacheConf, 0, currentSectionWriter);
+        if (currentDeleteFamilyBloomFilterWriter != null) {
+          currentDeleteFamilyBloomContext = new org.apache.hadoop.hbase.util.RowBloomContext(
+            currentDeleteFamilyBloomFilterWriter, fileContext.getCellComparator());
+        }
+      }
+      LOG.debug("Initialized bloom filters for tenant section ID: {}",
+        tenantSectionId == null ? "null" : Bytes.toStringBinary(tenantSectionId));
+    }
+
+    currentTenantSectionId = tenantSectionId;
+    sectionCount++;
+
+    LOG.info("Created new section writer for tenant section ID: {}, tenant ID: {}, offset: {}",
+      tenantSectionId == null ? "null" : Bytes.toStringBinary(tenantSectionId),
+      tenantId == null ? "null" : Bytes.toStringBinary(tenantId), sectionStartOffset);
+  }
+
+  @Override
+  public void close() throws IOException {
+    if (!closed.compareAndSet(false, true)) {
+      return;
+    }
+    if (outputStream == null) {
+      return;
+    }
+
+    try {
+      // Ensure all sections are closed and resources flushed
+      if (currentSectionWriter != null) {
+        closeCurrentSection();
+        currentSectionWriter = null;
+      }
+
+      // HFile v4 structure: Section Index + File Info + Trailer
+      // (Each section contains complete HFile v3 with its own blocks)
+      // Note: v4 readers skip initMetaAndIndex, so no meta block index needed
+      trailer = new FixedFileTrailer(getMajorVersion(), getMinorVersion());
+
+      // 1. Write Section Index Block (replaces data block index in v4)
+      // This is the core of HFile v4 - maps tenant prefixes to section locations
+      LOG.info("Writing section index with {} sections", sectionCount);
+      long rootIndexOffset = sectionIndexWriter.writeIndexBlocks(outputStream);
+      sectionIndexRootOffset = rootIndexOffset;
+      trailer.setSectionIndexOffset(sectionIndexRootOffset);
+      long loadOnOpenOffset =
+        maxSectionDataEndOffset > 0 ? maxSectionDataEndOffset : rootIndexOffset;
+      if (loadOnOpenOffset > rootIndexOffset) {
+        loadOnOpenOffset = rootIndexOffset;
+      }
+      trailer.setLoadOnOpenOffset(loadOnOpenOffset);
+
+      // 2. Write File Info Block (minimal v4-specific metadata)
+      LOG.info("Writing v4 file info");
+      finishFileInfo();
+      writeFileInfo(trailer, blockWriter.startWriting(BlockType.FILE_INFO));
+      blockWriter.writeHeaderAndData(outputStream);
+      totalUncompressedBytes += blockWriter.getUncompressedSizeWithHeader();
+
+      // 3. Write Trailer
+      finishClose(trailer);
+
+      LOG.info(
+        "MultiTenantHFileWriter closed: target={}, sections={}, entries={}, "
+          + "totalUncompressedBytes={}",
+        streamName, sectionCount, entryCount, totalUncompressedBytes);
+    } finally {
+      try {
+        if (blockWriter != null) {
+          blockWriter.release();
+        }
+      } finally {
+        if (closeOutputStream) {
+          try {
+            outputStream.close();
+          } catch (IOException e) {
+            LOG.warn("Failed to close output stream during cleanup for {}", streamName, e);
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Write file info similar to HFileWriterImpl but adapted for multi-tenant structure.
+   * @param trailer The file trailer to update with file info offset
+   * @param out     The output stream to write file info to
+   * @throws IOException if writing fails
+   */
+  private void writeFileInfo(FixedFileTrailer trailer, DataOutputStream out) throws IOException {
+    trailer.setFileInfoOffset(outputStream.getPos());
+    fileInfo.write(out);
+  }
+
+  /**
+   * Finish the close for HFile v4 trailer.
+   * <p>
+   * Sets v4-specific trailer fields including multi-tenant configuration and writes the final
+   * trailer to complete the file.
+   * @param trailer The trailer to finalize and write
+   * @throws IOException if trailer writing fails
+   */
+  private void finishClose(FixedFileTrailer trailer) throws IOException {
+    // Persist encryption metadata for v4 global blocks (section index/file-info), same as v3.
+    Encryption.Context cryptoContext = fileContext.getEncryptionContext();
+    if (cryptoContext != Encryption.Context.NONE) {
+      trailer.setEncryptionKey(EncryptionUtil.wrapKey(
+        cryptoContext.getConf(), cryptoContext.getConf()
+          .get(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, User.getCurrent().getShortName()),
+        cryptoContext.getKey()));
+    }
+
+    // Set v4-specific trailer fields
+    trailer.setNumDataIndexLevels(sectionIndexWriter.getNumLevels());
+    trailer.setUncompressedDataIndexSize(sectionIndexWriter.getTotalUncompressedSize());
+    trailer.setDataIndexCount(sectionIndexWriter.getNumRootEntries());
+
+    // Set multi-tenant configuration in the trailer
+    trailer.setMultiTenant(true);
+    trailer.setTenantPrefixLength(tenantExtractor.getPrefixLength());
+
+    // Compatibility contract: expose global min/max bounds so v2/v3-style callers do not fail.
+    // For multi-section v4 files this is an envelope, not a contiguous data-only guarantee.
+    // TODO: Migrate remaining callers to section-aware traversal and retire this compatibility
+    // path.
+    trailer.setFirstDataBlockOffset(globalFirstDataBlockOffset);
+    trailer.setLastDataBlockOffset(globalLastDataBlockOffset);
+
+    // Set other standard trailer fields
+    trailer.setComparatorClass(fileContext.getCellComparator().getClass());
+    trailer.setMetaIndexCount(0); // No global meta blocks for multi-tenant files
+    trailer.setTotalUncompressedBytes(totalUncompressedBytes + trailer.getTrailerSize());
+    trailer.setEntryCount(entryCount);
+    trailer.setCompressionCodec(fileContext.getCompression());
+
+    // Write trailer and close stream
+    long startTime = EnvironmentEdgeManager.currentTime();
+    trailer.serialize(outputStream);
+    HFile.updateWriteLatency(EnvironmentEdgeManager.currentTime() - startTime);
+
+    // Flush (but do not close) the output stream — close is handled by the finally in close()
+    try {
+      try {
+        outputStream.hflush();
+      } catch (UnsupportedOperationException uoe) {
+        outputStream.flush();
+      }
+    } catch (IOException e) {
+      LOG.error("Error finalizing MultiTenantHFileWriter for {}", streamName, e);
+      throw e;
+    }
+  }
+
+  /**
+   * Finish file info preparation for multi-tenant HFile v4.
+   * <p>
+   * Includes standard HFile metadata fields for compatibility with existing tooling, plus
+   * multi-tenant specific information.
+   * @throws IOException if file info preparation fails
+   */
+  private void finishFileInfo() throws IOException {
+    // Don't store the last key in global file info for tenant isolation
+    // This is intentionally removed to ensure we don't track first/last keys globally
+
+    // Average key length across all sections
+    int avgKeyLen = entryCount == 0 ? 0 : (int) (totalKeyLength / entryCount);
+    fileInfo.append(HFileInfo.AVG_KEY_LEN, Bytes.toBytes(avgKeyLen), false);
+
+    // File creation timestamp
+    fileInfo.append(HFileInfo.CREATE_TIME_TS, Bytes.toBytes(fileContext.getFileCreateTime()),
+      false);
+
+    // Average value length across all sections
+    int avgValueLength = entryCount == 0 ? 0 : (int) (totalValueLength / entryCount);
+    fileInfo.append(HFileInfo.AVG_VALUE_LEN, Bytes.toBytes(avgValueLength), false);
+
+    // Biggest cell info (key removed for tenant isolation)
+    // Only store length which doesn't expose key information
+    if (lenOfBiggestCell > 0) {
+      fileInfo.append(HFileInfo.LEN_OF_BIGGEST_CELL, Bytes.toBytes(lenOfBiggestCell), false);
+    }
+
+    // Global block encoding metadata (applies to all sections)
+    DataBlockEncoding dataBlockEncoding = fileContext.getDataBlockEncoding();
+    fileInfo.append(HFileDataBlockEncoder.DATA_BLOCK_ENCODING, dataBlockEncoding.getNameInBytes(),
+      false);
+    IndexBlockEncoding indexBlockEncoding = fileContext.getIndexBlockEncoding();
+    fileInfo.append(HFileIndexBlockEncoder.INDEX_BLOCK_ENCODING,
+      indexBlockEncoding.getNameInBytes(), false);
+
+    // Memstore and version metadata
+    if (fileContext.isIncludesMvcc()) {
+      fileInfo.append(MAX_MEMSTORE_TS_KEY, Bytes.toBytes(maxMemstoreTS), false);
+      fileInfo.append(KEY_VALUE_VERSION, Bytes.toBytes(KEY_VALUE_VER_WITH_MEMSTORE), false);
+    }
+
+    // Tags metadata
+    if (fileContext.isIncludesTags()) {
+      fileInfo.append(HFileInfo.MAX_TAGS_LEN, Bytes.toBytes(maxTagsLength), false);
+      boolean tagsCompressed = (fileContext.getDataBlockEncoding() != DataBlockEncoding.NONE)
+        && fileContext.isCompressTags();
+      fileInfo.append(HFileInfo.TAGS_COMPRESSED, Bytes.toBytes(tagsCompressed), false);
+    }
+
+    // === MULTI-TENANT SPECIFIC METADATA (v4 enhancements) ===
+
+    // Section and tenant information
+    fileInfo.append(Bytes.toBytes(FILEINFO_SECTION_COUNT), Bytes.toBytes(sectionCount), false);
+
+    // Tenant index structure information
+    int tenantIndexLevels = sectionIndexWriter.getNumLevels();
+    fileInfo.append(Bytes.toBytes(FILEINFO_TENANT_INDEX_LEVELS), Bytes.toBytes(tenantIndexLevels),
+      false);
+
+    // Store the configured max chunk size for tenant index
+    int maxChunkSize = conf.getInt(SectionIndexManager.SECTION_INDEX_MAX_CHUNK_SIZE,
+      SectionIndexManager.DEFAULT_MAX_CHUNK_SIZE);
+    fileInfo.append(Bytes.toBytes(FILEINFO_TENANT_INDEX_MAX_CHUNK), Bytes.toBytes(maxChunkSize),
+      false);
+
+    // Standard compatibility metadata expected by existing tooling
+    if (
+      globalTimeRangeTracker.getMax()
+          != org.apache.hadoop.hbase.regionserver.TimeRangeTracker.INITIAL_MAX_TIMESTAMP
+    ) {
+      fileInfo.append(org.apache.hadoop.hbase.regionserver.HStoreFile.TIMERANGE_KEY,
+        org.apache.hadoop.hbase.regionserver.TimeRangeTracker.toByteArray(globalTimeRangeTracker),
+        false);
+    }
+    // Keep parity with HFileWriterImpl: always emit EARLIEST_PUT_TS, using LATEST_TIMESTAMP as a
+    // sentinel when no Put was written. Compaction treats a missing key as an "old file" signal
+    // (OLDEST_TIMESTAMP), which would incorrectly retain delete markers for delete-only files.
+    fileInfo.append(org.apache.hadoop.hbase.regionserver.HStoreFile.EARLIEST_PUT_TS,
+      Bytes.toBytes(globalEarliestPutTs), false);
+    if (globalCustomTimeRangePresent) {
+      org.apache.hadoop.hbase.regionserver.TimeRangeTracker customTracker =
+        org.apache.hadoop.hbase.regionserver.TimeRangeTracker.create(
+          org.apache.hadoop.hbase.regionserver.TimeRangeTracker.Type.NON_SYNC,
+          globalCustomMinTimestamp, globalCustomMaxTimestamp);
+      fileInfo.append(
+        org.apache.hadoop.hbase.regionserver.CustomTieringMultiFileWriter.CUSTOM_TIERING_TIME_RANGE,
+        org.apache.hadoop.hbase.regionserver.TimeRangeTracker.toByteArray(customTracker), false);
+    }
+
+    byte[] existingMaxSeqIdBytes = fileInfo.get(HStoreFile.MAX_SEQ_ID_KEY);
+    long effectiveMaxSeqId = globalMaxSeqId;
+    if (existingMaxSeqIdBytes != null) {
+      effectiveMaxSeqId = Math.max(effectiveMaxSeqId, Bytes.toLong(existingMaxSeqIdBytes));
+    }
+    if (effectiveMaxSeqId != Long.MIN_VALUE) {
+      // Preserve externally provided metadata (for example flush sequence id), which can be larger
+      // than the max sequence id observed in the written cells.
+      fileInfo.put(HStoreFile.MAX_SEQ_ID_KEY, Bytes.toBytes(effectiveMaxSeqId));
+    }
+    if (fileContext.isIncludesMvcc()) {
+      byte[] existingMaxMemstoreTsBytes = fileInfo.get(HFile.Writer.MAX_MEMSTORE_TS_KEY);
+      long effectiveMaxMemstoreTs = maxMemstoreTS;
+      if (existingMaxMemstoreTsBytes != null) {
+        effectiveMaxMemstoreTs =
+          Math.max(effectiveMaxMemstoreTs, Bytes.toLong(existingMaxMemstoreTsBytes));
+      }
+      fileInfo.put(HFile.Writer.MAX_MEMSTORE_TS_KEY, Bytes.toBytes(effectiveMaxMemstoreTs));
+    }
+  }
+
+  @Override
+  public void appendFileInfo(byte[] key, byte[] value) throws IOException {
+    if (closed.get()) {
+      throw new IOException("Cannot append file info to a closed writer: " + streamName);
+    }
+    if (shouldStoreInGlobalFileInfo(key) && fileInfo.get(key) == null) {
+      fileInfo.append(key, value, true);
+    }
+    // Propagate only known-safe defaults across sections
+    if (isPropagatedDefaultKey(key)) {
+      sectionDefaultFileInfo.append(key, value, true);
+    }
+    // If a section is active, also apply immediately. Capture local reference
+    // to avoid NPE if a concurrent close() nulls the field.
+    SectionWriter section = currentSectionWriter;
+    if (section != null) {
+      section.appendFileInfo(key, value);
+    }
+  }
+
+  private boolean shouldStoreInGlobalFileInfo(byte[] key) {
+    for (byte[] allowed : GLOBAL_FILE_INFO_KEYS) {
+      if (Bytes.equals(allowed, key)) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  @Override
+  public void appendMetaBlock(String metaBlockName, Writable content) {
+    try {
+      if (currentSectionWriter == null) {
+        if (sectionCount == 0) {
+          LOG.debug("No section available when appending meta block {}; creating default section",
+            metaBlockName);
+          createNewSection(DEFAULT_TENANT_PREFIX, DEFAULT_TENANT_PREFIX);
+        } else {
+          throw new IllegalStateException(
+            "Active section expected when appending meta block " + metaBlockName);
+        }
+      }
+      currentSectionWriter.appendMetaBlock(metaBlockName, content);
+    } catch (IOException e) {
+      throw new UncheckedIOException("Failed to append meta block " + metaBlockName, e);
+    }
+  }
+
+  @Override
+  public void appendTrackedTimestampsToMetadata() throws IOException {
+    if (currentSectionWriter != null) {
+      currentSectionWriter.appendTrackedTimestampsToMetadata();
+    }
+  }
+
+  @Override
+  public void appendCustomCellTimestampsToMetadata(
+    org.apache.hadoop.hbase.regionserver.TimeRangeTracker timeRangeTracker) throws IOException {
+    if (timeRangeTracker != null) {
+      long max = timeRangeTracker.getMax();
+      if (max != org.apache.hadoop.hbase.regionserver.TimeRangeTracker.INITIAL_MAX_TIMESTAMP) {
+        long min = timeRangeTracker.getMin();
+        long effectiveMin =
+          min != org.apache.hadoop.hbase.regionserver.TimeRangeTracker.INITIAL_MIN_TIMESTAMP
+            ? min
+            : max;
+        globalCustomMinTimestamp = Math.min(globalCustomMinTimestamp, effectiveMin);
+        globalCustomMaxTimestamp = Math.max(globalCustomMaxTimestamp, max);
+        globalCustomTimeRangePresent = true;
+      }
+    }
+    if (currentSectionWriter != null && timeRangeTracker != null) {
+      currentSectionWriter.appendCustomCellTimestampsToMetadata(timeRangeTracker);
+    }
+  }
+
+  @Override
+  public void addInlineBlockWriter(InlineBlockWriter ibw) {
+    if (currentSectionWriter != null) {
+      currentSectionWriter.addInlineBlockWriter(ibw);
+    } else {
+      pendingInlineBlockWriters.add(ibw);
+    }
+  }
+
+  @Override
+  public void addGeneralBloomFilter(BloomFilterWriter bfw) {
+    // Per-section bloom filters are attached during closeCurrentSection().
+    // External callers (e.g. SingleStoreFileWriter) should not add a redundant global bloom.
+    LOG.debug("addGeneralBloomFilter ignored at global level; bloom managed per-section");
+  }
+
+  @Override
+  public boolean hasGeneralBloom() {
+    return bloomFilterEnabled && bloomFilterType != BloomType.NONE;
+  }
+
+  @Override
+  public BloomFilterWriter getGeneralBloomWriter() {
+    return currentBloomFilterWriter;
+  }
+
+  @Override
+  public void addDeleteFamilyBloomFilter(BloomFilterWriter bfw) throws IOException {
+    // For multi-tenant files, bloom filters are only added at section level
+    // This prevents creating bloom filters at the global level
+    if (bfw == null || bfw.getKeyCount() <= 0) {
+      LOG.debug("Ignoring empty or null delete family bloom filter at global level");
+      return;
+    }
+
+    // Only add to current section if one exists
+    if (currentSectionWriter != null) {
+      LOG.debug("Delegating delete family bloom filter with {} keys to current section",
+        bfw.getKeyCount());
+      // Ensure it's properly prepared for writing
+      bfw.compactBloom();
+      currentSectionWriter.addDeleteFamilyBloomFilter(bfw);
+    } else {
+      LOG.warn("Attempted to add delete family bloom filter with {} keys but no section is active",
+        bfw.getKeyCount());
+    }
+  }
+
+  @Override
+  public void beforeShipped() throws IOException {
+    if (currentSectionWriter != null) {
+      currentSectionWriter.beforeShipped();
+    }
+
+    // Clone cells for thread safety if necessary
+    if (this.lastCell != null) {
+      this.lastCell = KeyValueUtil.toNewKeyCell((ExtendedCell) this.lastCell);
+    }
+
+    // Copy bloom filter writers' prevCell references to on-heap before the scanner
+    // recycles the backing ByteBuff. In v3 this is handled by
+    // StoreFileWriter$SingleStoreFileWriter.beforeShipped(), but for v4 the bloom
+    // lifecycle is owned by MultiTenantHFileWriter so the external bloom writer is
+    // null and the copy is skipped unless we do it here.
+    if (currentBloomFilterWriter != null) {
+      currentBloomFilterWriter.beforeShipped();
+    }
+    if (currentDeleteFamilyBloomFilterWriter != null) {
+      currentDeleteFamilyBloomFilterWriter.beforeShipped();
+    }
+  }
+
+  @Override
+  public long getPos() throws IOException {
+    return outputStream.getPos();
+  }
+
+  @Override
+  public Path getPath() {
+    return path;
+  }
+
+  /**
+   * Registers a supplier that exposes the custom tiering time range tracker so SectionWriter
+   * instances can share it with the core {@link HFileWriterImpl} logic (e.g., block caching).
+   */
+  public void setCustomTieringTimeRangeSupplier(
+    Supplier<org.apache.hadoop.hbase.regionserver.TimeRangeTracker> supplier) {
+    this.customTieringSupplier = supplier;
+    if (currentSectionWriter != null) {
+      currentSectionWriter.setTimeRangeTrackerForTiering(supplier);
+    }
+  }
+
+  @Override
+  public HFileContext getFileContext() {
+    return fileContext;
+  }
+
+  public long getEntryCount() {
+    return entryCount;
+  }
+
+  @Override
+  public Cell getLastCell() {
+    return lastCell; // Keep API, but note this won't be used in global structures
+  }
+
+  /**
+   * The multi-tenant HFile writer always returns version 4, which is the first version to support
+   * multi-tenant HFiles.
+   * @return The major version for multi-tenant HFiles (4)
+   */
+  protected int getMajorVersion() {
+    return HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT;
+  }
+
+  /**
+   * The minor version of HFile format.
+   */
+  protected int getMinorVersion() {
+    return 0;
+  }
+
+  /**
+   * Get the current number of tenant sections.
+   * @return The section count
+   */
+  public int getSectionCount() {
+    return sectionCount;
+  }
+
+  /**
+   * Output stream that translates positions relative to section start.
+   * <p>
+   * This allows each section to maintain its own position tracking while writing to the shared
+   * parent file output stream.
+   */
+  private static class SectionOutputStream extends FSDataOutputStream {
+    private final FSDataOutputStream delegate;
+    private final long baseOffset;
+    private final String displayName;
+
+    public SectionOutputStream(FSDataOutputStream delegate, long baseOffset, String displayName) {
+      super(delegate.getWrappedStream(), null);
+      this.delegate = delegate;
+      this.baseOffset = baseOffset;
+      this.displayName = displayName;
+    }
+
+    @Override
+    public long getPos() {
+      return delegate.getPos() - baseOffset;
+    }
+
+    @Override
+    public void write(int b) throws IOException {
+      delegate.write(b);
+    }
+
+    @Override
+    public void write(byte[] b, int off, int len) throws IOException {
+      delegate.write(b, off, len);
+    }
+
+    @Override
+    public void flush() throws IOException {
+      delegate.flush();
+    }
+
+    @Override
+    public void close() throws IOException {
+      // Don't close the delegate - it's shared across sections
+      flush();
+    }
+
+    @Override
+    public String toString() {
+      return displayName;
+    }
+  }
+
+  /**
+   * A virtual writer for a tenant section within the HFile.
+   * <p>
+   * This handles writing data for a specific tenant section as a complete HFile v3 structure. Each
+   * section maintains its own bloom filters and metadata while sharing the parent file's output
+   * stream through position translation.
+   */
+  private class SectionWriter extends HFileWriterImpl {
+    /** The tenant section identifier for this section */
+    private final byte[] tenantSectionId;
+    /** The starting offset of this section in the parent file */
+    private final long sectionStartOffset;
+    /** Whether this section writer has been closed */
+    private volatile boolean closed = false;
+    /** Absolute offset where this section's load-on-open data begins */
+    private long sectionLoadOnOpenOffset = -1L;
+    /** Absolute offset of this section's first data block, or -1 if section is empty */
+    private long sectionFirstDataBlockOffset = -1L;
+    /** Absolute offset of this section's last data block, or -1 if section is empty */
+    private long sectionLastDataBlockOffset = -1L;
+
+    /**
+     * Creates a section writer for a specific tenant section.
+     * @param conf               Configuration settings
+     * @param cacheConf          Cache configuration
+     * @param outputStream       The parent file's output stream
+     * @param fileContext        HFile context for this section
+     * @param tenantSectionId    The tenant section identifier
+     * @param tenantId           The tenant identifier for metadata
+     * @param sectionStartOffset Starting offset of this section
+     * @throws IOException if section writer creation fails
+     */
+    public SectionWriter(Configuration conf, CacheConfig cacheConf, FSDataOutputStream outputStream,
+      HFileContext fileContext, byte[] tenantSectionId, byte[] tenantId, long sectionStartOffset)
+      throws IOException {
+      // Create a section-aware output stream that handles position translation
+      super(conf, cacheConf, MultiTenantHFileWriter.this.path,
+        new SectionOutputStream(outputStream, sectionStartOffset,
+          MultiTenantHFileWriter.this.path != null
+            ? MultiTenantHFileWriter.this.path.getName()
+            : MultiTenantHFileWriter.this.streamName),
+        fileContext);
+
+      this.tenantSectionId = tenantSectionId;
+      this.sectionStartOffset = sectionStartOffset;
+
+      // Store the tenant ID in the file info
+      if (tenantId != null && tenantId.length > 0) {
+        appendFileInfo(Bytes.toBytes(FILEINFO_TENANT_ID), tenantId);
+      }
+
+      // Store the section ID for reference
+      if (tenantSectionId != null) {
+        appendFileInfo(Bytes.toBytes(FILEINFO_TENANT_SECTION_ID), tenantSectionId);
+      }
+
+      LOG.debug("Created section writer at offset {} for tenant section {}, tenant ID {}",
+        sectionStartOffset,
+        tenantSectionId == null ? "default" : Bytes.toStringBinary(tenantSectionId),
+        tenantId == null ? "default" : Bytes.toStringBinary(tenantId));
+    }
+
+    @Override
+    protected BlockCacheKey buildCacheBlockKey(long offset, BlockType blockType) {
+      // Section writer offsets are section-relative; block cache keys must use container offsets.
+      long absoluteOffset = sectionStartOffset + offset;
+      Path writerPath = MultiTenantHFileWriter.this.path;
+      if (writerPath != null) {
+        return new BlockCacheKey(writerPath, absoluteOffset, true, blockType);
+      }
+      String cacheKeyName = MultiTenantHFileWriter.this.streamName != null
+        ? MultiTenantHFileWriter.this.streamName
+        : name;
+      return new BlockCacheKey(cacheKeyName, absoluteOffset, true, blockType);
+    }
+
+    @Override
+    public void append(ExtendedCell cell) throws IOException {
+      checkNotClosed();
+
+      super.append(cell);
+    }
+
+    /**
+     * Safely handle adding general bloom filters to the section
+     */
+    @Override
+    public void addGeneralBloomFilter(final BloomFilterWriter bfw) {
+      checkNotClosed();
+
+      // Skip empty bloom filters
+      if (bfw == null || bfw.getKeyCount() <= 0) {
+        LOG.debug("Skipping empty general bloom filter for tenant section: {}",
+          tenantSectionId == null ? "default" : Bytes.toStringBinary(tenantSectionId));
+        return;
+      }
+
+      // Ensure the bloom filter is properly initialized
+      bfw.compactBloom();
+
+      LOG.debug("Added general bloom filter with {} keys for tenant section: {}", bfw.getKeyCount(),
+        tenantSectionId == null ? "default" : Bytes.toStringBinary(tenantSectionId));
+
+      super.addGeneralBloomFilter(bfw);
+    }
+
+    /**
+     * Safely handle adding delete family bloom filters to the section
+     */
+    @Override
+    public void addDeleteFamilyBloomFilter(final BloomFilterWriter bfw) {
+      checkNotClosed();
+
+      // Skip empty bloom filters
+      if (bfw == null || bfw.getKeyCount() <= 0) {
+        LOG.debug("Skipping empty delete family bloom filter for tenant section: {}",
+          tenantSectionId == null ? "default" : Bytes.toStringBinary(tenantSectionId));
+        return;
+      }
+
+      // Ensure the bloom filter is properly initialized
+      bfw.compactBloom();
+
+      LOG.debug("Added delete family bloom filter with {} keys for tenant section: {}",
+        bfw.getKeyCount(),
+        tenantSectionId == null ? "default" : Bytes.toStringBinary(tenantSectionId));
+
+      // Call the parent implementation without try/catch since it doesn't actually throw
+      // IOException
+      // The HFileWriterImpl implementation doesn't throw IOException despite the interface
+      // declaration
+      super.addDeleteFamilyBloomFilter(bfw);
+    }
+
+    @Override
+    public void close() throws IOException {
+      if (closed) {
+        return;
+      }
+
+      LOG.debug("Closing section for tenant section ID: {}",
+        tenantSectionId == null ? "null" : Bytes.toStringBinary(tenantSectionId));
+
+      try {
+        super.close();
+      } catch (RuntimeException e) {
+        throw new IOException("Failed to close section writer for tenant "
+          + (tenantSectionId == null ? "null" : Bytes.toStringBinary(tenantSectionId)), e);
+      } finally {
+        closed = true;
+      }
+
+      LOG.debug("Closed section for tenant section: {}",
+        tenantSectionId == null ? "default" : Bytes.toStringBinary(tenantSectionId));
+    }
+
+    /**
+     * Get the starting offset of this section in the file.
+     * @return The section's starting offset
+     */
+    public long getSectionStartOffset() {
+      return sectionStartOffset;
+    }
+
+    public long getSectionDataEndOffset() {
+      return sectionLoadOnOpenOffset;
+    }
+
+    public long getSectionFirstDataBlockOffset() {
+      return sectionFirstDataBlockOffset;
+    }
+
+    public long getSectionLastDataBlockOffset() {
+      return sectionLastDataBlockOffset;
+    }
+
+    @Override
+    public Path getPath() {
+      // Return the parent file path
+      return MultiTenantHFileWriter.this.path;
+    }
+
+    @Override
+    public void appendFileInfo(byte[] key, byte[] value) throws IOException {
+      checkNotClosed();
+      super.appendFileInfo(key, value);
+    }
+
+    @Override
+    public void appendMetaBlock(String metaBlockName, Writable content) {
+      checkNotClosed();
+      super.appendMetaBlock(metaBlockName, content);
+    }
+
+    @Override
+    public void addInlineBlockWriter(InlineBlockWriter ibw) {
+      checkNotClosed();
+      super.addInlineBlockWriter(ibw);
+    }
+
+    @Override
+    public void beforeShipped() throws IOException {
+      checkNotClosed();
+      super.beforeShipped();
+    }
+
+    private void checkNotClosed() {
+      if (closed) {
+        throw new IllegalStateException("Section writer already closed");
+      }
+    }
+
+    // Override protected methods to make version 3 for each section
+    @Override
+    protected int getMajorVersion() {
+      return 3; // Each section uses version 3 format
+    }
+
+    @Override
+    protected void finishClose(FixedFileTrailer trailer) throws IOException {
+      long firstDataBlockOffset = trailer.getFirstDataBlockOffset();
+      if (firstDataBlockOffset >= 0) {
+        sectionFirstDataBlockOffset = sectionStartOffset + firstDataBlockOffset;
+      }
+      long lastDataBlockOffset = trailer.getLastDataBlockOffset();
+      if (lastDataBlockOffset >= 0) {
+        sectionLastDataBlockOffset = sectionStartOffset + lastDataBlockOffset;
+      }
+      sectionLoadOnOpenOffset = sectionStartOffset + trailer.getLoadOnOpenDataOffset();
+      super.finishClose(trailer);
+    }
+
+    public long getTotalUncompressedBytes() {
+      return this.totalUncompressedBytes;
+    }
+
+    /**
+     * Get the number of entries written to this section
+     * @return The entry count
+     */
+    public long getEntryCount() {
+      return this.entryCount;
+    }
+  }
+
+  /**
+   * An implementation of TenantExtractor that treats all data as belonging to a single default
+   * tenant.
+   * <p>
+   * This extractor is used when multi-tenant functionality is disabled via the
+   * TABLE_MULTI_TENANT_ENABLED property set to false. It ensures that all cells are treated as
+   * belonging to the same tenant section, effectively creating a single-tenant HFile v4 with one
+   * section containing all data.
+   * <p>
+   * Key characteristics:
+   * <ul>
+   * <li>Always returns the default empty tenant prefix for all cells</li>
+   * <li>Results in a single tenant section containing all data</li>
+   * <li>Maintains HFile v4 format compatibility while disabling multi-tenant features</li>
+   * <li>Useful for system tables or tables that don't require tenant isolation</li>
+   * </ul>
+   */
+  static class SingleTenantExtractor implements TenantExtractor {
+    @Override
+    public byte[] extractTenantId(Cell cell) {
+      return DEFAULT_TENANT_PREFIX;
+    }
+
+    @Override
+    public byte[] extractTenantSectionId(Cell cell) {
+      return DEFAULT_TENANT_PREFIX;
+    }
+
+    @Override
+    public int getPrefixLength() {
+      return 0;
+    }
+  }
+
+  /**
+   * Creates a specialized writer factory for multi-tenant HFiles format version 4.
+   * <p>
+   * This factory automatically determines whether to create a multi-tenant or single-tenant writer
+   * based on table properties and configuration. It handles the extraction of table properties from
+   * the HFile context and applies proper configuration precedence.
+   */
+  public static class WriterFactory extends HFile.WriterFactory {
+    /** Maintain our own copy of the file context */
+    private HFileContext writerFileContext;
+    private BloomType preferredBloomType;
+
+    /**
+     * Creates a new WriterFactory for multi-tenant HFiles.
+     * @param conf      Configuration settings
+     * @param cacheConf Cache configuration
+     */
+    public WriterFactory(Configuration conf, CacheConfig cacheConf) {
+      super(conf, cacheConf);
+    }
+
+    @Override
+    public HFile.WriterFactory withFileContext(HFileContext fileContext) {
+      this.writerFileContext = fileContext;
+      return super.withFileContext(fileContext);
+    }
+
+    public WriterFactory withPreferredBloomType(BloomType bloomType) {
+      this.preferredBloomType = bloomType;
+      return this;
+    }
+
+    @Override
+    public HFile.Writer create() throws IOException {
+      if ((path != null ? 1 : 0) + (ostream != null ? 1 : 0) != 1) {
+        throw new AssertionError("Please specify exactly one of filesystem/path or path");
+      }
+
+      boolean createdStream = false;
+      if (path != null) {
+        ostream = HFileWriterImpl.createOutputStream(conf, fs, path, favoredNodes);
+        createdStream = true;
+        try {
+          ostream.setDropBehind(shouldDropBehind && cacheConf.shouldDropBehindCompaction());
+        } catch (UnsupportedOperationException uoe) {
+          LOG.trace("Unable to set drop behind on {}", path, uoe);
+          LOG.debug("Unable to set drop behind on {}", path.getName());
+        }
+      }
+
+      boolean success = false;
+      try {
+        // IMPORTANT:
+        // This code path runs on regionserver/master threads during flush/compaction.
+        // Never perform any filesystem or RPC lookups here (e.g. fetching a TableDescriptor),
+        // as that can deadlock during shutdown and is also very expensive.
+        //
+        // The `conf` passed here is typically a Store-specific CompoundConfiguration which already
+        // includes table/CF descriptor values (see StoreUtils#createStoreConfiguration).
+        // TenantExtractorFactory reads multi-tenant enablement/prefix length from that
+        // Configuration.
+        Map<String, String> tableProperties = null;
+        BloomType columnFamilyBloomType = preferredBloomType;
+
+        boolean ownsStream = path != null;
+        HFile.Writer writer =
+          MultiTenantHFileWriter.create(fs, path, conf, cacheConf, tableProperties,
+            writerFileContext, columnFamilyBloomType, preferredBloomType, ostream, ownsStream);
+        success = true;
+        return writer;
+      } finally {
+        if (!success && createdStream && ostream != null) {
+          try {
+            ostream.close();
+          } catch (IOException e) {
+            LOG.warn("Failed to close output stream after WriterFactory failure for {}", path, e);
+          }
+        }
+      }
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileWriter.java
@@ -1272,7 +1272,8 @@ public class MultiTenantHFileWriter implements HFile.Writer, LastCellAwareWriter
     private final long baseOffset;
     private final String displayName;
 
-    public SectionOutputStream(FSDataOutputStream delegate, long baseOffset, String displayName) {
+    public SectionOutputStream(FSDataOutputStream delegate, long baseOffset, String displayName)
+        throws IOException {
       super(delegate.getWrappedStream(), null);
       this.delegate = delegate;
       this.baseOffset = baseOffset;
@@ -1280,7 +1281,7 @@ public class MultiTenantHFileWriter implements HFile.Writer, LastCellAwareWriter
     }
 
     @Override
-    public long getPos() {
+    public long getPos() throws IOException {
       return delegate.getPos() - baseOffset;
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileWriter.java
@@ -1273,22 +1273,26 @@ public class MultiTenantHFileWriter implements HFile.Writer, LastCellAwareWriter
     private final String displayName;
 
     public SectionOutputStream(FSDataOutputStream delegate, long baseOffset, String displayName)
-        throws IOException {
+      throws IOException {
       super(delegate.getWrappedStream(), null);
       this.delegate = delegate;
       this.baseOffset = baseOffset;
       this.displayName = displayName;
     }
 
+    // FSDataOutputStream.getPos() is declared `throws IOException` in Hadoop 2 but not in
+    // Hadoop 3. Catching Exception keeps this source compatible with both versions; the
+    // instanceof check is reachable when compiled against Hadoop 2, even though SpotBugs
+    // (which analyzes against one Hadoop version) thinks it is impossible.
+    @edu.umd.cs.findbugs.annotations.SuppressWarnings(value = "BC_IMPOSSIBLE_INSTANCEOF",
+        justification = "delegate.getPos() throws IOException on Hadoop 2; reachable there")
     @Override
     public long getPos() {
-      // FSDataOutputStream.getPos() is declared `throws IOException` in Hadoop 2 but not in
-      // Hadoop 3. Catching Exception keeps this source compatible with both versions.
       try {
         return delegate.getPos() - baseOffset;
       } catch (Exception e) {
-        throw new UncheckedIOException(
-          e instanceof IOException ? (IOException) e : new IOException(e));
+        IOException ioe = (e instanceof IOException) ? (IOException) e : new IOException(e);
+        throw new UncheckedIOException(ioe);
       }
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileWriter.java
@@ -1281,8 +1281,15 @@ public class MultiTenantHFileWriter implements HFile.Writer, LastCellAwareWriter
     }
 
     @Override
-    public long getPos() throws IOException {
-      return delegate.getPos() - baseOffset;
+    public long getPos() {
+      // FSDataOutputStream.getPos() is declared `throws IOException` in Hadoop 2 but not in
+      // Hadoop 3. Catching Exception keeps this source compatible with both versions.
+      try {
+        return delegate.getPos() - baseOffset;
+      } catch (Exception e) {
+        throw new UncheckedIOException(
+          e instanceof IOException ? (IOException) e : new IOException(e));
+      }
     }
 
     @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantPreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantPreadReader.java
@@ -1,0 +1,161 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HFile reader for multi-tenant HFiles in PREAD (random access) mode. This implementation creates
+ * HFilePreadReader instances for each tenant section.
+ */
+@InterfaceAudience.Private
+public class MultiTenantPreadReader extends AbstractMultiTenantReader {
+  private static final Logger LOG = LoggerFactory.getLogger(MultiTenantPreadReader.class);
+
+  /**
+   * Constructor for multi-tenant pread reader.
+   * @param context   Reader context info
+   * @param fileInfo  HFile info
+   * @param cacheConf Cache configuration values
+   * @param conf      Configuration
+   * @throws IOException If an error occurs during initialization
+   */
+  public MultiTenantPreadReader(ReaderContext context, HFileInfo fileInfo, CacheConfig cacheConf,
+    Configuration conf) throws IOException {
+    super(context, fileInfo, cacheConf, conf);
+    // Tenant index structure is loaded and logged by the parent class
+    prefetchBlocksOnOpenIfRequested();
+  }
+
+  /**
+   * Create a section reader for a specific tenant.
+   * <p>
+   * Creates a PreadSectionReader that handles positional read access to a specific tenant section
+   * within the multi-tenant HFile.
+   * @param tenantSectionId The tenant section ID
+   * @param metadata        The section metadata containing offset and size
+   * @return A section reader for the tenant
+   * @throws IOException If an error occurs creating the reader
+   */
+  @Override
+  protected SectionReader createSectionReader(byte[] tenantSectionId, SectionMetadata metadata)
+    throws IOException {
+    LOG.debug("Creating section reader for tenant section: {}, offset: {}, size: {}",
+      Bytes.toStringBinary(tenantSectionId), metadata.getOffset(), metadata.getSize());
+
+    return new PreadSectionReader(tenantSectionId, metadata);
+  }
+
+  /**
+   * Section reader implementation for pread (positional read) access mode.
+   * <p>
+   * This implementation creates HFilePreadReader instances for each tenant section, providing
+   * efficient random access to data within specific tenant boundaries.
+   */
+  protected class PreadSectionReader extends SectionReader {
+
+    /**
+     * Constructor for PreadSectionReader.
+     * @param tenantSectionId The tenant section ID
+     * @param metadata        The section metadata
+     */
+    public PreadSectionReader(byte[] tenantSectionId, SectionMetadata metadata) {
+      super(tenantSectionId, metadata);
+      LOG.debug("Created PreadSectionReader for tenant section ID: {}",
+        Bytes.toStringBinary(this.tenantSectionId));
+    }
+
+    @Override
+    public HFileReaderImpl getReader() throws IOException {
+      HFileReaderImpl local = reader;
+      if (local != null) {
+        return local;
+      }
+
+      synchronized (this) {
+        local = reader;
+        if (local != null) {
+          return local;
+        }
+
+        try {
+          ReaderContext sectionContext =
+            buildSectionContext(metadata, ReaderContext.ReaderType.PREAD);
+          if (sectionContext == null) {
+            throw new IOException(
+              "Section too small to read at offset " + metadata.getOffset() + ", size "
+                + metadata.getSize() + " for tenant " + Bytes.toStringBinary(tenantSectionId));
+          }
+
+          Path containerPath = sectionContext.getFilePath();
+          String tenantSectionIdStr = Bytes.toStringBinary(tenantSectionId);
+          Path perSectionPath = new Path(containerPath.toString() + "#" + tenantSectionIdStr);
+          ReaderContext perSectionContext =
+            ReaderContextBuilder.newBuilder(sectionContext).withFilePath(perSectionPath).build();
+
+          HFileInfo info = new HFileInfo(perSectionContext, getConf());
+          boolean infoSuccess = false;
+          try {
+            local = new HFilePreadReader(perSectionContext, info, cacheConf, getConf());
+            infoSuccess = true;
+          } finally {
+            if (!infoSuccess) {
+              info.close();
+            }
+          }
+
+          reader = local;
+          LOG.debug("Successfully initialized HFilePreadReader for tenant section ID: {}",
+            Bytes.toStringBinary(tenantSectionId));
+
+          return local;
+        } catch (IOException e) {
+          LOG.error("Failed to initialize section reader for tenant section at offset {}",
+            metadata.getOffset(), e);
+          throw e;
+        }
+      }
+    }
+
+    @Override
+    public HFileScanner getScanner(Configuration conf, boolean cacheBlocks, boolean pread,
+      boolean isCompaction) throws IOException {
+      HFileReaderImpl local = getReader();
+      HFileScanner scanner = local.getScanner(conf, cacheBlocks, true, isCompaction);
+      LOG.debug(
+        "PreadSectionReader.getScanner for tenant section ID: {}, reader: {}, " + "scanner: {}",
+        Bytes.toStringBinary(tenantSectionId), local, scanner);
+      return scanner;
+    }
+
+    @Override
+    public void close(boolean evictOnClose) throws IOException {
+      HFileReaderImpl local = reader;
+      if (local != null) {
+        reader = null;
+        local.close(evictOnClose);
+      }
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantReaderFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantReaderFactory.java
@@ -1,0 +1,62 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory for creating appropriate multi-tenant HFile readers based on the reader type. This
+ * handles both stream and pread access modes for multi-tenant HFiles.
+ */
+@InterfaceAudience.Private
+public class MultiTenantReaderFactory {
+  private static final Logger LOG = LoggerFactory.getLogger(MultiTenantReaderFactory.class);
+
+  private MultiTenantReaderFactory() {
+    // Utility class, no instantiation
+  }
+
+  /**
+   * Create the appropriate multi-tenant reader based on the reader type.
+   * @param context   Reader context info
+   * @param fileInfo  HFile info
+   * @param cacheConf Cache configuration values
+   * @param conf      Configuration
+   * @return An appropriate multi-tenant HFile reader
+   * @throws IOException If an error occurs creating the reader
+   */
+  public static HFile.Reader create(ReaderContext context, HFileInfo fileInfo,
+    CacheConfig cacheConf, Configuration conf) throws IOException {
+
+    switch (context.getReaderType()) {
+      case STREAM:
+        LOG.debug("Creating MultiTenantStreamReader for {}", context.getFilePath());
+        return new MultiTenantStreamReader(context, fileInfo, cacheConf, conf);
+      case PREAD:
+        LOG.debug("Creating MultiTenantPreadReader for {}", context.getFilePath());
+        return new MultiTenantPreadReader(context, fileInfo, cacheConf, conf);
+      default:
+        throw new IllegalArgumentException(
+          "Unknown reader type: " + context.getReaderType() + " for " + context.getFilePath());
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantStreamReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/MultiTenantStreamReader.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * HFile reader for multi-tenant HFiles in STREAM (sequential access) mode. This implementation
+ * creates HFileStreamReader instances for each tenant section.
+ */
+@InterfaceAudience.Private
+public class MultiTenantStreamReader extends AbstractMultiTenantReader {
+  private static final Logger LOG = LoggerFactory.getLogger(MultiTenantStreamReader.class);
+
+  /**
+   * Constructor for multi-tenant stream reader.
+   * @param context   Reader context info
+   * @param fileInfo  HFile info
+   * @param cacheConf Cache configuration values
+   * @param conf      Configuration
+   * @throws IOException If an error occurs during initialization
+   */
+  public MultiTenantStreamReader(ReaderContext context, HFileInfo fileInfo, CacheConfig cacheConf,
+    Configuration conf) throws IOException {
+    super(context, fileInfo, cacheConf, conf);
+    // Tenant index structure is loaded and logged by the parent class
+  }
+
+  /**
+   * Create a section reader for a specific tenant.
+   * <p>
+   * Creates a StreamSectionReader that handles sequential access to a specific tenant section
+   * within the multi-tenant HFile.
+   * @param tenantSectionId The tenant section ID
+   * @param metadata        The section metadata containing offset and size
+   * @return A section reader for the tenant
+   * @throws IOException If an error occurs creating the reader
+   */
+  @Override
+  protected SectionReader createSectionReader(byte[] tenantSectionId, SectionMetadata metadata)
+    throws IOException {
+    LOG.debug("Creating section reader for tenant section: {}, offset: {}, size: {}",
+      Bytes.toStringBinary(tenantSectionId), metadata.getOffset(), metadata.getSize());
+    return new StreamSectionReader(tenantSectionId, metadata);
+  }
+
+  /**
+   * Section reader implementation for stream (sequential access) mode.
+   * <p>
+   * This implementation creates HFileStreamReader instances for each tenant section, providing
+   * efficient sequential access to data within specific tenant boundaries. Stream readers are
+   * optimized for sequential scans and compaction operations.
+   */
+  protected class StreamSectionReader extends SectionReader {
+
+    /**
+     * Constructor for StreamSectionReader.
+     * @param tenantSectionId The tenant section ID
+     * @param metadata        The section metadata
+     */
+    public StreamSectionReader(byte[] tenantSectionId, SectionMetadata metadata) {
+      super(tenantSectionId, metadata);
+    }
+
+    @Override
+    public HFileReaderImpl getReader() throws IOException {
+      HFileReaderImpl local = reader;
+      if (local != null) {
+        return local;
+      }
+
+      synchronized (this) {
+        local = reader;
+        if (local != null) {
+          return local;
+        }
+
+        ReaderContext sectionContext =
+          buildSectionContext(metadata, ReaderContext.ReaderType.STREAM);
+        if (sectionContext == null) {
+          throw new IOException(
+            "Section too small to read at offset " + metadata.getOffset() + ", size "
+              + metadata.getSize() + " for tenant " + Bytes.toStringBinary(tenantSectionId));
+        }
+
+        try {
+          Path containerPath = sectionContext.getFilePath();
+          String tenantSectionIdStr = Bytes.toStringBinary(tenantSectionId);
+          Path perSectionPath = new Path(containerPath.toString() + "#" + tenantSectionIdStr);
+          ReaderContext perSectionContext =
+            ReaderContextBuilder.newBuilder(sectionContext).withFilePath(perSectionPath).build();
+
+          HFileInfo sectionFileInfo = new HFileInfo(perSectionContext, getConf());
+          local = new HFileStreamReader(perSectionContext, sectionFileInfo, cacheConf, getConf());
+
+          LOG.debug("Initializing section indices for tenant at offset {}", metadata.getOffset());
+          sectionFileInfo.initMetaAndIndex(local);
+          LOG.debug("Successfully initialized indices for section at offset {}",
+            metadata.getOffset());
+
+          reader = local;
+          LOG.debug("Initialized HFileStreamReader for tenant section ID: {}",
+            Bytes.toStringBinary(tenantSectionId));
+        } catch (IOException e) {
+          if (local != null) {
+            try {
+              local.close();
+            } catch (Exception closeEx) {
+              e.addSuppressed(closeEx);
+            }
+          }
+          LOG.error("Failed to initialize section reader", e);
+          throw e;
+        }
+
+        return local;
+      }
+    }
+
+    @Override
+    public HFileScanner getScanner(Configuration conf, boolean cacheBlocks, boolean pread,
+      boolean isCompaction) throws IOException {
+      return getReader().getScanner(conf, cacheBlocks, pread, isCompaction);
+    }
+
+    @Override
+    public void close(boolean evictOnClose) throws IOException {
+      HFileReaderImpl local = reader;
+      if (local != null) {
+        reader = null;
+        // HFileStreamReader.close() does not close fileInfo (by design — V3 readers don't
+        // own it). But section readers create their own HFileInfo, so we must close it
+        // explicitly to free load-on-open block buffers.
+        HFileInfo sectionInfo = local.getHFileInfo();
+        local.close(evictOnClose);
+        if (sectionInfo != null) {
+          sectionInfo.close();
+        }
+        local.getContext().getInputStreamWrapper().close();
+      }
+    }
+  }
+
+  // No close overrides needed; inherited from AbstractMultiTenantReader
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/SectionIndexManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/SectionIndexManager.java
@@ -1,0 +1,846 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import java.io.DataInputStream;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Manages the section index for multi-tenant HFile version 4. This class contains both writer and
+ * reader functionality for section indices, which map tenant prefixes to file sections, allowing
+ * for efficient lookup of tenant-specific data in a multi-tenant HFile.
+ */
+@InterfaceAudience.Private
+public class SectionIndexManager {
+
+  private SectionIndexManager() {
+    // Utility class, no instantiation
+  }
+
+  /**
+   * Default maximum number of entries in a single index block
+   */
+  public static final int DEFAULT_MAX_CHUNK_SIZE = 128;
+
+  /**
+   * Default minimum number of entries in the root index block
+   */
+  public static final int DEFAULT_MIN_INDEX_NUM_ENTRIES = 16;
+
+  /**
+   * Configuration key for maximum chunk size
+   */
+  public static final String SECTION_INDEX_MAX_CHUNK_SIZE = "hbase.section.index.max.chunk.size";
+
+  /**
+   * Configuration key for minimum number of root entries
+   */
+  public static final String SECTION_INDEX_MIN_NUM_ENTRIES = "hbase.section.index.min.num.entries";
+
+  /**
+   * Represents a tenant section entry in the index.
+   */
+  public static class SectionIndexEntry {
+    /** The tenant prefix for this section */
+    private final byte[] tenantPrefix;
+    /** The file offset where the section starts */
+    private final long offset;
+    /** The size of the section in bytes */
+    private final int sectionSize;
+
+    /**
+     * Constructor for SectionIndexEntry.
+     * @param tenantPrefix the tenant prefix for this section
+     * @param offset       the file offset where the section starts
+     * @param sectionSize  the size of the section in bytes
+     */
+    public SectionIndexEntry(byte[] tenantPrefix, long offset, int sectionSize) {
+      this.tenantPrefix =
+        (tenantPrefix != null) ? Arrays.copyOf(tenantPrefix, tenantPrefix.length) : new byte[0];
+      if (offset < 0) {
+        throw new IllegalArgumentException("Section offset must be non-negative, got: " + offset);
+      }
+      if (sectionSize <= 0) {
+        throw new IllegalArgumentException("Section size must be positive, got: " + sectionSize);
+      }
+      this.offset = offset;
+      this.sectionSize = sectionSize;
+    }
+
+    /**
+     * Get the tenant prefix for this section.
+     * @return a defensive copy of the tenant prefix
+     */
+    public byte[] getTenantPrefix() {
+      return Arrays.copyOf(tenantPrefix, tenantPrefix.length);
+    }
+
+    /**
+     * Get the file offset where the section starts.
+     * @return the offset
+     */
+    public long getOffset() {
+      return offset;
+    }
+
+    /**
+     * Get the size of the section in bytes.
+     * @return the section size
+     */
+    public int getSectionSize() {
+      return sectionSize;
+    }
+
+    @Override
+    public String toString() {
+      return "SectionIndexEntry{" + "tenantPrefix=" + Bytes.toStringBinary(tenantPrefix)
+        + ", offset=" + offset + ", sectionSize=" + sectionSize + '}';
+    }
+  }
+
+  /**
+   * Represents a block in the multi-level section index.
+   */
+  private static class SectionIndexBlock {
+    /** List of entries in this block */
+    private final List<SectionIndexEntry> entries = new ArrayList<>();
+    /** The offset of this block in the file */
+    private long blockOffset;
+    /** The size of this block in bytes */
+    private int blockSize;
+
+    /**
+     * Add an entry to this block.
+     * @param entry the entry to add
+     */
+    public void addEntry(SectionIndexEntry entry) {
+      entries.add(entry);
+    }
+
+    /**
+     * Get all entries in this block.
+     * @return the list of entries
+     */
+    public List<SectionIndexEntry> getEntries() {
+      return entries;
+    }
+
+    /**
+     * Get the number of entries in this block.
+     * @return the entry count
+     */
+    public int getEntryCount() {
+      return entries.size();
+    }
+
+    /**
+     * Get the first entry in this block.
+     * @return the first entry, or null if the block is empty
+     */
+    public SectionIndexEntry getFirstEntry() {
+      return entries.isEmpty() ? null : entries.get(0);
+    }
+
+    /**
+     * Set the metadata for this block.
+     * @param offset the offset of this block in the file
+     * @param size   the size of this block in bytes
+     */
+    public void setBlockMetadata(long offset, int size) {
+      this.blockOffset = offset;
+      this.blockSize = size;
+    }
+
+    /**
+     * Get the offset of this block in the file.
+     * @return the block offset
+     */
+    public long getBlockOffset() {
+      return blockOffset;
+    }
+
+    /**
+     * Get the size of this block in bytes.
+     * @return the block size
+     */
+    public int getBlockSize() {
+      return blockSize;
+    }
+  }
+
+  /**
+   * Writer for section indices in multi-tenant HFile version 4. This writer collects section
+   * entries and writes them to the file as a multi-level index to support large tenant sets
+   * efficiently.
+   */
+  public static class Writer {
+    private static final Logger LOG = LoggerFactory.getLogger(Writer.class);
+
+    /** List of all section entries */
+    private final List<SectionIndexEntry> entries = new ArrayList<>();
+    /** Block writer to use for index blocks */
+    private final HFileBlock.Writer blockWriter;
+    /** Cache configuration (unused for section index blocks) */
+    @SuppressWarnings("unused")
+    private final CacheConfig cacheConf;
+    /** File name to use for caching, or null if no caching (unused) */
+    @SuppressWarnings("unused")
+    private final String nameForCaching;
+
+    /** Maximum number of entries in a single index block */
+    private int maxChunkSize = DEFAULT_MAX_CHUNK_SIZE;
+    /** Minimum number of entries in the root-level index block */
+    private int minIndexNumEntries = DEFAULT_MIN_INDEX_NUM_ENTRIES;
+    /** Total uncompressed size of the index */
+    private int totalUncompressedSize = 0;
+    /** Number of levels in this index */
+    private int numLevels = 1;
+
+    /** Track leaf blocks for building the multi-level index */
+    private final List<SectionIndexBlock> leafBlocks = new ArrayList<>();
+    /** Track intermediate blocks for building the multi-level index */
+    private final List<SectionIndexBlock> intermediateBlocks = new ArrayList<>();
+
+    /**
+     * Constructor for Writer.
+     * @param blockWriter    block writer to use for index blocks
+     * @param cacheConf      cache configuration
+     * @param nameForCaching file name to use for caching, or null if no caching
+     */
+    public Writer(HFileBlock.Writer blockWriter, CacheConfig cacheConf, String nameForCaching) {
+      this.blockWriter = blockWriter;
+      this.cacheConf = cacheConf;
+      this.nameForCaching = nameForCaching;
+    }
+
+    /**
+     * Set the maximum number of entries in a single index block.
+     * @param maxChunkSize The maximum number of entries per block
+     */
+    public void setMaxChunkSize(int maxChunkSize) {
+      if (maxChunkSize <= 0) {
+        throw new IllegalArgumentException("maxChunkSize must be positive, got: " + maxChunkSize);
+      }
+      this.maxChunkSize = maxChunkSize;
+    }
+
+    /**
+     * Set the minimum number of entries in the root-level index block.
+     * @param minIndexNumEntries The minimum number of entries
+     */
+    public void setMinIndexNumEntries(int minIndexNumEntries) {
+      this.minIndexNumEntries = minIndexNumEntries;
+    }
+
+    /**
+     * Add a section entry to the index.
+     * @param tenantPrefix the tenant prefix for this section
+     * @param offset       the file offset where the section starts
+     * @param sectionSize  the size of the section in bytes
+     */
+    public void addEntry(byte[] tenantPrefix, long offset, int sectionSize) throws IOException {
+      if (offset < 0) {
+        throw new IOException(
+          "Section offset must be non-negative, got: " + offset + " for tenant: "
+            + (tenantPrefix != null ? Bytes.toStringBinary(tenantPrefix) : "default"));
+      }
+      if (sectionSize <= 0) {
+        throw new IOException("Section size must be positive, got: " + sectionSize + " for tenant: "
+          + (tenantPrefix != null ? Bytes.toStringBinary(tenantPrefix) : "default"));
+      }
+      byte[] prefix = tenantPrefix != null ? tenantPrefix : new byte[0];
+      if (!entries.isEmpty()) {
+        byte[] lastPrefix = entries.get(entries.size() - 1).getTenantPrefix();
+        if (Bytes.compareTo(lastPrefix, prefix) >= 0) {
+          throw new IOException(
+            "Section index entries must be in strictly increasing prefix order. " + "Previous: "
+              + Bytes.toStringBinary(lastPrefix) + ", current: " + Bytes.toStringBinary(prefix));
+        }
+      }
+      entries.add(new SectionIndexEntry(prefix, offset, sectionSize));
+
+      LOG.debug("Added section index entry: tenant={}, offset={}, size={}",
+        Bytes.toStringBinary(prefix), offset, sectionSize);
+    }
+
+    /**
+     * Helper to write a single section index entry (prefix, offset, size).
+     */
+    private void writeEntry(DataOutputStream out, SectionIndexEntry entry) throws IOException {
+      byte[] prefix = entry.getTenantPrefix();
+      out.writeInt(prefix.length);
+      out.write(prefix);
+      out.writeLong(entry.getOffset());
+      out.writeInt(entry.getSectionSize());
+    }
+
+    /**
+     * Write the section index blocks to the output stream. For large tenant sets, this builds a
+     * multi-level index.
+     * @param outputStream the output stream to write to
+     * @return the offset where the section index root block starts
+     * @throws IOException if an I/O error occurs
+     */
+    public long writeIndexBlocks(FSDataOutputStream outputStream) throws IOException {
+      // Handle empty indexes like HFileBlockIndex does - write valid empty structure
+      if (entries.isEmpty()) {
+        LOG.info("Writing empty section index (no tenant sections)");
+        return writeEmptyIndex(outputStream);
+      }
+
+      // Keep entries in their original order for sequential access
+
+      // Determine if we need a multi-level index based on entry count
+      boolean multiLevel = entries.size() > maxChunkSize;
+
+      // Clear any existing block tracking
+      leafBlocks.clear();
+      intermediateBlocks.clear();
+
+      // For small indices, just write a single-level root block
+      if (!multiLevel) {
+        numLevels = 1;
+        return writeSingleLevelIndex(outputStream);
+      }
+
+      // Split entries into leaf blocks
+      int numLeafBlocks = (entries.size() + maxChunkSize - 1) / maxChunkSize;
+      for (int blockIndex = 0; blockIndex < numLeafBlocks; blockIndex++) {
+        SectionIndexBlock block = new SectionIndexBlock();
+        int startIndex = blockIndex * maxChunkSize;
+        int endIndex = Math.min((blockIndex + 1) * maxChunkSize, entries.size());
+
+        for (int entryIndex = startIndex; entryIndex < endIndex; entryIndex++) {
+          block.addEntry(entries.get(entryIndex));
+        }
+
+        leafBlocks.add(block);
+      }
+
+      // Write leaf blocks
+      writeLeafBlocks(outputStream);
+
+      // If we have few enough leaf blocks, root can point directly to them
+      if (leafBlocks.size() <= minIndexNumEntries) {
+        numLevels = 2; // Root + leaf level
+        return writeIntermediateBlock(outputStream, leafBlocks, true);
+      }
+
+      // Otherwise, we need intermediate blocks
+      numLevels = 3; // Root + intermediate + leaf
+
+      // Group leaf blocks into intermediate blocks
+      int intermediateBlocksNeeded = (leafBlocks.size() + maxChunkSize - 1) / maxChunkSize;
+      for (int blockIndex = 0; blockIndex < intermediateBlocksNeeded; blockIndex++) {
+        SectionIndexBlock block = new SectionIndexBlock();
+        int startIndex = blockIndex * maxChunkSize;
+        int endIndex = Math.min((blockIndex + 1) * maxChunkSize, leafBlocks.size());
+
+        for (int leafIndex = startIndex; leafIndex < endIndex; leafIndex++) {
+          SectionIndexBlock leafBlock = leafBlocks.get(leafIndex);
+          // Add the first entry from this leaf block to the intermediate block
+          block.addEntry(leafBlock.getFirstEntry());
+        }
+
+        intermediateBlocks.add(block);
+      }
+
+      // Write intermediate blocks
+      writeIntermediateBlocks(outputStream);
+
+      // Write root block (pointing to intermediate blocks)
+      return writeIntermediateBlock(outputStream, intermediateBlocks, true);
+    }
+
+    /**
+     * Write an empty index structure. This creates a valid but empty root block similar to how
+     * HFileBlockIndex handles empty indexes.
+     * @param out the output stream to write to
+     * @return the offset where the empty root block starts
+     * @throws IOException if an I/O error occurs
+     */
+    private long writeEmptyIndex(FSDataOutputStream out) throws IOException {
+      // Record root offset
+      long rootOffset = out.getPos();
+
+      // Write empty root block
+      DataOutputStream dos = blockWriter.startWriting(BlockType.ROOT_INDEX);
+      dos.writeInt(0); // Zero entries
+      blockWriter.writeHeaderAndData(out);
+
+      // Update metrics
+      totalUncompressedSize += blockWriter.getUncompressedSizeWithHeader();
+      numLevels = 1;
+
+      LOG.info("Wrote empty section index at offset {}", rootOffset);
+
+      return rootOffset;
+    }
+
+    /**
+     * Write a single-level index (just the root block).
+     */
+    private long writeSingleLevelIndex(FSDataOutputStream out) throws IOException {
+      // Record root offset
+      long rootOffset = out.getPos();
+
+      // Write root block containing all entries
+      DataOutputStream dos = blockWriter.startWriting(BlockType.ROOT_INDEX);
+      writeRootBlock(dos, entries);
+      blockWriter.writeHeaderAndData(out);
+
+      // Update metrics
+      totalUncompressedSize += blockWriter.getUncompressedSizeWithHeader();
+
+      LOG.info("Wrote single-level section index with {} entries at offset {}", entries.size(),
+        rootOffset);
+
+      return rootOffset;
+    }
+
+    /**
+     * Write all leaf-level blocks.
+     */
+    private void writeLeafBlocks(FSDataOutputStream out) throws IOException {
+      for (SectionIndexBlock block : leafBlocks) {
+        // Write leaf block
+        long blockOffset = out.getPos();
+        DataOutputStream dos = blockWriter.startWriting(BlockType.LEAF_INDEX);
+        writeIndexBlock(dos, block.getEntries());
+        blockWriter.writeHeaderAndData(out);
+
+        // Record block metadata for higher levels
+        block.setBlockMetadata(blockOffset, blockWriter.getOnDiskSizeWithHeader());
+
+        // Update metrics
+        totalUncompressedSize += blockWriter.getUncompressedSizeWithHeader();
+
+        LOG.debug("Wrote leaf section index block with {} entries at offset {}",
+          block.getEntryCount(), blockOffset);
+      }
+    }
+
+    /**
+     * Write all intermediate-level blocks.
+     */
+    private void writeIntermediateBlocks(FSDataOutputStream out) throws IOException {
+      for (int blockIndex = 0; blockIndex < intermediateBlocks.size(); blockIndex++) {
+        SectionIndexBlock block = intermediateBlocks.get(blockIndex);
+        long blockOffset = out.getPos();
+        DataOutputStream dos = blockWriter.startWriting(BlockType.INTERMEDIATE_INDEX);
+
+        int entryCount = block.getEntryCount();
+        dos.writeInt(entryCount);
+
+        // Entries in this intermediate block correspond to leaf blocks in range
+        // [startIndex, startIndex + entryCount)
+        int startIndex = blockIndex * maxChunkSize;
+        for (int i = 0; i < entryCount; i++) {
+          int leafIndex = startIndex + i;
+          SectionIndexBlock leafBlock = leafBlocks.get(leafIndex);
+          SectionIndexEntry firstEntry = leafBlock.getFirstEntry();
+
+          byte[] prefix = firstEntry.getTenantPrefix();
+          dos.writeInt(prefix.length);
+          dos.write(prefix);
+          dos.writeLong(leafBlock.getBlockOffset());
+          dos.writeInt(leafBlock.getBlockSize());
+        }
+
+        blockWriter.writeHeaderAndData(out);
+
+        // Record block metadata for higher levels
+        block.setBlockMetadata(blockOffset, blockWriter.getOnDiskSizeWithHeader());
+
+        // Update metrics
+        totalUncompressedSize += blockWriter.getUncompressedSizeWithHeader();
+
+        LOG.debug("Wrote intermediate section index block with {} entries at offset {}",
+          block.getEntryCount(), blockOffset);
+      }
+    }
+
+    /**
+     * Write an intermediate or root block that points to other blocks.
+     */
+    private long writeIntermediateBlock(FSDataOutputStream out, List<SectionIndexBlock> blocks,
+      boolean isRoot) throws IOException {
+      long blockOffset = out.getPos();
+      DataOutputStream dos =
+        blockWriter.startWriting(isRoot ? BlockType.ROOT_INDEX : BlockType.INTERMEDIATE_INDEX);
+
+      // Write block count
+      dos.writeInt(blocks.size());
+
+      // Write entries using helper + block metadata
+      for (SectionIndexBlock block : blocks) {
+        SectionIndexEntry firstEntry = block.getFirstEntry();
+        writeEntry(dos, firstEntry);
+        dos.writeLong(block.getBlockOffset());
+        dos.writeInt(block.getBlockSize());
+      }
+
+      blockWriter.writeHeaderAndData(out);
+
+      // Update metrics
+      totalUncompressedSize += blockWriter.getUncompressedSizeWithHeader();
+
+      LOG.debug("Wrote {} section index block with {} entries at offset {}",
+        isRoot ? "root" : "intermediate", blocks.size(), blockOffset);
+
+      return blockOffset;
+    }
+
+    /**
+     * Write a standard index block with section entries.
+     */
+    private void writeIndexBlock(DataOutputStream out, List<SectionIndexEntry> blockEntries)
+      throws IOException {
+      // Write entry count
+      out.writeInt(blockEntries.size());
+
+      // Write each entry using helper
+      for (SectionIndexEntry entry : blockEntries) {
+        writeEntry(out, entry);
+      }
+    }
+
+    /**
+     * Write a root block.
+     */
+    private void writeRootBlock(DataOutputStream out, List<SectionIndexEntry> entries)
+      throws IOException {
+      // Just delegate to the standard index block writer
+      writeIndexBlock(out, entries);
+    }
+
+    /**
+     * Get the number of root entries in the index.
+     * @return the number of entries at the root level
+     */
+    public int getNumRootEntries() {
+      if (numLevels == 1) {
+        return entries.size();
+      } else if (numLevels == 2) {
+        return leafBlocks.size();
+      } else {
+        return intermediateBlocks.size();
+      }
+    }
+
+    /**
+     * Get the number of levels in this index.
+     * @return the number of levels (1 for single level, 2+ for multi-level)
+     */
+    public int getNumLevels() {
+      return numLevels;
+    }
+
+    /**
+     * Get the total uncompressed size of the index.
+     * @return the total uncompressed size in bytes
+     */
+    public int getTotalUncompressedSize() {
+      return totalUncompressedSize;
+    }
+
+    /**
+     * Clear all entries from the index.
+     */
+    public void clear() {
+      entries.clear();
+      leafBlocks.clear();
+      intermediateBlocks.clear();
+      totalUncompressedSize = 0;
+      numLevels = 1;
+    }
+  }
+
+  /**
+   * Reader for section indices in multi-tenant HFile version 4. Supports both single-level and
+   * multi-level indices.
+   */
+  public static class Reader {
+    private static final Logger LOG = LoggerFactory.getLogger(Reader.class);
+
+    private static final int MAX_PREFIX_LENGTH = 64 * 1024;
+    private static final int MAX_SECTION_COUNT = 1_000_000;
+
+    /** List of all section entries loaded from the index */
+    private final List<SectionIndexEntry> sections = new ArrayList<>();
+    /** Fast prefix-to-entry lookup built after loading */
+    private final Map<ImmutableBytesWritable, SectionIndexEntry> sectionsByPrefix = new HashMap<>();
+    /** Number of levels in the loaded index */
+    private int numLevels = 1;
+
+    /**
+     * Default constructor for Reader.
+     */
+    public Reader() {
+      // Empty constructor
+    }
+
+    /**
+     * Load a section index from an HFile block.
+     * @param block the HFile block containing the section index
+     * @throws IOException if an I/O error occurs
+     */
+    public void loadSectionIndex(HFileBlock block) throws IOException {
+      if (block.getBlockType() != BlockType.ROOT_INDEX) {
+        throw new IOException(
+          "Block is not a ROOT_INDEX for section index: " + block.getBlockType());
+      }
+
+      sections.clear();
+      DataInputStream in = block.getByteStream();
+
+      try {
+        // Read the number of sections
+        int numSections = in.readInt();
+        if (numSections < 0 || numSections > MAX_SECTION_COUNT) {
+          throw new IOException(
+            "Invalid section count: " + numSections + " (max " + MAX_SECTION_COUNT + ")");
+        }
+
+        // Read each section entry
+        for (int i = 0; i < numSections; i++) {
+          // Read tenant prefix
+          int prefixLength = in.readInt();
+          if (prefixLength < 0 || prefixLength > MAX_PREFIX_LENGTH) {
+            throw new IOException("Invalid tenant prefix length: " + prefixLength + " at entry " + i
+              + " (max " + MAX_PREFIX_LENGTH + ")");
+          }
+          byte[] prefix = new byte[prefixLength];
+          in.readFully(prefix);
+
+          // Read offset and size
+          long offset = in.readLong();
+          int size = in.readInt();
+
+          // Add the entry
+          sections.add(new SectionIndexEntry(prefix, offset, size));
+        }
+
+        buildLookupMap();
+        LOG.debug("Loaded section index with {} entries", sections.size());
+      } catch (IOException e) {
+        LOG.error("Failed to load section index", e);
+        sections.clear();
+        sectionsByPrefix.clear();
+        throw e;
+      }
+    }
+
+    /**
+     * Load a (potentially multi-level) section index from the given root index block. This API
+     * requires the number of index levels (from the trailer) and an FS reader for fetching
+     * intermediate/leaf blocks when needed.
+     * @param rootBlock the ROOT_INDEX block where the section index starts
+     * @param levels    the number of index levels; 1 for single-level, >=2 for multi-level
+     * @param fsReader  the filesystem block reader to fetch child index blocks
+     */
+    public void loadSectionIndex(HFileBlock rootBlock, int levels, HFileBlock.FSReader fsReader)
+      throws IOException {
+      if (rootBlock.getBlockType() != BlockType.ROOT_INDEX) {
+        throw new IOException(
+          "Block is not a ROOT_INDEX for section index: " + rootBlock.getBlockType());
+      }
+      if (levels < 1) {
+        throw new IOException("Invalid index level count: " + levels);
+      }
+      sections.clear();
+      this.numLevels = levels;
+
+      if (levels == 1) {
+        // Single-level index: entries are directly in the root
+        loadSectionIndex(rootBlock);
+        return;
+      }
+
+      if (fsReader == null) {
+        throw new IOException("FSReader is required to read multi-level section index");
+      }
+
+      // Multi-level: root contains pointers to next-level blocks.
+      DataInputStream in = rootBlock.getByteStream();
+      int fanout = in.readInt();
+      if (fanout < 0) {
+        throw new IOException("Negative root entry count in section index: " + fanout);
+      }
+      for (int i = 0; i < fanout; i++) {
+        // Root entry: first leaf entry (prefix, offset, size) + child pointer (offset, size)
+        int prefixLength = in.readInt();
+        if (prefixLength < 0 || prefixLength > MAX_PREFIX_LENGTH) {
+          throw new IOException("Invalid tenant prefix length: " + prefixLength + " at root entry "
+            + i + " (max " + MAX_PREFIX_LENGTH + ")");
+        }
+        byte[] prefix = new byte[prefixLength];
+        in.readFully(prefix);
+        in.readLong(); // first entry offset (ignored)
+        in.readInt(); // first entry size (ignored)
+        long childBlockOffset = in.readLong();
+        int childBlockSize = in.readInt();
+
+        readChildIndexSubtree(childBlockOffset, childBlockSize, levels - 1, fsReader);
+      }
+
+      buildLookupMap();
+      LOG.debug("Loaded multi-level section index: levels={}, sections={}", this.numLevels,
+        sections.size());
+    }
+
+    /**
+     * Recursively read intermediate/leaf index blocks and collect section entries.
+     */
+    private void readChildIndexSubtree(long blockOffset, int blockSize, int levelsRemaining,
+      HFileBlock.FSReader fsReader) throws IOException {
+      HFileBlock child = fsReader.readBlockData(blockOffset, blockSize, true, true, true);
+      HFileBlock blockToRead = null;
+      try {
+        blockToRead = child.unpack(child.getHFileContext(), fsReader);
+        if (levelsRemaining == 1) {
+          // Leaf level: contains actual section entries
+          if (blockToRead.getBlockType() != BlockType.LEAF_INDEX) {
+            LOG.warn("Expected LEAF_INDEX at leaf level but found {}", blockToRead.getBlockType());
+          }
+          readLeafBlock(blockToRead);
+          return;
+        }
+
+        // Intermediate level: each entry points to a child block
+        if (blockToRead.getBlockType() != BlockType.INTERMEDIATE_INDEX) {
+          LOG.warn("Expected INTERMEDIATE_INDEX at level {} but found {}", levelsRemaining,
+            blockToRead.getBlockType());
+        }
+        DataInputStream in = blockToRead.getByteStream();
+        int entryCount = in.readInt();
+        if (entryCount < 0) {
+          throw new IOException(
+            "Negative intermediate entry count in section index: " + entryCount);
+        }
+        for (int i = 0; i < entryCount; i++) {
+          int prefixLength = in.readInt();
+          if (prefixLength < 0 || prefixLength > MAX_PREFIX_LENGTH) {
+            throw new IOException("Invalid tenant prefix length: " + prefixLength
+              + " at intermediate entry " + i + " (max " + MAX_PREFIX_LENGTH + ")");
+          }
+          byte[] prefix = new byte[prefixLength];
+          in.readFully(prefix);
+          long nextOffset = in.readLong();
+          int nextSize = in.readInt();
+          readChildIndexSubtree(nextOffset, nextSize, levelsRemaining - 1, fsReader);
+        }
+      } finally {
+        // Release as these are non-root, transient blocks
+        if (blockToRead != null && blockToRead != child) {
+          try {
+            blockToRead.release();
+          } catch (Throwable t) {
+            // ignore
+          }
+        }
+        try {
+          child.release();
+        } catch (Throwable t) {
+          // ignore
+        }
+      }
+    }
+
+    /**
+     * Parse a leaf index block and append all section entries.
+     */
+    private void readLeafBlock(HFileBlock leafBlock) throws IOException {
+      DataInputStream in = leafBlock.getByteStream();
+      int num = in.readInt();
+      if (num < 0) {
+        throw new IOException("Negative leaf entry count in section index: " + num);
+      }
+      for (int i = 0; i < num; i++) {
+        int prefixLength = in.readInt();
+        if (prefixLength < 0 || prefixLength > MAX_PREFIX_LENGTH) {
+          throw new IOException("Invalid tenant prefix length: " + prefixLength + " at leaf entry "
+            + i + " (max " + MAX_PREFIX_LENGTH + ")");
+        }
+        byte[] prefix = new byte[prefixLength];
+        in.readFully(prefix);
+        long offset = in.readLong();
+        int size = in.readInt();
+        sections.add(new SectionIndexEntry(prefix, offset, size));
+      }
+    }
+
+    /**
+     * Find the section entry for a given tenant prefix.
+     * @param tenantPrefix the tenant prefix to look up
+     * @return the section entry, or null if not found
+     */
+    public SectionIndexEntry findSection(byte[] tenantPrefix) {
+      return sectionsByPrefix.get(new ImmutableBytesWritable(tenantPrefix));
+    }
+
+    private void buildLookupMap() {
+      sectionsByPrefix.clear();
+      for (SectionIndexEntry entry : sections) {
+        sectionsByPrefix.put(new ImmutableBytesWritable(entry.getTenantPrefix()), entry);
+      }
+    }
+
+    /**
+     * Get all section entries in the index.
+     * @return the list of section entries
+     */
+    public List<SectionIndexEntry> getSections() {
+      return new ArrayList<>(sections);
+    }
+
+    /**
+     * Get the number of sections in the index.
+     * @return the number of sections
+     */
+    public int getNumSections() {
+      return sections.size();
+    }
+
+    @Override
+    public String toString() {
+      StringBuilder sb = new StringBuilder();
+      sb.append("SectionIndexReader{sections=").append(sections.size()).append(", entries=[");
+      for (int i = 0; i < sections.size(); i++) {
+        if (i > 0) {
+          sb.append(", ");
+        }
+        sb.append(sections.get(i));
+      }
+      sb.append("]}");
+      return sb.toString();
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/SectionIndexManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/SectionIndexManager.java
@@ -358,6 +358,17 @@ public class SectionIndexManager {
 
       // Group leaf blocks into intermediate blocks
       int intermediateBlocksNeeded = (leafBlocks.size() + maxChunkSize - 1) / maxChunkSize;
+      // The root block is built from one entry per intermediate block. With the current
+      // numLevels=3 cap, the root has to fit in a single block of `maxChunkSize` entries —
+      // i.e. the index can hold at most maxChunkSize² leaf entries (default 128² = 16,384
+      // sections). Beyond that the root would overflow a single block and produce a
+      // structurally invalid file the reader silently mis-parses (HBASE-29588 review).
+      if (intermediateBlocksNeeded > maxChunkSize) {
+        throw new IOException("Section index would require " + intermediateBlocksNeeded
+          + " intermediate blocks which exceeds the per-block fan-out limit of " + maxChunkSize
+          + " (entries=" + entries.size() + ", maxChunkSize=" + maxChunkSize + "). Increase "
+          + SECTION_INDEX_MAX_CHUNK_SIZE + " or split the file across fewer tenants.");
+      }
       for (int blockIndex = 0; blockIndex < intermediateBlocksNeeded; blockIndex++) {
         SectionIndexBlock block = new SectionIndexBlock();
         int startIndex = blockIndex * maxChunkSize;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/TenantExtractor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/TenantExtractor.java
@@ -1,0 +1,63 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import org.apache.hadoop.hbase.Cell;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Strategy interface for extracting tenant information from cells following SOLID's Interface
+ * Segregation Principle.
+ */
+@InterfaceAudience.Private
+public interface TenantExtractor {
+  /**
+   * Extract tenant ID from a cell
+   * @param cell The cell to extract tenant information from
+   * @return The tenant ID as a byte array, or null if the row key is too short
+   */
+  byte[] extractTenantId(Cell cell);
+
+  /**
+   * Extract tenant section ID from a cell for use in section index blocks
+   * @param cell The cell to extract tenant section information from
+   * @return The tenant section ID as a byte array, or null if the row key is too short
+   */
+  byte[] extractTenantSectionId(Cell cell);
+
+  /**
+   * Get the tenant prefix length used for extraction
+   * @return The length of the tenant prefix in bytes
+   */
+  int getPrefixLength();
+
+  /**
+   * Fast comparison: checks whether the cell belongs to the same tenant section as the given ID
+   * without allocating a new byte array. Avoids O(n) allocation on the hot write path.
+   * @param cell             The cell to check
+   * @param currentSectionId The current tenant section ID to compare against (may be null)
+   * @return true if the cell's tenant prefix matches currentSectionId
+   */
+  default boolean matchesTenantSectionId(Cell cell, byte[] currentSectionId) {
+    byte[] extracted = extractTenantSectionId(cell);
+    if (extracted == null || currentSectionId == null) {
+      return extracted == currentSectionId;
+    }
+    return org.apache.hadoop.hbase.util.Bytes.equals(extracted, currentSectionId);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/TenantExtractorFactory.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/TenantExtractorFactory.java
@@ -1,0 +1,157 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Factory for creating TenantExtractor instances based on configuration.
+ * <p>
+ * Tenant configuration is obtained from cluster configuration and table properties, not from
+ * HFileContext.
+ * <p>
+ * For HFile v4, tenant configuration is stored in the file trailer, allowing it to be accessed
+ * before the file info blocks are loaded. This resolves timing issues in the reader initialization
+ * process.
+ */
+@InterfaceAudience.Private
+public class TenantExtractorFactory {
+  /** Logger for this class */
+  private static final Logger LOG = LoggerFactory.getLogger(TenantExtractorFactory.class);
+
+  private TenantExtractorFactory() {
+    // Utility class, no instantiation
+  }
+
+  /** Default tenant prefix length when not specified in configuration */
+  private static final int DEFAULT_PREFIX_LENGTH = 4;
+
+  /**
+   * Create a TenantExtractor from HFile's reader context. This method is called during HFile
+   * reading to determine how to extract tenant information.
+   * @param reader The HFile reader that contains file info
+   * @return Appropriate TenantExtractor implementation
+   */
+  public static TenantExtractor createFromReader(HFile.Reader reader) {
+    // Check if this is a v4 file with tenant configuration in the trailer
+    FixedFileTrailer trailer = reader.getTrailer();
+    if (trailer.getMajorVersion() >= HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT) {
+      if (trailer.isMultiTenant()) {
+        int prefixLength = trailer.getTenantPrefixLength();
+        if (prefixLength <= 0) {
+          LOG.debug("HFile v4 single-tenant mode (prefixLength={}), using SingleTenantExtractor",
+            prefixLength);
+          return new MultiTenantHFileWriter.SingleTenantExtractor();
+        }
+        try {
+          LOG.debug("Multi-tenant enabled from HFile v4 trailer, prefixLength={}", prefixLength);
+          return new DefaultTenantExtractor(prefixLength);
+        } catch (IllegalArgumentException e) {
+          LOG.warn("Invalid tenant prefix length {} from trailer of {}, "
+            + "falling back to SingleTenantExtractor", prefixLength, reader.getPath(), e);
+          return new MultiTenantHFileWriter.SingleTenantExtractor();
+        }
+      } else {
+        LOG.debug("HFile v4+ format, but multi-tenant not enabled in trailer");
+        return new MultiTenantHFileWriter.SingleTenantExtractor();
+      }
+    }
+
+    // For non-v4 files, always use SingleTenantExtractor
+    LOG.debug("Non-v4 HFile format (v{}), using SingleTenantExtractor", trailer.getMajorVersion());
+    return new MultiTenantHFileWriter.SingleTenantExtractor();
+  }
+
+  /**
+   * Create a tenant extractor based on configuration. This applies configuration with proper
+   * precedence: 1. Table level settings have highest precedence 2. Cluster level settings are used
+   * as fallback 3. Default values are used if neither is specified
+   * @param conf            HBase configuration for cluster defaults
+   * @param tableProperties Table properties for table-specific settings
+   * @return A configured TenantExtractor
+   */
+  public static TenantExtractor createTenantExtractor(Configuration conf,
+    Map<String, String> tableProperties) {
+
+    // Check if multi-tenant functionality is enabled for this table
+    //
+    // IMPORTANT:
+    // - In regionserver/master write paths, the `conf` passed here is usually a Store-specific
+    // CompoundConfiguration that already includes table descriptor values (see
+    // StoreUtils#createStoreConfiguration).
+    // - In other call paths, callers may provide `tableProperties` explicitly.
+    //
+    // We therefore support both, with precedence: tableProperties > conf > default(false).
+    String multiTenantEnabledStr = tableProperties != null
+      ? tableProperties.get(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED)
+      : null;
+    if (multiTenantEnabledStr == null) {
+      multiTenantEnabledStr = conf.get(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED);
+    }
+    boolean multiTenantEnabled = Boolean.parseBoolean(multiTenantEnabledStr);
+
+    // If multi-tenant is disabled, return SingleTenantExtractor
+    if (!multiTenantEnabled) {
+      LOG.debug("Multi-tenant functionality disabled for this table, using SingleTenantExtractor");
+      return new MultiTenantHFileWriter.SingleTenantExtractor();
+    }
+
+    // Multi-tenant enabled - configure DefaultTenantExtractor
+
+    // First try table level settings (highest precedence)
+    String tablePrefixLengthStr = tableProperties != null
+      ? tableProperties.get(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH)
+      : null;
+    if (tablePrefixLengthStr == null) {
+      tablePrefixLengthStr = conf.get(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH);
+    }
+
+    // If not found at table level, try cluster level settings
+    int clusterPrefixLength =
+      conf.getInt(MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, DEFAULT_PREFIX_LENGTH);
+
+    // Use table settings if available, otherwise use cluster settings
+    int prefixLength;
+    if (tablePrefixLengthStr != null) {
+      try {
+        prefixLength = Integer.parseInt(tablePrefixLengthStr);
+      } catch (NumberFormatException nfe) {
+        LOG.warn("Invalid table-level tenant prefix length '{}', using cluster default {}",
+          tablePrefixLengthStr, clusterPrefixLength);
+        prefixLength = clusterPrefixLength;
+      }
+    } else {
+      prefixLength = clusterPrefixLength;
+    }
+
+    if (prefixLength <= 0) {
+      LOG.warn("Configured tenant prefix length {} is invalid (must be > 0), "
+        + "falling back to SingleTenantExtractor", prefixLength);
+      return new MultiTenantHFileWriter.SingleTenantExtractor();
+    }
+
+    LOG.debug("Tenant configuration initialized: prefixLength={}, from table properties: {}",
+      prefixLength, (tablePrefixLengthStr != null));
+
+    return new DefaultTenantExtractor(prefixLength);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/TinyLfuBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/TinyLfuBlockCache.java
@@ -236,7 +236,7 @@ public final class TinyLfuBlockCache implements FirstLevelBlockCache {
   public int evictBlocksByHfileName(String hfileName) {
     int evicted = 0;
     for (BlockCacheKey key : cache.asMap().keySet()) {
-      if (key.getHfileName().equals(hfileName) && evictBlock(key)) {
+      if (BlockCacheUtil.matchesHFileName(key.getHfileName(), hfileName) && evictBlock(key)) {
         evicted++;
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -1937,18 +1937,11 @@ public class BucketCache implements BlockCache, HeapSize {
 
   @Override
   public int evictBlocksRangeByHfileName(String hfileName, long initOffset, long endOffset) {
+    // getAllCacheKeysForFile already scans both the backing map (O(log n + matches) via
+    // skiplist subSet) and ramCache (O(n) over delegate.keySet) — no need to re-scan ramCache
+    // here. Previously this method walked the full ramCache keySet a second time, which was a
+    // measurable regression on store-file replacement under many open files.
     Set<BlockCacheKey> keySet = getAllCacheKeysForFile(hfileName, initOffset, endOffset);
-    // Also collect matching keys still in ramCache (not yet written to the backing map by the
-    // writer thread). Without this, blocks that were recently cached but not yet persisted to the
-    // IOEngine would be missed by eviction, leaving stale entries and an inflated block count.
-    for (BlockCacheKey key : ramCache.delegate.keySet()) {
-      if (
-        key.getOffset() >= initOffset && key.getOffset() <= endOffset
-          && BlockCacheUtil.matchesHFileName(key.getHfileName(), hfileName)
-      ) {
-        keySet.add(key);
-      }
-    }
     LOG.debug("found {} blocks for file {}, starting offset: {}, end offset: {}", keySet.size(),
       hfileName, initOffset, endOffset);
     return evictBlockSet(keySet);
@@ -1967,6 +1960,15 @@ public class BucketCache implements BlockCache, HeapSize {
   private Set<BlockCacheKey> getAllCacheKeysForFile(String hfileName, long init, long end) {
     Set<BlockCacheKey> keys = new HashSet<>(blocksByHFile.subSet(new BlockCacheKey(hfileName, init),
       true, new BlockCacheKey(hfileName, end), true));
+    // HBASE-29862: also include blocks still in ramCache that have not yet been published to
+    // the backingMap. doDrain() removes from ramCache only AFTER inserting into the backingMap,
+    // so reading ramCache here cannot double-count, and skipping it lets the first attempt of
+    // notifyFileCachingCompleted observe an undercount that the retry loop must paper over.
+    for (BlockCacheKey key : ramCache.getRamBlockCacheKeysForHFile(hfileName)) {
+      if (key.getOffset() >= init && key.getOffset() <= end) {
+        keys.add(key);
+      }
+    }
     if (!BlockCacheUtil.isMultiTenantSectionHFileName(hfileName)) {
       String prefix = hfileName + BlockCacheUtil.MULTI_TENANT_HFILE_NAME_DELIMITER;
       // Also include blocks cached under section-decorated names (hfileName#tenantId).
@@ -1974,6 +1976,16 @@ public class BucketCache implements BlockCache, HeapSize {
         new BlockCacheKey(prefix + Character.MAX_VALUE, Long.MAX_VALUE), true)) {
         if (
           key.getHfileName().startsWith(prefix) && key.getOffset() >= init && key.getOffset() <= end
+        ) {
+          keys.add(key);
+        }
+      }
+      // Same as above for ramCache: pull section-decorated names too.
+      for (BlockCacheKey key : ramCache.delegate.keySet()) {
+        String name = key.getHfileName();
+        if (
+          name != null && name.startsWith(prefix) && key.getOffset() >= init
+            && key.getOffset() <= end
         ) {
           keys.add(key);
         }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/BucketCache.java
@@ -747,19 +747,24 @@ public class BucketCache implements BlockCache, HeapSize {
   }
 
   private void fileNotFullyCached(BlockCacheKey key, BucketEntry entry) {
-    // Update the updateRegionCachedSize before removing the file from fullyCachedFiles.
-    // This computation should happen even if the file is not in fullyCachedFiles map.
-    updateRegionCachedSize(key, (entry.getLength() * -1));
-    fullyCachedFiles.remove(key.getHfileName());
+    // Keep region metrics in sync with backingMap updates.
+    updateRegionCachedSize(key, -entry.getLength());
+    String baseHFileName = BlockCacheUtil.getBaseHFileName(key.getHfileName());
+    if (baseHFileName != null) {
+      fullyCachedFiles.remove(baseHFileName);
+    }
   }
 
   public void fileCacheCompleted(Path filePath, long size) {
-    Pair<String, Long> pair = new Pair<>();
+    String baseHFileName = BlockCacheUtil.getBaseHFileName(filePath.getName());
+    if (baseHFileName == null) {
+      return;
+    }
+
     // sets the region name
     String regionName = filePath.getParent().getParent().getName();
-    pair.setFirst(regionName);
-    pair.setSecond(size);
-    fullyCachedFiles.put(filePath.getName(), pair);
+    Pair<String, Long> pair = new Pair<>(regionName, size);
+    fullyCachedFiles.put(baseHFileName, pair);
   }
 
   private void updateRegionCachedSize(BlockCacheKey key, long cachedSize) {
@@ -1933,8 +1938,17 @@ public class BucketCache implements BlockCache, HeapSize {
   @Override
   public int evictBlocksRangeByHfileName(String hfileName, long initOffset, long endOffset) {
     Set<BlockCacheKey> keySet = getAllCacheKeysForFile(hfileName, initOffset, endOffset);
-    // We need to make sure whether we are evicting all blocks for this given file. In case of
-    // split references, we might be evicting just half of the blocks
+    // Also collect matching keys still in ramCache (not yet written to the backing map by the
+    // writer thread). Without this, blocks that were recently cached but not yet persisted to the
+    // IOEngine would be missed by eviction, leaving stale entries and an inflated block count.
+    for (BlockCacheKey key : ramCache.delegate.keySet()) {
+      if (
+        key.getOffset() >= initOffset && key.getOffset() <= endOffset
+          && BlockCacheUtil.matchesHFileName(key.getHfileName(), hfileName)
+      ) {
+        keySet.add(key);
+      }
+    }
     LOG.debug("found {} blocks for file {}, starting offset: {}, end offset: {}", keySet.size(),
       hfileName, initOffset, endOffset);
     return evictBlockSet(keySet);
@@ -1951,22 +1965,21 @@ public class BucketCache implements BlockCache, HeapSize {
   }
 
   private Set<BlockCacheKey> getAllCacheKeysForFile(String hfileName, long init, long end) {
-    Set<BlockCacheKey> cacheKeys = new HashSet<>();
-    // At this moment, Some Bucket Entries may be in the WriterThread queue, and not yet put into
-    // the backingMap. So, when executing this method, we should check both the RAMCache and
-    // backingMap to ensure all CacheKeys are obtained.
-    // For more details, please refer to HBASE-29862.
-    Set<BlockCacheKey> ramCacheKeySet = ramCache.getRamBlockCacheKeysForHFile(hfileName);
-    for (BlockCacheKey key : ramCacheKeySet) {
-      if (key.getOffset() >= init && key.getOffset() <= end) {
-        cacheKeys.add(key);
+    Set<BlockCacheKey> keys = new HashSet<>(blocksByHFile.subSet(new BlockCacheKey(hfileName, init),
+      true, new BlockCacheKey(hfileName, end), true));
+    if (!BlockCacheUtil.isMultiTenantSectionHFileName(hfileName)) {
+      String prefix = hfileName + BlockCacheUtil.MULTI_TENANT_HFILE_NAME_DELIMITER;
+      // Also include blocks cached under section-decorated names (hfileName#tenantId).
+      for (BlockCacheKey key : blocksByHFile.subSet(new BlockCacheKey(prefix, 0), true,
+        new BlockCacheKey(prefix + Character.MAX_VALUE, Long.MAX_VALUE), true)) {
+        if (
+          key.getHfileName().startsWith(prefix) && key.getOffset() >= init && key.getOffset() <= end
+        ) {
+          keys.add(key);
+        }
       }
     }
-
-    // These keys are just for comparison and are short lived, so we need only file name and offset
-    cacheKeys.addAll(blocksByHFile.subSet(new BlockCacheKey(hfileName, init), true,
-      new BlockCacheKey(hfileName, end), true));
-    return cacheKeys;
+    return keys;
   }
 
   /**
@@ -2358,14 +2371,15 @@ public class BucketCache implements BlockCache, HeapSize {
     }
 
     public boolean hasBlocksForFile(String fileName) {
-      return delegate.keySet().stream().filter(key -> key.getHfileName().equals(fileName))
-        .findFirst().isPresent();
+      return delegate.keySet().stream()
+        .filter(key -> BlockCacheUtil.matchesHFileName(key.getHfileName(), fileName)).findFirst()
+        .isPresent();
     }
 
     public Set<BlockCacheKey> getRamBlockCacheKeysForHFile(String fileName) {
       Set<BlockCacheKey> ramCacheKeySet = new HashSet<>();
       for (BlockCacheKey blockCacheKey : delegate.keySet()) {
-        if (blockCacheKey.getHfileName().equals(fileName)) {
+        if (BlockCacheUtil.matchesHFileName(blockCacheKey.getHfileName(), fileName)) {
           ramCacheKeySet.add(blockCacheKey);
         }
       }
@@ -2401,53 +2415,68 @@ public class BucketCache implements BlockCache, HeapSize {
     return Optional.empty();
   }
 
+  static final int CACHE_COMPLETION_MAX_RETRIES = 50;
+  static final long CACHE_COMPLETION_RETRY_INTERVAL_MS = 100;
+
   @Override
   public void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
     long size) {
-    // block eviction may be happening in the background as prefetch runs,
-    // so we need to count all blocks for this file in the backing map under
-    // a read lock for the block offset
-    final List<ReentrantReadWriteLock> locks = new ArrayList<>();
+    // Multi-tenant readers may pass section-decorated names (<hfile>#<tenantSectionId>) to the
+    // prefetch completion callback. When block cache keys are normalized to the container HFile
+    // name (base name) and absolute offsets, we must also normalize here, otherwise we will not
+    // find the cached blocks and we will never mark the file/region as cached.
+    final String requestedFileName = fileName.getName();
+    final String baseFileName = BlockCacheUtil.getBaseHFileName(requestedFileName);
     LOG.debug("Notifying caching completed for file {}, with total blocks {}, and data blocks {}",
       fileName, totalBlockCount, dataBlockCount);
-    try {
-      int count = 0;
-      LOG.debug("iterating over {} entries in the backing map", backingMap.size());
-      Set<BlockCacheKey> result = getAllCacheKeysForFile(fileName.getName(), 0, Long.MAX_VALUE);
-      if (result.isEmpty() && StoreFileInfo.isReference(fileName)) {
-        result = getAllCacheKeysForFile(
-          StoreFileInfo.getReferredToRegionAndFile(fileName.getName()).getSecond(), 0,
-          Long.MAX_VALUE);
-      }
-      for (BlockCacheKey entry : result) {
-        LOG.debug("found block for file {} in the backing map. Acquiring read lock for offset {}",
-          fileName.getName(), entry.getOffset());
-        ReentrantReadWriteLock lock = offsetLock.getLock(entry.getOffset());
-        lock.readLock().lock();
-        locks.add(lock);
-        if (backingMap.containsKey(entry) && entry.getBlockType().isData()) {
-          count++;
+    // Tracks whether ramCache was empty on the previous scan. doDrain() publishes each block to
+    // backingMap/blocksByHFile BEFORE removing it from ramCache, so once ramCache is empty all
+    // blocks are visible in blocksByHFile. However, our getAllCacheKeysForFile snapshot may be
+    // stale. When ramCache first becomes empty we do one immediate rescan (no sleep) to pick up
+    // blocks that moved during the previous scan.
+    boolean ramCacheWasEmpty = false;
+    for (int attempt = 0; attempt <= CACHE_COMPLETION_MAX_RETRIES; attempt++) {
+      // block eviction may be happening in the background as prefetch runs,
+      // so we need to count all blocks for this file in the backing map under
+      // a read lock for the block offset
+      final List<ReentrantReadWriteLock> locks = new ArrayList<>();
+      try {
+        int count = 0;
+        LOG.debug("iterating over {} entries in the backing map (attempt {})", backingMap.size(),
+          attempt);
+        Set<BlockCacheKey> result = getAllCacheKeysForFile(baseFileName, 0, Long.MAX_VALUE);
+        if (result.isEmpty() && StoreFileInfo.isReference(baseFileName)) {
+          result = getAllCacheKeysForFile(
+            StoreFileInfo.getReferredToRegionAndFile(baseFileName).getSecond(), 0, Long.MAX_VALUE);
         }
-      }
-      // BucketCache would only have data blocks
-      if (dataBlockCount == count) {
-        LOG.debug("File {} has now been fully cached.", fileName);
-        fileCacheCompleted(fileName, size);
-      } else {
-        LOG.debug(
-          "Prefetch executor completed for {}, but only {} data blocks were cached. "
-            + "Total data blocks for file: {}. "
-            + "Checking for blocks pending cache in cache writer queue.",
-          fileName, count, dataBlockCount);
-        if (ramCache.hasBlocksForFile(fileName.getName())) {
-          for (ReentrantReadWriteLock lock : locks) {
-            lock.readLock().unlock();
+        for (BlockCacheKey entry : result) {
+          LOG.debug("found block for file {} in the backing map. Acquiring read lock for offset {}",
+            baseFileName, entry.getOffset());
+          ReentrantReadWriteLock lock = offsetLock.getLock(entry.getOffset());
+          lock.readLock().lock();
+          locks.add(lock);
+          if (backingMap.containsKey(entry) && entry.getBlockType().isData()) {
+            count++;
           }
-          locks.clear();
-          LOG.debug("There are still blocks pending caching for file {}. Will sleep 100ms "
-            + "and try the verification again.", fileName.getName());
-          Thread.sleep(100);
-          notifyFileCachingCompleted(fileName, totalBlockCount, dataBlockCount, size);
+        }
+        // BucketCache would only have data blocks
+        if (dataBlockCount == count) {
+          LOG.debug("File {} has now been fully cached.", fileName);
+          fileCacheCompleted(fileName, size);
+          return;
+        }
+        if (ramCache.hasBlocksForFile(baseFileName)) {
+          ramCacheWasEmpty = false;
+          LOG.debug(
+            "There are still blocks pending caching for file {}. "
+              + "Will retry after {}ms (attempt {}).",
+            fileName, CACHE_COMPLETION_RETRY_INTERVAL_MS, attempt);
+        } else if (!ramCacheWasEmpty) {
+          // ramCache just became empty. Rescan immediately (no sleep) to close the TOCTOU
+          // window: getAllCacheKeysForFile above may have captured a stale blocksByHFile
+          // snapshot that missed blocks the writer thread published after our scan started.
+          ramCacheWasEmpty = true;
+          continue;
         } else {
           LOG.info(
             "The total block count was {}. We found only {} data blocks cached from "
@@ -2455,15 +2484,24 @@ public class BucketCache implements BlockCache, HeapSize {
               + "but no blocks pending caching. Maybe cache is full or evictions "
               + "happened concurrently to cache prefetch.",
             totalBlockCount, count, dataBlockCount, fileName);
+          return;
+        }
+      } finally {
+        for (ReentrantReadWriteLock lock : locks) {
+          lock.readLock().unlock();
         }
       }
-    } catch (InterruptedException e) {
-      throw new RuntimeException(e);
-    } finally {
-      for (ReentrantReadWriteLock lock : locks) {
-        lock.readLock().unlock();
+      try {
+        Thread.sleep(CACHE_COMPLETION_RETRY_INTERVAL_MS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new RuntimeException(e);
       }
     }
+    LOG.warn(
+      "File {} was not fully cached after {} retries. "
+        + "Found fewer than {} expected data blocks.",
+      fileName, CACHE_COMPLETION_MAX_RETRIES, dataBlockCount);
   }
 
   @Override
@@ -2496,7 +2534,11 @@ public class BucketCache implements BlockCache, HeapSize {
       return Optional.of(false);
     }
     // if we don't have the file in fullyCachedFiles, we should cache it
-    return Optional.of(!fullyCachedFiles.containsKey(fileName));
+    String baseHFileName = BlockCacheUtil.getBaseHFileName(fileName);
+    if (baseHFileName == null) {
+      return Optional.of(true);
+    }
+    return Optional.of(!fullyCachedFiles.containsKey(baseHFileName));
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/mob/MobFile.java
@@ -68,7 +68,17 @@ public class MobFile {
    * @return The cell in the mob file.
    */
   public MobCell readCell(ExtendedCell search, boolean cacheMobBlocks) throws IOException {
-    return readCell(search, cacheMobBlocks, sf.getMaxMemStoreTS());
+    if (sf == null) {
+      throw new IOException("Mob file reader has been closed");
+    }
+    sf.initReader();
+    long readPoint = sf.getMaxMemStoreTS();
+    if (readPoint < 0) {
+      // Reader metadata (including MAX_MEMSTORE_TS_KEY) is loaded only after initReader().
+      // Fall back to disabling MVCC filtering when metadata is unavailable (e.g., legacy files).
+      readPoint = Long.MAX_VALUE;
+    }
+    return readCell(search, cacheMobBlocks, readPoint);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CustomTieringMultiFileWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/CustomTieringMultiFileWriter.java
@@ -26,7 +26,6 @@ import java.util.TreeMap;
 import java.util.function.Function;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.ExtendedCell;
-import org.apache.hadoop.hbase.io.hfile.HFileWriterImpl;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -56,8 +55,8 @@ public class CustomTieringMultiFileWriter extends DateTieredMultiFileWriter {
       timeRangeTracker.setMin(tieringValue);
       timeRangeTracker.setMax(tieringValue);
       lowerBoundary2TimeRanger.put(entry.getKey(), timeRangeTracker);
-      ((HFileWriterImpl) lowerBoundary2Writer.get(entry.getKey()).getLiveFileWriter())
-        .setTimeRangeTrackerForTiering(() -> timeRangeTracker);
+      lowerBoundary2Writer.get(entry.getKey())
+        .setCustomTieringTimeRangeSupplier(() -> timeRangeTracker);
     } else {
       TimeRangeTracker timeRangeTracker = entry.getValue();
       if (timeRangeTracker.getMin() > tieringValue) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HStoreFile.java
@@ -403,7 +403,14 @@ public class HStoreFile implements StoreFile {
     StoreFileReader reader = fileInfo.preStoreFileReaderOpen(context, cacheConf);
     if (reader == null) {
       reader = fileInfo.createReader(context, cacheConf);
-      fileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+      // Only initialize meta and index for non-multi-tenant files (v3 and below)
+      // Multi-tenant files (v4) skip this initialization just like in HFile.createReader()
+      if (
+        fileInfo.getHFileInfo().getTrailer().getMajorVersion()
+            != HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT
+      ) {
+        fileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+      }
     }
     this.initialReader = fileInfo.postStoreFileReaderOpen(context, cacheConf, reader);
 
@@ -524,9 +531,9 @@ public class HStoreFile implements StoreFile {
    * Initialize the reader used for pread.
    */
   public void initReader() throws IOException {
-    if (initialReader == null) {
+    if (initialReader == null || initialReader.isClosed()) {
       synchronized (this) {
-        if (initialReader == null) {
+        if (initialReader == null || initialReader.isClosed()) {
           try {
             open();
           } catch (Exception e) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileReader.java
@@ -381,6 +381,21 @@ public class StoreFileReader {
   }
 
   /**
+   * Cell-based overload retained for binary compatibility with Phoenix releases compiled against
+   * older branch-2 builds (this class is {@code @InterfaceAudience.LimitedPrivate(PHOENIX)}).
+   * Delegates to the {@link ExtendedCell} variant when applicable; if the supplied {@link Cell} is
+   * not an {@link ExtendedCell}, the bloom filter is treated as inconclusive and we return
+   * {@code true} (callers will fall back to a real read).
+   * @return True if the cell may pass the bloom filter
+   */
+  public boolean passesGeneralRowColBloomFilter(Cell cell) {
+    if (cell instanceof ExtendedCell) {
+      return passesGeneralRowColBloomFilter((ExtendedCell) cell);
+    }
+    return true;
+  }
+
+  /**
    * A method for checking Bloom filters. Called directly from StoreFileScanner in case of a
    * multi-column query. the cell to check if present in BloomFilter
    * @return True if passes

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileReader.java
@@ -46,6 +46,7 @@ import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
 import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
+import org.apache.hadoop.hbase.io.hfile.MultiTenantBloomSupport;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext.ReaderType;
 import org.apache.hadoop.hbase.nio.ByteBuff;
@@ -78,6 +79,11 @@ public class StoreFileReader {
   private KeyValue.KeyOnlyKeyValue lastBloomKeyOnlyKV = null;
   private boolean skipResetSeqId = true;
   private int prefixLength = -1;
+  /**
+   * True when bloom metrics need explicit tracking in this class because the loaded BloomFilter
+   * instance is sourced from a multi-tenant section reader and is not wired with metrics.
+   */
+  private boolean bloomMetricsTrackedExternally = false;
   protected Configuration conf;
 
   /**
@@ -87,6 +93,30 @@ public class StoreFileReader {
    */
   private final StoreFileInfo storeFileInfo;
   private final ReaderContext context;
+  private volatile boolean closed;
+
+  private void incrementBloomEligible() {
+    if (bloomFilterMetrics != null) {
+      bloomFilterMetrics.incrementEligible();
+    }
+  }
+
+  private void incrementBloomRequests(boolean passed) {
+    if (bloomFilterMetrics != null) {
+      bloomFilterMetrics.incrementRequests(passed);
+    }
+  }
+
+  private void recordExternalBloomMetric(boolean passed) {
+    if (!bloomMetricsTrackedExternally) {
+      return;
+    }
+    if (bloomFilterType == BloomType.NONE || generalBloomFilter == null) {
+      incrementBloomEligible();
+      return;
+    }
+    incrementBloomRequests(passed);
+  }
 
   private StoreFileReader(HFile.Reader reader, StoreFileInfo storeFileInfo, ReaderContext context,
     Configuration conf) {
@@ -107,6 +137,7 @@ public class StoreFileReader {
     this.deleteFamilyBloomFilter = storeFileReader.deleteFamilyBloomFilter;
     this.bloomFilterType = storeFileReader.bloomFilterType;
     this.bloomFilterMetrics = storeFileReader.bloomFilterMetrics;
+    this.bloomMetricsTrackedExternally = storeFileReader.bloomMetricsTrackedExternally;
     this.sequenceID = storeFileReader.sequenceID;
     this.timeRange = storeFileReader.timeRange;
     this.lastBloomKey = storeFileReader.lastBloomKey;
@@ -213,7 +244,20 @@ public class StoreFileReader {
   }
 
   public void close(boolean evictOnClose) throws IOException {
-    reader.close(evictOnClose);
+    if (closed) {
+      return;
+    }
+    try {
+      if (reader != null) {
+        reader.close(evictOnClose);
+      }
+    } finally {
+      closed = true;
+    }
+  }
+
+  boolean isClosed() {
+    return closed;
   }
 
   /**
@@ -259,7 +303,8 @@ public class StoreFileReader {
         if (columns != null && columns.size() == 1) {
           byte[] column = columns.first();
           // create the required fake key
-          Cell kvKey = PrivateCellUtil.createFirstOnRow(row, HConstants.EMPTY_BYTE_ARRAY, column);
+          ExtendedCell kvKey =
+            PrivateCellUtil.createFirstOnRow(row, HConstants.EMPTY_BYTE_ARRAY, column);
           return passesGeneralRowColBloomFilter(kvKey);
         }
 
@@ -270,36 +315,40 @@ public class StoreFileReader {
         return passesGeneralRowPrefixBloomFilter(scan);
       default:
         if (scan.isGetScan()) {
-          bloomFilterMetrics.incrementEligible();
+          incrementBloomEligible();
         }
         return true;
     }
   }
 
   public boolean passesDeleteFamilyBloomFilter(byte[] row, int rowOffset, int rowLen) {
-    // Cache Bloom filter as a local variable in case it is set to null by
-    // another thread on an IO error.
     BloomFilter bloomFilter = this.deleteFamilyBloomFilter;
 
-    // Empty file or there is no delete family at all
     if (reader.getTrailer().getEntryCount() == 0 || deleteFamilyCnt == 0) {
       return false;
     }
 
-    if (bloomFilter == null) {
+    if (bloomFilter != null) {
+      try {
+        if (!bloomFilter.supportsAutoLoading()) {
+          return true;
+        }
+        return bloomFilter.contains(row, rowOffset, rowLen, null);
+      } catch (IllegalArgumentException e) {
+        LOG.error("Bad Delete Family bloom filter data -- proceeding without", e);
+        setDeleteFamilyBloomFilterFaulty();
+      }
       return true;
     }
-
-    try {
-      if (!bloomFilter.supportsAutoLoading()) {
+    if (reader instanceof MultiTenantBloomSupport) {
+      try {
+        return ((MultiTenantBloomSupport) reader).passesDeleteFamilyBloomFilter(row, rowOffset,
+          rowLen);
+      } catch (IOException e) {
+        LOG.warn("Failed multi-tenant delete-family bloom check, proceeding without", e);
         return true;
       }
-      return bloomFilter.contains(row, rowOffset, rowLen, null);
-    } catch (IllegalArgumentException e) {
-      LOG.error("Bad Delete Family bloom filter data -- proceeding without", e);
-      setDeleteFamilyBloomFilterFaulty();
     }
-
     return true;
   }
 
@@ -310,18 +359,25 @@ public class StoreFileReader {
    */
   private boolean passesGeneralRowBloomFilter(byte[] row, int rowOffset, int rowLen) {
     BloomFilter bloomFilter = this.generalBloomFilter;
-    if (bloomFilter == null) {
-      bloomFilterMetrics.incrementEligible();
-      return true;
+    if (bloomFilter != null) {
+      if (rowOffset != 0 || rowLen != row.length) {
+        throw new AssertionError("For row-only Bloom filters the row must occupy the whole array");
+      }
+      return checkGeneralBloomFilter(row, null, bloomFilter);
     }
-
-    // Used in ROW bloom
-    byte[] key = null;
-    if (rowOffset != 0 || rowLen != row.length) {
-      throw new AssertionError("For row-only Bloom filters the row must occupy the whole array");
+    if (reader instanceof MultiTenantBloomSupport) {
+      try {
+        boolean passed =
+          ((MultiTenantBloomSupport) reader).passesGeneralRowBloomFilter(row, rowOffset, rowLen);
+        recordExternalBloomMetric(passed);
+        return passed;
+      } catch (IOException e) {
+        LOG.warn("Failed multi-tenant row bloom check, proceeding without", e);
+        return true;
+      }
     }
-    key = row;
-    return checkGeneralBloomFilter(key, null, bloomFilter);
+    incrementBloomEligible();
+    return true;
   }
 
   /**
@@ -329,21 +385,29 @@ public class StoreFileReader {
    * multi-column query. the cell to check if present in BloomFilter
    * @return True if passes
    */
-  public boolean passesGeneralRowColBloomFilter(Cell cell) {
+  public boolean passesGeneralRowColBloomFilter(ExtendedCell cell) {
     BloomFilter bloomFilter = this.generalBloomFilter;
-    if (bloomFilter == null) {
-      bloomFilterMetrics.incrementEligible();
-      return true;
+    if (bloomFilter != null) {
+      ExtendedCell kvKey;
+      if (cell.getTypeByte() == KeyValue.Type.Maximum.getCode() && cell.getFamilyLength() == 0) {
+        kvKey = cell;
+      } else {
+        kvKey = PrivateCellUtil.createFirstOnRowCol(cell);
+      }
+      return checkGeneralBloomFilter(null, kvKey, bloomFilter);
     }
-    // Used in ROW_COL bloom
-    Cell kvKey = null;
-    // Already if the incoming key is a fake rowcol key then use it as it is
-    if (cell.getTypeByte() == KeyValue.Type.Maximum.getCode() && cell.getFamilyLength() == 0) {
-      kvKey = cell;
-    } else {
-      kvKey = PrivateCellUtil.createFirstOnRowCol(cell);
+    if (reader instanceof MultiTenantBloomSupport) {
+      try {
+        boolean passed = ((MultiTenantBloomSupport) reader).passesGeneralRowColBloomFilter(cell);
+        recordExternalBloomMetric(passed);
+        return passed;
+      } catch (IOException e) {
+        LOG.warn("Failed multi-tenant row/col bloom check, proceeding without", e);
+        return true;
+      }
     }
-    return checkGeneralBloomFilter(null, kvKey, bloomFilter);
+    incrementBloomEligible();
+    return true;
   }
 
   /**
@@ -352,29 +416,36 @@ public class StoreFileReader {
    * @return True if passes
    */
   private boolean passesGeneralRowPrefixBloomFilter(Scan scan) {
-    BloomFilter bloomFilter = this.generalBloomFilter;
-    if (bloomFilter == null) {
-      bloomFilterMetrics.incrementEligible();
-      return true;
-    }
-
     byte[] row = scan.getStartRow();
     byte[] rowPrefix;
     if (scan.isGetScan()) {
       rowPrefix = Bytes.copy(row, 0, Math.min(prefixLength, row.length));
     } else {
-      // For non-get scans
-      // Find out the common prefix of startRow and stopRow.
       int commonLength = Bytes.findCommonPrefix(scan.getStartRow(), scan.getStopRow(),
         scan.getStartRow().length, scan.getStopRow().length, 0, 0);
-      // startRow and stopRow don't have the common prefix.
-      // Or the common prefix length is less than prefixLength
       if (commonLength <= 0 || commonLength < prefixLength) {
         return true;
       }
       rowPrefix = Bytes.copy(row, 0, prefixLength);
     }
-    return checkGeneralBloomFilter(rowPrefix, null, bloomFilter);
+
+    BloomFilter bloomFilter = this.generalBloomFilter;
+    if (bloomFilter != null) {
+      return checkGeneralBloomFilter(rowPrefix, null, bloomFilter);
+    }
+    if (reader instanceof MultiTenantBloomSupport) {
+      try {
+        boolean passed = ((MultiTenantBloomSupport) reader)
+          .passesGeneralRowPrefixBloomFilter(rowPrefix, 0, rowPrefix.length);
+        recordExternalBloomMetric(passed);
+        return passed;
+      } catch (IOException e) {
+        LOG.warn("Failed multi-tenant row prefix bloom check, proceeding without", e);
+        return true;
+      }
+    }
+    incrementBloomEligible();
+    return true;
   }
 
   private boolean checkGeneralBloomFilter(byte[] key, Cell kvKey, BloomFilter bloomFilter) {
@@ -430,6 +501,7 @@ public class StoreFileReader {
           exists = !keyIsAfterLast && bloomFilter.contains(key, 0, key.length, bloom);
         }
 
+        recordExternalBloomMetric(exists);
         return exists;
       }
     } catch (IOException e) {
@@ -484,18 +556,41 @@ public class StoreFileReader {
       bloomFilterType = BloomType.valueOf(Bytes.toString(b));
     }
 
+    if (bloomFilterType == BloomType.NONE && reader instanceof MultiTenantBloomSupport) {
+      bloomFilterType = ((MultiTenantBloomSupport) reader).getGeneralBloomFilterType();
+    }
+
     byte[] p = fi.get(BLOOM_FILTER_PARAM_KEY);
-    if (bloomFilterType == BloomType.ROWPREFIX_FIXED_LENGTH) {
+    if (p != null) {
       prefixLength = Bytes.toInt(p);
+    } else if (reader instanceof MultiTenantBloomSupport) {
+      try {
+        prefixLength = ((MultiTenantBloomSupport) reader).getGeneralBloomPrefixLength();
+      } catch (IOException e) {
+        LOG.debug("Failed to obtain prefix length from multi-tenant reader", e);
+      }
     }
 
     lastBloomKey = fi.get(LAST_BLOOM_KEY);
-    if (bloomFilterType == BloomType.ROWCOL) {
+    if (lastBloomKey == null && reader instanceof MultiTenantBloomSupport) {
+      try {
+        lastBloomKey = ((MultiTenantBloomSupport) reader).getLastBloomKey();
+      } catch (IOException e) {
+        LOG.debug("Failed to obtain last bloom key from multi-tenant reader", e);
+      }
+    }
+    if (bloomFilterType == BloomType.ROWCOL && lastBloomKey != null) {
       lastBloomKeyOnlyKV = new KeyValue.KeyOnlyKeyValue(lastBloomKey, 0, lastBloomKey.length);
     }
     byte[] cnt = fi.get(DELETE_FAMILY_COUNT);
     if (cnt != null) {
       deleteFamilyCnt = Bytes.toLong(cnt);
+    } else if (reader instanceof MultiTenantBloomSupport) {
+      try {
+        deleteFamilyCnt = ((MultiTenantBloomSupport) reader).getDeleteFamilyBloomCount();
+      } catch (IOException e) {
+        LOG.debug("Failed to obtain delete family bloom count from multi-tenant reader", e);
+      }
     }
 
     return fi;
@@ -512,6 +607,7 @@ public class StoreFileReader {
     try {
       this.bloomFilterMetrics = metrics;
       if (blockType == BlockType.GENERAL_BLOOM_META) {
+        bloomMetricsTrackedExternally = false;
         if (this.generalBloomFilter != null) return; // Bloom has been loaded
 
         DataInput bloomMeta = reader.getGeneralBloomFilterMetadata();
@@ -527,6 +623,13 @@ public class StoreFileReader {
                 + reader.getName());
             }
           }
+        } else if (reader instanceof MultiTenantBloomSupport) {
+          try {
+            generalBloomFilter = ((MultiTenantBloomSupport) reader).getGeneralBloomFilterInstance();
+            bloomMetricsTrackedExternally = generalBloomFilter != null;
+          } catch (IOException e) {
+            LOG.debug("Failed to obtain general bloom filter from multi-tenant reader", e);
+          }
         }
       } else if (blockType == BlockType.DELETE_FAMILY_BLOOM_META) {
         if (this.deleteFamilyBloomFilter != null) return; // Bloom has been loaded
@@ -539,6 +642,13 @@ public class StoreFileReader {
           LOG.info(
             "Loaded Delete Family Bloom (" + deleteFamilyBloomFilter.getClass().getSimpleName()
               + ") metadata for " + reader.getName());
+        } else if (reader instanceof MultiTenantBloomSupport) {
+          try {
+            deleteFamilyBloomFilter =
+              ((MultiTenantBloomSupport) reader).getDeleteFamilyBloomFilterInstance();
+          } catch (IOException e) {
+            LOG.debug("Failed to obtain delete family bloom filter from multi-tenant reader", e);
+          }
         }
       } else {
         throw new RuntimeException(

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileWriter.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreFileWriter.java
@@ -58,6 +58,7 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileWriterImpl;
+import org.apache.hadoop.hbase.io.hfile.MultiTenantHFileWriter;
 import org.apache.hadoop.hbase.mob.MobUtils;
 import org.apache.hadoop.hbase.regionserver.compactions.DefaultCompactor;
 import org.apache.hadoop.hbase.util.BloomContext;
@@ -117,6 +118,7 @@ public class StoreFileWriter implements CellSink, ShipperListener {
   private int livePutCellCount;
   private final int maxVersions;
   private final boolean newVersionBehavior;
+  private volatile boolean closed = false;
 
   /**
    * Creates an HFile.Writer that also write helpful meta data.
@@ -264,6 +266,20 @@ public class StoreFileWriter implements CellSink, ShipperListener {
     }
   }
 
+  /**
+   * Registers a supplier that exposes the custom tiering {@link TimeRangeTracker}. Concrete
+   * {@link HFile.Writer} implementations can use it to tune caching decisions or emit metadata.
+   */
+  public void setCustomTieringTimeRangeSupplier(Supplier<TimeRangeTracker> supplier) {
+    if (supplier == null) {
+      return;
+    }
+    liveFileWriter.setCustomTieringTimeRangeSupplier(supplier);
+    if (historicalFileWriter != null) {
+      historicalFileWriter.setCustomTieringTimeRangeSupplier(supplier);
+    }
+  }
+
   @Override
   public void beforeShipped() throws IOException {
     liveFileWriter.beforeShipped();
@@ -293,10 +309,14 @@ public class StoreFileWriter implements CellSink, ShipperListener {
    */
   @InterfaceAudience.LimitedPrivate(HBaseInterfaceAudience.UNITTEST)
   public BloomFilterWriter getGeneralBloomWriter() {
-    return liveFileWriter.generalBloomFilterWriter;
+    return liveFileWriter.getGeneralBloomWriter();
   }
 
   public void close() throws IOException {
+    if (closed) {
+      return;
+    }
+    closed = true;
     liveFileWriter.appendFileInfo(HISTORICAL_KEY, Bytes.toBytes(false));
     liveFileWriter.close();
     if (historicalFileWriter != null) {
@@ -310,6 +330,72 @@ public class StoreFileWriter implements CellSink, ShipperListener {
     if (historicalFileWriter != null) {
       historicalFileWriter.appendFileInfo(key, value);
     }
+  }
+
+  /**
+   * Thread compaction context into the writer so downstream formats (e.g., v4 sections) can reflect
+   * MAJOR_COMPACTION_KEY/HISTORICAL/COMPACTION_EVENT_KEY consistently. Should be called immediately
+   * after writer creation and before any cells are appended.
+   * <p>
+   * Effects:
+   * <ul>
+   * <li>Writes {@link HStoreFile#MAJOR_COMPACTION_KEY} to indicate major/minor compaction.</li>
+   * <li>Writes {@link HStoreFile#COMPACTION_EVENT_KEY} built from the compaction input set. See
+   * {@link #buildCompactionEventTrackerBytes(java.util.function.Supplier, java.util.Collection)}
+   * for inclusion semantics.</li>
+   * <li>Writes {@link HStoreFile#HISTORICAL_KEY}: {@code false} for the live writer and
+   * {@code true} for the historical writer (when dual-writing is enabled).</li>
+   * </ul>
+   * For HFile v4 (multi-tenant) writers, these file info entries are propagated to each newly
+   * created tenant section so that every section reflects the real compaction context.
+   * @param majorCompaction {@code true} if this compaction is major, otherwise {@code false}
+   * @param storeFiles      the set of input store files being compacted into this writer
+   * @throws IOException if writing file info fails
+   */
+  public void appendCompactionContext(final boolean majorCompaction,
+    final Collection<HStoreFile> storeFiles) throws IOException {
+    byte[] eventBytes = buildCompactionEventTrackerBytes(this.compactedFilesSupplier, storeFiles);
+    // live file
+    liveFileWriter.appendFileInfo(MAJOR_COMPACTION_KEY, Bytes.toBytes(majorCompaction));
+    liveFileWriter.appendFileInfo(COMPACTION_EVENT_KEY, eventBytes);
+    liveFileWriter.appendFileInfo(HISTORICAL_KEY, Bytes.toBytes(false));
+    // historical file if enabled
+    if (historicalFileWriter != null) {
+      historicalFileWriter.appendFileInfo(MAJOR_COMPACTION_KEY, Bytes.toBytes(majorCompaction));
+      historicalFileWriter.appendFileInfo(COMPACTION_EVENT_KEY, eventBytes);
+      historicalFileWriter.appendFileInfo(HISTORICAL_KEY, Bytes.toBytes(true));
+    }
+  }
+
+  /**
+   * Used when write {@link HStoreFile#COMPACTION_EVENT_KEY} to new file's file info. The compacted
+   * store files' names are needed. If a compacted store file is itself the result of compaction,
+   * its compacted files which are still not archived are needed, too. We do not add compacted files
+   * recursively.
+   * <p>
+   * Example: If files A, B, C compacted to new file D, and file D compacted to new file E, we will
+   * write A, B, C, D to file E's compacted files. If later file E compacted to new file F, we will
+   * add E to F's compacted files first, then add E's compacted files (A, B, C, D) to it. There is
+   * no need to add D's compacted file again, as D's compacted files have already been included in
+   * E's compacted files. See HBASE-20724 for more details.
+   * @param compactedFilesSupplier supplier returning store files compacted but not yet archived
+   * @param storeFiles             the compacted store files to generate this new file
+   * @return bytes of CompactionEventTracker
+   */
+  private static byte[] buildCompactionEventTrackerBytes(
+    Supplier<Collection<HStoreFile>> compactedFilesSupplier, Collection<HStoreFile> storeFiles) {
+    Set<String> notArchivedCompactedStoreFiles = compactedFilesSupplier.get().stream()
+      .map(sf -> sf.getPath().getName()).collect(Collectors.toSet());
+    Set<String> compactedStoreFiles = new HashSet<>();
+    for (HStoreFile storeFile : storeFiles) {
+      compactedStoreFiles.add(storeFile.getFileInfo().getPath().getName());
+      for (String csf : storeFile.getCompactedStoreFiles()) {
+        if (notArchivedCompactedStoreFiles.contains(csf)) {
+          compactedStoreFiles.add(csf);
+        }
+      }
+    }
+    return ProtobufUtil.toCompactionEventTrackerBytes(compactedStoreFiles);
   }
 
   /**
@@ -530,63 +616,81 @@ public class StoreFileWriter implements CellSink, ShipperListener {
       Supplier<Collection<HStoreFile>> compactedFilesSupplier) throws IOException {
       this.compactedFilesSupplier = compactedFilesSupplier;
       // TODO : Change all writers to be specifically created for compaction context
-      writer =
-        HFile.getWriterFactory(conf, cacheConf).withPath(fs, path).withFavoredNodes(favoredNodes)
-          .withFileContext(fileContext).withShouldDropCacheBehind(shouldDropCacheBehind).create();
+      HFile.WriterFactory writerFactory = HFile.getWriterFactory(conf, cacheConf);
+      if (
+        writerFactory instanceof org.apache.hadoop.hbase.io.hfile.MultiTenantHFileWriter.WriterFactory
+      ) {
+        ((org.apache.hadoop.hbase.io.hfile.MultiTenantHFileWriter.WriterFactory) writerFactory)
+          .withPreferredBloomType(bloomType);
+      }
+      writer = writerFactory.withPath(fs, path).withFavoredNodes(favoredNodes)
+        .withFileContext(fileContext).withShouldDropCacheBehind(shouldDropCacheBehind).create();
 
-      generalBloomFilterWriter = BloomFilterFactory.createGeneralBloomAtWrite(conf, cacheConf,
-        bloomType, (int) Math.min(maxKeys, Integer.MAX_VALUE), writer);
-
-      if (generalBloomFilterWriter != null) {
+      if (writer.hasGeneralBloom()) {
+        // The writer manages Bloom filter lifecycle internally (e.g. per-section in HFile v4).
+        // No need to create a redundant Bloom filter at this level.
+        this.generalBloomFilterWriter = null;
+        this.deleteFamilyBloomFilterWriter = null;
         this.bloomType = bloomType;
-        this.bloomParam = BloomFilterUtil.getBloomFilterParam(bloomType, conf);
-        if (LOG.isTraceEnabled()) {
-          LOG.trace("Bloom filter type for " + path + ": " + this.bloomType + ", param: "
-            + (bloomType == BloomType.ROWPREFIX_FIXED_LENGTH
-              ? Bytes.toInt(bloomParam)
-              : Bytes.toStringBinary(bloomParam))
-            + ", " + generalBloomFilterWriter.getClass().getSimpleName());
-        }
-        // init bloom context
-        switch (bloomType) {
-          case ROW:
-            bloomContext =
-              new RowBloomContext(generalBloomFilterWriter, fileContext.getCellComparator());
-            break;
-          case ROWCOL:
-            bloomContext =
-              new RowColBloomContext(generalBloomFilterWriter, fileContext.getCellComparator());
-            break;
-          case ROWPREFIX_FIXED_LENGTH:
-            bloomContext = new RowPrefixFixedLengthBloomContext(generalBloomFilterWriter,
-              fileContext.getCellComparator(), Bytes.toInt(bloomParam));
-            break;
-          default:
-            throw new IOException(
-              "Invalid Bloom filter type: " + bloomType + " (ROW or ROWCOL or ROWPREFIX expected)");
-        }
+        this.bloomParam = null;
       } else {
-        // Not using Bloom filters.
-        this.bloomType = BloomType.NONE;
-      }
+        generalBloomFilterWriter = BloomFilterFactory.createGeneralBloomAtWrite(conf, cacheConf,
+          bloomType, (int) Math.min(maxKeys, Integer.MAX_VALUE), writer);
 
-      // initialize delete family Bloom filter when there is NO RowCol Bloom filter
-      if (this.bloomType != BloomType.ROWCOL) {
-        this.deleteFamilyBloomFilterWriter = BloomFilterFactory.createDeleteBloomAtWrite(conf,
-          cacheConf, (int) Math.min(maxKeys, Integer.MAX_VALUE), writer);
-        deleteFamilyBloomContext =
-          new RowBloomContext(deleteFamilyBloomFilterWriter, fileContext.getCellComparator());
-      } else {
-        deleteFamilyBloomFilterWriter = null;
-      }
-      if (deleteFamilyBloomFilterWriter != null && LOG.isTraceEnabled()) {
-        LOG.trace("Delete Family Bloom filter type for " + path + ": "
-          + deleteFamilyBloomFilterWriter.getClass().getSimpleName());
+        if (generalBloomFilterWriter != null) {
+          this.bloomType = bloomType;
+          this.bloomParam = BloomFilterUtil.getBloomFilterParam(bloomType, conf);
+          if (LOG.isTraceEnabled()) {
+            LOG.trace("Bloom filter type for " + path + ": " + this.bloomType + ", param: "
+              + (bloomType == BloomType.ROWPREFIX_FIXED_LENGTH
+                ? Bytes.toInt(bloomParam)
+                : Bytes.toStringBinary(bloomParam))
+              + ", " + generalBloomFilterWriter.getClass().getSimpleName());
+          }
+          // init bloom context
+          switch (bloomType) {
+            case ROW:
+              bloomContext =
+                new RowBloomContext(generalBloomFilterWriter, fileContext.getCellComparator());
+              break;
+            case ROWCOL:
+              bloomContext =
+                new RowColBloomContext(generalBloomFilterWriter, fileContext.getCellComparator());
+              break;
+            case ROWPREFIX_FIXED_LENGTH:
+              bloomContext = new RowPrefixFixedLengthBloomContext(generalBloomFilterWriter,
+                fileContext.getCellComparator(), Bytes.toInt(bloomParam));
+              break;
+            default:
+              throw new IOException("Invalid Bloom filter type: " + bloomType
+                + " (ROW or ROWCOL or ROWPREFIX expected)");
+          }
+        } else {
+          // Not using Bloom filters.
+          this.bloomType = BloomType.NONE;
+          this.bloomParam = null;
+        }
+
+        // initialize delete family Bloom filter when there is NO RowCol Bloom filter
+        if (this.bloomType != BloomType.ROWCOL) {
+          this.deleteFamilyBloomFilterWriter = BloomFilterFactory.createDeleteBloomAtWrite(conf,
+            cacheConf, (int) Math.min(maxKeys, Integer.MAX_VALUE), writer);
+          if (deleteFamilyBloomFilterWriter != null) {
+            deleteFamilyBloomContext =
+              new RowBloomContext(deleteFamilyBloomFilterWriter, fileContext.getCellComparator());
+          }
+        } else {
+          this.deleteFamilyBloomFilterWriter = null;
+        }
+        if (deleteFamilyBloomFilterWriter != null && LOG.isTraceEnabled()) {
+          LOG.trace("Delete Family Bloom filter type for " + path + ": "
+            + deleteFamilyBloomFilterWriter.getClass().getSimpleName());
+        }
       }
     }
 
     private long getPos() throws IOException {
-      return ((HFileWriterImpl) writer).getPos();
+      return writer.getPos();
     }
 
     /**
@@ -611,35 +715,9 @@ public class StoreFileWriter implements CellSink, ShipperListener {
       final Collection<HStoreFile> storeFiles) throws IOException {
       writer.appendFileInfo(MAX_SEQ_ID_KEY, Bytes.toBytes(maxSequenceId));
       writer.appendFileInfo(MAJOR_COMPACTION_KEY, Bytes.toBytes(majorCompaction));
-      writer.appendFileInfo(COMPACTION_EVENT_KEY, toCompactionEventTrackerBytes(storeFiles));
+      writer.appendFileInfo(COMPACTION_EVENT_KEY,
+        StoreFileWriter.buildCompactionEventTrackerBytes(this.compactedFilesSupplier, storeFiles));
       appendTrackedTimestampsToMetadata();
-    }
-
-    /**
-     * Used when write {@link HStoreFile#COMPACTION_EVENT_KEY} to new file's file info. The
-     * compacted store files's name is needed. But if the compacted store file is a result of
-     * compaction, it's compacted files which still not archived is needed, too. And don't need to
-     * add compacted files recursively. If file A, B, C compacted to new file D, and file D
-     * compacted to new file E, will write A, B, C, D to file E's compacted files. So if file E
-     * compacted to new file F, will add E to F's compacted files first, then add E's compacted
-     * files: A, B, C, D to it. And no need to add D's compacted file, as D's compacted files has
-     * been in E's compacted files, too. See HBASE-20724 for more details.
-     * @param storeFiles The compacted store files to generate this new file
-     * @return bytes of CompactionEventTracker
-     */
-    private byte[] toCompactionEventTrackerBytes(Collection<HStoreFile> storeFiles) {
-      Set<String> notArchivedCompactedStoreFiles = this.compactedFilesSupplier.get().stream()
-        .map(sf -> sf.getPath().getName()).collect(Collectors.toSet());
-      Set<String> compactedStoreFiles = new HashSet<>();
-      for (HStoreFile storeFile : storeFiles) {
-        compactedStoreFiles.add(storeFile.getFileInfo().getPath().getName());
-        for (String csf : storeFile.getCompactedStoreFiles()) {
-          if (notArchivedCompactedStoreFiles.contains(csf)) {
-            compactedStoreFiles.add(csf);
-          }
-        }
-      }
-      return ProtobufUtil.toCompactionEventTrackerBytes(compactedStoreFiles);
     }
 
     /**
@@ -725,7 +803,7 @@ public class StoreFileWriter implements CellSink, ShipperListener {
     }
 
     private boolean hasGeneralBloom() {
-      return this.generalBloomFilterWriter != null;
+      return this.generalBloomFilterWriter != null || writer.hasGeneralBloom();
     }
 
     /**
@@ -733,7 +811,9 @@ public class StoreFileWriter implements CellSink, ShipperListener {
      * @return the Bloom filter used by this writer.
      */
     BloomFilterWriter getGeneralBloomWriter() {
-      return generalBloomFilterWriter;
+      return generalBloomFilterWriter != null
+        ? generalBloomFilterWriter
+        : writer.getGeneralBloomWriter();
     }
 
     private boolean closeBloomFilter(BloomFilterWriter bfw) throws IOException {
@@ -755,11 +835,18 @@ public class StoreFileWriter implements CellSink, ShipperListener {
           writer.appendFileInfo(BLOOM_FILTER_PARAM_KEY, bloomParam);
         }
         bloomContext.addLastBloomKey(writer);
+      } else if (writer.hasGeneralBloom()) {
+        // Writer manages bloom lifecycle internally; report its state for logging.
+        hasGeneralBloom = true;
       }
       return hasGeneralBloom;
     }
 
     private boolean closeDeleteFamilyBloomFilter() throws IOException {
+      if (deleteFamilyBloomFilterWriter == null && writer.hasGeneralBloom()) {
+        // Writer manages bloom lifecycle internally (including delete-family per section).
+        return false;
+      }
       boolean hasDeleteFamilyBloom = closeBloomFilter(deleteFamilyBloomFilterWriter);
 
       // add the delete family Bloom filter writer
@@ -792,6 +879,14 @@ public class StoreFileWriter implements CellSink, ShipperListener {
 
     private void appendFileInfo(byte[] key, byte[] value) throws IOException {
       writer.appendFileInfo(key, value);
+    }
+
+    private void setCustomTieringTimeRangeSupplier(Supplier<TimeRangeTracker> supplier) {
+      if (writer instanceof HFileWriterImpl) {
+        ((HFileWriterImpl) writer).setTimeRangeTrackerForTiering(supplier);
+      } else if (writer instanceof MultiTenantHFileWriter) {
+        ((MultiTenantHFileWriter) writer).setCustomTieringTimeRangeSupplier(supplier);
+      }
     }
 
     /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/compactions/Compactor.java
@@ -364,6 +364,11 @@ public abstract class Compactor<T extends CellSink> {
       }
       writer = sinkFactory.createWriter(scanner, fd, dropCache, request.isMajor(),
         request.getWriterCreationTracker());
+      // Thread compaction context to writer so downstream formats (e.g., v4 sections) inherit
+      if (writer instanceof org.apache.hadoop.hbase.regionserver.StoreFileWriter) {
+        ((org.apache.hadoop.hbase.regionserver.StoreFileWriter) writer)
+          .appendCompactionContext(request.isAllFiles(), request.getFiles());
+      }
       finished = performCompaction(fd, scanner, writer, smallestReadPoint, cleanSeqId,
         throughputController, request, progress);
       if (!finished) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/AcidGuaranteesTestBase.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/AcidGuaranteesTestBase.java
@@ -26,6 +26,7 @@ import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.regionserver.CompactingMemStore;
 import org.apache.hadoop.hbase.regionserver.ConstantSizeRegionSplitPolicy;
 import org.apache.hadoop.hbase.regionserver.MemStoreLAB;
@@ -66,7 +67,19 @@ public abstract class AcidGuaranteesTestBase {
     // prevent aggressive region split
     conf.set(HConstants.HBASE_REGION_SPLIT_POLICY_KEY,
       ConstantSizeRegionSplitPolicy.class.getName());
-    conf.setInt("hfile.format.version", 3); // for mob tests
+    // Ensure the mini cluster uses the current HFile writer version. HBase 4.x defaults to v4.
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
+    // HFile v4 flushes have slightly more overhead (section index, per-section bloom filters,
+    // extra stream flushes during section close). With the tiny 128KB flush size and crazyFlush
+    // mode, the memstore can exceed the blocking threshold, causing RegionTooBusyException.
+    // The default client timeouts make flush and teardown retries outlive the test timeout.
+    // Cap both operation and per-RPC timeouts so this suite fails fast under CI back-pressure.
+    conf.setInt(HConstants.HBASE_CLIENT_OPERATION_TIMEOUT, 60000);
+    conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 10);
+    conf.setInt(HConstants.HBASE_RPC_TIMEOUT_KEY, 30000);
+    // Raise the blocking multiplier to tolerate transient memstore back-pressure.
+    // Default is 4 (blocking at 512KB for 128KB flush), which is too tight under v4.
+    conf.setInt(HConstants.HREGION_MEMSTORE_BLOCK_MULTIPLIER, 8);
     UTIL.startMiniCluster(1);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/AcidGuaranteesTestTool.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/AcidGuaranteesTestTool.java
@@ -20,23 +20,29 @@ package org.apache.hadoop.hbase;
 import java.io.IOException;
 import java.util.List;
 import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.stream.Stream;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.MultithreadedTestUtil.RepeatingTestThread;
 import org.apache.hadoop.hbase.MultithreadedTestUtil.TestContext;
 import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.AsyncAdmin;
+import org.apache.hadoop.hbase.client.AsyncConnection;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptor;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Connection;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Scan;
@@ -73,6 +79,9 @@ public class AcidGuaranteesTestTool extends AbstractHBaseTool {
   public static final byte[][] FAMILIES = new byte[][] { FAMILY_A, FAMILY_B, FAMILY_C };
 
   public static int NUM_COLS_TO_CHECK = 50;
+
+  private static final long FLUSH_TIMEOUT_SECONDS = 30;
+  private static final long FLUSH_INTERVAL_MILLIS = TimeUnit.MINUTES.toMillis(1);
 
   private ExecutorService sharedPool;
 
@@ -318,6 +327,61 @@ public class AcidGuaranteesTestTool extends AbstractHBaseTool {
     }
   }
 
+  /**
+   * Thread that flushes the table by region. Using region flush avoids the table flush procedure
+   * path, which is more likely to stall under CI back-pressure for MOB data.
+   */
+  public static class AtomicityFlusher extends RepeatingTestThread {
+    private final AsyncConnection connection;
+    private final AsyncAdmin admin;
+    private final List<RegionInfo> regions;
+    private final boolean crazyFlush;
+
+    public AtomicityFlusher(TestContext ctx, List<RegionInfo> regions, boolean crazyFlush)
+      throws Exception {
+      super(ctx);
+      this.connection = ConnectionFactory.createAsyncConnection(ctx.getConf()).get();
+      this.admin = connection.getAdmin();
+      this.regions = regions;
+      this.crazyFlush = crazyFlush;
+    }
+
+    @Override
+    public void doAnAction() throws Exception {
+      for (RegionInfo region : regions) {
+        try {
+          admin.flushRegion(region.getRegionName()).get(FLUSH_TIMEOUT_SECONDS, TimeUnit.SECONDS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          return;
+        } catch (ExecutionException | TimeoutException e) {
+          LOG.warn("Ignoring exception while flushing region {}: {}", region.getEncodedName(),
+            StringUtils.stringifyException(e));
+        }
+      }
+      // Flushing has been a source of ACID violations previously (see HBASE-2856), so ideally,
+      // we would flush as often as possible. On a running cluster, this isn't practical:
+      // (1) we will cause a lot of load due to all the flushing and compacting
+      // (2) we cannot change the flushing/compacting related Configuration options to try to
+      // alleviate this
+      // (3) it is an unrealistic workload, since no one would actually flush that often.
+      // Therefore, let's flush every minute to have more flushes than usual, but not overload
+      // the running cluster.
+      if (!crazyFlush) {
+        try {
+          Thread.sleep(FLUSH_INTERVAL_MILLIS);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+      }
+    }
+
+    @Override
+    public void workDone() throws IOException {
+      connection.close();
+    }
+  }
+
   private void createTableIfMissing(Admin admin, boolean useMob) throws IOException {
     if (!admin.tableExists(TABLE_NAME)) {
       TableDescriptorBuilder builder = TableDescriptorBuilder.newBuilder(TABLE_NAME);
@@ -347,28 +411,16 @@ public class AcidGuaranteesTestTool extends AbstractHBaseTool {
       writers.add(writer);
       ctx.addThread(writer);
     }
-    // Add a flusher
-    ctx.addThread(new RepeatingTestThread(ctx) {
-      @Override
-      public void doAnAction() throws Exception {
-        try {
-          admin.flush(TABLE_NAME);
-        } catch (IOException ioe) {
-          LOG.warn("Ignoring exception while flushing: " + StringUtils.stringifyException(ioe));
-        }
-        // Flushing has been a source of ACID violations previously (see HBASE-2856), so ideally,
-        // we would flush as often as possible. On a running cluster, this isn't practical:
-        // (1) we will cause a lot of load due to all the flushing and compacting
-        // (2) we cannot change the flushing/compacting related Configuration options to try to
-        // alleviate this
-        // (3) it is an unrealistic workload, since no one would actually flush that often.
-        // Therefore, let's flush every minute to have more flushes than usual, but not overload
-        // the running cluster.
-        if (!crazyFlush) {
-          Thread.sleep(60000);
-        }
+    List<RegionInfo> regionsToFlush = Lists.newArrayList();
+    for (RegionInfo region : admin.getRegions(TABLE_NAME)) {
+      if (RegionReplicaUtil.isDefaultReplica(region)) {
+        regionsToFlush.add(region);
       }
-    });
+    }
+    if (regionsToFlush.isEmpty()) {
+      throw new IllegalStateException("No default regions found for " + TABLE_NAME);
+    }
+    ctx.addThread(new AtomicityFlusher(ctx, regionsToFlush, crazyFlush));
 
     List<AtomicGetReader> getters = Lists.newArrayList();
     for (int i = 0; i < numGetters; i++) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HFilePerformanceEvaluation.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HFilePerformanceEvaluation.java
@@ -124,7 +124,7 @@ public class HFilePerformanceEvaluation {
     final Configuration aesconf = new Configuration();
     aesconf.set(HConstants.CRYPTO_KEYPROVIDER_CONF_KEY, KeyProviderForTesting.class.getName());
     aesconf.set(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, "hbase");
-    aesconf.setInt("hfile.format.version", 3);
+    aesconf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     final FileSystem aesfs = FileSystem.get(aesconf);
     final Path aesmf = aesfs.makeQualified(new Path("performanceevaluation.aes.mapfile"));
 
@@ -140,7 +140,7 @@ public class HFilePerformanceEvaluation {
     final Configuration cryptoconf = new Configuration();
     cryptoconf.set(HConstants.CRYPTO_KEYPROVIDER_CONF_KEY, KeyProviderForTesting.class.getName());
     cryptoconf.set(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, "hbase");
-    cryptoconf.setInt("hfile.format.version", 3);
+    cryptoconf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     cryptoconf.set(HConstants.CRYPTO_CIPHERPROVIDER_CONF_KEY, CryptoCipherProvider.class.getName());
     final FileSystem cryptofs = FileSystem.get(cryptoconf);
     final Path cryptof = cryptofs.makeQualified(new Path("performanceevaluation.aes.mapfile"));

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestResultSizeEstimation.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestResultSizeEstimation.java
@@ -57,7 +57,7 @@ public class TestResultSizeEstimation {
   public static void setUpBeforeClass() throws Exception {
     Configuration conf = TEST_UTIL.getConfiguration();
     // Need HFileV3
-    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_TAGS);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     // effectively limit max result size to one entry if it has tags
     conf.setLong(HConstants.HBASE_CLIENT_SCANNER_MAX_RESULT_SIZE_KEY, SCANNER_DATA_LIMIT);
     conf.setBoolean(ScannerCallable.LOG_SCANNER_ACTIVITY, true);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/encoding/TestEncodedSeekers.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/encoding/TestEncodedSeekers.java
@@ -111,7 +111,7 @@ public class TestEncodedSeekers {
     System.err.println("Testing encoded seekers for encoding : " + encoding + ", includeTags : "
       + includeTags + ", compressTags : " + compressTags);
     if (includeTags) {
-      testUtil.getConfiguration().setInt(HFile.FORMAT_VERSION_KEY, 3);
+      testUtil.getConfiguration().setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     }
 
     LruBlockCache cache =

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileIntegrationTest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileIntegrationTest.java
@@ -1,0 +1,856 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.Cell;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Delete;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for multi-tenant HFile functionality.
+ * <p>
+ * This test validates the complete multi-tenant HFile workflow:
+ * <ol>
+ * <li><strong>Setup:</strong> Creates table with multi-tenant configuration</li>
+ * <li><strong>Data Writing:</strong> Writes data for multiple tenants with distinct prefixes</li>
+ * <li><strong>Flushing:</strong> Forces memstore flush to create multi-tenant HFile v4 files</li>
+ * <li><strong>Verification:</strong> Tests various read patterns and tenant isolation</li>
+ * <li><strong>Format Validation:</strong> Verifies HFile v4 structure and tenant sections</li>
+ * </ol>
+ * <p>
+ * The test ensures tenant data isolation, format compliance, and data integrity across different
+ * access patterns (GET, SCAN, tenant-specific scans).
+ */
+@Category(MediumTests.class)
+public class MultiTenantHFileIntegrationTest {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(MultiTenantHFileIntegrationTest.class);
+
+  private static final Logger LOG = LoggerFactory.getLogger(MultiTenantHFileIntegrationTest.class);
+
+  private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  private static final TableName TABLE_NAME = TableName.valueOf("TestMultiTenantTable");
+  private static final byte[] FAMILY = Bytes.toBytes("f");
+  private static final byte[] QUALIFIER = Bytes.toBytes("q");
+
+  private static final int TENANT_PREFIX_LENGTH = 3;
+  private static final String[] TENANTS =
+    { "T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", "T10" };
+  private static final int[] ROWS_PER_TENANT = { 5, 8, 12, 3, 15, 7, 20, 6, 10, 14 };
+  private static final Map<String, Integer> TENANT_DELETE_FAMILY_COUNTS = new HashMap<>();
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    LOG.info("=== Setting up Multi-Tenant HFile Integration Test ===");
+    Configuration conf = TEST_UTIL.getConfiguration();
+
+    // Configure multi-tenant HFile settings
+    conf.setInt(MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, TENANT_PREFIX_LENGTH);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+
+    LOG.info("Starting mini cluster with multi-tenant HFile configuration");
+    LOG.info("  - Tenant prefix length: {}", TENANT_PREFIX_LENGTH);
+    LOG.info("  - HFile format version: {}", HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+
+    TEST_UTIL.startMiniCluster(1);
+    LOG.info("Mini cluster started successfully");
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    LOG.info("=== Shutting down Multi-Tenant HFile Integration Test ===");
+    TEST_UTIL.shutdownMiniCluster();
+    LOG.info("Mini cluster shutdown complete");
+  }
+
+  /**
+   * End-to-end test of multi-tenant HFile functionality.
+   * <p>
+   * Test execution flow:
+   * <ol>
+   * <li>Create table with multi-tenant configuration</li>
+   * <li>Write test data for {} tenants with varying row counts</li>
+   * <li>Flush memstore to create multi-tenant HFiles</li>
+   * <li>Verify data integrity using GET operations</li>
+   * <li>Verify data using full table SCAN</li>
+   * <li>Verify tenant isolation using tenant-specific scans</li>
+   * <li>Test edge cases and cross-tenant isolation</li>
+   * <li>Validate HFile format and tenant section structure</li>
+   * </ol>
+   */
+  @Test(timeout = 180000)
+  public void testMultiTenantHFileCreation() throws Exception {
+    LOG.info("=== Starting Multi-Tenant HFile Integration Test ===");
+    LOG.info("Test will process {} tenants with {} total expected rows", TENANTS.length,
+      calculateTotalExpectedRows());
+
+    // Phase 1: Setup
+    LOG.info("Phase 1: Creating test table with multi-tenant configuration");
+    createTestTable();
+
+    // Phase 2: Data Writing
+    LOG.info("Phase 2: Writing test data for {} tenants", TENANTS.length);
+    writeTestData();
+
+    // Phase 3: Pre-flush Verification
+    LOG.info("Phase 3: Verifying memstore state before flush");
+    assertTableMemStoreNotEmpty();
+
+    // Phase 4: Flushing
+    LOG.info("Phase 4: Flushing memstore to create multi-tenant HFiles");
+    flushTable();
+
+    // Phase 5: Post-flush Verification
+    LOG.info("Phase 5: Verifying memstore state after flush");
+    assertTableMemStoreEmpty();
+
+    // Wait for HFiles to stabilize
+    LOG.info("Waiting for HFiles to stabilize...");
+    Thread.sleep(2000);
+
+    // Phase 6: Data Verification
+    LOG.info("Phase 6: Starting comprehensive data verification");
+    verifyDataWithGet();
+    verifyDataWithScan();
+    verifyDataWithTenantSpecificScans();
+    verifyEdgeCasesAndCrossTenantIsolation();
+
+    // Phase 7: HFile Format Verification
+    LOG.info("Phase 7: Verifying HFile format and structure");
+    List<Path> hfilePaths = findHFilePaths();
+    assertFalse("No HFiles found after flush", hfilePaths.isEmpty());
+    LOG.info("Found {} HFiles for verification", hfilePaths.size());
+    verifyHFileFormat(hfilePaths);
+
+    LOG.info("=== Multi-tenant HFile integration test completed successfully ===");
+  }
+
+  /**
+   * Calculate total expected rows across all tenants.
+   * @return sum of rows across all tenants
+   */
+  private static int calculateTotalExpectedRows() {
+    int total = 0;
+    for (int rows : ROWS_PER_TENANT) {
+      total += rows;
+    }
+    return total;
+  }
+
+  /**
+   * Create test table with multi-tenant configuration. Sets up table properties required for
+   * multi-tenant HFile functionality.
+   */
+  private void createTestTable() throws IOException {
+    try (Admin admin = TEST_UTIL.getAdmin()) {
+      TableDescriptorBuilder tableBuilder = TableDescriptorBuilder.newBuilder(TABLE_NAME);
+
+      // Set multi-tenant properties
+      tableBuilder.setValue(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH,
+        String.valueOf(TENANT_PREFIX_LENGTH));
+      tableBuilder.setValue(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+
+      tableBuilder.setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(FAMILY).build());
+
+      admin.createTable(tableBuilder.build());
+      LOG.info("Created table {} with multi-tenant configuration", TABLE_NAME);
+
+      try {
+        TEST_UTIL.waitTableAvailable(TABLE_NAME);
+        LOG.info("Table {} is now available", TABLE_NAME);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+        throw new IOException("Interrupted waiting for table", e);
+      }
+    }
+  }
+
+  /**
+   * Write test data for all tenants. Creates rows with format: {tenantId}row{paddedIndex} ->
+   * value_tenant-{tenantId}_row-{paddedIndex}
+   */
+  private void writeTestData() throws IOException {
+    try (Connection connection = TEST_UTIL.getConnection();
+      Table table = connection.getTable(TABLE_NAME)) {
+
+      List<Put> batchPuts = new ArrayList<>();
+      List<Delete> batchDeletes = new ArrayList<>();
+      TENANT_DELETE_FAMILY_COUNTS.clear();
+
+      LOG.info("Generating test data for {} tenants:", TENANTS.length);
+      for (int tenantIndex = 0; tenantIndex < TENANTS.length; tenantIndex++) {
+        String tenantId = TENANTS[tenantIndex];
+        TENANT_DELETE_FAMILY_COUNTS.put(tenantId, 0);
+        int rowsForThisTenant = ROWS_PER_TENANT[tenantIndex];
+        LOG.info("  - Tenant {}: {} rows", tenantId, rowsForThisTenant);
+
+        for (int rowIndex = 0; rowIndex < rowsForThisTenant; rowIndex++) {
+          String rowKey = String.format("%srow%03d", tenantId, rowIndex);
+          Put putOperation = new Put(Bytes.toBytes(rowKey));
+
+          String cellValue = String.format("value_tenant-%s_row-%03d", tenantId, rowIndex);
+          putOperation.addColumn(FAMILY, QUALIFIER, Bytes.toBytes(cellValue));
+          batchPuts.add(putOperation);
+
+          if (rowIndex == 0 || rowIndex == rowsForThisTenant - 1) {
+            Delete delete = new Delete(Bytes.toBytes(rowKey));
+            delete.addFamily(FAMILY, 0L);
+            batchDeletes.add(delete);
+            TENANT_DELETE_FAMILY_COUNTS.merge(tenantId, 1, Integer::sum);
+          }
+        }
+      }
+
+      LOG.info("Writing {} total rows to table in batch operation", batchPuts.size());
+      table.put(batchPuts);
+      if (!batchDeletes.isEmpty()) {
+        LOG.info("Writing {} delete family markers with timestamp 0", batchDeletes.size());
+        table.delete(batchDeletes);
+      }
+      LOG.info("Successfully wrote all test data to table {}", TABLE_NAME);
+    }
+  }
+
+  /**
+   * Verify that memstore contains data before flush.
+   */
+  private void assertTableMemStoreNotEmpty() {
+    List<HRegion> regions = TEST_UTIL.getHBaseCluster().getRegions(TABLE_NAME);
+    long totalSize = regions.stream().mapToLong(HRegion::getMemStoreDataSize).sum();
+    assertTrue("Table memstore should not be empty", totalSize > 0);
+    LOG.info("Memstore contains {} bytes of data before flush", totalSize);
+  }
+
+  /**
+   * Verify that memstore is empty after flush.
+   */
+  private void assertTableMemStoreEmpty() {
+    List<HRegion> regions = TEST_UTIL.getHBaseCluster().getRegions(TABLE_NAME);
+    long totalSize = regions.stream().mapToLong(HRegion::getMemStoreDataSize).sum();
+    assertEquals("Table memstore should be empty after flush", 0, totalSize);
+    LOG.info("Memstore is empty after flush (size: {} bytes)", totalSize);
+  }
+
+  /**
+   * Flush table to create HFiles on disk.
+   */
+  private void flushTable() throws IOException {
+    LOG.info("Initiating flush operation for table {}", TABLE_NAME);
+    TEST_UTIL.flush(TABLE_NAME);
+
+    // Wait for flush to complete
+    try {
+      Thread.sleep(5000);
+      TEST_UTIL.waitTableAvailable(TABLE_NAME, 30000);
+      LOG.info("Flush operation completed successfully");
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("Interrupted while waiting for flush", e);
+    } catch (Exception e) {
+      LOG.warn("Exception while waiting for table availability: {}", e.getMessage());
+    }
+  }
+
+  /**
+   * Verify data integrity using individual GET operations. Tests that each row can be retrieved
+   * correctly with expected values.
+   */
+  private void verifyDataWithGet() throws Exception {
+    LOG.info("=== Verification Phase 1: GET Operations ===");
+
+    try (Connection conn = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration());
+      Table table = conn.getTable(TABLE_NAME)) {
+
+      int totalRowsVerified = 0;
+
+      for (int tenantIndex = 0; tenantIndex < TENANTS.length; tenantIndex++) {
+        String tenant = TENANTS[tenantIndex];
+        int rowsForThisTenant = ROWS_PER_TENANT[tenantIndex];
+
+        LOG.info("Verifying GET operations for tenant {}: {} rows", tenant, rowsForThisTenant);
+
+        for (int i = 0; i < rowsForThisTenant; i++) {
+          String rowKey = tenant + "row" + String.format("%03d", i);
+          String expectedValue = "value_tenant-" + tenant + "_row-" + String.format("%03d", i);
+
+          Get get = new Get(Bytes.toBytes(rowKey));
+          get.addColumn(FAMILY, QUALIFIER);
+
+          Result result = table.get(get);
+          if (result.isEmpty()) {
+            fail("No result found for row: " + rowKey);
+          }
+
+          byte[] actualValue = result.getValue(FAMILY, QUALIFIER);
+          String actualValueStr = Bytes.toString(actualValue);
+          assertEquals("Value mismatch for row " + rowKey, expectedValue, actualValueStr);
+          totalRowsVerified++;
+        }
+
+        LOG.info("Successfully verified {} GET operations for tenant {}", rowsForThisTenant,
+          tenant);
+      }
+
+      LOG.info("GET verification completed: {}/{} rows verified successfully", totalRowsVerified,
+        calculateTotalExpectedRows());
+    }
+  }
+
+  /**
+   * Verify data integrity using full table SCAN. Tests complete data retrieval and checks for
+   * tenant data mixing.
+   */
+  private void verifyDataWithScan() throws IOException {
+    LOG.info("=== Verification Phase 2: Full Table SCAN ===");
+
+    try (Connection connection = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration());
+      Table table = connection.getTable(TABLE_NAME)) {
+
+      org.apache.hadoop.hbase.client.Scan tableScan = new org.apache.hadoop.hbase.client.Scan();
+      tableScan.addColumn(FAMILY, QUALIFIER);
+
+      try (
+        org.apache.hadoop.hbase.client.ResultScanner resultScanner = table.getScanner(tableScan)) {
+        int totalRowCount = 0;
+
+        LOG.info("Starting full table scan to verify all data");
+
+        for (org.apache.hadoop.hbase.client.Result scanResult : resultScanner) {
+          String rowKey = Bytes.toString(scanResult.getRow());
+          String extractedTenantId = rowKey.substring(0, TENANT_PREFIX_LENGTH);
+
+          byte[] cellValue = scanResult.getValue(FAMILY, QUALIFIER);
+          if (cellValue != null) {
+            String actualValueString = Bytes.toString(cellValue);
+            if (!actualValueString.contains(extractedTenantId)) {
+              fail("Tenant data mixing detected: Row " + rowKey + " expected tenant "
+                + extractedTenantId + " but got value " + actualValueString);
+            }
+          } else {
+            fail("Missing value for row: " + rowKey);
+          }
+
+          totalRowCount++;
+        }
+
+        int expectedTotalRows = calculateTotalExpectedRows();
+        assertEquals("Row count mismatch", expectedTotalRows, totalRowCount);
+
+        LOG.info("Full table SCAN completed: {}/{} rows scanned successfully", totalRowCount,
+          expectedTotalRows);
+      }
+    }
+  }
+
+  /**
+   * Verify tenant isolation using tenant-specific SCAN operations. Tests that each tenant's data
+   * can be accessed independently without cross-tenant leakage.
+   */
+  private void verifyDataWithTenantSpecificScans() throws IOException {
+    LOG.info("=== Verification Phase 3: Tenant-Specific SCANs ===");
+
+    try (Connection connection = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration());
+      Table table = connection.getTable(TABLE_NAME)) {
+
+      int totalTenantsVerified = 0;
+
+      for (int tenantIndex = 0; tenantIndex < TENANTS.length; tenantIndex++) {
+        String targetTenantId = TENANTS[tenantIndex];
+        int expectedRowsForThisTenant = ROWS_PER_TENANT[tenantIndex];
+
+        LOG.info("Verifying tenant-specific scan for tenant {}: expecting {} rows", targetTenantId,
+          expectedRowsForThisTenant);
+
+        org.apache.hadoop.hbase.client.Scan tenantScan = new org.apache.hadoop.hbase.client.Scan();
+        tenantScan.addColumn(FAMILY, QUALIFIER);
+        tenantScan.withStartRow(Bytes.toBytes(targetTenantId + "row"));
+        tenantScan.withStopRow(Bytes.toBytes(targetTenantId + "row" + "\uFFFF"));
+
+        try (org.apache.hadoop.hbase.client.ResultScanner tenantScanner =
+          table.getScanner(tenantScan)) {
+          int tenantRowCount = 0;
+          List<String> foundRows = new ArrayList<>();
+
+          for (org.apache.hadoop.hbase.client.Result scanResult : tenantScanner) {
+            String rowKey = Bytes.toString(scanResult.getRow());
+            foundRows.add(rowKey);
+
+            if (!rowKey.startsWith(targetTenantId)) {
+              fail("Tenant scan violation: Found row " + rowKey + " in scan for tenant "
+                + targetTenantId);
+            }
+
+            tenantRowCount++;
+          }
+
+          // Debug logging to see which rows were found
+          LOG.info("Tenant {} scan found {} rows: {}", targetTenantId, tenantRowCount, foundRows);
+
+          if (tenantRowCount != expectedRowsForThisTenant) {
+            // Generate expected rows for comparison
+            List<String> expectedRows = new ArrayList<>();
+            for (int j = 0; j < expectedRowsForThisTenant; j++) {
+              expectedRows.add(targetTenantId + "row" + String.format("%03d", j));
+            }
+            LOG.error("Expected rows for {}: {}", targetTenantId, expectedRows);
+            LOG.error("Found rows for {}: {}", targetTenantId, foundRows);
+
+            // Find missing rows
+            List<String> missingRows = new ArrayList<>(expectedRows);
+            missingRows.removeAll(foundRows);
+            LOG.error("Missing rows for {}: {}", targetTenantId, missingRows);
+          }
+
+          assertEquals("Row count mismatch for tenant " + targetTenantId, expectedRowsForThisTenant,
+            tenantRowCount);
+
+          LOG.info("Tenant {} scan successful: {}/{} rows verified", targetTenantId, tenantRowCount,
+            expectedRowsForThisTenant);
+        }
+
+        totalTenantsVerified++;
+      }
+
+      LOG.info("Tenant-specific SCAN verification completed: {}/{} tenants verified successfully",
+        totalTenantsVerified, TENANTS.length);
+    }
+  }
+
+  /**
+   * Verify edge cases and cross-tenant isolation boundaries. Tests non-existent tenant queries,
+   * empty scan behavior, and tenant boundary conditions.
+   */
+  private void verifyEdgeCasesAndCrossTenantIsolation() throws IOException {
+    LOG.info("=== Verification Phase 4: Edge Cases and Cross-Tenant Isolation ===");
+
+    try (Connection conn = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration());
+      Table table = conn.getTable(TABLE_NAME)) {
+
+      // Test 1: Non-existent tenant prefix
+      LOG.info("Test 1: Scanning with non-existent tenant prefix");
+      verifyNonExistentTenantScan(table);
+
+      // Test 2: Tenant boundary isolation
+      LOG.info("Test 2: Verifying tenant boundary isolation");
+      verifyTenantBoundaries(table);
+
+      // Test 3: Empty scan returns all rows
+      LOG.info("Test 3: Verifying empty scan behavior");
+      verifyEmptyScan(table);
+
+      LOG.info("Edge cases and cross-tenant isolation verification completed successfully");
+    }
+  }
+
+  /**
+   * Verify that scanning with a non-existent tenant prefix returns no results.
+   */
+  private void verifyNonExistentTenantScan(Table table) throws IOException {
+    String nonExistentPrefix = "ZZZ";
+    LOG.info("Testing scan with non-existent tenant prefix: {}", nonExistentPrefix);
+
+    org.apache.hadoop.hbase.client.Scan scan = new org.apache.hadoop.hbase.client.Scan();
+    scan.addColumn(FAMILY, QUALIFIER);
+    scan.withStartRow(Bytes.toBytes(nonExistentPrefix + "row"));
+    scan.withStopRow(Bytes.toBytes(nonExistentPrefix + "row" + "\uFFFF"));
+
+    try (org.apache.hadoop.hbase.client.ResultScanner scanner = table.getScanner(scan)) {
+      int rowCount = 0;
+      for (org.apache.hadoop.hbase.client.Result result : scanner) {
+        LOG.error("Unexpected row found for non-existent tenant: {}",
+          Bytes.toString(result.getRow()));
+        rowCount++;
+      }
+
+      assertEquals("Scan with non-existent tenant prefix should return no results", 0, rowCount);
+      LOG.info("Non-existent tenant scan test passed: {} rows returned", rowCount);
+    }
+  }
+
+  /**
+   * Verify tenant boundaries are properly enforced by scanning across adjacent tenant boundaries.
+   * This test scans from the last row of one tenant to the first row of the next tenant to ensure
+   * proper tenant isolation at boundaries.
+   */
+  private void verifyTenantBoundaries(Table table) throws IOException {
+    LOG.info("Verifying tenant boundary isolation between adjacent tenants");
+
+    int boundariesTested = 0;
+
+    // Test boundaries between adjacent tenants
+    for (int i = 0; i < TENANTS.length - 1; i++) {
+      String tenant1 = TENANTS[i];
+      String tenant2 = TENANTS[i + 1];
+      int tenant1RowCount = ROWS_PER_TENANT[i];
+      int tenant2RowCount = ROWS_PER_TENANT[i + 1];
+
+      LOG.info("Testing boundary between tenant {} ({} rows) and tenant {} ({} rows)", tenant1,
+        tenant1RowCount, tenant2, tenant2RowCount);
+
+      // Create a scan that covers the boundary between tenant1 and tenant2
+      org.apache.hadoop.hbase.client.Scan scan = new org.apache.hadoop.hbase.client.Scan();
+      scan.addColumn(FAMILY, QUALIFIER);
+
+      // Set start row to last row of tenant1
+      String startRow = tenant1 + "row" + String.format("%03d", tenant1RowCount - 1);
+      // Set stop row to second row of tenant2 (to ensure we get at least first row of tenant2)
+      String stopRow = tenant2 + "row" + String.format("%03d", Math.min(1, tenant2RowCount - 1));
+
+      LOG.info("  Boundary scan range: [{}] to [{}]", startRow, stopRow);
+
+      scan.withStartRow(Bytes.toBytes(startRow));
+      scan.withStopRow(Bytes.toBytes(stopRow));
+
+      try (org.apache.hadoop.hbase.client.ResultScanner scanner = table.getScanner(scan)) {
+        int tenant1Count = 0;
+        int tenant2Count = 0;
+        List<String> scannedRows = new ArrayList<>();
+
+        for (org.apache.hadoop.hbase.client.Result result : scanner) {
+          String rowKey = Bytes.toString(result.getRow());
+          scannedRows.add(rowKey);
+
+          if (rowKey.startsWith(tenant1)) {
+            tenant1Count++;
+          } else if (rowKey.startsWith(tenant2)) {
+            tenant2Count++;
+          } else {
+            LOG.error("Unexpected tenant in boundary scan: {}", rowKey);
+            fail("Unexpected tenant in boundary scan: " + rowKey);
+          }
+        }
+
+        LOG.info("  Boundary scan results:");
+        LOG.info("    - Rows from {}: {}", tenant1, tenant1Count);
+        LOG.info("    - Rows from {}: {}", tenant2, tenant2Count);
+        LOG.info("    - Total rows scanned: {}", scannedRows.size());
+
+        // Log the actual rows found for debugging
+        if (scannedRows.size() <= 5) {
+          LOG.info("    - Scanned rows: {}", scannedRows);
+        } else {
+          LOG.info("    - Scanned rows (first 5): {}", scannedRows.subList(0, 5));
+        }
+
+        // We should find the last row from tenant1
+        assertTrue("Should find at least one row from tenant " + tenant1, tenant1Count > 0);
+
+        // We should find at least the first row from tenant2 (if tenant2 has any rows)
+        if (tenant2RowCount > 0) {
+          assertTrue("Should find at least one row from tenant " + tenant2, tenant2Count > 0);
+        }
+
+        // Ensure proper tenant separation - no unexpected tenants
+        int totalFoundRows = tenant1Count + tenant2Count;
+        assertEquals("All scanned rows should belong to expected tenants", scannedRows.size(),
+          totalFoundRows);
+
+        LOG.info("  Boundary test passed for tenants {} and {}", tenant1, tenant2);
+      }
+
+      boundariesTested++;
+    }
+
+    LOG.info("Tenant boundary verification completed: {}/{} boundaries tested successfully",
+      boundariesTested, TENANTS.length - 1);
+  }
+
+  /**
+   * Verify that an empty scan returns all rows across all tenants.
+   */
+  private void verifyEmptyScan(Table table) throws IOException {
+    LOG.info("Testing empty scan to verify it returns all rows across all tenants");
+
+    org.apache.hadoop.hbase.client.Scan emptyScan = new org.apache.hadoop.hbase.client.Scan();
+    emptyScan.addColumn(FAMILY, QUALIFIER);
+
+    try (org.apache.hadoop.hbase.client.ResultScanner emptyScanner = table.getScanner(emptyScan)) {
+      int rowCount = 0;
+      for (org.apache.hadoop.hbase.client.Result result : emptyScanner) {
+        rowCount++;
+      }
+
+      int expectedTotal = calculateTotalExpectedRows();
+      assertEquals("Empty scan should return all rows", expectedTotal, rowCount);
+      LOG.info("Empty scan test passed: {}/{} rows returned", rowCount, expectedTotal);
+    }
+  }
+
+  /**
+   * Verify HFile format and multi-tenant structure. Validates that HFiles are properly formatted as
+   * v4 with tenant sections.
+   */
+  private void verifyHFileFormat(List<Path> hfilePaths) throws IOException {
+    LOG.info("=== HFile Format Verification ===");
+    LOG.info("Verifying {} HFiles for multi-tenant format compliance", hfilePaths.size());
+
+    FileSystem fs = TEST_UTIL.getTestFileSystem();
+    Configuration conf = TEST_UTIL.getConfiguration();
+    CacheConfig cacheConf = new CacheConfig(conf);
+
+    int totalHFilesVerified = 0;
+    int totalCellsFoundAcrossAllFiles = 0;
+
+    for (Path path : hfilePaths) {
+      LOG.info("Verifying HFile: {}", path.getName());
+
+      try (HFile.Reader reader = HFile.createReader(fs, path, cacheConf, true, conf)) {
+        // Verify HFile version
+        int version = reader.getTrailer().getMajorVersion();
+        assertEquals("HFile should be version 4", HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT,
+          version);
+        LOG.info("  HFile version: {} (correct)", version);
+
+        // Verify reader type
+        assertTrue("Reader should be an AbstractMultiTenantReader",
+          reader instanceof AbstractMultiTenantReader);
+        LOG.info("  Reader type: AbstractMultiTenantReader (correct)");
+
+        AbstractMultiTenantReader mtReader = (AbstractMultiTenantReader) reader;
+        byte[][] allTenantSectionIds = mtReader.getAllTenantSectionIds();
+
+        assertTrue("Should have tenant sections", allTenantSectionIds.length > 0);
+        LOG.info("  Found {} tenant sections in HFile", allTenantSectionIds.length);
+
+        int totalCellsInThisFile = 0;
+        int sectionsWithData = 0;
+
+        for (byte[] tenantSectionId : allTenantSectionIds) {
+          String tenantId = Bytes.toString(tenantSectionId);
+          try {
+            AbstractMultiTenantReader.SectionReaderLease sectionReaderLease =
+              mtReader.getSectionReader(tenantSectionId);
+
+            if (sectionReaderLease != null) {
+              try (AbstractMultiTenantReader.SectionReaderLease lease = sectionReaderLease) {
+                HFileReaderImpl sectionHFileReader = lease.getReader();
+
+                HFileInfo sectionInfo = sectionHFileReader.getHFileInfo();
+                byte[] deleteCountBytes = sectionInfo
+                  .get(org.apache.hadoop.hbase.regionserver.HStoreFile.DELETE_FAMILY_COUNT);
+                if (deleteCountBytes != null) {
+                  long deleteCount = Bytes.toLong(deleteCountBytes);
+                  int expectedCount = TENANT_DELETE_FAMILY_COUNTS.getOrDefault(tenantId, 0);
+                  assertEquals("Delete family count mismatch for tenant " + tenantId, expectedCount,
+                    deleteCount);
+                }
+
+                HFileScanner sectionScanner = sectionHFileReader.getScanner(conf, false, false);
+
+                boolean hasData = sectionScanner.seekTo();
+                if (hasData) {
+                  int sectionCellCount = 0;
+                  do {
+                    Cell cell = sectionScanner.getCell();
+                    if (cell != null) {
+                      // Verify tenant prefix matches section ID for every entry
+                      byte[] rowKeyBytes = CellUtil.cloneRow(cell);
+                      byte[] rowTenantPrefix = new byte[TENANT_PREFIX_LENGTH];
+                      System.arraycopy(rowKeyBytes, 0, rowTenantPrefix, 0, TENANT_PREFIX_LENGTH);
+
+                      assertTrue("Row tenant prefix should match section ID",
+                        Bytes.equals(tenantSectionId, rowTenantPrefix));
+
+                      if (cell.getType() == Cell.Type.Put) {
+                        sectionCellCount++;
+                        totalCellsInThisFile++;
+                      }
+                    }
+                  } while (sectionScanner.next());
+
+                  assertTrue("Should have found data in tenant section", sectionCellCount > 0);
+                  sectionsWithData++;
+                  LOG.info("    Section {}: {} cells", tenantId, sectionCellCount);
+                }
+              }
+            }
+          } catch (Exception e) {
+            LOG.warn("Failed to access tenant section: " + tenantId, e);
+          }
+        }
+
+        LOG.info("  Tenant sections with data: {}/{}", sectionsWithData,
+          allTenantSectionIds.length);
+        LOG.info("  Total cells in this HFile: {}", totalCellsInThisFile);
+        totalCellsFoundAcrossAllFiles += totalCellsInThisFile;
+
+        // Verify HFile metadata contains multi-tenant information
+        LOG.info("  Verifying HFile metadata and structure");
+        verifyHFileMetadata(reader, allTenantSectionIds, mtReader);
+
+        LOG.info("  HFile verification completed for: {}", path.getName());
+        totalHFilesVerified++;
+      }
+    }
+
+    int expectedTotal = calculateTotalExpectedRows();
+    assertEquals("Should have found all cells across all HFiles", expectedTotal,
+      totalCellsFoundAcrossAllFiles);
+
+    LOG.info("HFile format verification completed successfully:");
+    LOG.info("  - HFiles verified: {}/{}", totalHFilesVerified, hfilePaths.size());
+    LOG.info("  - Total cells verified: {}/{}", totalCellsFoundAcrossAllFiles, expectedTotal);
+    LOG.info("  - All HFiles are properly formatted as multi-tenant v4");
+  }
+
+  /**
+   * Verify HFile metadata contains expected multi-tenant information. Checks for section count,
+   * tenant index levels, and other v4 metadata.
+   */
+  private void verifyHFileMetadata(HFile.Reader reader, byte[][] allTenantSectionIds,
+    AbstractMultiTenantReader mtReader) throws IOException {
+    HFileInfo fileInfo = reader.getHFileInfo();
+    if (fileInfo == null) {
+      LOG.warn("    - HFile info is null - cannot verify metadata");
+      return;
+    }
+
+    // Verify section count metadata
+    byte[] sectionCountBytes =
+      fileInfo.get(Bytes.toBytes(MultiTenantHFileWriter.FILEINFO_SECTION_COUNT));
+    if (sectionCountBytes != null) {
+      int sectionCount = Bytes.toInt(sectionCountBytes);
+      LOG.info("    - HFile section count: {}", sectionCount);
+      assertTrue("HFile should have tenant sections", sectionCount > 0);
+      assertEquals("Section count should match found tenant sections", allTenantSectionIds.length,
+        sectionCount);
+    } else {
+      LOG.warn("    - Missing SECTION_COUNT metadata in HFile info");
+    }
+
+    // Verify tenant index structure metadata
+    byte[] tenantIndexLevelsBytes =
+      fileInfo.get(Bytes.toBytes(MultiTenantHFileWriter.FILEINFO_TENANT_INDEX_LEVELS));
+    if (tenantIndexLevelsBytes != null) {
+      int tenantIndexLevels = Bytes.toInt(tenantIndexLevelsBytes);
+      LOG.info("    - Tenant index levels: {}", tenantIndexLevels);
+      assertTrue("HFile should have tenant index levels", tenantIndexLevels > 0);
+
+      // Log index structure details
+      if (tenantIndexLevels == 1) {
+        LOG.info("    - Using single-level tenant index (suitable for {} sections)",
+          allTenantSectionIds.length);
+      } else {
+        LOG.info("    - Using multi-level tenant index ({} levels for {} sections)",
+          tenantIndexLevels, allTenantSectionIds.length);
+      }
+    } else {
+      LOG.warn("    - Missing TENANT_INDEX_LEVELS metadata in HFile info");
+    }
+
+    // Verify reader provides multi-tenant specific information
+    LOG.info("    - Multi-tenant reader statistics:");
+    LOG.info("      * Total sections: {}", mtReader.getTotalSectionCount());
+    LOG.info("      * Tenant index levels: {}", mtReader.getTenantIndexLevels());
+    LOG.info("      * Tenant index max chunk size: {}", mtReader.getTenantIndexMaxChunkSize());
+
+    // Verify consistency between metadata and reader state
+    if (tenantIndexLevelsBytes != null) {
+      int metadataTenantIndexLevels = Bytes.toInt(tenantIndexLevelsBytes);
+      assertEquals("Tenant index levels should match between metadata and reader",
+        metadataTenantIndexLevels, mtReader.getTenantIndexLevels());
+    }
+
+    assertEquals("Total section count should match found sections", allTenantSectionIds.length,
+      mtReader.getTotalSectionCount());
+
+    LOG.info("    - HFile metadata verification passed");
+  }
+
+  /**
+   * Find all HFiles created for the test table. Scans the filesystem to locate HFiles in the
+   * table's directory structure.
+   */
+  private List<Path> findHFilePaths() throws IOException {
+    LOG.info("Searching for HFiles in table directory structure");
+
+    List<Path> hfilePaths = new ArrayList<>();
+
+    FileSystem fs = TEST_UTIL.getTestFileSystem();
+    Path rootDir = TEST_UTIL.getDataTestDirOnTestFS();
+    Path tableDir = new Path(rootDir, "data/default/" + TABLE_NAME.getNameAsString());
+
+    if (fs.exists(tableDir)) {
+      FileStatus[] regionDirs = fs.listStatus(tableDir);
+      LOG.info("Found {} region directories to scan", regionDirs.length);
+
+      for (FileStatus regionDir : regionDirs) {
+        if (regionDir.isDirectory() && !regionDir.getPath().getName().startsWith(".")) {
+          Path familyDir = new Path(regionDir.getPath(), Bytes.toString(FAMILY));
+
+          if (fs.exists(familyDir)) {
+            FileStatus[] hfiles = fs.listStatus(familyDir);
+
+            for (FileStatus hfile : hfiles) {
+              if (
+                !hfile.getPath().getName().startsWith(".")
+                  && !hfile.getPath().getName().endsWith(".tmp")
+              ) {
+                hfilePaths.add(hfile.getPath());
+                LOG.info("Found HFile: {} (size: {} bytes)", hfile.getPath().getName(),
+                  hfile.getLen());
+              }
+            }
+          }
+        }
+      }
+    }
+
+    LOG.info("HFile discovery completed: {} HFiles found", hfilePaths.size());
+    return hfilePaths;
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileMultiLevelIndexTest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileMultiLevelIndexTest.java
@@ -1,0 +1,204 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates that multi-tenant HFile v4 builds and reads a multi-level section index. This test
+ * forces a multi-level index by setting small chunk sizes and writing many tenants.
+ */
+@Category(MediumTests.class)
+public class MultiTenantHFileMultiLevelIndexTest {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(MultiTenantHFileMultiLevelIndexTest.class);
+
+  private static final Logger LOG =
+    LoggerFactory.getLogger(MultiTenantHFileMultiLevelIndexTest.class);
+
+  private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  private static final TableName TABLE_NAME = TableName.valueOf("TestMultiLevelIndex");
+  private static final byte[] FAMILY = Bytes.toBytes("f");
+  private static final byte[] QUALIFIER = Bytes.toBytes("q");
+
+  private static final int TENANT_PREFIX_LENGTH = 3;
+  // Force small chunking so we create multiple leaf blocks and an intermediate level.
+  private static final int FORCED_MAX_CHUNK_SIZE = 3; // entries per index block
+  private static final int FORCED_MIN_INDEX_ENTRIES = 4; // root fanout threshold
+
+  // Create enough tenants to exceed FORCED_MAX_CHUNK_SIZE and FORCED_MIN_INDEX_ENTRIES
+  private static final int NUM_TENANTS = 20;
+  private static final int ROWS_PER_TENANT = 2;
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.setInt(MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, TENANT_PREFIX_LENGTH);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    // Force multi-level section index with small blocks
+    conf.setInt(SectionIndexManager.SECTION_INDEX_MAX_CHUNK_SIZE, FORCED_MAX_CHUNK_SIZE);
+    conf.setInt(SectionIndexManager.SECTION_INDEX_MIN_NUM_ENTRIES, FORCED_MIN_INDEX_ENTRIES);
+    TEST_UTIL.startMiniCluster(1);
+    try (Admin admin = TEST_UTIL.getAdmin()) {
+      TableDescriptorBuilder tdb = TableDescriptorBuilder.newBuilder(TABLE_NAME);
+      tdb.setValue(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH,
+        String.valueOf(TENANT_PREFIX_LENGTH));
+      tdb.setValue(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+      tdb.setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(FAMILY).build());
+      admin.createTable(tdb.build());
+    }
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test(timeout = 120000)
+  public void testMultiLevelSectionIndexTraversal() throws Exception {
+    writeManyTenants();
+    TEST_UTIL.flush(TABLE_NAME);
+
+    // Wait a bit for files to land
+    Thread.sleep(2000);
+
+    List<Path> hfiles = findHFiles();
+    assertTrue("Expected at least one HFile", !hfiles.isEmpty());
+
+    int totalRows = 0;
+    java.util.Set<String> uniqueSectionIds = new java.util.HashSet<>();
+    for (Path p : hfiles) {
+      try (HFile.Reader r = HFile.createReader(TEST_UTIL.getTestFileSystem(), p,
+        new CacheConfig(TEST_UTIL.getConfiguration()), true, TEST_UTIL.getConfiguration())) {
+        assertEquals("HFile should be version 4", HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT,
+          r.getTrailer().getMajorVersion());
+        assertTrue("Reader should be multi-tenant", r instanceof AbstractMultiTenantReader);
+
+        // Validate multi-level index per trailer
+        int levels = r.getTrailer().getNumDataIndexLevels();
+        LOG.info("HFile {} trailer reports section index levels: {}", p.getName(), levels);
+        assertTrue("Expected multi-level section index (>=2 levels)", levels >= 2);
+
+        byte[][] tenantSections = ((AbstractMultiTenantReader) r).getAllTenantSectionIds();
+        for (byte[] id : tenantSections) {
+          uniqueSectionIds.add(Bytes.toStringBinary(id));
+        }
+
+        // Scan all data via the multi-tenant reader to ensure traversal works across levels
+        HFileScanner scanner =
+          ((AbstractMultiTenantReader) r).getScanner(TEST_UTIL.getConfiguration(), false, false);
+        int rowsInThisFile = 0;
+        if (scanner.seekTo()) {
+          do {
+            rowsInThisFile++;
+          } while (scanner.next());
+        }
+        LOG.info("HFile {} contains {} cells", p.getName(), rowsInThisFile);
+        totalRows += rowsInThisFile;
+      }
+    }
+
+    assertEquals("Unique tenant sections across all files should equal tenants", NUM_TENANTS,
+      uniqueSectionIds.size());
+
+    assertEquals("Total cells should match expected write count", NUM_TENANTS * ROWS_PER_TENANT,
+      totalRows);
+  }
+
+  private static void writeManyTenants() throws IOException {
+    try (Connection conn = ConnectionFactory.createConnection(TEST_UTIL.getConfiguration());
+      Table table = conn.getTable(TABLE_NAME)) {
+      List<Put> puts = new ArrayList<>();
+      for (int t = 0; t < NUM_TENANTS; t++) {
+        String tenant = String.format("T%02d", t); // e.g., T00, T01 ... T19
+        String tenantPrefix = tenant; // length 3 when combined with another char? Ensure 3 chars
+        // Ensure prefix is exactly TENANT_PREFIX_LENGTH by padding if needed
+        if (tenantPrefix.length() < TENANT_PREFIX_LENGTH) {
+          tenantPrefix = String.format("%-3s", tenantPrefix).replace(' ', 'X');
+        } else if (tenantPrefix.length() > TENANT_PREFIX_LENGTH) {
+          tenantPrefix = tenantPrefix.substring(0, TENANT_PREFIX_LENGTH);
+        }
+        for (int i = 0; i < ROWS_PER_TENANT; i++) {
+          String row = tenantPrefix + "row" + String.format("%03d", i);
+          Put p = new Put(Bytes.toBytes(row));
+          p.addColumn(FAMILY, QUALIFIER, Bytes.toBytes("v-" + tenantPrefix + "-" + i));
+          puts.add(p);
+        }
+      }
+      table.put(puts);
+    }
+  }
+
+  private static List<Path> findHFiles() throws IOException {
+    List<Path> hfiles = new ArrayList<>();
+    FileSystem fs = TEST_UTIL.getTestFileSystem();
+    Path rootDir = TEST_UTIL.getDataTestDirOnTestFS();
+    Path tableDir = new Path(rootDir, "data/default/" + TABLE_NAME.getNameAsString());
+    if (!fs.exists(tableDir)) {
+      return hfiles;
+    }
+    for (FileStatus regionDir : fs.listStatus(tableDir)) {
+      if (!regionDir.isDirectory() || regionDir.getPath().getName().startsWith(".")) {
+        continue;
+      }
+      Path familyDir = new Path(regionDir.getPath(), Bytes.toString(FAMILY));
+      if (!fs.exists(familyDir)) {
+        continue;
+      }
+      for (FileStatus hfile : fs.listStatus(familyDir)) {
+        if (
+          !hfile.getPath().getName().startsWith(".") && !hfile.getPath().getName().endsWith(".tmp")
+        ) {
+          hfiles.add(hfile.getPath());
+        }
+      }
+    }
+    return hfiles;
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileSplittingTest.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/MultiTenantHFileSplittingTest.java
@@ -1,0 +1,1007 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.fail;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.ExtendedCell;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Integration test for HFile v4 multi-tenant splitting logic using isolated test pattern.
+ * <p>
+ * Each test method runs independently with its own fresh cluster to ensure complete isolation and
+ * avoid connection interference issues between tests.
+ * <p>
+ * This test validates the complete multi-tenant HFile v4 splitting workflow:
+ * <ol>
+ * <li><strong>Setup:</strong> Creates table with multi-tenant configuration</li>
+ * <li><strong>Data Writing:</strong> Writes large datasets with different tenant distributions</li>
+ * <li><strong>Flushing:</strong> Forces memstore flush to create multi-tenant HFile v4 files</li>
+ * <li><strong>Splitting:</strong> Tests midkey calculation and file splitting</li>
+ * <li><strong>Verification:</strong> Validates split balance and data integrity</li>
+ * </ol>
+ */
+@Category(LargeTests.class)
+public class MultiTenantHFileSplittingTest {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(MultiTenantHFileSplittingTest.class);
+
+  private static final Logger LOG = LoggerFactory.getLogger(MultiTenantHFileSplittingTest.class);
+
+  private HBaseTestingUtility testUtil;
+
+  private static final byte[] FAMILY = Bytes.toBytes("f");
+  private static final byte[] QUALIFIER = Bytes.toBytes("q");
+  private static final int TENANT_PREFIX_LENGTH = 3;
+
+  @Before
+  public void setUp() throws Exception {
+    LOG.info("=== Setting up isolated test environment ===");
+
+    // Create fresh testing utility for each test
+    testUtil = new HBaseTestingUtility();
+
+    // Configure test settings
+    Configuration conf = testUtil.getConfiguration();
+
+    // Set HFile format version for multi-tenant support
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    conf.setInt(MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, TENANT_PREFIX_LENGTH);
+
+    // Set smaller region size to make splits easier to trigger
+    conf.setLong("hbase.hregion.max.filesize", 10 * 1024 * 1024); // 10MB
+    conf.setInt("hbase.regionserver.region.split.policy.check.period", 1000);
+
+    // Use policy that allows manual splits
+    conf.set("hbase.regionserver.region.split.policy",
+      "org.apache.hadoop.hbase.regionserver.IncreasingToUpperBoundRegionSplitPolicy");
+
+    // Configure mini cluster settings for stability
+    conf.setInt("hbase.regionserver.msginterval", 100);
+    conf.setInt("hbase.client.pause", 250);
+    conf.setInt("hbase.client.retries.number", 6);
+    conf.setBoolean("hbase.master.enabletable.roundrobin", true);
+
+    // Increase timeouts for split operations
+    conf.setLong("hbase.regionserver.fileSplitTimeout", 600000); // 10 minutes
+    conf.setInt("hbase.client.operation.timeout", 600000); // 10 minutes
+
+    LOG.info("Configured HFile format version: {}", conf.getInt(HFile.FORMAT_VERSION_KEY, -1));
+
+    // Start fresh mini cluster for this test
+    LOG.info("Starting fresh mini cluster for test");
+    testUtil.startMiniCluster(1);
+
+    // Wait for cluster to be ready
+    testUtil.waitUntilAllRegionsAssigned(TableName.META_TABLE_NAME);
+
+    LOG.info("Fresh cluster ready for test");
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    LOG.info("=== Cleaning up isolated test environment ===");
+
+    if (testUtil != null) {
+      try {
+        testUtil.shutdownMiniCluster();
+        LOG.info("Successfully shut down test cluster");
+      } catch (Exception e) {
+        LOG.warn("Error during cluster shutdown", e);
+      }
+    }
+  }
+
+  /**
+   * Test 1: Single tenant with large amount of data
+   */
+  @Test(timeout = 600000) // 10 minute timeout
+  public void testSingleTenantSplitting() throws Exception {
+    String[] tenants = { "T01" };
+    int[] rowsPerTenant = { 10000 };
+
+    executeTestScenario(tenants, rowsPerTenant);
+  }
+
+  /**
+   * Test 2: Three tenants with even distribution
+   */
+  @Test(timeout = 600000) // 10 minute timeout
+  public void testEvenDistributionSplitting() throws Exception {
+    String[] tenants = { "T01", "T02", "T03" };
+    int[] rowsPerTenant = { 3000, 3000, 3000 };
+
+    executeTestScenario(tenants, rowsPerTenant);
+  }
+
+  /**
+   * Test 3: Three tenants with uneven distribution
+   */
+  @Test(timeout = 600000) // 10 minute timeout
+  public void testUnevenDistributionSplitting() throws Exception {
+    String[] tenants = { "T01", "T02", "T03" };
+    int[] rowsPerTenant = { 1000, 2000, 1000 };
+
+    executeTestScenario(tenants, rowsPerTenant);
+  }
+
+  /**
+   * Test 4: Skewed distribution with one dominant tenant
+   */
+  @Test(timeout = 600000) // 10 minute timeout
+  public void testSkewedDistributionSplitting() throws Exception {
+    String[] tenants = { "T01", "T02", "T03", "T04" };
+    int[] rowsPerTenant = { 100, 100, 5000, 100 };
+
+    executeTestScenario(tenants, rowsPerTenant);
+  }
+
+  /**
+   * Test 5: Many small tenants
+   */
+  @Test(timeout = 600000) // 10 minute timeout
+  public void testManySmallTenantsSplitting() throws Exception {
+    String[] tenants = { "T01", "T02", "T03", "T04", "T05", "T06", "T07", "T08", "T09", "T10" };
+    int[] rowsPerTenant = { 500, 500, 500, 500, 500, 500, 500, 500, 500, 500 };
+
+    executeTestScenario(tenants, rowsPerTenant);
+  }
+
+  /**
+   * Test 6: Few large tenants
+   */
+  @Test(timeout = 600000) // 10 minute timeout
+  public void testFewLargeTenantsSplitting() throws Exception {
+    String[] tenants = { "T01", "T02" };
+    int[] rowsPerTenant = { 5000, 5000 };
+
+    executeTestScenario(tenants, rowsPerTenant);
+  }
+
+  /**
+   * Execute a test scenario with the given configuration. The table will be created fresh for this
+   * test.
+   */
+  private void executeTestScenario(String[] tenants, int[] rowsPerTenant) throws Exception {
+    LOG.info("=== Starting test scenario ===");
+
+    String testName = Thread.currentThread().getStackTrace()[2].getMethodName();
+    TableName tableName = TableName.valueOf(testName);
+
+    // Validate input parameters
+    if (tenants.length != rowsPerTenant.length) {
+      throw new IllegalArgumentException("Tenants and rowsPerTenant arrays must have same length");
+    }
+
+    try {
+      // Phase 1: Create fresh table
+      LOG.info("Phase 1: Creating fresh table {}", tableName);
+      createTestTable(tableName);
+
+      // Wait for table to be ready
+      Thread.sleep(1000);
+
+      // Phase 2: Write test data
+      LOG.info("Phase 2: Writing test data");
+      writeTestData(tableName, tenants, rowsPerTenant);
+
+      // Phase 3: Flush memstore to create HFiles
+      LOG.info("Phase 3: Flushing table");
+      testUtil.flush(tableName);
+
+      // Wait for flush to complete
+      Thread.sleep(2000);
+
+      // Phase 4: Verify midkey before split
+      LOG.info("Phase 4: Verifying midkey calculation");
+      verifyMidkeyCalculation(tableName, tenants, rowsPerTenant);
+
+      // Phase 5: Trigger split
+      LOG.info("Phase 5: Triggering region split");
+      triggerRegionSplit(tenants, rowsPerTenant, tableName);
+
+      // Phase 6: Compact after split to ensure proper HFile structure
+      LOG.info("Phase 6: Compacting table after split");
+      testUtil.compact(tableName, true); // Major compaction
+
+      // Wait for compaction to complete
+      Thread.sleep(3000);
+
+      // Phase 7: Comprehensive data integrity verification after split
+      LOG.info("Phase 7: Starting comprehensive data integrity verification after split");
+      verifyDataIntegrityWithScanning(tableName, tenants, rowsPerTenant);
+      verifyDataIntegrityAfterSplit(tableName, tenants, rowsPerTenant);
+
+      LOG.info("=== Test scenario completed successfully ===");
+
+    } catch (Exception e) {
+      LOG.error("Test scenario failed", e);
+      throw e;
+    } finally {
+      // Clean up table
+      try {
+        if (testUtil.getAdmin() != null && testUtil.getAdmin().tableExists(tableName)) {
+          testUtil.deleteTable(tableName);
+        }
+      } catch (Exception cleanupException) {
+        LOG.warn("Failed to cleanup table {}: {}", tableName, cleanupException.getMessage());
+      }
+    }
+  }
+
+  /**
+   * Create test table with multi-tenant configuration.
+   */
+  private void createTestTable(TableName tableName) throws IOException, InterruptedException {
+    LOG.info("Creating table: {} with multi-tenant configuration", tableName);
+
+    // Build table descriptor with multi-tenant properties
+    TableDescriptorBuilder tableBuilder = TableDescriptorBuilder.newBuilder(tableName);
+
+    // Set multi-tenant properties
+    tableBuilder.setValue(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH,
+      String.valueOf(TENANT_PREFIX_LENGTH));
+    tableBuilder.setValue(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+
+    // Configure column family with proper settings
+    ColumnFamilyDescriptorBuilder cfBuilder = ColumnFamilyDescriptorBuilder.newBuilder(FAMILY);
+
+    // Ensure HFile v4 format is used at column family level
+    cfBuilder.setValue(HFile.FORMAT_VERSION_KEY,
+      String.valueOf(HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT));
+
+    // Set smaller block size for easier testing
+    cfBuilder.setBlocksize(8 * 1024); // 8KB blocks
+
+    tableBuilder.setColumnFamily(cfBuilder.build());
+
+    // Create the table
+    testUtil.createTable(tableBuilder.build(), null);
+
+    LOG.info("Created table {} with multi-tenant configuration", tableName);
+  }
+
+  /**
+   * Write test data for all tenants in lexicographic order to avoid key ordering violations.
+   */
+  private void writeTestData(TableName tableName, String[] tenants, int[] rowsPerTenant)
+    throws IOException {
+    try (Connection connection = ConnectionFactory.createConnection(testUtil.getConfiguration());
+      Table table = connection.getTable(tableName)) {
+
+      List<Put> batchPuts = new ArrayList<>();
+
+      // Generate all row keys first
+      for (int tenantIndex = 0; tenantIndex < tenants.length; tenantIndex++) {
+        String tenantId = tenants[tenantIndex];
+        int rowsForThisTenant = rowsPerTenant[tenantIndex];
+
+        for (int rowIndex = 0; rowIndex < rowsForThisTenant; rowIndex++) {
+          String rowKey = String.format("%srow%05d", tenantId, rowIndex);
+          Put putOperation = new Put(Bytes.toBytes(rowKey));
+
+          String cellValue = String.format("value_tenant-%s_row-%05d", tenantId, rowIndex);
+          putOperation.addColumn(FAMILY, QUALIFIER, Bytes.toBytes(cellValue));
+          batchPuts.add(putOperation);
+        }
+      }
+
+      // Sort puts by row key to ensure lexicographic ordering
+      batchPuts.sort((p1, p2) -> Bytes.compareTo(p1.getRow(), p2.getRow()));
+
+      LOG.info("Writing {} total rows to table in lexicographic order", batchPuts.size());
+      table.put(batchPuts);
+      LOG.info("Successfully wrote all test data to table {}", tableName);
+    }
+  }
+
+  /**
+   * Verify midkey calculation for the HFile.
+   */
+  private void verifyMidkeyCalculation(TableName tableName, String[] tenants, int[] rowsPerTenant)
+    throws IOException {
+    LOG.info("Verifying midkey calculation for table: {}", tableName);
+
+    // Find the HFile path for the table
+    List<Path> hfilePaths = findHFilePaths(tableName);
+    assertTrue("Should have at least one HFile", hfilePaths.size() > 0);
+
+    Path hfilePath = hfilePaths.get(0); // Use the first HFile
+    LOG.info("Checking midkey for HFile: {}", hfilePath);
+
+    FileSystem fs = testUtil.getTestFileSystem();
+    CacheConfig cacheConf = new CacheConfig(testUtil.getConfiguration());
+
+    try (HFile.Reader reader =
+      HFile.createReader(fs, hfilePath, cacheConf, true, testUtil.getConfiguration())) {
+      assertTrue("Reader should be AbstractMultiTenantReader",
+        reader instanceof AbstractMultiTenantReader);
+
+      // Get the midkey
+      Optional<ExtendedCell> midkey = reader.midKey();
+      assertTrue("Midkey should be present", midkey.isPresent());
+
+      String midkeyString = Bytes.toString(CellUtil.cloneRow(midkey.get()));
+      LOG.info("Midkey: {}", midkeyString);
+
+      // Analyze the midkey
+      int totalRows = 0;
+      for (int rows : rowsPerTenant) {
+        totalRows += rows;
+      }
+
+      // Log HFile properties
+      LOG.info("HFile properties:");
+      LOG.info("  - First key: {}",
+        reader.getFirstRowKey().isPresent()
+          ? Bytes.toString(reader.getFirstRowKey().get())
+          : "N/A");
+      LOG.info("  - Last key: {}",
+        reader.getLastRowKey().isPresent() ? Bytes.toString(reader.getLastRowKey().get()) : "N/A");
+      LOG.info("  - Entry count: {}", reader.getEntries());
+
+      // Determine which tenant and position within that tenant
+      String midkeyTenant = midkeyString.substring(0, TENANT_PREFIX_LENGTH);
+      int midkeyPosition = 0;
+      boolean foundTenant = false;
+
+      for (int i = 0; i < tenants.length; i++) {
+        if (tenants[i].equals(midkeyTenant)) {
+          int rowNum = Integer.parseInt(midkeyString.substring(TENANT_PREFIX_LENGTH + 3));
+          midkeyPosition += rowNum;
+          foundTenant = true;
+          LOG.info("Midkey analysis:");
+          LOG.info("  - Located in tenant: {}", midkeyTenant);
+          LOG.info("  - Row number within tenant: {}/{}", rowNum, rowsPerTenant[i]);
+          LOG.info("  - Position in file: {}/{} ({}%)", midkeyPosition, totalRows,
+            String.format("%.1f", (midkeyPosition * 100.0) / totalRows));
+          LOG.info("  - Target midpoint: {}/{} (50.0%)", totalRows / 2, totalRows);
+          LOG.info("  - Deviation from midpoint: {}%",
+            String.format("%.1f", Math.abs(midkeyPosition - totalRows / 2) * 100.0 / totalRows));
+          break;
+        } else {
+          midkeyPosition += rowsPerTenant[i];
+        }
+      }
+
+      assertTrue("Midkey tenant should be found in tenant list", foundTenant);
+
+      // First and last keys for comparison
+      if (reader.getFirstRowKey().isPresent() && reader.getLastRowKey().isPresent()) {
+        String firstKey = Bytes.toString(reader.getFirstRowKey().get());
+        String lastKey = Bytes.toString(reader.getLastRowKey().get());
+        LOG.info("First key: {}", firstKey);
+        LOG.info("Last key: {}", lastKey);
+        LOG.info("Midkey comparison - first: {}, midkey: {}, last: {}", firstKey, midkeyString,
+          lastKey);
+      }
+
+      LOG.info("Total rows in dataset: {}", totalRows);
+    }
+  }
+
+  /**
+   * Comprehensive data integrity verification using scanning operations. This method tests various
+   * scanning scenarios to ensure data integrity after split.
+   */
+  private void verifyDataIntegrityWithScanning(TableName tableName, String[] tenants,
+    int[] rowsPerTenant) throws Exception {
+    LOG.info("=== Comprehensive Scanning Verification After Split ===");
+
+    try (Connection conn = ConnectionFactory.createConnection(testUtil.getConfiguration());
+      Table table = conn.getTable(tableName)) {
+
+      // Test 1: Full table scan verification
+      LOG.info("Test 1: Full table scan verification");
+      verifyFullTableScanAfterSplit(table, tenants, rowsPerTenant);
+
+      // Test 2: Tenant-specific scan verification
+      LOG.info("Test 2: Tenant-specific scan verification");
+      verifyTenantSpecificScansAfterSplit(table, tenants, rowsPerTenant);
+
+      // Test 3: Cross-region boundary scanning
+      LOG.info("Test 3: Cross-region boundary scanning");
+      verifyCrossRegionBoundaryScanning(table, tenants, rowsPerTenant);
+
+      // Test 4: Edge cases and tenant isolation
+      LOG.info("Test 4: Edge cases and tenant isolation verification");
+      verifyEdgeCasesAfterSplit(table, tenants, rowsPerTenant);
+
+      LOG.info("Comprehensive scanning verification completed successfully");
+    }
+  }
+
+  /**
+   * Verify full table scan returns all data correctly after split.
+   */
+  private void verifyFullTableScanAfterSplit(Table table, String[] tenants, int[] rowsPerTenant)
+    throws IOException {
+    LOG.info("Performing full table scan to verify all data after split");
+
+    org.apache.hadoop.hbase.client.Scan fullScan = new org.apache.hadoop.hbase.client.Scan();
+    fullScan.addColumn(FAMILY, QUALIFIER);
+
+    try (org.apache.hadoop.hbase.client.ResultScanner scanner = table.getScanner(fullScan)) {
+      int totalRowsScanned = 0;
+      int[] tenantRowCounts = new int[tenants.length];
+      // Track seen rows per tenant to identify gaps later
+      @SuppressWarnings("unchecked")
+      java.util.Set<String>[] seenRowsPerTenant = new java.util.HashSet[tenants.length];
+      for (int i = 0; i < tenants.length; i++) {
+        seenRowsPerTenant[i] = new java.util.HashSet<>();
+      }
+
+      String previousRowKey = null;
+
+      for (org.apache.hadoop.hbase.client.Result result : scanner) {
+        if (result.isEmpty()) {
+          LOG.warn("Empty result encountered during scan");
+          continue;
+        }
+
+        String rowKey = Bytes.toString(result.getRow());
+
+        // Verify row ordering
+        if (previousRowKey != null) {
+          assertTrue(
+            "Rows should be in lexicographic order: " + previousRowKey + " should be <= " + rowKey,
+            Bytes.compareTo(Bytes.toBytes(previousRowKey), Bytes.toBytes(rowKey)) <= 0);
+        }
+
+        String tenantPrefix = rowKey.substring(0, TENANT_PREFIX_LENGTH);
+
+        // Find which tenant this row belongs to
+        int tenantIndex = -1;
+        for (int i = 0; i < tenants.length; i++) {
+          if (tenants[i].equals(tenantPrefix)) {
+            tenantIndex = i;
+            break;
+          }
+        }
+
+        if (tenantIndex == -1) {
+          fail("Found row with unknown tenant prefix: " + rowKey);
+        }
+
+        // Verify data integrity
+        byte[] cellValue = result.getValue(FAMILY, QUALIFIER);
+        if (cellValue == null) {
+          fail("Missing value for row: " + rowKey);
+        }
+
+        String actualValue = Bytes.toString(cellValue);
+        if (!actualValue.contains(tenantPrefix)) {
+          fail("Tenant data mixing detected in full scan: Row " + rowKey + " expected tenant "
+            + tenantPrefix + " but got value " + actualValue);
+        }
+
+        tenantRowCounts[tenantIndex]++;
+        seenRowsPerTenant[tenantIndex].add(rowKey);
+
+        // Log every 1000th row for progress tracking
+        if (totalRowsScanned % 1000 == 0) {
+          LOG.info("Scanned {} rows so far, current row: {}", totalRowsScanned, rowKey);
+        }
+
+        previousRowKey = rowKey;
+        totalRowsScanned++;
+      }
+
+      // Detailed logging of per-tenant counts before assertions
+      StringBuilder sb = new StringBuilder();
+      sb.append("Per-tenant scan results: ");
+      for (int i = 0; i < tenants.length; i++) {
+        sb.append(tenants[i]).append("=").append(tenantRowCounts[i]).append("/")
+          .append(rowsPerTenant[i]).append(", ");
+      }
+      sb.append("total=").append(totalRowsScanned);
+      LOG.info(sb.toString());
+
+      // Verify total row count
+      int expectedTotal = Arrays.stream(rowsPerTenant).sum();
+      if (totalRowsScanned != expectedTotal) {
+        LOG.error("Row count mismatch in full scan:");
+        LOG.error("  Expected: {}", expectedTotal);
+        LOG.error("  Scanned: {}", totalRowsScanned);
+
+        // Log missing rows per tenant
+        for (int i = 0; i < tenants.length; i++) {
+          if (tenantRowCounts[i] != rowsPerTenant[i]) {
+            java.util.List<String> missing = new java.util.ArrayList<>();
+            for (int r = 0; r < rowsPerTenant[i]; r++) {
+              String expectedKey = String.format("%srow%05d", tenants[i], r);
+              if (!seenRowsPerTenant[i].contains(expectedKey)) {
+                missing.add(expectedKey);
+              }
+            }
+            LOG.error("Missing rows for tenant {} ({} missing): {}", tenants[i], missing.size(),
+              missing.size() <= 10 ? missing : missing.subList(0, 10) + "...");
+          }
+        }
+
+        fail("Full scan should return all rows after split. Expected: " + expectedTotal + ", Got: "
+          + totalRowsScanned);
+      }
+
+      // Verify per-tenant row counts
+      for (int i = 0; i < tenants.length; i++) {
+        if (tenantRowCounts[i] != rowsPerTenant[i]) {
+          LOG.error("Row count mismatch for tenant {} in full scan: expected {}, got {}",
+            tenants[i], rowsPerTenant[i], tenantRowCounts[i]);
+
+          // Log some missing rows for debugging
+          java.util.List<String> missing = new java.util.ArrayList<>();
+          for (int r = 0; r < rowsPerTenant[i]; r++) {
+            String expectedKey = String.format("%srow%05d", tenants[i], r);
+            if (!seenRowsPerTenant[i].contains(expectedKey)) {
+              missing.add(expectedKey);
+              if (missing.size() >= 5) {
+                break; // Show first 5 missing rows
+              }
+            }
+          }
+          LOG.error("Sample missing rows for tenant {}: {}", tenants[i], missing);
+
+          fail("Row count mismatch for tenant " + tenants[i] + " in full scan: expected "
+            + rowsPerTenant[i] + ", got " + tenantRowCounts[i]);
+        }
+      }
+
+      LOG.info("Full table scan verified successfully: {}/{} rows scanned", totalRowsScanned,
+        expectedTotal);
+    }
+  }
+
+  /**
+   * Verify tenant-specific scans work correctly after split.
+   */
+  private void verifyTenantSpecificScansAfterSplit(Table table, String[] tenants,
+    int[] rowsPerTenant) throws IOException {
+    LOG.info("Verifying tenant-specific scans after split");
+
+    for (int tenantIndex = 0; tenantIndex < tenants.length; tenantIndex++) {
+      String tenant = tenants[tenantIndex];
+      int expectedRows = rowsPerTenant[tenantIndex];
+
+      LOG.info("Testing tenant-specific scan for tenant {}: expecting {} rows", tenant,
+        expectedRows);
+
+      org.apache.hadoop.hbase.client.Scan tenantScan = new org.apache.hadoop.hbase.client.Scan();
+      tenantScan.addColumn(FAMILY, QUALIFIER);
+      tenantScan.withStartRow(Bytes.toBytes(tenant + "row"));
+      tenantScan.withStopRow(Bytes.toBytes(tenant + "row" + "\uFFFF"));
+
+      try (
+        org.apache.hadoop.hbase.client.ResultScanner tenantScanner = table.getScanner(tenantScan)) {
+        int tenantRowCount = 0;
+        List<String> foundRows = new ArrayList<>();
+
+        for (org.apache.hadoop.hbase.client.Result result : tenantScanner) {
+          String rowKey = Bytes.toString(result.getRow());
+          foundRows.add(rowKey);
+
+          if (!rowKey.startsWith(tenant)) {
+            fail("Tenant scan violation after split: Found row " + rowKey + " in scan for tenant "
+              + tenant);
+          }
+
+          // Verify data integrity for this row
+          byte[] cellValue = result.getValue(FAMILY, QUALIFIER);
+          if (cellValue == null) {
+            fail("Missing value for tenant row: " + rowKey);
+          }
+
+          String actualValue = Bytes.toString(cellValue);
+          if (!actualValue.contains(tenant)) {
+            fail("Tenant data corruption after split: Row " + rowKey + " expected tenant " + tenant
+              + " but got value " + actualValue);
+          }
+
+          tenantRowCount++;
+        }
+
+        if (tenantRowCount != expectedRows) {
+          LOG.error("Row count mismatch for tenant {} after split:", tenant);
+          LOG.error("  Expected: {}", expectedRows);
+          LOG.error("  Found: {}", tenantRowCount);
+          LOG.error("  Found rows: {}", foundRows);
+        }
+
+        assertEquals("Row count mismatch for tenant " + tenant + " after split", expectedRows,
+          tenantRowCount);
+
+        LOG.info("Tenant {} scan successful after split: {}/{} rows verified", tenant,
+          tenantRowCount, expectedRows);
+      }
+    }
+
+    LOG.info("All tenant-specific scans verified successfully after split");
+  }
+
+  /**
+   * Verify scanning across region boundaries works correctly.
+   */
+  private void verifyCrossRegionBoundaryScanning(Table table, String[] tenants, int[] rowsPerTenant)
+    throws IOException {
+    LOG.info("Verifying cross-region boundary scanning after split");
+
+    // Test scanning across the split point
+    // Find a range that likely spans both regions
+    String firstTenant = tenants[0];
+    String lastTenant = tenants[tenants.length - 1];
+
+    org.apache.hadoop.hbase.client.Scan crossRegionScan = new org.apache.hadoop.hbase.client.Scan();
+    crossRegionScan.addColumn(FAMILY, QUALIFIER);
+    crossRegionScan.withStartRow(Bytes.toBytes(firstTenant + "row000"));
+    crossRegionScan.withStopRow(Bytes.toBytes(lastTenant + "row999"));
+
+    try (org.apache.hadoop.hbase.client.ResultScanner scanner = table.getScanner(crossRegionScan)) {
+      int totalRowsScanned = 0;
+      String previousRowKey = null;
+
+      for (org.apache.hadoop.hbase.client.Result result : scanner) {
+        String rowKey = Bytes.toString(result.getRow());
+
+        // Verify row ordering is maintained across regions
+        if (previousRowKey != null) {
+          assertTrue("Row ordering should be maintained across regions: " + previousRowKey
+            + " should be <= " + rowKey,
+            Bytes.compareTo(Bytes.toBytes(previousRowKey), Bytes.toBytes(rowKey)) <= 0);
+        }
+
+        // Verify data integrity
+        byte[] cellValue = result.getValue(FAMILY, QUALIFIER);
+        if (cellValue == null) {
+          fail("Missing value in cross-region scan for row: " + rowKey);
+        }
+
+        String tenantPrefix = rowKey.substring(0, TENANT_PREFIX_LENGTH);
+        String actualValue = Bytes.toString(cellValue);
+        if (!actualValue.contains(tenantPrefix)) {
+          fail("Data corruption in cross-region scan: Row " + rowKey + " expected tenant "
+            + tenantPrefix + " but got value " + actualValue);
+        }
+
+        previousRowKey = rowKey;
+        totalRowsScanned++;
+      }
+
+      assertTrue("Cross-region scan should find data", totalRowsScanned > 0);
+      LOG.info("Cross-region boundary scan verified: {} rows scanned with proper ordering",
+        totalRowsScanned);
+    }
+  }
+
+  /**
+   * Verify edge cases and tenant isolation after split.
+   */
+  private void verifyEdgeCasesAfterSplit(Table table, String[] tenants, int[] rowsPerTenant)
+    throws IOException {
+    LOG.info("Verifying edge cases and tenant isolation after split");
+
+    // Test 1: Non-existent tenant scan
+    LOG.info("Testing scan with non-existent tenant prefix");
+    String nonExistentTenant = "ZZZ";
+    org.apache.hadoop.hbase.client.Scan nonExistentScan = new org.apache.hadoop.hbase.client.Scan();
+    nonExistentScan.addColumn(FAMILY, QUALIFIER);
+    nonExistentScan.withStartRow(Bytes.toBytes(nonExistentTenant + "row"));
+    nonExistentScan.withStopRow(Bytes.toBytes(nonExistentTenant + "row" + "\uFFFF"));
+
+    try (org.apache.hadoop.hbase.client.ResultScanner scanner = table.getScanner(nonExistentScan)) {
+      int rowCount = 0;
+      for (org.apache.hadoop.hbase.client.Result result : scanner) {
+        rowCount++;
+      }
+      assertEquals("Non-existent tenant scan should return no results after split", 0, rowCount);
+    }
+
+    // Test 2: Tenant boundary isolation
+    LOG.info("Testing tenant boundary isolation after split");
+    for (int i = 0; i < tenants.length - 1; i++) {
+      String tenant1 = tenants[i];
+      String tenant2 = tenants[i + 1];
+
+      // Scan from last row of tenant1 to first row of tenant2
+      org.apache.hadoop.hbase.client.Scan boundaryScan = new org.apache.hadoop.hbase.client.Scan();
+      boundaryScan.addColumn(FAMILY, QUALIFIER);
+      boundaryScan
+        .withStartRow(Bytes.toBytes(tenant1 + "row" + String.format("%05d", rowsPerTenant[i] - 1)));
+      boundaryScan.withStopRow(Bytes.toBytes(tenant2 + "row001"));
+
+      try (org.apache.hadoop.hbase.client.ResultScanner scanner = table.getScanner(boundaryScan)) {
+        boolean foundTenant1 = false;
+        boolean foundTenant2 = false;
+
+        for (org.apache.hadoop.hbase.client.Result result : scanner) {
+          String rowKey = Bytes.toString(result.getRow());
+
+          if (rowKey.startsWith(tenant1)) {
+            foundTenant1 = true;
+          } else if (rowKey.startsWith(tenant2)) {
+            foundTenant2 = true;
+          } else {
+            fail("Unexpected tenant in boundary scan after split: " + rowKey);
+          }
+        }
+
+        // We should find data from both tenants at the boundary
+        assertTrue("Should find tenant " + tenant1 + " data in boundary scan", foundTenant1);
+        if (rowsPerTenant[i + 1] > 0) {
+          assertTrue("Should find tenant " + tenant2 + " data in boundary scan", foundTenant2);
+        }
+      }
+    }
+
+    LOG.info("Edge cases and tenant isolation verification completed successfully");
+  }
+
+  /**
+   * Verify data integrity after split using GET operations.
+   */
+  private void verifyDataIntegrityAfterSplit(TableName tableName, String[] tenants,
+    int[] rowsPerTenant) throws Exception {
+    LOG.info("Verifying data integrity with GET operations");
+
+    try (Connection conn = ConnectionFactory.createConnection(testUtil.getConfiguration());
+      Table table = conn.getTable(tableName)) {
+
+      int totalRowsVerified = 0;
+
+      for (int tenantIndex = 0; tenantIndex < tenants.length; tenantIndex++) {
+        String tenant = tenants[tenantIndex];
+        int rowsForThisTenant = rowsPerTenant[tenantIndex];
+
+        for (int i = 0; i < rowsForThisTenant; i++) {
+          String rowKey = String.format("%srow%05d", tenant, i);
+          String expectedValue = String.format("value_tenant-%s_row-%05d", tenant, i);
+
+          Get get = new Get(Bytes.toBytes(rowKey));
+          get.addColumn(FAMILY, QUALIFIER);
+
+          Result result = table.get(get);
+          assertFalse("Result should not be empty for row: " + rowKey, result.isEmpty());
+
+          byte[] actualValue = result.getValue(FAMILY, QUALIFIER);
+          String actualValueStr = Bytes.toString(actualValue);
+          assertEquals("Value mismatch for row " + rowKey, expectedValue, actualValueStr);
+          totalRowsVerified++;
+        }
+      }
+
+      int expectedTotal = Arrays.stream(rowsPerTenant).sum();
+      assertEquals("All rows should be verified", expectedTotal, totalRowsVerified);
+      LOG.info("Data integrity verified: {}/{} rows", totalRowsVerified, expectedTotal);
+    }
+  }
+
+  /**
+   * Find all HFiles created for the test table.
+   */
+  private List<Path> findHFilePaths(TableName tableName) throws IOException {
+    List<Path> hfilePaths = new ArrayList<>();
+
+    Path rootDir = testUtil.getDataTestDirOnTestFS();
+    Path tableDir = new Path(rootDir, "data/default/" + tableName.getNameAsString());
+
+    if (testUtil.getTestFileSystem().exists(tableDir)) {
+      FileStatus[] regionDirs = testUtil.getTestFileSystem().listStatus(tableDir);
+
+      for (FileStatus regionDir : regionDirs) {
+        if (regionDir.isDirectory() && !regionDir.getPath().getName().startsWith(".")) {
+          Path familyDir = new Path(regionDir.getPath(), Bytes.toString(FAMILY));
+
+          if (testUtil.getTestFileSystem().exists(familyDir)) {
+            FileStatus[] hfiles = testUtil.getTestFileSystem().listStatus(familyDir);
+
+            for (FileStatus hfile : hfiles) {
+              if (
+                !hfile.getPath().getName().startsWith(".")
+                  && !hfile.getPath().getName().endsWith(".tmp")
+              ) {
+                hfilePaths.add(hfile.getPath());
+                LOG.debug("Found HFile: {} (size: {} bytes)", hfile.getPath().getName(),
+                  hfile.getLen());
+              }
+            }
+          }
+        }
+      }
+    }
+
+    LOG.info("Found {} HFiles total", hfilePaths.size());
+    return hfilePaths;
+  }
+
+  /**
+   * Trigger region split and wait for completion using HBaseTestingUtility methods.
+   */
+  private void triggerRegionSplit(String[] tenants, int[] rowsPerTenant, TableName tableName)
+    throws Exception {
+    LOG.info("Starting region split for table: {}", tableName);
+
+    // First ensure cluster is healthy and responsive
+    LOG.info("Checking cluster health before split");
+    try {
+      // Verify cluster is running
+      assertTrue("Mini cluster should be running", testUtil.getMiniHBaseCluster() != null);
+      LOG.info("Mini cluster is up and running");
+
+      // Add more debug info about cluster state
+      LOG.info("Master is active: {}", testUtil.getMiniHBaseCluster().getMaster().isActiveMaster());
+      LOG.info("Number of region servers: {}",
+        testUtil.getMiniHBaseCluster().getNumLiveRegionServers());
+      LOG.info("Master address: {}", testUtil.getMiniHBaseCluster().getMaster().getServerName());
+
+      // Ensure no regions are in transition before starting split
+      testUtil.waitUntilNoRegionsInTransition(60000);
+
+    } catch (Exception e) {
+      LOG.warn("Cluster health check failed: {}", e.getMessage());
+      throw new RuntimeException("Cluster is not healthy before split attempt", e);
+    }
+
+    // Get initial region count and submit split request
+    LOG.info("Getting initial region count and submitting split");
+    try (Connection connection = ConnectionFactory.createConnection(testUtil.getConfiguration());
+      Admin admin = connection.getAdmin()) {
+
+      // Ensure table exists and is available
+      LOG.info("Verifying table exists: {}", tableName);
+      boolean tableExists = admin.tableExists(tableName);
+      if (!tableExists) {
+        throw new RuntimeException("Table " + tableName + " does not exist before split");
+      }
+
+      // Ensure table is enabled
+      if (!admin.isTableEnabled(tableName)) {
+        LOG.info("Table {} is disabled, enabling it", tableName);
+        admin.enableTable(tableName);
+        testUtil.waitTableEnabled(tableName.getName(), 30000);
+      }
+
+      LOG.info("Table {} exists and is enabled", tableName);
+
+      List<RegionInfo> regions = admin.getRegions(tableName);
+      assertEquals("Should have exactly one region before split", 1, regions.size());
+      LOG.info("Pre-split verification passed. Table {} has {} region(s)", tableName,
+        regions.size());
+
+      RegionInfo regionToSplit = regions.get(0);
+      LOG.info("Region to split: {} [{} -> {}]", regionToSplit.getEncodedName(),
+        Bytes.toStringBinary(regionToSplit.getStartKey()),
+        Bytes.toStringBinary(regionToSplit.getEndKey()));
+
+      // Trigger the split - let HBase choose the split point based on midkey calculation
+      LOG.info("Submitting split request for table: {}", tableName);
+      admin.split(tableName);
+      LOG.info("Split request submitted successfully for table: {}", tableName);
+
+      // Wait a moment for split request to be processed
+      Thread.sleep(2000);
+    }
+
+    // Wait for split to complete using HBaseTestingUtility methods with extended timeouts
+    LOG.info("Waiting for split processing to complete...");
+
+    // First wait for no regions in transition
+    boolean splitCompleted = false;
+    int maxWaitCycles = 12; // 12 * 10 seconds = 2 minutes max
+    int waitCycle = 0;
+
+    while (!splitCompleted && waitCycle < maxWaitCycles) {
+      waitCycle++;
+      LOG.info("Split wait cycle {}/{}: Waiting for regions to stabilize...", waitCycle,
+        maxWaitCycles);
+
+      try {
+        // Wait for no regions in transition (10 second timeout per cycle)
+        testUtil.waitUntilNoRegionsInTransition(10000);
+
+        // Check if split actually completed
+        try (Connection conn = ConnectionFactory.createConnection(testUtil.getConfiguration());
+          Admin checkAdmin = conn.getAdmin()) {
+
+          List<RegionInfo> currentRegions = checkAdmin.getRegions(tableName);
+          if (currentRegions.size() > 1) {
+            splitCompleted = true;
+            LOG.info("Split completed successfully! Regions after split: {}",
+              currentRegions.size());
+          } else {
+            LOG.info("Split not yet complete, still {} region(s). Waiting...",
+              currentRegions.size());
+            Thread.sleep(5000); // Wait 5 seconds before next check
+          }
+        }
+
+      } catch (Exception e) {
+        LOG.warn("Error during split wait cycle {}: {}", waitCycle, e.getMessage());
+        if (waitCycle == maxWaitCycles) {
+          throw new RuntimeException("Split failed after maximum wait time", e);
+        }
+        Thread.sleep(5000); // Wait before retrying
+      }
+    }
+
+    if (!splitCompleted) {
+      throw new RuntimeException("Region split did not complete within timeout period");
+    }
+
+    // Give additional time for the split to fully stabilize
+    LOG.info("Split completed, waiting for final stabilization...");
+    Thread.sleep(3000);
+
+    // Final verification of split completion
+    LOG.info("Performing final verification of split completion...");
+    try (Connection conn = ConnectionFactory.createConnection(testUtil.getConfiguration());
+      Admin finalAdmin = conn.getAdmin()) {
+
+      List<RegionInfo> regionsAfterSplit = finalAdmin.getRegions(tableName);
+      if (regionsAfterSplit.size() <= 1) {
+        fail("Region split did not complete successfully. Expected > 1 region, got: "
+          + regionsAfterSplit.size());
+      }
+      LOG.info("Final verification passed. Regions after split: {}", regionsAfterSplit.size());
+
+      // Log region details for debugging
+      for (int i = 0; i < regionsAfterSplit.size(); i++) {
+        RegionInfo region = regionsAfterSplit.get(i);
+        LOG.info("Region {}: {} [{} -> {}]", i + 1, region.getEncodedName(),
+          Bytes.toStringBinary(region.getStartKey()), Bytes.toStringBinary(region.getEndKey()));
+      }
+
+      LOG.info("Split operation completed successfully.");
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestFixedFileTrailer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestFixedFileTrailer.java
@@ -73,7 +73,7 @@ public class TestFixedFileTrailer {
    * The number of used fields by version. Indexed by version minus two. Min version that we support
    * is V2
    */
-  private static final int[] NUM_FIELDS_BY_VERSION = new int[] { 14, 15 };
+  private static final int[] NUM_FIELDS_BY_VERSION = new int[] { 14, 15, 16 };
 
   private HBaseTestingUtility util = new HBaseTestingUtility();
   private FileSystem fs;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
@@ -815,7 +815,7 @@ public class TestHFile {
    */
   void basicWithSomeCodec(String codec, boolean useTags) throws IOException {
     if (useTags) {
-      conf.setInt("hfile.format.version", 3);
+      conf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     }
     Path ncHFile = new Path(ROOT_DIR, "basic.hfile." + codec.toString() + useTags);
     FSDataOutputStream fout = createFSOutput(ncHFile);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
@@ -161,6 +161,29 @@ public class TestHFile {
     Assert.assertEquals(alloc.getFreeBufferCount(), bufCount);
   }
 
+  private BlockCacheKey cacheKeyFor(HFile.Reader reader, HFileBlock block) {
+    // Use the same key derivation as the reader implementation, especially for multi-tenant files
+    // where the reader may use an offset-translating stream wrapper. This ensures tests validate
+    // real cache behavior rather than a particular naming convention.
+    if (reader instanceof HFileReaderImpl) {
+      HFileReaderImpl impl = (HFileReaderImpl) reader;
+      String hfileName = impl.getNameForCaching();
+      long offset = impl.getOffsetForCaching(block.getOffset());
+      BlockType blockType = block.getBlockType() != null ? block.getBlockType() : BlockType.DATA;
+      return new BlockCacheKey(hfileName, offset, true, blockType);
+    }
+
+    String hfileName = block.getHFileContext().getHFileName();
+    if (hfileName == null) {
+      hfileName = reader.getName();
+      if (reader instanceof AbstractMultiTenantReader && !hfileName.endsWith("#")) {
+        hfileName = hfileName + "#";
+      }
+    }
+    BlockType blockType = block.getBlockType() != null ? block.getBlockType() : BlockType.DATA;
+    return new BlockCacheKey(hfileName, block.getOffset(), true, blockType);
+  }
+
   @Test
   public void testReaderWithoutBlockCache() throws Exception {
     int bufCount = 32;
@@ -189,8 +212,8 @@ public class TestHFile {
     HFile.Reader reader = HFile.createReader(fs, storeFilePath, cacheConfig, true, conf);
     long offset = 0;
     while (offset < reader.getTrailer().getLoadOnOpenDataOffset()) {
-      BlockCacheKey key = new BlockCacheKey(storeFilePath.getName(), offset);
       HFileBlock block = reader.readBlock(offset, -1, true, true, false, true, null, null);
+      BlockCacheKey key = cacheKeyFor(reader, block);
       offset += block.getOnDiskSizeWithHeader();
       // Ensure the block is an heap one.
       Cacheable cachedBlock = lru.getBlock(key, false, false, true);
@@ -279,7 +302,7 @@ public class TestHFile {
 
     // Read the first block in HFile from the block cache.
     final int offset = 0;
-    BlockCacheKey cacheKey = new BlockCacheKey(storeFilePath.getName(), offset);
+    BlockCacheKey cacheKey = new BlockCacheKey(reader.getName(), offset);
     HFileBlock block = (HFileBlock) lru.getBlock(cacheKey, false, false, true);
     Assert.assertNull(block);
 
@@ -294,14 +317,27 @@ public class TestHFile {
     // Read the first block from the HFile.
     block = reader.readBlock(offset, -1, true, true, false, true, BlockType.DATA, null);
     Assert.assertNotNull(block);
+    cacheKey = cacheKeyFor(reader, block);
     int bytesReadFromFs = block.getOnDiskSizeWithHeader();
     if (block.getNextBlockOnDiskSize() > 0) {
       bytesReadFromFs += block.headerSize();
     }
     block.release();
     // Assert that disk I/O happened to read the first block.
+    long bytesReadFromFsMetric = ThreadLocalServerSideScanMetrics.getBytesReadFromFsAndReset();
+    long effectiveBytesReadFromFs = bytesReadFromFsMetric;
+    if (isScanMetricsEnabled) {
+      if (bytesReadFromFsMetric < bytesReadFromFs) {
+        Assert.assertEquals(bytesReadFromFs, bytesReadFromFsMetric);
+      } else if (bytesReadFromFsMetric > bytesReadFromFs) {
+        long initializationBytes = bytesReadFromFsMetric - bytesReadFromFs;
+        Assert.assertEquals(HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT,
+          reader.getTrailer().getMajorVersion());
+        effectiveBytesReadFromFs -= initializationBytes;
+      }
+    }
     Assert.assertEquals(isScanMetricsEnabled ? bytesReadFromFs : 0,
-      ThreadLocalServerSideScanMetrics.getBytesReadFromFsAndReset());
+      isScanMetricsEnabled ? effectiveBytesReadFromFs : bytesReadFromFsMetric);
     Assert.assertEquals(0, ThreadLocalServerSideScanMetrics.getBytesReadFromBlockCacheAndReset());
 
     // Read the first block again and assert that it has been cached in the block cache.
@@ -372,8 +408,8 @@ public class TestHFile {
     HFile.Reader reader = HFile.createReader(fs, storeFilePath, cacheConfig, true, conf);
     long offset = 0;
     while (offset < reader.getTrailer().getLoadOnOpenDataOffset()) {
-      BlockCacheKey key = new BlockCacheKey(storeFilePath.getName(), offset);
       HFileBlock block = reader.readBlock(offset, -1, true, true, false, true, null, null);
+      BlockCacheKey key = cacheKeyFor(reader, block);
       offset += block.getOnDiskSizeWithHeader();
       // Read the cached block.
       Cacheable cachedBlock = combined.getBlock(key, false, false, true);
@@ -1122,8 +1158,8 @@ public class TestHFile {
       Path f = new Path(ROOT_DIR, testName.getMethodName() + "_" + encoding);
       HFileContext context =
         new HFileContextBuilder().withIncludesTags(false).withDataBlockEncoding(encoding).build();
-      HFileWriterImpl writer = (HFileWriterImpl) HFile.getWriterFactory(conf, cacheConf)
-        .withPath(fs, f).withFileContext(context).create();
+      Writer writer =
+        HFile.getWriterFactory(conf, cacheConf).withPath(fs, f).withFileContext(context).create();
 
       KeyValue kv = new KeyValue(Bytes.toBytes("testkey1"), Bytes.toBytes("family"),
         Bytes.toBytes("qual"), Bytes.toBytes("testvalue"));
@@ -1186,8 +1222,8 @@ public class TestHFile {
     long offset = 0;
     Cacheable cachedBlock = null;
     while (offset < reader.getTrailer().getLoadOnOpenDataOffset()) {
-      BlockCacheKey key = new BlockCacheKey(storeFilePath.getName(), offset);
       HFileBlock block = reader.readBlock(offset, -1, true, true, false, true, null, null);
+      BlockCacheKey key = cacheKeyFor(reader, block);
       offset += block.getOnDiskSizeWithHeader();
       // Read the cached block.
       cachedBlock = combined.getBlock(key, false, false, true);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlock.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlock.java
@@ -349,7 +349,7 @@ public class TestHFileBlock {
   protected void testReaderV2Internals() throws IOException {
     final Configuration conf = TEST_UTIL.getConfiguration();
     if (includesTag) {
-      conf.setInt("hfile.format.version", 3);
+      conf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     }
     for (Compression.Algorithm algo : COMPRESSION_ALGORITHMS) {
       for (boolean pread : new boolean[] { false, true }) {
@@ -432,7 +432,7 @@ public class TestHFileBlock {
     final int numBlocks = 5;
     final Configuration conf = TEST_UTIL.getConfiguration();
     if (includesTag) {
-      conf.setInt("hfile.format.version", 3);
+      conf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     }
     for (Compression.Algorithm algo : COMPRESSION_ALGORITHMS) {
       for (boolean pread : new boolean[] { false, true }) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
@@ -133,8 +133,10 @@ public class TestHFileBlockIndex {
     conf = TEST_UTIL.getConfiguration();
     RNG.setSeed(2389757);
 
-    // This test requires at least HFile format version 2.
-    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
+    // This test validates the v3 data block index behavior (HFileBlockIndex + FixedFileTrailer
+    // numDataIndexLevels). HFile v4 has a different layout and repurposes trailer fields for the
+    // section index, so keep this pinned to v3.
+    conf.setInt(HFile.FORMAT_VERSION_KEY, 3);
 
     fs = HFileSystem.get(conf);
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
@@ -133,9 +133,12 @@ public class TestHFileBlockIndex {
     conf = TEST_UTIL.getConfiguration();
     RNG.setSeed(2389757);
 
-    // This test validates the v3 data block index behavior (HFileBlockIndex + FixedFileTrailer
-    // numDataIndexLevels). HFile v4 has a different layout and repurposes trailer fields for the
-    // section index, so keep this pinned to v3.
+    // This test asserts v3 in-file layout: contiguous LEAF_INDEX blocks in the load-on-open
+    // area, fixed numDataIndexLevels in the trailer, and exact uncompressed-data-index byte
+    // sizes. HFile v4 reorganizes the load-on-open area around a section-index root and moves
+    // data block indexes inside each tenant section, so these invariants do not apply. v4 layout
+    // is covered by TestHFileV4BlockIndex and TestMultiTenantHFileMultiLevelIndex; keep this
+    // test pinned to v3.
     conf.setInt(HFile.FORMAT_VERSION_KEY, 3);
 
     fs = HFileSystem.get(conf);
@@ -289,7 +292,12 @@ public class TestHFileBlockIndex {
     conf = TEST_UTIL.getConfiguration();
     RNG.setSeed(2389757);
 
-    // This test requires at least HFile format version 2.
+    // This test asserts v3 in-file layout: contiguous LEAF_INDEX blocks in the load-on-open
+    // area, fixed numDataIndexLevels in the trailer, and exact uncompressed-data-index byte
+    // sizes. HFile v4 reorganizes the load-on-open area around a section-index root and moves
+    // data block indexes inside each tenant section, so these invariants do not apply. v4 layout
+    // is covered by TestHFileV4BlockIndex and TestMultiTenantHFileMultiLevelIndex; keep this
+    // test pinned to v3.
     conf.setInt(HFile.FORMAT_VERSION_KEY, 3);
 
     fs = HFileSystem.get(conf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileEncryption.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileEncryption.java
@@ -78,7 +78,7 @@ public class TestHFileEncryption {
     conf.setFloat(HConstants.HFILE_BLOCK_CACHE_SIZE_KEY, 0.0f);
     conf.set(HConstants.CRYPTO_KEYPROVIDER_CONF_KEY, KeyProviderForTesting.class.getName());
     conf.set(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, "hbase");
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
 
     fs = FileSystem.get(conf);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFilePrettyPrinter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFilePrettyPrinter.java
@@ -87,14 +87,21 @@ public class TestHFilePrettyPrinter {
     System.setOut(ps);
     new HFilePrettyPrinter(conf).run(new String[] { "-v", String.valueOf(fileNotInRootDir) });
     String result = new String(stream.toByteArray());
-    String expectedResult = "Scanning -> " + fileNotInRootDir + "\n" + "Scanned kv count -> 1000\n";
-    assertEquals(expectedResult, result);
+    String expectedFirstLine = "Scanning -> " + fileNotInRootDir + "\n";
+    String expectedCountLine = "Scanned kv count -> 1000\n";
+    assertTrue("expected to contain start line: '" + expectedFirstLine + "'",
+      result.contains(expectedFirstLine));
+    assertTrue("expected to contain count line: '" + expectedCountLine + "'",
+      result.contains(expectedCountLine));
+    assertTrue("expected start line to appear before count line",
+      result.indexOf(expectedFirstLine) >= 0
+        && result.indexOf(expectedCountLine) > result.indexOf(expectedFirstLine));
   }
 
   @Test
   public void testHFilePrettyPrinterRootDir() throws Exception {
     Path rootPath = CommonFSUtils.getRootDir(conf);
-    String rootString = rootPath + rootPath.SEPARATOR;
+    String rootString = rootPath + Path.SEPARATOR;
     Path fileInRootDir = new Path(rootString + "hfile");
     TestHRegionServerBulkLoad.createHFile(fs, fileInRootDir, cf, fam, value, 1000);
     assertTrue("directory used is a root dir", fileInRootDir.toString().startsWith(rootString));
@@ -105,8 +112,15 @@ public class TestHFilePrettyPrinter {
     printer.processFile(fileInRootDir, true);
     printer.run(new String[] { "-v", String.valueOf(fileInRootDir) });
     String result = new String(stream.toByteArray());
-    String expectedResult = "Scanning -> " + fileInRootDir + "\n" + "Scanned kv count -> 1000\n";
-    assertEquals(expectedResult, result);
+    String expectedFirstLine = "Scanning -> " + fileInRootDir + "\n";
+    String expectedCountLine = "Scanned kv count -> 1000\n";
+    assertTrue("expected to contain start line: '" + expectedFirstLine + "'",
+      result.contains(expectedFirstLine));
+    assertTrue("expected to contain count line: '" + expectedCountLine + "'",
+      result.contains(expectedCountLine));
+    assertTrue("expected start line to appear before count line",
+      result.indexOf(expectedFirstLine) >= 0
+        && result.indexOf(expectedCountLine) > result.indexOf(expectedFirstLine));
   }
 
   @Test
@@ -124,8 +138,15 @@ public class TestHFilePrettyPrinter {
     new HFilePrettyPrinter(conf)
       .run(new String[] { "-v", "-w" + firstRowKey, String.valueOf(fileNotInRootDir) });
     String result = new String(stream.toByteArray());
-    String expectedResult = "Scanning -> " + fileNotInRootDir + "\n" + "Scanned kv count -> 1\n";
-    assertEquals(expectedResult, result);
+    String expectedFirstLine = "Scanning -> " + fileNotInRootDir + "\n";
+    String expectedCountLine = "Scanned kv count -> 1\n";
+    assertTrue("expected to contain start line: '" + expectedFirstLine + "'",
+      result.contains(expectedFirstLine));
+    assertTrue("expected to contain count line: '" + expectedCountLine + "'",
+      result.contains(expectedCountLine));
+    assertTrue("expected start line to appear before count line",
+      result.indexOf(expectedFirstLine) >= 0
+        && result.indexOf(expectedCountLine) > result.indexOf(expectedFirstLine));
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileReaderImpl.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileReaderImpl.java
@@ -98,8 +98,7 @@ public class TestHFileReaderImpl {
     Configuration conf = TEST_UTIL.getConfiguration();
     HFile.Reader reader = HFile.createReader(fs, p, CacheConfig.DISABLED, true, conf);
 
-    try (HFileReaderImpl.HFileScannerImpl scanner =
-      (HFileReaderImpl.HFileScannerImpl) reader.getScanner(conf, true, true, false)) {
+    try (HFileScanner scanner = reader.getScanner(conf, true, true, false)) {
       scanner.seekTo();
 
       scanner.recordBlockSize(

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileV4BlockIndex.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileV4BlockIndex.java
@@ -1,0 +1,918 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutput;
+import java.io.DataOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Random;
+import java.util.concurrent.atomic.AtomicInteger;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
+import org.apache.hadoop.fs.FSDataOutputStream;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.CellBuilderType;
+import org.apache.hadoop.hbase.CellComparatorImpl;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.ExtendedCellBuilderFactory;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseCommonTestingUtility;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.KeyValueUtil;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.fs.HFileSystem;
+import org.apache.hadoop.hbase.io.ByteBuffAllocator;
+import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.compress.Compression.Algorithm;
+import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoding;
+import org.apache.hadoop.hbase.io.hfile.HFile.Writer;
+import org.apache.hadoop.hbase.io.hfile.HFileBlockIndex.BlockIndexReader;
+import org.apache.hadoop.hbase.io.hfile.NoOpIndexBlockEncoder.NoOpEncodedSeeker;
+import org.apache.hadoop.hbase.nio.MultiByteBuff;
+import org.apache.hadoop.hbase.nio.RefCnt;
+import org.apache.hadoop.hbase.testclassification.IOTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.ClassSize;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.junit.runners.Parameterized.Parameters;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import org.apache.hbase.thirdparty.io.netty.util.ResourceLeakDetector;
+
+/**
+ * This test mirrors {@link TestHFileBlockIndex} but writes HFiles using format version 4
+ * (multi-tenant).
+ * <p>
+ * HFile v4 is a container of one or more HFile v3 "sections". For parity with the v3 tests, we
+ * create single-section v4 files (tenant prefix length = 0) and validate the embedded v3 section's
+ * data block index behavior through the v4 reader.
+ */
+@RunWith(Parameterized.class)
+@Category({ IOTests.class, MediumTests.class })
+public class TestHFileV4BlockIndex {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestHFileV4BlockIndex.class);
+
+  @Parameters
+  public static Collection<Object[]> compressionAlgorithms() {
+    return HBaseCommonTestingUtility.COMPRESSION_ALGORITHMS_PARAMETERIZED;
+  }
+
+  public TestHFileV4BlockIndex(Compression.Algorithm compr) {
+    this.compr = compr;
+  }
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestHFileV4BlockIndex.class);
+  private static final Random RNG = new Random(); // This test depends on Random#setSeed
+  private static final int NUM_DATA_BLOCKS = 1000;
+  private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  private static final int SMALL_BLOCK_SIZE = 4096;
+  private static final int NUM_KV = 10000;
+
+  private static FileSystem fs;
+  private Path path;
+  private long rootIndexOffset;
+  private int numRootEntries;
+  private int numLevels;
+  private static final List<byte[]> keys = new ArrayList<>();
+  private final Compression.Algorithm compr;
+  private byte[] firstKeyInFile;
+  private Configuration conf;
+
+  private static final int[] INDEX_CHUNK_SIZES = { 4096, 512, 384 };
+  private static final int[] EXPECTED_NUM_LEVELS = { 2, 3, 4 };
+  private static final int[] UNCOMPRESSED_INDEX_SIZES = { 19187, 21813, 23086 };
+
+  private static final boolean includesMemstoreTS = true;
+
+  static {
+    assert INDEX_CHUNK_SIZES.length == EXPECTED_NUM_LEVELS.length;
+    assert INDEX_CHUNK_SIZES.length == UNCOMPRESSED_INDEX_SIZES.length;
+  }
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    TEST_UTIL.startMiniCluster(1);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Before
+  public void setUp() throws IOException {
+    keys.clear();
+    firstKeyInFile = null;
+    conf = TEST_UTIL.getConfiguration();
+    RNG.setSeed(2389757);
+
+    // Force v4 writer/reader for this parity test.
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+
+    fs = HFileSystem.get(conf);
+  }
+
+  @Test
+  public void testBlockIndex() throws IOException {
+    testBlockIndexInternals(false);
+    clear();
+    testBlockIndexInternals(true);
+  }
+
+  private void writeDataBlocksAndCreateIndex(HFileBlock.Writer hbw, FSDataOutputStream outputStream,
+    HFileBlockIndex.BlockIndexWriter biw) throws IOException {
+    for (int i = 0; i < NUM_DATA_BLOCKS; ++i) {
+      hbw.startWriting(BlockType.DATA).write(Bytes.toBytes(String.valueOf(RNG.nextInt(1000))));
+      long blockOffset = outputStream.getPos();
+      hbw.writeHeaderAndData(outputStream);
+
+      byte[] firstKey = null;
+      byte[] family = Bytes.toBytes("f");
+      byte[] qualifier = Bytes.toBytes("q");
+      for (int j = 0; j < 16; ++j) {
+        byte[] k = new KeyValue(RandomKeyValueUtil.randomOrderedKey(RNG, i * 16 + j), family,
+          qualifier, EnvironmentEdgeManager.currentTime(), KeyValue.Type.Put).getKey();
+        keys.add(k);
+        if (j == 8) {
+          firstKey = k;
+        }
+      }
+      assertTrue(firstKey != null);
+      if (firstKeyInFile == null) {
+        firstKeyInFile = firstKey;
+      }
+      biw.addEntry(firstKey, blockOffset, hbw.getOnDiskSizeWithHeader());
+
+      writeInlineBlocks(hbw, outputStream, biw, false);
+    }
+    writeInlineBlocks(hbw, outputStream, biw, true);
+    rootIndexOffset = biw.writeIndexBlocks(outputStream);
+    outputStream.close();
+  }
+
+  @Test
+  public void testBlockIndexWithOffHeapBuffer() throws Exception {
+    ResourceLeakDetector.setLevel(ResourceLeakDetector.Level.PARANOID);
+    path = new Path(TEST_UTIL.getDataTestDir(), "block_index_testBlockIndexWithOffHeapBuffer_v4");
+    assertEquals(0, keys.size());
+    HFileContext meta = new HFileContextBuilder().withHBaseCheckSum(true)
+      .withIncludesMvcc(includesMemstoreTS).withIncludesTags(true).withCompression(compr)
+      .withBytesPerCheckSum(HFile.DEFAULT_BYTES_PER_CHECKSUM).build();
+    ByteBuffAllocator allocator = ByteBuffAllocator.create(TEST_UTIL.getConfiguration(), true);
+    HFileBlock.Writer hbw = new HFileBlock.Writer(TEST_UTIL.getConfiguration(), null, meta,
+      allocator, meta.getBlocksize());
+    FSDataOutputStream outputStream = fs.create(path);
+
+    final AtomicInteger counter = new AtomicInteger();
+    RefCnt.detector.setLeakListener(new ResourceLeakDetector.LeakListener() {
+      @Override
+      public void onLeak(String s, String s1) {
+        counter.incrementAndGet();
+      }
+    });
+
+    long maxSize = NUM_DATA_BLOCKS * 1000;
+    long blockSize = 1000;
+    LruBlockCache cache = new LruBlockCache(maxSize, blockSize);
+    CacheConfig cacheConfig = new CacheConfig(TEST_UTIL.getConfiguration(), null, cache, allocator);
+
+    HFileBlockIndex.BlockIndexWriter biw =
+      new HFileBlockIndex.BlockIndexWriter(hbw, cacheConfig, path.getName(), null);
+
+    writeDataBlocksAndCreateIndex(hbw, outputStream, biw);
+
+    System.gc();
+    Thread.sleep(1000);
+
+    allocator.allocate(128 * 1024).release();
+
+    assertEquals(0, counter.get());
+  }
+
+  private void clear() throws IOException {
+    keys.clear();
+    firstKeyInFile = null;
+    conf = TEST_UTIL.getConfiguration();
+    RNG.setSeed(2389757);
+
+    // Force v4 writer/reader for this parity test.
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+
+    fs = HFileSystem.get(conf);
+  }
+
+  private void testBlockIndexInternals(boolean useTags) throws IOException {
+    path = new Path(TEST_UTIL.getDataTestDir(), "block_index_v4_" + compr + useTags);
+    writeWholeIndex(useTags);
+    readIndex(useTags);
+  }
+
+  /**
+   * A wrapper around a block reader which only caches the results of the last operation. Not
+   * thread-safe.
+   */
+  private static class BlockReaderWrapper implements HFile.CachingBlockReader {
+
+    private HFileBlock.FSReader realReader;
+    private long prevOffset;
+    private long prevOnDiskSize;
+    private boolean prevPread;
+    private HFileBlock prevBlock;
+
+    public int hitCount = 0;
+    public int missCount = 0;
+
+    public BlockReaderWrapper(HFileBlock.FSReader realReader) {
+      this.realReader = realReader;
+    }
+
+    @Override
+    public HFileBlock readBlock(long offset, long onDiskSize, boolean cacheBlock, boolean pread,
+      boolean isCompaction, boolean updateCacheMetrics, BlockType expectedBlockType,
+      DataBlockEncoding expectedDataBlockEncoding) throws IOException {
+      return readBlock(offset, onDiskSize, cacheBlock, pread, isCompaction, updateCacheMetrics,
+        expectedBlockType, expectedDataBlockEncoding, false);
+    }
+
+    @Override
+    public HFileBlock readBlock(long offset, long onDiskSize, boolean cacheBlock, boolean pread,
+      boolean isCompaction, boolean updateCacheMetrics, BlockType expectedBlockType,
+      DataBlockEncoding expectedDataBlockEncoding, boolean cacheOnly) throws IOException {
+      if (offset == prevOffset && onDiskSize == prevOnDiskSize && pread == prevPread) {
+        hitCount += 1;
+        return prevBlock;
+      }
+
+      missCount += 1;
+      prevBlock = realReader.readBlockData(offset, onDiskSize, pread, false, true);
+      prevOffset = offset;
+      prevOnDiskSize = onDiskSize;
+      prevPread = pread;
+
+      return prevBlock;
+    }
+  }
+
+  private void readIndex(boolean useTags) throws IOException {
+    long fileSize = fs.getFileStatus(path).getLen();
+    LOG.info("Size of {}: {} compression={}", path, fileSize, compr.toString());
+
+    FSDataInputStream istream = fs.open(path);
+    HFileContext meta =
+      new HFileContextBuilder().withHBaseCheckSum(true).withIncludesMvcc(includesMemstoreTS)
+        .withIncludesTags(useTags).withCompression(compr).build();
+    ReaderContext context = new ReaderContextBuilder().withFileSystemAndPath(fs, path).build();
+    HFileBlock.FSReader blockReader =
+      new HFileBlock.FSReaderImpl(context, meta, ByteBuffAllocator.HEAP, conf);
+
+    BlockReaderWrapper brw = new BlockReaderWrapper(blockReader);
+    HFileBlockIndex.BlockIndexReader indexReader =
+      new HFileBlockIndex.CellBasedKeyBlockIndexReader(CellComparatorImpl.COMPARATOR, numLevels);
+
+    indexReader.readRootIndex(blockReader.blockRange(rootIndexOffset, fileSize)
+      .nextBlockWithBlockType(BlockType.ROOT_INDEX), numRootEntries);
+
+    long prevOffset = -1;
+    int i = 0;
+    int expectedHitCount = 0;
+    int expectedMissCount = 0;
+    LOG.info("Total number of keys: " + keys.size());
+    for (byte[] key : keys) {
+      assertTrue(key != null);
+      assertTrue(indexReader != null);
+      KeyValue.KeyOnlyKeyValue keyOnlyKey = new KeyValue.KeyOnlyKeyValue(key, 0, key.length);
+      HFileBlock b = indexReader.seekToDataBlock(keyOnlyKey, null, true, true, false, null, brw);
+      if (
+        PrivateCellUtil.compare(CellComparatorImpl.COMPARATOR, keyOnlyKey, firstKeyInFile, 0,
+          firstKeyInFile.length) < 0
+      ) {
+        assertTrue(b == null);
+        ++i;
+        continue;
+      }
+
+      String keyStr = "key #" + i + ", " + Bytes.toStringBinary(key);
+
+      assertTrue("seekToDataBlock failed for " + keyStr, b != null);
+
+      if (prevOffset == b.getOffset()) {
+        assertEquals(++expectedHitCount, brw.hitCount);
+      } else {
+        LOG.info("First key in a new block: " + keyStr + ", block offset: " + b.getOffset() + ")");
+        assertTrue(b.getOffset() > prevOffset);
+        assertEquals(++expectedMissCount, brw.missCount);
+        prevOffset = b.getOffset();
+      }
+      ++i;
+    }
+
+    istream.close();
+  }
+
+  private void writeWholeIndex(boolean useTags) throws IOException {
+    assertEquals(0, keys.size());
+    HFileContext meta = new HFileContextBuilder().withHBaseCheckSum(true)
+      .withIncludesMvcc(includesMemstoreTS).withIncludesTags(useTags).withCompression(compr)
+      .withBytesPerCheckSum(HFile.DEFAULT_BYTES_PER_CHECKSUM).build();
+    HFileBlock.Writer hbw = new HFileBlock.Writer(TEST_UTIL.getConfiguration(), null, meta);
+    FSDataOutputStream outputStream = fs.create(path);
+    HFileBlockIndex.BlockIndexWriter biw =
+      new HFileBlockIndex.BlockIndexWriter(hbw, null, null, null);
+    writeDataBlocksAndCreateIndex(hbw, outputStream, biw);
+
+    numLevels = biw.getNumLevels();
+    numRootEntries = biw.getNumRootEntries();
+
+    LOG.info("Index written: numLevels=" + numLevels + ", numRootEntries=" + numRootEntries
+      + ", rootIndexOffset=" + rootIndexOffset);
+  }
+
+  private void writeInlineBlocks(HFileBlock.Writer hbw, FSDataOutputStream outputStream,
+    HFileBlockIndex.BlockIndexWriter biw, boolean isClosing) throws IOException {
+    while (biw.shouldWriteBlock(isClosing)) {
+      long offset = outputStream.getPos();
+      biw.writeInlineBlock(hbw.startWriting(biw.getInlineBlockType()));
+      hbw.writeHeaderAndData(outputStream);
+      biw.blockWritten(offset, hbw.getOnDiskSizeWithHeader(),
+        hbw.getUncompressedSizeWithoutHeader());
+      LOG.info(
+        "Wrote an inline index block at " + offset + ", size " + hbw.getOnDiskSizeWithHeader());
+    }
+  }
+
+  private static final long getDummyFileOffset(int i) {
+    return i * 185 + 379;
+  }
+
+  private static final int getDummyOnDiskSize(int i) {
+    return i * i * 37 + i * 19 + 13;
+  }
+
+  @Test
+  public void testSecondaryIndexBinarySearch() throws IOException {
+    int numTotalKeys = 99;
+    assertTrue(numTotalKeys % 2 == 1); // Ensure no one made this even.
+
+    // We only add odd-index keys into the array that we will binary-search.
+    int numSearchedKeys = (numTotalKeys - 1) / 2;
+
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    DataOutputStream dos = new DataOutputStream(baos);
+
+    dos.writeInt(numSearchedKeys);
+    int curAllEntriesSize = 0;
+    int numEntriesAdded = 0;
+
+    // Only odd-index elements of this array are used to keep the secondary
+    // index entries of the corresponding keys.
+    int secondaryIndexEntries[] = new int[numTotalKeys];
+
+    for (int i = 0; i < numTotalKeys; ++i) {
+      byte[] k = RandomKeyValueUtil.randomOrderedKey(RNG, i * 2);
+      KeyValue cell = new KeyValue(k, Bytes.toBytes("f"), Bytes.toBytes("q"), Bytes.toBytes("val"));
+      // KeyValue cell = new KeyValue.KeyOnlyKeyValue(k, 0, k.length);
+      keys.add(cell.getKey());
+      String msgPrefix = "Key #" + i + " (" + Bytes.toStringBinary(k) + "): ";
+      StringBuilder padding = new StringBuilder();
+      while (msgPrefix.length() + padding.length() < 70) {
+        padding.append(' ');
+      }
+      msgPrefix += padding;
+      if (i % 2 == 1) {
+        dos.writeInt(curAllEntriesSize);
+        secondaryIndexEntries[i] = curAllEntriesSize;
+        LOG.info(
+          msgPrefix + "secondary index entry #" + ((i - 1) / 2) + ", offset " + curAllEntriesSize);
+        curAllEntriesSize += cell.getKey().length + HFileBlockIndex.SECONDARY_INDEX_ENTRY_OVERHEAD;
+        ++numEntriesAdded;
+      } else {
+        secondaryIndexEntries[i] = -1;
+        LOG.info(msgPrefix + "not in the searched array");
+      }
+    }
+
+    // Make sure the keys are increasing.
+    for (int i = 0; i < keys.size() - 1; ++i) {
+      assertTrue(CellComparatorImpl.COMPARATOR.compare(
+        new KeyValue.KeyOnlyKeyValue(keys.get(i), 0, keys.get(i).length),
+        new KeyValue.KeyOnlyKeyValue(keys.get(i + 1), 0, keys.get(i + 1).length)) < 0);
+    }
+
+    dos.writeInt(curAllEntriesSize);
+    assertEquals(numSearchedKeys, numEntriesAdded);
+    int secondaryIndexOffset = dos.size();
+    assertEquals(Bytes.SIZEOF_INT * (numSearchedKeys + 2), secondaryIndexOffset);
+
+    for (int i = 1; i <= numTotalKeys - 1; i += 2) {
+      assertEquals(dos.size(), secondaryIndexOffset + secondaryIndexEntries[i]);
+      long dummyFileOffset = getDummyFileOffset(i);
+      int dummyOnDiskSize = getDummyOnDiskSize(i);
+      LOG.debug("Storing file offset=" + dummyFileOffset + " and onDiskSize=" + dummyOnDiskSize
+        + " at offset " + dos.size());
+      dos.writeLong(dummyFileOffset);
+      dos.writeInt(dummyOnDiskSize);
+      LOG.debug("Stored key " + ((i - 1) / 2) + " at offset " + dos.size());
+      dos.write(keys.get(i));
+    }
+
+    dos.writeInt(curAllEntriesSize);
+
+    ByteBuffer nonRootIndex = ByteBuffer.wrap(baos.toByteArray());
+    for (int i = 0; i < numTotalKeys; ++i) {
+      byte[] searchKey = keys.get(i);
+      byte[] arrayHoldingKey = new byte[searchKey.length + searchKey.length / 2];
+
+      // To make things a bit more interesting, store the key we are looking
+      // for at a non-zero offset in a new array.
+      System.arraycopy(searchKey, 0, arrayHoldingKey, searchKey.length / 2, searchKey.length);
+
+      KeyValue.KeyOnlyKeyValue cell =
+        new KeyValue.KeyOnlyKeyValue(arrayHoldingKey, searchKey.length / 2, searchKey.length);
+      int searchResult = BlockIndexReader.binarySearchNonRootIndex(cell,
+        new MultiByteBuff(nonRootIndex), CellComparatorImpl.COMPARATOR);
+      String lookupFailureMsg =
+        "Failed to look up key #" + i + " (" + Bytes.toStringBinary(searchKey) + ")";
+
+      int expectedResult;
+      int referenceItem;
+
+      if (i % 2 == 1) {
+        // This key is in the array we search as the element (i - 1) / 2. Make
+        // sure we find it.
+        expectedResult = (i - 1) / 2;
+        referenceItem = i;
+      } else {
+        // This key is not in the array but between two elements on the array,
+        // in the beginning, or in the end. The result should be the previous
+        // key in the searched array, or -1 for i = 0.
+        expectedResult = i / 2 - 1;
+        referenceItem = i - 1;
+      }
+
+      assertEquals(lookupFailureMsg, expectedResult, searchResult);
+
+      // Now test we can get the offset and the on-disk-size using a
+      // higher-level API function.s
+      boolean locateBlockResult =
+        (BlockIndexReader.locateNonRootIndexEntry(new MultiByteBuff(nonRootIndex), cell,
+          CellComparatorImpl.COMPARATOR) != -1);
+
+      if (i == 0) {
+        assertFalse(locateBlockResult);
+      } else {
+        assertTrue(locateBlockResult);
+        String errorMsg = "i=" + i + ", position=" + nonRootIndex.position();
+        assertEquals(errorMsg, getDummyFileOffset(referenceItem), nonRootIndex.getLong());
+        assertEquals(errorMsg, getDummyOnDiskSize(referenceItem), nonRootIndex.getInt());
+      }
+    }
+  }
+
+  @Test
+  public void testBlockIndexChunk() throws IOException {
+    BlockIndexChunk c = new HFileBlockIndex.BlockIndexChunkImpl();
+    HFileIndexBlockEncoder indexBlockEncoder = NoOpIndexBlockEncoder.INSTANCE;
+    ByteArrayOutputStream baos = new ByteArrayOutputStream();
+    int N = 1000;
+    int[] numSubEntriesAt = new int[N];
+    int numSubEntries = 0;
+    for (int i = 0; i < N; ++i) {
+      baos.reset();
+      DataOutputStream dos = new DataOutputStream(baos);
+      indexBlockEncoder.encode(c, false, dos);
+      assertEquals(c.getNonRootSize(), dos.size());
+
+      baos.reset();
+      dos = new DataOutputStream(baos);
+      indexBlockEncoder.encode(c, true, dos);
+      assertEquals(c.getRootSize(), dos.size());
+
+      byte[] k = RandomKeyValueUtil.randomOrderedKey(RNG, i);
+      numSubEntries += RNG.nextInt(5) + 1;
+      numSubEntriesAt[i] = numSubEntries;
+      keys.add(k);
+      c.add(k, getDummyFileOffset(i), getDummyOnDiskSize(i), numSubEntries);
+    }
+
+    // Test the ability to look up the entry that contains a particular
+    // deeper-level index block's entry ("sub-entry"), assuming a global
+    // 0-based ordering of sub-entries. This is needed for mid-key calculation.
+    for (int i = 0; i < N; ++i) {
+      for (int j = i == 0 ? 0 : numSubEntriesAt[i - 1]; j < numSubEntriesAt[i]; ++j) {
+        assertEquals(i, c.getEntryBySubEntry(j));
+      }
+    }
+  }
+
+  /** Checks if the HeapSize calculator is within reason */
+  @Test
+  public void testHeapSizeForBlockIndex() throws IOException {
+    Class<HFileBlockIndex.BlockIndexReader> cl = HFileBlockIndex.BlockIndexReader.class;
+    long expected = ClassSize.estimateBase(cl, false);
+
+    HFileBlockIndex.BlockIndexReader bi = new HFileBlockIndex.ByteArrayKeyBlockIndexReader(1);
+    long actual = bi.heapSize();
+
+    // Since the arrays in BlockIndex(byte [][] blockKeys, long [] blockOffsets,
+    // int [] blockDataSizes) are all null they are not going to show up in the
+    // HeapSize calculation, so need to remove those array costs from expected.
+    // Already the block keys are not there in this case
+    expected -= ClassSize.align(2 * ClassSize.ARRAY);
+
+    if (expected != actual) {
+      expected = ClassSize.estimateBase(cl, true);
+      assertEquals(expected, actual);
+    }
+  }
+
+  /**
+   * to check if looks good when midKey on a leaf index block boundary
+   */
+  @Test
+  public void testMidKeyOnLeafIndexBlockBoundary() throws IOException {
+    Path hfilePath = new Path(TEST_UTIL.getDataTestDir(), "hfile_v4_for_midkey");
+    int maxChunkSize = 512;
+    conf.setInt(HFileBlockIndex.MAX_CHUNK_SIZE_KEY, maxChunkSize);
+    // should open hfile.block.index.cacheonwrite
+    conf.setBoolean(CacheConfig.CACHE_INDEX_BLOCKS_ON_WRITE_KEY, true);
+    CacheConfig cacheConf = new CacheConfig(conf, BlockCacheFactory.createBlockCache(conf));
+    BlockCache blockCache = cacheConf.getBlockCache().get();
+    // Evict all blocks that were cached-on-write by the previous invocation.
+    blockCache.evictBlocksByHfileName(hfilePath.getName());
+    // Write the HFile
+    HFileContext meta = new HFileContextBuilder().withBlockSize(SMALL_BLOCK_SIZE)
+      .withCompression(Algorithm.NONE).withDataBlockEncoding(DataBlockEncoding.NONE).build();
+    HFile.Writer writer = HFile.getWriterFactory(conf, cacheConf).withPath(fs, hfilePath)
+      .withFileContext(meta).create();
+    Random rand = new Random(19231737);
+    byte[] family = Bytes.toBytes("f");
+    byte[] qualifier = Bytes.toBytes("q");
+    int kvNumberToBeWritten = 16;
+    // the new generated hfile will contain 2 leaf-index blocks and 16 data blocks,
+    // midkey is just on the boundary of the first leaf-index block
+    for (int i = 0; i < kvNumberToBeWritten; ++i) {
+      byte[] row = RandomKeyValueUtil.randomOrderedFixedLengthKey(rand, i, 30);
+
+      // Key will be interpreted by KeyValue.KEY_COMPARATOR
+      KeyValue kv = new KeyValue(row, family, qualifier, EnvironmentEdgeManager.currentTime(),
+        RandomKeyValueUtil.randomFixedLengthValue(rand, SMALL_BLOCK_SIZE));
+      writer.append(kv);
+    }
+    writer.close();
+
+    // close hfile.block.index.cacheonwrite
+    conf.setBoolean(CacheConfig.CACHE_INDEX_BLOCKS_ON_WRITE_KEY, false);
+
+    // Read the HFile
+    HFile.Reader reader = HFile.createReader(fs, hfilePath, cacheConf, true, conf);
+
+    assertEquals(HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT, reader.getTrailer().getMajorVersion());
+
+    boolean hasArrayIndexOutOfBoundsException = false;
+    try {
+      // get the mid-key.
+      reader.midKey();
+    } catch (ArrayIndexOutOfBoundsException e) {
+      hasArrayIndexOutOfBoundsException = true;
+    } finally {
+      reader.close();
+    }
+
+    // to check if ArrayIndexOutOfBoundsException occurred
+    assertFalse(hasArrayIndexOutOfBoundsException);
+  }
+
+  /**
+   * Testing block index through the HFile writer/reader APIs. Allows to test setting index block
+   * size through configuration, intermediate-level index blocks, and caching index blocks on write.
+   * <p>
+   * For v4 files, the v3 block index lives inside the single embedded section, so we validate using
+   * that section reader.
+   */
+  @Test
+  public void testHFileWriterAndReader() throws IOException {
+    Path hfilePath = new Path(TEST_UTIL.getDataTestDir(), "hfile_v4_for_block_index");
+    CacheConfig cacheConf = new CacheConfig(conf, BlockCacheFactory.createBlockCache(conf));
+    BlockCache blockCache = cacheConf.getBlockCache().get();
+
+    for (int testI = 0; testI < INDEX_CHUNK_SIZES.length; ++testI) {
+      int indexBlockSize = INDEX_CHUNK_SIZES[testI];
+      int expectedNumLevels = EXPECTED_NUM_LEVELS[testI];
+      LOG.info("Index block size: " + indexBlockSize + ", compression: " + compr);
+      // Evict all blocks that were cached-on-write by the previous invocation.
+      blockCache.evictBlocksByHfileName(hfilePath.getName());
+
+      conf.setInt(HFileBlockIndex.MAX_CHUNK_SIZE_KEY, indexBlockSize);
+      byte[][] keys = new byte[NUM_KV][];
+      byte[][] values = new byte[NUM_KV][];
+
+      // Write the HFile (v4 container; single section v3 inside)
+      {
+        HFileContext meta =
+          new HFileContextBuilder().withBlockSize(SMALL_BLOCK_SIZE).withCompression(compr).build();
+        HFile.Writer writer = HFile.getWriterFactory(conf, cacheConf).withPath(fs, hfilePath)
+          .withFileContext(meta).create();
+        Random rand = new Random(19231737);
+        byte[] family = Bytes.toBytes("f");
+        byte[] qualifier = Bytes.toBytes("q");
+        for (int i = 0; i < NUM_KV; ++i) {
+          byte[] row = RandomKeyValueUtil.randomOrderedKey(rand, i);
+
+          // Key will be interpreted by KeyValue.KEY_COMPARATOR
+          KeyValue kv = new KeyValue(row, family, qualifier, EnvironmentEdgeManager.currentTime(),
+            RandomKeyValueUtil.randomValue(rand));
+          byte[] k = kv.getKey();
+          writer.append(kv);
+          keys[i] = k;
+          values[i] = CellUtil.cloneValue(kv);
+        }
+
+        writer.close();
+      }
+
+      // Read the HFile and validate the embedded v3 section index behavior.
+      try (AbstractMultiTenantReader mtReader =
+        (AbstractMultiTenantReader) HFile.createReader(fs, hfilePath, cacheConf, true, conf)) {
+        assertEquals(HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT,
+          mtReader.getTrailer().getMajorVersion());
+        byte[][] sectionIds = mtReader.getAllTenantSectionIds();
+        assertEquals(1, sectionIds.length);
+
+        try (AbstractMultiTenantReader.SectionReaderLease lease =
+          mtReader.getSectionReader(sectionIds[0])) {
+          HFileReaderImpl reader = lease.getReader();
+
+          assertEquals(3, reader.getTrailer().getMajorVersion());
+          assertEquals(expectedNumLevels, reader.getTrailer().getNumDataIndexLevels());
+
+          assertTrue(Bytes.equals(keys[0], ((KeyValue) reader.getFirstKey().get()).getKey()));
+          assertTrue(
+            Bytes.equals(keys[NUM_KV - 1], ((KeyValue) reader.getLastKey().get()).getKey()));
+          LOG.info("Last key: " + Bytes.toStringBinary(keys[NUM_KV - 1]));
+
+          for (boolean pread : new boolean[] { false, true }) {
+            HFileScanner scanner = reader.getScanner(conf, true, pread);
+            for (int i = 0; i < NUM_KV; ++i) {
+              checkSeekTo(keys, scanner, i);
+              checkKeyValue("i=" + i, keys[i], values[i],
+                ByteBuffer.wrap(((KeyValue) scanner.getKey()).getKey()), scanner.getValue());
+            }
+            assertTrue(scanner.seekTo());
+            for (int i = NUM_KV - 1; i >= 0; --i) {
+              checkSeekTo(keys, scanner, i);
+              checkKeyValue("i=" + i, keys[i], values[i],
+                ByteBuffer.wrap(((KeyValue) scanner.getKey()).getKey()), scanner.getValue());
+            }
+          }
+
+          // Manually compute the mid-key and validate it (same logic as v3 test).
+          HFile.Reader reader2 = reader;
+          HFileBlock.FSReader fsReader = reader2.getUncachedBlockReader();
+
+          HFileBlock.BlockIterator iter =
+            fsReader.blockRange(0, reader.getTrailer().getLoadOnOpenDataOffset());
+          HFileBlock block;
+          List<byte[]> blockKeys = new ArrayList<>();
+          while ((block = iter.nextBlock()) != null) {
+            if (block.getBlockType() != BlockType.LEAF_INDEX) {
+              return;
+            }
+            org.apache.hadoop.hbase.nio.ByteBuff b = block.getBufferReadOnly();
+            int n = b.getIntAfterPosition(0);
+            // One int for the number of items, and n + 1 for the secondary index.
+            int entriesOffset = Bytes.SIZEOF_INT * (n + 2);
+
+            // Get all the keys from the leaf index block.
+            for (int i = 0; i < n; ++i) {
+              int keyRelOffset = b.getIntAfterPosition(Bytes.SIZEOF_INT * (i + 1));
+              int nextKeyRelOffset = b.getIntAfterPosition(Bytes.SIZEOF_INT * (i + 2));
+              int keyLen = nextKeyRelOffset - keyRelOffset;
+              int keyOffset = b.arrayOffset() + entriesOffset + keyRelOffset
+                + HFileBlockIndex.SECONDARY_INDEX_ENTRY_OVERHEAD;
+              byte[] blockKey = Arrays.copyOfRange(b.array(), keyOffset, keyOffset + keyLen);
+              blockKeys.add(blockKey);
+            }
+          }
+
+          // Validate the mid-key (note: the v3 test does not dereference Optional here).
+          assertEquals(Bytes.toStringBinary(blockKeys.get((blockKeys.size() - 1) / 2)),
+            reader.midKey());
+
+          assertEquals(UNCOMPRESSED_INDEX_SIZES[testI],
+            reader.getTrailer().getUncompressedDataIndexSize());
+        }
+      }
+    }
+  }
+
+  private void checkSeekTo(byte[][] keys, HFileScanner scanner, int i) throws IOException {
+    assertEquals("Failed to seek to key #" + i + " (" + Bytes.toStringBinary(keys[i]) + ")", 0,
+      scanner.seekTo(KeyValueUtil.createKeyValueFromKey(keys[i])));
+  }
+
+  private void assertArrayEqualsBuffer(String msgPrefix, byte[] arr, ByteBuffer buf) {
+    assertEquals(
+      msgPrefix + ": expected " + Bytes.toStringBinary(arr) + ", actual "
+        + Bytes.toStringBinary(buf),
+      0, Bytes.compareTo(arr, 0, arr.length, buf.array(), buf.arrayOffset(), buf.limit()));
+  }
+
+  /** Check a key/value pair after it was read by the reader */
+  private void checkKeyValue(String msgPrefix, byte[] expectedKey, byte[] expectedValue,
+    ByteBuffer keyRead, ByteBuffer valueRead) {
+    if (!msgPrefix.isEmpty()) {
+      msgPrefix += ". ";
+    }
+
+    assertArrayEqualsBuffer(msgPrefix + "Invalid key", expectedKey, keyRead);
+    assertArrayEqualsBuffer(msgPrefix + "Invalid value", expectedValue, valueRead);
+  }
+
+  @Test
+  public void testIntermediateLevelIndicesWithLargeKeys() throws IOException {
+    testIntermediateLevelIndicesWithLargeKeys(16);
+  }
+
+  @Test
+  public void testIntermediateLevelIndicesWithLargeKeysWithMinNumEntries() throws IOException {
+    // because of the large rowKeys, we will end up with a 50-level block index without sanity check
+    testIntermediateLevelIndicesWithLargeKeys(2);
+  }
+
+  public void testIntermediateLevelIndicesWithLargeKeys(int minNumEntries) throws IOException {
+    Path hfPath =
+      new Path(TEST_UTIL.getDataTestDir(), "testIntermediateLevelIndicesWithLargeKeys_v4.hfile");
+    int maxChunkSize = 1024;
+    FileSystem fs = FileSystem.get(conf);
+    CacheConfig cacheConf = new CacheConfig(conf);
+    conf.setInt(HFileBlockIndex.MAX_CHUNK_SIZE_KEY, maxChunkSize);
+    conf.setInt(HFileBlockIndex.MIN_INDEX_NUM_ENTRIES_KEY, minNumEntries);
+    HFileContext context = new HFileContextBuilder().withBlockSize(16).build();
+    HFile.Writer hfw = HFile.getWriterFactory(conf, cacheConf).withFileContext(context)
+      .withPath(fs, hfPath).create();
+    List<byte[]> keys = new ArrayList<>();
+
+    // This should result in leaf-level indices and a root level index
+    for (int i = 0; i < 100; i++) {
+      byte[] rowkey = new byte[maxChunkSize + 1];
+      byte[] b = Bytes.toBytes(i);
+      System.arraycopy(b, 0, rowkey, rowkey.length - b.length, b.length);
+      keys.add(rowkey);
+      hfw.append(ExtendedCellBuilderFactory.create(CellBuilderType.DEEP_COPY).setRow(rowkey)
+        .setFamily(HConstants.EMPTY_BYTE_ARRAY).setQualifier(HConstants.EMPTY_BYTE_ARRAY)
+        .setTimestamp(HConstants.LATEST_TIMESTAMP).setType(KeyValue.Type.Maximum.getCode())
+        .setValue(HConstants.EMPTY_BYTE_ARRAY).build());
+    }
+    hfw.close();
+
+    HFile.Reader reader = HFile.createReader(fs, hfPath, cacheConf, true, conf);
+    assertEquals(HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT, reader.getTrailer().getMajorVersion());
+    // Scanner doesn't do Cells yet. Fix.
+    HFileScanner scanner = reader.getScanner(conf, true, true);
+    for (int i = 0; i < keys.size(); ++i) {
+      scanner.seekTo(ExtendedCellBuilderFactory.create(CellBuilderType.DEEP_COPY)
+        .setRow(keys.get(i)).setFamily(HConstants.EMPTY_BYTE_ARRAY)
+        .setQualifier(HConstants.EMPTY_BYTE_ARRAY).setTimestamp(HConstants.LATEST_TIMESTAMP)
+        .setType(KeyValue.Type.Maximum.getCode()).setValue(HConstants.EMPTY_BYTE_ARRAY).build());
+    }
+    reader.close();
+  }
+
+  /**
+   * This test is for HBASE-27940, which midkey metadata in root index block would always be ignored
+   * by {@link BlockIndexReader#readMultiLevelIndexRoot}.
+   * <p>
+   * For v4, we validate the embedded v3 section's root index block.
+   */
+  @Test
+  public void testMidKeyReadSuccessfullyFromRootIndexBlock() throws IOException {
+    conf.setInt(HFileBlockIndex.MAX_CHUNK_SIZE_KEY, 128);
+    Path hfilePath =
+      new Path(TEST_UTIL.getDataTestDir(), "testMidKeyReadSuccessfullyFromRootIndexBlock_v4");
+    Compression.Algorithm compressAlgo = Compression.Algorithm.NONE;
+    int entryCount = 50000;
+    HFileContext context = new HFileContextBuilder().withBlockSize(4096).withIncludesTags(false)
+      .withDataBlockEncoding(DataBlockEncoding.NONE).withCompression(compressAlgo).build();
+
+    try (HFile.Writer writer = HFile.getWriterFactory(conf, new CacheConfig(conf))
+      .withPath(fs, hfilePath).withFileContext(context).create()) {
+
+      List<KeyValue> keyValues = new ArrayList<>(entryCount);
+      for (int i = 0; i < entryCount; ++i) {
+        byte[] keyBytes = RandomKeyValueUtil.randomOrderedKey(RNG, i);
+        // A random-length random value.
+        byte[] valueBytes = RandomKeyValueUtil.randomValue(RNG);
+        KeyValue keyValue =
+          new KeyValue(keyBytes, null, null, HConstants.LATEST_TIMESTAMP, valueBytes);
+        writer.append(keyValue);
+        keyValues.add(keyValue);
+      }
+    }
+
+    try (AbstractMultiTenantReader mtReader = (AbstractMultiTenantReader) HFile.createReader(fs,
+      hfilePath, new CacheConfig(conf), true, conf)) {
+      assertEquals(HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT,
+        mtReader.getTrailer().getMajorVersion());
+      byte[][] sectionIds = mtReader.getAllTenantSectionIds();
+      assertEquals(1, sectionIds.length);
+
+      try (AbstractMultiTenantReader.SectionReaderLease lease =
+        mtReader.getSectionReader(sectionIds[0])) {
+        HFileReaderImpl sectionReader = lease.getReader();
+        FixedFileTrailer trailer = sectionReader.getTrailer();
+
+        assertEquals(3, trailer.getMajorVersion());
+        assertEquals(entryCount, trailer.getEntryCount());
+
+        HFileBlock.FSReader blockReader = sectionReader.getUncachedBlockReader();
+
+        MyEncoder encoder = new MyEncoder();
+        HFileBlockIndex.CellBasedKeyBlockIndexReaderV2 dataBlockIndexReader =
+          new HFileBlockIndex.CellBasedKeyBlockIndexReaderV2(trailer.createComparator(),
+            trailer.getNumDataIndexLevels(), encoder);
+
+        long fileSize = sectionReader.length();
+        HFileBlock.BlockIterator blockIter = blockReader
+          .blockRange(trailer.getLoadOnOpenDataOffset(), fileSize - trailer.getTrailerSize());
+        dataBlockIndexReader.readMultiLevelIndexRoot(
+          blockIter.nextBlockWithBlockType(BlockType.ROOT_INDEX), trailer.getDataIndexCount());
+
+        NoOpEncodedSeeker noOpEncodedSeeker = (NoOpEncodedSeeker) encoder.encoderSeeker;
+        // Assert we have read midkey metadata successfully.
+        assertTrue(noOpEncodedSeeker.midLeafBlockOffset >= 0);
+        assertTrue(noOpEncodedSeeker.midLeafBlockOnDiskSize > 0);
+        assertTrue(noOpEncodedSeeker.midKeyEntry >= 0);
+      }
+    }
+  }
+
+  static class MyEncoder implements HFileIndexBlockEncoder {
+
+    EncodedSeeker encoderSeeker;
+
+    @Override
+    public void saveMetadata(Writer writer) throws IOException {
+      NoOpIndexBlockEncoder.INSTANCE.saveMetadata(writer);
+    }
+
+    @Override
+    public void encode(BlockIndexChunk blockIndexChunk, boolean rootIndexBlock, DataOutput out)
+      throws IOException {
+      NoOpIndexBlockEncoder.INSTANCE.encode(blockIndexChunk, rootIndexBlock, out);
+    }
+
+    @Override
+    public IndexBlockEncoding getIndexBlockEncoding() {
+      return NoOpIndexBlockEncoder.INSTANCE.getIndexBlockEncoding();
+    }
+
+    @Override
+    public EncodedSeeker createSeeker() {
+      encoderSeeker = NoOpIndexBlockEncoder.INSTANCE.createSeeker();
+      return encoderSeeker;
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileV4PrettyPrinter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileV4PrettyPrinter.java
@@ -1,0 +1,258 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.ByteArrayOutputStream;
+import java.io.PrintStream;
+import java.util.ArrayList;
+import java.util.List;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.testclassification.IOTests;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests for HFilePrettyPrinter with HFile v4 multi-tenant features. This test validates that the
+ * pretty printer correctly handles v4 HFiles with multi-tenant capabilities including tenant
+ * information display, tenant-aware block analysis, and comprehensive output formatting.
+ */
+@Category({ IOTests.class, MediumTests.class })
+public class TestHFileV4PrettyPrinter {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestHFileV4PrettyPrinter.class);
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestHFileV4PrettyPrinter.class);
+
+  private static final HBaseTestingUtility UTIL = new HBaseTestingUtility();
+  private static final int TENANT_PREFIX_LENGTH = 3;
+  private static final String[] TENANTS = { "T01", "T02", "T03" };
+  private static final int TEST_TIMEOUT_MS = 120000; // 2 minutes
+
+  private static FileSystem fs;
+  private static Configuration conf;
+  private static final byte[] cf = Bytes.toBytes("cf");
+  private static final byte[] fam = Bytes.toBytes("fam");
+  private static PrintStream original;
+  private static PrintStream ps;
+  private static ByteArrayOutputStream stream;
+
+  @Before
+  public void setup() throws Exception {
+    conf = UTIL.getConfiguration();
+
+    // Configure HFile v4 multi-tenant settings
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    conf.setInt(MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, TENANT_PREFIX_LENGTH);
+
+    // Runs on local filesystem. Test does not need sync. Turn off checks.
+    conf.setBoolean(CommonFSUtils.UNSAFE_STREAM_CAPABILITY_ENFORCE, false);
+
+    // Start mini cluster for v4 HFile creation
+    UTIL.startMiniCluster(1);
+
+    fs = UTIL.getTestFileSystem();
+    stream = new ByteArrayOutputStream();
+    ps = new PrintStream(stream);
+    original = System.out;
+
+    LOG.info("Setup complete with HFile v4 configuration");
+  }
+
+  @After
+  public void teardown() throws Exception {
+    System.setOut(original);
+    if (UTIL != null) {
+      UTIL.shutdownMiniCluster();
+    }
+  }
+
+  /**
+   * Create a v4 multi-tenant HFile with test data.
+   */
+  private Path createV4HFile(String testName, int rowCount) throws Exception {
+    TableName tableName = TableName.valueOf(testName + "_" + System.currentTimeMillis());
+
+    try (Admin admin = UTIL.getAdmin()) {
+      // Create table with multi-tenant configuration
+      TableDescriptorBuilder tableBuilder = TableDescriptorBuilder.newBuilder(tableName);
+
+      // Set multi-tenant properties
+      tableBuilder.setValue(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH,
+        String.valueOf(TENANT_PREFIX_LENGTH));
+      tableBuilder.setValue(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+
+      // Configure column family for HFile v4
+      ColumnFamilyDescriptorBuilder cfBuilder = ColumnFamilyDescriptorBuilder.newBuilder(cf);
+      cfBuilder.setValue(HFile.FORMAT_VERSION_KEY,
+        String.valueOf(HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT));
+      tableBuilder.setColumnFamily(cfBuilder.build());
+
+      admin.createTable(tableBuilder.build());
+      UTIL.waitTableAvailable(tableName);
+
+      // Write test data with tenant prefixes
+      try (Connection connection = ConnectionFactory.createConnection(conf);
+        Table table = connection.getTable(tableName)) {
+
+        List<Put> puts = new ArrayList<>();
+        int rowsPerTenant = rowCount / TENANTS.length;
+
+        for (String tenantId : TENANTS) {
+          for (int i = 0; i < rowsPerTenant; i++) {
+            String rowKey = String.format("%srow%03d", tenantId, i);
+            Put put = new Put(Bytes.toBytes(rowKey));
+            String cellValue = String.format("value_tenant-%s_row-%03d", tenantId, i);
+            put.addColumn(cf, fam, Bytes.toBytes(cellValue));
+            puts.add(put);
+          }
+        }
+
+        table.put(puts);
+        LOG.info("Wrote {} rows to v4 multi-tenant table {}", puts.size(), tableName);
+      }
+
+      // Flush to create HFile v4
+      UTIL.flush(tableName);
+      Thread.sleep(1000); // Wait for flush to complete
+
+      // Find the created HFile
+      List<Path> hfiles =
+        UTIL.getHBaseCluster().getRegions(tableName).get(0).getStore(cf).getStorefiles().stream()
+          .map(sf -> sf.getPath()).collect(java.util.stream.Collectors.toList());
+
+      assertTrue("Should have created at least one HFile", !hfiles.isEmpty());
+      Path originalHfilePath = hfiles.get(0);
+
+      LOG.info("Found original v4 HFile: {}", originalHfilePath);
+
+      // Copy HFile to test data directory before table cleanup
+      Path testDataDir = UTIL.getDataTestDir(testName);
+      Path copiedHfilePath = new Path(testDataDir, "hfile_v4_" + System.currentTimeMillis());
+
+      // Use FileUtil to copy the file
+      org.apache.hadoop.fs.FileUtil.copy(fs, originalHfilePath, fs, copiedHfilePath, false, conf);
+
+      LOG.info("Copied v4 HFile from {} to {}", originalHfilePath, copiedHfilePath);
+
+      // Verify the copied file is actually v4
+      try (HFile.Reader reader =
+        HFile.createReader(fs, copiedHfilePath, CacheConfig.DISABLED, true, conf)) {
+        int version = reader.getTrailer().getMajorVersion();
+        assertEquals("Should be HFile v4", HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT, version);
+        LOG.info("Verified copied HFile v4 format: version {}", version);
+      }
+
+      // Clean up table (original HFiles will be deleted but our copy is safe)
+      admin.disableTable(tableName);
+      admin.deleteTable(tableName);
+
+      return copiedHfilePath;
+    }
+  }
+
+  /**
+   * Comprehensive test for HFilePrettyPrinter with HFile v4 multi-tenant features. This test
+   * validates: - HFile v4 format detection and verification - All command-line options
+   * functionality (-m, -p, -v, -t, -b, -h, -s, -d) - Multi-tenant specific output including tenant
+   * information - Tenant boundary detection and display - Block-level analysis with v4 multi-tenant
+   * structure - Key/value pair display with tenant context
+   */
+  @Test(timeout = TEST_TIMEOUT_MS)
+  public void testComprehensiveV4Output() throws Exception {
+    Path testFile = createV4HFile("hfile_comprehensive_v4", 90);
+
+    // First, verify the created file is actually v4 format (version detection)
+    try (HFile.Reader reader = HFile.createReader(fs, testFile, CacheConfig.DISABLED, true, conf)) {
+      int majorVersion = reader.getTrailer().getMajorVersion();
+      LOG.info("Detected HFile version: {} (v4 threshold: {})", majorVersion,
+        HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+      assertTrue("Test file should be v4",
+        majorVersion == HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    }
+
+    System.setOut(ps);
+    HFilePrettyPrinter printer = new HFilePrettyPrinter(conf);
+
+    LOG.info("=== COMPREHENSIVE HFILE V4 OUTPUT TEST ===");
+    LOG.info("Testing file: {}", testFile);
+
+    // Run with ALL possible options for comprehensive output
+    printer.run(new String[] { "-m", // metadata
+      "-p", // print key/value pairs
+      "-v", // verbose
+      "-t", // tenant info (v4 specific)
+      "-b", // block index
+      "-h", // block headers
+      "-s", // statistics/histograms
+      "-d", // detailed output
+      "-f", testFile.toString() });
+
+    String comprehensiveResult = stream.toString();
+
+    LOG.info("=== FULL HFILE V4 COMPREHENSIVE OUTPUT START ===");
+    LOG.info("\n{}", comprehensiveResult);
+    LOG.info("=== FULL HFILE V4 COMPREHENSIVE OUTPUT END ===");
+
+    // Verify all expected sections are present
+    assertTrue("Should contain trailer information", comprehensiveResult.contains("Trailer:"));
+    assertTrue("Should contain file info", comprehensiveResult.contains("Fileinfo:"));
+    assertTrue("Should contain v4-specific information",
+      comprehensiveResult.contains("HFile v4 Specific Information:"));
+    assertTrue("Should contain tenant information",
+      comprehensiveResult.contains("Tenant Information:"));
+    assertTrue("Should contain block index", comprehensiveResult.contains("Block Index:"));
+    assertTrue("Should contain block headers", comprehensiveResult.contains("Block Headers:"));
+    assertTrue("Should contain key/value pairs", comprehensiveResult.contains("K: "));
+    assertTrue("Should contain tenant boundaries",
+      comprehensiveResult.contains("--- Start of tenant section:")
+        || comprehensiveResult.contains("Scanning multi-tenant HFile v4"));
+
+    // Verify tenant-specific data is present
+    for (String tenant : TENANTS) {
+      assertTrue("Should contain data for tenant " + tenant,
+        comprehensiveResult.contains(tenant + "row"));
+    }
+
+    LOG.info("Comprehensive V4 test completed successfully");
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantConfigPrecedence.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantConfigPrecedence.java
@@ -1,0 +1,264 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileStatus;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseClassTestRule;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.Waiter;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Validates multi-tenant configuration precedence and enforces that column-family settings are
+ * ignored in favor of table/cluster scope.
+ */
+@Category(MediumTests.class)
+public class TestMultiTenantConfigPrecedence {
+
+  @ClassRule
+  public static final HBaseClassTestRule CLASS_RULE =
+    HBaseClassTestRule.forClass(TestMultiTenantConfigPrecedence.class);
+
+  private static final Logger LOG = LoggerFactory.getLogger(TestMultiTenantConfigPrecedence.class);
+
+  private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
+
+  private static final byte[] FAMILY = Bytes.toBytes("f");
+  private static final byte[] QUALIFIER = Bytes.toBytes("q");
+
+  private static final int CLUSTER_PREFIX_LENGTH = 2;
+  private static final int TABLE_PREFIX_LENGTH = 3;
+
+  private static final TableName TABLE_DISABLE_OVERRIDE =
+    TableName.valueOf("TestMultiTenantDisableOverride");
+  private static final TableName TABLE_PREFIX_OVERRIDE =
+    TableName.valueOf("TestMultiTenantPrefixOverride");
+  private static final TableName TABLE_CLUSTER_FALLBACK =
+    TableName.valueOf("TestMultiTenantClusterFallback");
+  private static final TableName TABLE_INVALID_PREFIX =
+    TableName.valueOf("TestMultiTenantInvalidPrefix");
+
+  @BeforeClass
+  public static void setUpBeforeClass() throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    conf.setInt(MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, CLUSTER_PREFIX_LENGTH);
+    conf.set(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+    TEST_UTIL.startMiniCluster(1);
+  }
+
+  @AfterClass
+  public static void tearDownAfterClass() throws Exception {
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test(timeout = 120000)
+  public void testTablePropertyDisablesMultiTenant() throws Exception {
+    createTable(TABLE_DISABLE_OVERRIDE, "false", String.valueOf(TABLE_PREFIX_LENGTH),
+      cfConfig(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true",
+        MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH, "5",
+        MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, "7"));
+
+    writeTenantRows(TABLE_DISABLE_OVERRIDE, new String[] { "AAA", "BBB" }, 3);
+    assertTenantConfiguration(TABLE_DISABLE_OVERRIDE, 0, 1);
+  }
+
+  @Test(timeout = 120000)
+  public void testTablePropertyOverridesClusterPrefixLength() throws Exception {
+    createTable(TABLE_PREFIX_OVERRIDE, "true", String.valueOf(TABLE_PREFIX_LENGTH),
+      cfConfig(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH, "1",
+        MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, "1"));
+
+    writeTenantRows(TABLE_PREFIX_OVERRIDE, new String[] { "T01", "T02", "T03" }, 2);
+    assertTenantConfiguration(TABLE_PREFIX_OVERRIDE, TABLE_PREFIX_LENGTH, 3);
+  }
+
+  @Test(timeout = 120000)
+  public void testClusterConfigUsedWhenTablePropertiesMissing() throws Exception {
+    createTable(TABLE_CLUSTER_FALLBACK, null, null,
+      cfConfig(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "false",
+        MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH, "9",
+        MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, "9"));
+
+    writeTenantRows(TABLE_CLUSTER_FALLBACK, new String[] { "AA", "BB" }, 3);
+    assertTenantConfiguration(TABLE_CLUSTER_FALLBACK, CLUSTER_PREFIX_LENGTH, 2);
+  }
+
+  @Test(timeout = 120000)
+  public void testInvalidTablePrefixLengthFallsBackToCluster() throws Exception {
+    createTable(TABLE_INVALID_PREFIX, "true", "not-a-number",
+      cfConfig(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH, "6",
+        MultiTenantHFileWriter.TENANT_PREFIX_LENGTH, "6"));
+
+    writeTenantRows(TABLE_INVALID_PREFIX, new String[] { "CC", "DD" }, 2);
+    assertTenantConfiguration(TABLE_INVALID_PREFIX, CLUSTER_PREFIX_LENGTH, 2);
+  }
+
+  private static void createTable(TableName tableName, String tableMultiTenantEnabled,
+    String tablePrefixLength, Map<String, String> cfConfiguration) throws IOException {
+    try (Admin admin = TEST_UTIL.getAdmin()) {
+      TableDescriptorBuilder tableBuilder = TableDescriptorBuilder.newBuilder(tableName);
+      ColumnFamilyDescriptorBuilder familyBuilder =
+        ColumnFamilyDescriptorBuilder.newBuilder(FAMILY);
+      if (cfConfiguration != null) {
+        for (Map.Entry<String, String> entry : cfConfiguration.entrySet()) {
+          familyBuilder.setConfiguration(entry.getKey(), entry.getValue());
+        }
+      }
+      tableBuilder.setColumnFamily(familyBuilder.build());
+      if (tableMultiTenantEnabled != null) {
+        tableBuilder.setValue(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED,
+          tableMultiTenantEnabled);
+      }
+      if (tablePrefixLength != null) {
+        tableBuilder.setValue(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH, tablePrefixLength);
+      }
+      admin.createTable(tableBuilder.build());
+    }
+    try {
+      TEST_UTIL.waitTableAvailable(tableName);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      throw new IOException("Interrupted waiting for table " + tableName, e);
+    }
+  }
+
+  private static Map<String, String> cfConfig(String... entries) {
+    Map<String, String> config = new HashMap<>();
+    if (entries == null) {
+      return config;
+    }
+    if (entries.length % 2 != 0) {
+      throw new IllegalArgumentException("cfConfig requires key/value pairs");
+    }
+    for (int i = 0; i < entries.length; i += 2) {
+      config.put(entries[i], entries[i + 1]);
+    }
+    return config;
+  }
+
+  private static void writeTenantRows(TableName tableName, String[] tenantPrefixes,
+    int rowsPerTenant) throws IOException {
+    List<Put> puts = new ArrayList<>();
+    for (String tenantPrefix : tenantPrefixes) {
+      for (int i = 0; i < rowsPerTenant; i++) {
+        String rowKey = tenantPrefix + "_row_" + i;
+        Put put = new Put(Bytes.toBytes(rowKey));
+        put.addColumn(FAMILY, QUALIFIER, Bytes.toBytes("v"));
+        puts.add(put);
+      }
+    }
+    try (Table table = TEST_UTIL.getConnection().getTable(tableName)) {
+      table.put(puts);
+    }
+    TEST_UTIL.flush(tableName);
+  }
+
+  private static void assertTenantConfiguration(TableName tableName, int expectedPrefixLength,
+    int expectedUniqueSections) throws Exception {
+    List<Path> hfiles = waitForHFiles(tableName);
+    assertFalse("No HFiles found for " + tableName, hfiles.isEmpty());
+
+    Set<String> sectionIds = new HashSet<>();
+    FileSystem fs = TEST_UTIL.getTestFileSystem();
+    Configuration conf = TEST_UTIL.getConfiguration();
+    CacheConfig cacheConfig = new CacheConfig(conf);
+    for (Path hfile : hfiles) {
+      try (HFile.Reader reader = HFile.createReader(fs, hfile, cacheConfig, true, conf)) {
+        assertEquals("HFile should be version 4", HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT,
+          reader.getTrailer().getMajorVersion());
+        assertTrue("Reader should be multi-tenant", reader instanceof AbstractMultiTenantReader);
+        assertEquals("Tenant prefix length mismatch for " + hfile, expectedPrefixLength,
+          reader.getTrailer().getTenantPrefixLength());
+
+        byte[][] tenantSections = ((AbstractMultiTenantReader) reader).getAllTenantSectionIds();
+        for (byte[] sectionId : tenantSections) {
+          sectionIds.add(Bytes.toStringBinary(sectionId));
+        }
+      }
+    }
+
+    assertEquals("Unexpected unique tenant section count for " + tableName, expectedUniqueSections,
+      sectionIds.size());
+  }
+
+  private static List<Path> waitForHFiles(TableName tableName) throws Exception {
+    Configuration conf = TEST_UTIL.getConfiguration();
+    Waiter.waitFor(conf, 30000, () -> !findHFiles(tableName).isEmpty());
+    return findHFiles(tableName);
+  }
+
+  private static List<Path> findHFiles(TableName tableName) throws IOException {
+    List<Path> hfiles = new ArrayList<>();
+    FileSystem fs = TEST_UTIL.getTestFileSystem();
+    Path rootDir = CommonFSUtils.getRootDir(TEST_UTIL.getConfiguration());
+    Path tableDir = CommonFSUtils.getTableDir(rootDir, tableName);
+    if (!fs.exists(tableDir)) {
+      return hfiles;
+    }
+
+    FileStatus[] regionDirs = fs.listStatus(tableDir);
+    for (FileStatus regionDir : regionDirs) {
+      if (!regionDir.isDirectory()) {
+        continue;
+      }
+      Path familyDir = new Path(regionDir.getPath(), Bytes.toString(FAMILY));
+      if (!fs.exists(familyDir)) {
+        continue;
+      }
+      for (FileStatus hfile : fs.listStatus(familyDir)) {
+        String name = hfile.getPath().getName();
+        if (name.startsWith(".") || name.endsWith(".tmp")) {
+          continue;
+        }
+        hfiles.add(hfile.getPath());
+      }
+    }
+    LOG.info("Found {} HFiles for {}", hfiles.size(), tableName);
+    return hfiles;
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantHFileIntegration.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantHFileIntegration.java
@@ -73,13 +73,13 @@ import org.slf4j.LoggerFactory;
  * access patterns (GET, SCAN, tenant-specific scans).
  */
 @Category(MediumTests.class)
-public class MultiTenantHFileIntegrationTest {
+public class TestMultiTenantHFileIntegration {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-    HBaseClassTestRule.forClass(MultiTenantHFileIntegrationTest.class);
+    HBaseClassTestRule.forClass(TestMultiTenantHFileIntegration.class);
 
-  private static final Logger LOG = LoggerFactory.getLogger(MultiTenantHFileIntegrationTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestMultiTenantHFileIntegration.class);
 
   private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantHFileMultiLevelIndex.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantHFileMultiLevelIndex.java
@@ -52,14 +52,14 @@ import org.slf4j.LoggerFactory;
  * forces a multi-level index by setting small chunk sizes and writing many tenants.
  */
 @Category(MediumTests.class)
-public class MultiTenantHFileMultiLevelIndexTest {
+public class TestMultiTenantHFileMultiLevelIndex {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-    HBaseClassTestRule.forClass(MultiTenantHFileMultiLevelIndexTest.class);
+    HBaseClassTestRule.forClass(TestMultiTenantHFileMultiLevelIndex.class);
 
   private static final Logger LOG =
-    LoggerFactory.getLogger(MultiTenantHFileMultiLevelIndexTest.class);
+    LoggerFactory.getLogger(TestMultiTenantHFileMultiLevelIndex.class);
 
   private static final HBaseTestingUtility TEST_UTIL = new HBaseTestingUtility();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantHFileSplitting.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantHFileSplitting.java
@@ -72,13 +72,13 @@ import org.slf4j.LoggerFactory;
  * </ol>
  */
 @Category(LargeTests.class)
-public class MultiTenantHFileSplittingTest {
+public class TestMultiTenantHFileSplitting {
 
   @ClassRule
   public static final HBaseClassTestRule CLASS_RULE =
-    HBaseClassTestRule.forClass(MultiTenantHFileSplittingTest.class);
+    HBaseClassTestRule.forClass(TestMultiTenantHFileSplitting.class);
 
-  private static final Logger LOG = LoggerFactory.getLogger(MultiTenantHFileSplittingTest.class);
+  private static final Logger LOG = LoggerFactory.getLogger(TestMultiTenantHFileSplitting.class);
 
   private HBaseTestingUtility testUtil;
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantScannerReseekTo.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantScannerReseekTo.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests for {@link AbstractMultiTenantReader.MultiTenantScanner#reseekTo} forward-only contract.
+ * <p>
+ * The reseekTo contract requires forward-only movement. When the scanner is positioned in section N
+ * and reseekTo targets a key in an earlier section, the scanner must NOT rewind — it should report
+ * "already past" and keep its current position.
+ */
+@Category(SmallTests.class)
+public class TestMultiTenantScannerReseekTo {
+
+  private static final byte[] CF = Bytes.toBytes("cf");
+  private static final byte[] QUAL = Bytes.toBytes("q");
+
+  private Path writeMultiTenantFile(Configuration conf, FileSystem fs, Path baseDir)
+    throws IOException {
+    Path file = StoreFileWriter.getUniqueFile(fs, baseDir);
+
+    CacheConfig cacheConfig = new CacheConfig(conf);
+    Map<String, String> tableProps = new HashMap<>();
+    tableProps.put(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+    tableProps.put(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH, "2");
+
+    HFileContext context = new HFileContextBuilder().withBlockSize(4096).withColumnFamily(CF)
+      .withTableName(Bytes.toBytes("tbl")).build();
+
+    MultiTenantHFileWriter writer = MultiTenantHFileWriter.create(fs, file, conf, cacheConfig,
+      tableProps, context, BloomType.ROW, BloomType.ROW, null, true);
+
+    long ts = EnvironmentEdgeManager.currentTime();
+
+    // Section "aa": 3 rows
+    writer.append(new KeyValue(Bytes.toBytes("aa-0001"), CF, QUAL, ts, Bytes.toBytes("v1")));
+    writer.append(new KeyValue(Bytes.toBytes("aa-0002"), CF, QUAL, ts, Bytes.toBytes("v2")));
+    writer.append(new KeyValue(Bytes.toBytes("aa-0003"), CF, QUAL, ts, Bytes.toBytes("v3")));
+
+    // Section "bb": 3 rows
+    writer.append(new KeyValue(Bytes.toBytes("bb-0001"), CF, QUAL, ts, Bytes.toBytes("v4")));
+    writer.append(new KeyValue(Bytes.toBytes("bb-0002"), CF, QUAL, ts, Bytes.toBytes("v5")));
+    writer.append(new KeyValue(Bytes.toBytes("bb-0003"), CF, QUAL, ts, Bytes.toBytes("v6")));
+
+    writer.close();
+    return file;
+  }
+
+  /**
+   * reseekTo with a key in an earlier section must not rewind. The scanner should stay in its
+   * current section and not move backward.
+   */
+  @Test
+  public void testReseekToDoesNotRewindToPreviousSection() throws Exception {
+    Configuration conf = HBaseConfiguration.create();
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    FileSystem fs = FileSystem.getLocal(conf);
+    Path baseDir = new Path(Files.createTempDirectory("reseekto-test").toUri());
+
+    try {
+      Path file = writeMultiTenantFile(conf, fs, baseDir);
+
+      try (HFile.Reader reader = HFile.createReader(fs, file, new CacheConfig(conf), true, conf)) {
+        HFileScanner scanner = reader.getScanner(conf, false, true);
+
+        // Position at start, then advance into section "bb"
+        assertTrue("seekTo start should succeed", scanner.seekTo());
+        while (Bytes.toString(CellUtil.cloneRow(scanner.getCell())).startsWith("aa")) {
+          assertTrue("next should succeed while in section aa", scanner.next());
+        }
+
+        String posBeforeReseek = Bytes.toString(CellUtil.cloneRow(scanner.getCell()));
+        assertTrue("Should be in section bb now", posBeforeReseek.startsWith("bb"));
+
+        // reseekTo a key in section "aa" — BEFORE current position
+        KeyValue aaKey = new KeyValue(Bytes.toBytes("aa-0001"), CF, QUAL,
+          EnvironmentEdgeManager.currentTime(), KeyValue.Type.Maximum);
+        int reseekResult = scanner.reseekTo(aaKey);
+
+        // Must return 1 (already past) and keep a valid position in section "bb"
+        assertEquals("reseekTo backward key should return 1 (already past)", 1, reseekResult);
+        assertTrue("Scanner should still be seeked after backward reseekTo",
+          scanner.getCell() != null);
+        String posAfterReseek = Bytes.toString(CellUtil.cloneRow(scanner.getCell()));
+        assertTrue("Scanner must not rewind to section aa, but was at: " + posAfterReseek,
+          posAfterReseek.startsWith("bb"));
+        assertEquals("Scanner should stay at original position", posBeforeReseek, posAfterReseek);
+      }
+    } finally {
+      fs.delete(baseDir, true);
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantScannerSeekBefore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestMultiTenantScannerSeekBefore.java
@@ -1,0 +1,190 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.regionserver.BloomType;
+import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+/**
+ * Tests for {@link AbstractMultiTenantReader.MultiTenantScanner#seekBefore} cross-section fallback.
+ * <p>
+ * When seekBefore targets a key at or before the first key of section N, the scanner must fall back
+ * to the last key of section N-1. Without this fallback, reverse scans and seekToPreviousRow miss
+ * data at tenant section boundaries.
+ */
+@Category(SmallTests.class)
+public class TestMultiTenantScannerSeekBefore {
+
+  private static final byte[] CF = Bytes.toBytes("cf");
+  private static final byte[] QUAL = Bytes.toBytes("q");
+
+  /**
+   * Writes a multi-tenant V4 HFile with two tenant sections ("aa" and "bb"), each containing
+   * several rows. Returns the file path.
+   */
+  private Path writeMultiTenantFile(Configuration conf, FileSystem fs, Path baseDir)
+    throws IOException {
+    Path file = StoreFileWriter.getUniqueFile(fs, baseDir);
+
+    CacheConfig cacheConfig = new CacheConfig(conf);
+    Map<String, String> tableProps = new HashMap<>();
+    tableProps.put(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+    tableProps.put(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH, "2");
+
+    HFileContext context = new HFileContextBuilder().withBlockSize(4096).withColumnFamily(CF)
+      .withTableName(Bytes.toBytes("tbl")).build();
+
+    MultiTenantHFileWriter writer = MultiTenantHFileWriter.create(fs, file, conf, cacheConfig,
+      tableProps, context, BloomType.ROW, BloomType.ROW, null, true);
+
+    long ts = EnvironmentEdgeManager.currentTime();
+
+    // Section "aa": 3 rows
+    writer.append(new KeyValue(Bytes.toBytes("aa-0001"), CF, QUAL, ts, Bytes.toBytes("v1")));
+    writer.append(new KeyValue(Bytes.toBytes("aa-0002"), CF, QUAL, ts, Bytes.toBytes("v2")));
+    writer.append(new KeyValue(Bytes.toBytes("aa-0003"), CF, QUAL, ts, Bytes.toBytes("v3")));
+
+    // Section "bb": 3 rows
+    writer.append(new KeyValue(Bytes.toBytes("bb-0001"), CF, QUAL, ts, Bytes.toBytes("v4")));
+    writer.append(new KeyValue(Bytes.toBytes("bb-0002"), CF, QUAL, ts, Bytes.toBytes("v5")));
+    writer.append(new KeyValue(Bytes.toBytes("bb-0003"), CF, QUAL, ts, Bytes.toBytes("v6")));
+
+    writer.close();
+    return file;
+  }
+
+  /**
+   * Opens a multi-tenant reader and its scanner for the given HFile.
+   */
+  private HFile.Reader openReader(Configuration conf, FileSystem fs, Path file) throws IOException {
+    return HFile.createReader(fs, file, new CacheConfig(conf), true, conf);
+  }
+
+  /**
+   * seekBefore at the first key of the second section must fall back to the last key of the first
+   * section. This is the core C5 bug — without cross-section fallback, seekBefore returns false and
+   * reverse scans miss data at section boundaries.
+   */
+  @Test
+  public void testSeekBeforeFallsToPreviousSection() throws Exception {
+    Configuration conf = HBaseConfiguration.create();
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    FileSystem fs = FileSystem.getLocal(conf);
+    Path baseDir = new Path(Files.createTempDirectory("seekbefore-test").toUri());
+
+    try {
+      Path file = writeMultiTenantFile(conf, fs, baseDir);
+
+      try (HFile.Reader reader = openReader(conf, fs, file)) {
+        HFileScanner scanner = reader.getScanner(conf, false, true);
+
+        // seekBefore the first key of section "bb" → should land on last key of section "aa"
+        KeyValue target = new KeyValue(Bytes.toBytes("bb-0001"), CF, QUAL,
+          EnvironmentEdgeManager.currentTime(), KeyValue.Type.Maximum);
+        boolean found = scanner.seekBefore(target);
+
+        assertTrue("seekBefore(bb-0001) should succeed by falling back to section 'aa'", found);
+
+        String row = Bytes.toString(CellUtil.cloneRow(scanner.getCell()));
+        assertEquals("Should be positioned at last key of section 'aa'", "aa-0003", row);
+      }
+    } finally {
+      fs.delete(baseDir, true);
+    }
+  }
+
+  /**
+   * seekBefore within the same section (not at the boundary) should work as usual — no
+   * cross-section fallback needed.
+   */
+  @Test
+  public void testSeekBeforeWithinSameSection() throws Exception {
+    Configuration conf = HBaseConfiguration.create();
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    FileSystem fs = FileSystem.getLocal(conf);
+    Path baseDir = new Path(Files.createTempDirectory("seekbefore-same").toUri());
+
+    try {
+      Path file = writeMultiTenantFile(conf, fs, baseDir);
+
+      try (HFile.Reader reader = openReader(conf, fs, file)) {
+        HFileScanner scanner = reader.getScanner(conf, false, true);
+
+        // seekBefore(bb-0002) should position to bb-0001 (within same section)
+        KeyValue target = new KeyValue(Bytes.toBytes("bb-0002"), CF, QUAL,
+          EnvironmentEdgeManager.currentTime(), KeyValue.Type.Maximum);
+        boolean found = scanner.seekBefore(target);
+
+        assertTrue("seekBefore(bb-0002) should succeed within section 'bb'", found);
+
+        String row = Bytes.toString(CellUtil.cloneRow(scanner.getCell()));
+        assertEquals("Should be positioned at bb-0001", "bb-0001", row);
+      }
+    } finally {
+      fs.delete(baseDir, true);
+    }
+  }
+
+  /**
+   * seekBefore the first key of the first section (and of the entire file) should return false —
+   * there is no earlier key to position to.
+   */
+  @Test
+  public void testSeekBeforeFirstKeyReturnsFalse() throws Exception {
+    Configuration conf = HBaseConfiguration.create();
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    FileSystem fs = FileSystem.getLocal(conf);
+    Path baseDir = new Path(Files.createTempDirectory("seekbefore-first").toUri());
+
+    try {
+      Path file = writeMultiTenantFile(conf, fs, baseDir);
+
+      try (HFile.Reader reader = openReader(conf, fs, file)) {
+        HFileScanner scanner = reader.getScanner(conf, false, true);
+
+        // seekBefore the very first key → no earlier key exists
+        KeyValue target = new KeyValue(Bytes.toBytes("aa-0001"), CF, QUAL,
+          EnvironmentEdgeManager.currentTime(), KeyValue.Type.Maximum);
+        boolean found = scanner.seekBefore(target);
+
+        assertFalse("seekBefore first key in entire file should return false", found);
+      }
+    } finally {
+      fs.delete(baseDir, true);
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestReseekTo.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestReseekTo.java
@@ -60,7 +60,7 @@ public class TestReseekTo {
     Path ncTFile = new Path(TEST_UTIL.getDataTestDir(), "basic.hfile");
     FSDataOutputStream fout = TEST_UTIL.getTestFileSystem().create(ncTFile);
     if (tagUsage != TagUsage.NO_TAG) {
-      TEST_UTIL.getConfiguration().setInt("hfile.format.version", 3);
+      TEST_UTIL.getConfiguration().setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     }
     CacheConfig cacheConf = new CacheConfig(TEST_UTIL.getConfiguration());
     HFileContext context = new HFileContextBuilder().withBlockSize(4000).build();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestSeekBeforeWithInlineBlocks.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestSeekBeforeWithInlineBlocks.java
@@ -135,32 +135,50 @@ public class TestSeekBeforeWithInlineBlocks {
           }
 
           // Read the HFile
-          HFile.Reader reader = HFile.createReader(fs, hfilePath, cacheConf, true, conf);
-
-          // Sanity check the HFile index level
-          assertEquals(expectedNumLevels, reader.getTrailer().getNumDataIndexLevels());
-
-          // Check that we can seekBefore in either direction and with both pread
-          // enabled and disabled
-          for (boolean pread : new boolean[] { false, true }) {
-            HFileScanner scanner = reader.getScanner(conf, true, pread);
-            checkNoSeekBefore(cells, scanner, 0);
-            for (int i = 1; i < NUM_KV; i++) {
-              checkSeekBefore(cells, scanner, i);
-              checkCell(cells[i - 1], scanner.getCell());
+          // HFile v4 is a multi-tenant container format and repurposes the trailer
+          // numDataIndexLevels field for the tenant section index. The data block index lives in
+          // the embedded v3 section reader, so assert levels and run the seekBefore checks against
+          // that section reader.
+          if (hfileVersion >= HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT) {
+            try (AbstractMultiTenantReader mtReader = (AbstractMultiTenantReader) HFile
+              .createReader(fs, hfilePath, cacheConf, true, conf)) {
+              byte[][] sectionIds = mtReader.getAllTenantSectionIds();
+              assertEquals(1, sectionIds.length);
+              try (AbstractMultiTenantReader.SectionReaderLease lease =
+                mtReader.getSectionReader(sectionIds[0])) {
+                HFileReaderImpl sectionReader = lease.getReader();
+                assertEquals(expectedNumLevels, sectionReader.getTrailer().getNumDataIndexLevels());
+                runSeekBeforeChecks(cells, sectionReader);
+              }
             }
-            assertTrue(scanner.seekTo());
-            for (int i = NUM_KV - 1; i >= 1; i--) {
-              checkSeekBefore(cells, scanner, i);
-              checkCell(cells[i - 1], scanner.getCell());
+          } else {
+            try (HFile.Reader reader = HFile.createReader(fs, hfilePath, cacheConf, true, conf)) {
+              // Sanity check the HFile index level (v3 layout).
+              assertEquals(expectedNumLevels, reader.getTrailer().getNumDataIndexLevels());
+              runSeekBeforeChecks(cells, reader);
             }
-            checkNoSeekBefore(cells, scanner, 0);
-            scanner.close();
           }
-
-          reader.close();
         }
       }
+    }
+  }
+
+  private void runSeekBeforeChecks(ExtendedCell[] cells, HFile.Reader reader) throws IOException {
+    // Check that we can seekBefore in either direction and with both pread enabled and disabled
+    for (boolean pread : new boolean[] { false, true }) {
+      HFileScanner scanner = reader.getScanner(conf, true, pread);
+      checkNoSeekBefore(cells, scanner, 0);
+      for (int i = 1; i < NUM_KV; i++) {
+        checkSeekBefore(cells, scanner, i);
+        checkCell(cells[i - 1], scanner.getCell());
+      }
+      assertTrue(scanner.seekTo());
+      for (int i = NUM_KV - 1; i >= 1; i--) {
+        checkSeekBefore(cells, scanner, i);
+        checkCell(cells[i - 1], scanner.getCell());
+      }
+      checkNoSeekBefore(cells, scanner, 0);
+      scanner.close();
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestPrefetchWithBucketCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestPrefetchWithBucketCache.java
@@ -322,11 +322,9 @@ public class TestPrefetchWithBucketCache {
   public void testPrefetchRunTriggersEvictions() throws Exception {
     conf.setLong(BUCKET_CACHE_SIZE_KEY, 1);
     conf.set(BUCKET_CACHE_BUCKETS_KEY, "3072");
-    // Use full capacity as the "acceptable" size so prefetch does not stop at ~98% total usage
-    // (via blockFitsIntoTheCache) before the cache writer path must run freeSpace/evictions.
-    conf.setDouble("hbase.bucketcache.acceptfactor", 1.0);
-    conf.setDouble("hbase.bucketcache.minfactor", 1.0);
-    conf.setDouble("hbase.bucketcache.extrafreefactor", 0.0);
+    conf.setDouble("hbase.bucketcache.acceptfactor", 0.98);
+    conf.setDouble("hbase.bucketcache.minfactor", 0.95);
+    conf.setDouble("hbase.bucketcache.extrafreefactor", 0.01);
     conf.setLong(QUEUE_ADDITION_WAIT_TIME, 0);
     // Ensures no prefetch interruption due to heap usage in the event of freeMemory() returning 0.
     conf.setDouble(CacheConfig.PREFETCH_HEAP_USAGE_THRESHOLD, Double.MAX_VALUE);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestVerifyBucketCacheFile.java
@@ -110,7 +110,8 @@ public class TestVerifyBucketCacheFile {
     try {
       bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
         constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen,
-        testDir + "/bucket.persistence" + name.getMethodName());
+        testDir + "/bucket.persistence" + name.getMethodName(), DEFAULT_ERROR_TOLERATION_DURATION,
+        conf);
       assertTrue(bucketCache.waitForCacheInitialization(10000));
       long usedSize = bucketCache.getAllocator().getUsedSize();
       assertEquals(0, usedSize);
@@ -128,7 +129,8 @@ public class TestVerifyBucketCacheFile {
       // restore cache from file
       bucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
         constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen,
-        testDir + "/bucket.persistence" + name.getMethodName());
+        testDir + "/bucket.persistence" + name.getMethodName(), DEFAULT_ERROR_TOLERATION_DURATION,
+        conf);
       assertTrue(bucketCache.waitForCacheInitialization(10000));
       assertEquals(usedSize, bucketCache.getAllocator().getUsedSize());
       // persist cache to file
@@ -141,7 +143,8 @@ public class TestVerifyBucketCacheFile {
       // can't restore cache from file
       recoveredBucketCache = new BucketCache("file:" + testDir + "/bucket.cache", capacitySize,
         constructedBlockSize, constructedBlockSizes, writeThreads, writerQLen,
-        testDir + "/bucket.persistence" + name.getMethodName());
+        testDir + "/bucket.persistence" + name.getMethodName(), DEFAULT_ERROR_TOLERATION_DURATION,
+        conf);
       assertTrue(recoveredBucketCache.waitForCacheInitialization(10000));
       waitPersistentCacheValidation(conf, recoveredBucketCache);
       assertEquals(0, recoveredBucketCache.getAllocator().getUsedSize());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/MobStressToolRunner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/MobStressToolRunner.java
@@ -115,7 +115,7 @@ public class MobStressToolRunner {
 
   private void initConf() {
 
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt("hfile.format.version", 4);
     conf.setLong(TimeToLiveHFileCleaner.TTL_CONF_KEY, 0);
     conf.setInt("hbase.client.retries.number", 100);
     conf.setInt("hbase.hregion.max.filesize", 200000000);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestExpiredMobFileCleaner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestExpiredMobFileCleaner.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hbase.client.Admin;
 import org.apache.hadoop.hbase.client.BufferedMutator;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
@@ -61,7 +62,7 @@ public class TestExpiredMobFileCleaner {
 
   @BeforeAll
   public static void setUpBeforeClass() throws Exception {
-    TEST_UTIL.getConfiguration().setInt("hfile.format.version", 3);
+    TEST_UTIL.getConfiguration().setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     TEST_UTIL.getConfiguration().setInt(MOB_CLEANER_BATCH_SIZE_UPPER_BOUND, 2);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestExpiredMobFileCleanerChore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestExpiredMobFileCleanerChore.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.ConnectionFactory;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -63,7 +64,7 @@ public class TestExpiredMobFileCleanerChore {
 
   @BeforeAll
   public static void setUp() throws Exception {
-    TEST_UTIL.getConfiguration().setInt("hfile.format.version", 3);
+    TEST_UTIL.getConfiguration().setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     TEST_UTIL.getConfiguration().setInt(MOB_CLEANER_BATCH_SIZE_UPPER_BOUND, 2);
     TEST_UTIL.startMiniCluster(1);
     mobFileCleanerChore = TEST_UTIL.getMiniHBaseCluster().getMaster().getMobFileCleanerChore();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestMobCompactionWithDefaults.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestMobCompactionWithDefaults.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -105,7 +106,7 @@ public class TestMobCompactionWithDefaults {
   protected void htuStart() throws Exception {
     HTU = new HBaseTestingUtility();
     conf = HTU.getConfiguration();
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     // Disable automatic MOB compaction
     conf.setLong(MobConstants.MOB_COMPACTION_CHORE_PERIOD, 0);
     // Disable automatic MOB file cleaner chore

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestMobFileCleanupUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestMobFileCleanupUtil.java
@@ -39,6 +39,7 @@ import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.master.cleaner.TimeToLiveHFileCleaner;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -99,7 +100,7 @@ public class TestMobFileCleanupUtil {
 
   private void initConf() {
 
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     conf.setLong(TimeToLiveHFileCleaner.TTL_CONF_KEY, 0);
     conf.setInt("hbase.client.retries.number", 100);
     conf.setInt("hbase.hregion.max.filesize", 200000000);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestRSMobFileCleanerChore.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/mob/TestRSMobFileCleanerChore.java
@@ -45,6 +45,7 @@ import org.apache.hadoop.hbase.client.ResultScanner;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.master.cleaner.TimeToLiveHFileCleaner;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HStore;
@@ -106,7 +107,7 @@ public class TestRSMobFileCleanerChore {
 
   private void initConf() {
 
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     conf.setLong(TimeToLiveHFileCleaner.TTL_CONF_KEY, 0);
     conf.setInt("hbase.client.retries.number", 100);
     conf.setInt("hbase.hregion.max.filesize", 200000000);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaStatusRPCs.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaStatusRPCs.java
@@ -191,16 +191,42 @@ public class TestQuotaStatusRPCs {
 
   @Test
   public void testQuotaStatusFromMaster() throws Exception {
-    final long sizeLimit = 1024L * 25L; // 25KB
-    // As of 2.0.0-beta-2, this 1KB of "Cells" actually results in about 15KB on disk (HFiles)
-    // This is skewed a bit since we're writing such little data, so the test needs to keep
-    // this in mind; else, the quota will be in violation before the test expects it to be.
+    // On-disk overhead per HFile varies across format versions (v3 ≈ 15KB, v4 ≈ 39KB for 1KB
+    // of cell data spread over 10 regions). Rather than hardcoding a size limit that bakes in
+    // format-specific assumptions, we write initial data first, measure the actual reported
+    // disk usage, then set the quota limit proportionally. This keeps the test agnostic of
+    // HFile version and tenant layout.
     final long tableSize = 1024L * 1; // 1KB
     final long nsLimit = Long.MAX_VALUE;
     final int numRegions = 10;
     final TableName tn = helper.createTableWithRegions(numRegions);
 
-    // Define the quota
+    // Write initial data before setting quotas so we can measure actual on-disk size.
+    helper.writeData(tn, tableSize);
+
+    final Connection conn = TEST_UTIL.getConnection();
+
+    // Wait for the actual table size to be reported to the master.
+    final AtomicLong reportedTableSize = new AtomicLong(0);
+    Waiter.waitFor(TEST_UTIL.getConfiguration(), 30 * 1000, new Predicate<Exception>() {
+      @Override
+      public boolean evaluate() throws Exception {
+        Map<TableName, Long> sizes = TEST_UTIL.getAdmin().getSpaceQuotaTableSizes();
+        Long size = sizes.get(tn);
+        if (size != null && size > 0) {
+          reportedTableSize.set(size);
+          return true;
+        }
+        return false;
+      }
+    });
+
+    // Set the limit to 2x the actual reported size: the initial write is comfortably under
+    // the limit, while a subsequent write of equal size will push total usage past it.
+    final long sizeLimit = reportedTableSize.get() * 2;
+    LOG.info("Measured on-disk size after initial write: {}, quota limit set to: {}",
+      reportedTableSize.get(), sizeLimit);
+
     QuotaSettings settings =
       QuotaSettingsFactory.limitTableSpace(tn, sizeLimit, SpaceViolationPolicy.NO_INSERTS);
     TEST_UTIL.getAdmin().setQuota(settings);
@@ -208,11 +234,7 @@ public class TestQuotaStatusRPCs {
       nsLimit, SpaceViolationPolicy.NO_INSERTS);
     TEST_UTIL.getAdmin().setQuota(nsSettings);
 
-    // Write at least `tableSize` data
-    helper.writeData(tn, tableSize);
-
-    final Connection conn = TEST_UTIL.getConnection();
-    // Make sure the master has a snapshot for our table
+    // Make sure the master has a snapshot for our table with the dynamically computed limit.
     Waiter.waitFor(TEST_UTIL.getConfiguration(), 30 * 1000, new Predicate<Exception>() {
       @Override
       public boolean evaluate() throws Exception {
@@ -241,13 +263,15 @@ public class TestQuotaStatusRPCs {
       }
     });
 
-    // Sanity check: the below assertions will fail if we somehow write too much data
-    // and force the table to move into violation before we write the second bit of data.
+    // Sanity check: with the limit at 2x measured size the table must not be in violation.
     SpaceQuotaSnapshot snapshot =
       (SpaceQuotaSnapshot) conn.getAdmin().getCurrentSpaceQuotaSnapshot(tn);
     assertTrue(snapshot != null && !snapshot.getQuotaStatus().isInViolation(),
       "QuotaSnapshot for " + tn + " should be non-null and not in violation");
 
+    // Write enough additional data to exceed the quota. Writing 2x the initial amount
+    // produces a comparable number of new HFiles (with their per-file overhead), pushing
+    // total usage well past the 2x limit.
     try {
       helper.writeData(tn, tableSize * 2L);
     } catch (RetriesExhaustedWithDetailsException | SpaceLimitingException e) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDataTieringManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestDataTieringManager.java
@@ -744,7 +744,7 @@ public class TestDataTieringManager {
     initializeTestEnvironment();
     // hStoreFiles[3] is a cold file. the blocks should not get loaded after a readBlock call.
     HStoreFile hStoreFile = hStoreFiles.get(3);
-    BlockCacheKey cacheKey = new BlockCacheKey(hStoreFile.getPath(), 0, true, BlockType.DATA);
+    BlockCacheKey cacheKey = createBlockCacheKey(hStoreFile, 0, BlockType.DATA);
     testCacheOnRead(hStoreFile, cacheKey, -1, false);
   }
 
@@ -753,8 +753,7 @@ public class TestDataTieringManager {
     initializeTestEnvironment();
     // hStoreFiles[0] is a hot file. the blocks should get loaded after a readBlock call.
     HStoreFile hStoreFile = hStoreFiles.get(0);
-    BlockCacheKey cacheKey =
-      new BlockCacheKey(hStoreFiles.get(0).getPath(), 0, true, BlockType.DATA);
+    BlockCacheKey cacheKey = createBlockCacheKey(hStoreFile, 0, BlockType.DATA);
     testCacheOnRead(hStoreFile, cacheKey, -1, true);
   }
 
@@ -777,7 +776,6 @@ public class TestDataTieringManager {
     int numHotBlocks = 0, numColdBlocks = 0;
 
     Waiter.waitFor(defaultConf, 10000, 100, () -> (expectedTotalKeys == keys.size()));
-    int iter = 0;
     for (BlockCacheKey key : keys) {
       try {
         if (dataTieringManager.isHotData(key)) {
@@ -817,6 +815,15 @@ public class TestDataTieringManager {
   private void testDataTieringMethodWithKeyNoException(DataTieringMethodCallerWithKey caller,
     BlockCacheKey key, boolean expectedResult) {
     testDataTieringMethodWithKey(caller, key, expectedResult, null);
+  }
+
+  private BlockCacheKey createBlockCacheKey(HStoreFile hStoreFile, long blockOffset,
+    BlockType blockType) {
+    // For multi-tenant (v4) HFiles, section readers may use section-specific paths (e.g.
+    // "<hfile>#<sectionId>") for internal routing, but block cache keys are always based on the
+    // container file path to avoid caching the same physical block multiple times under different
+    // names.
+    return new BlockCacheKey(hStoreFile.getPath(), blockOffset, true, blockType);
   }
 
   private static void initializeTestEnvironment() throws IOException {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEncryptionDisabled.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEncryptionDisabled.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.io.crypto.Encryption;
 import org.apache.hadoop.hbase.io.crypto.KeyProviderForTesting;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -55,7 +56,7 @@ public class TestEncryptionDisabled {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     conf.set(HConstants.CRYPTO_KEYPROVIDER_CONF_KEY, KeyProviderForTesting.class.getName());
     conf.set(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, "hbase");
     conf.set(Encryption.CRYPTO_ENABLED_CONF_KEY, "false");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEncryptionKeyRotation.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEncryptionKeyRotation.java
@@ -86,7 +86,7 @@ public class TestEncryptionKeyRotation {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     conf.set(HConstants.CRYPTO_KEYPROVIDER_CONF_KEY, KeyProviderForTesting.class.getName());
     conf.set(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, "hbase");
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEncryptionRandomKeying.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestEncryptionRandomKeying.java
@@ -88,7 +88,7 @@ public class TestEncryptionRandomKeying {
 
   @BeforeClass
   public static void setUp() throws Exception {
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     conf.set(HConstants.CRYPTO_KEYPROVIDER_CONF_KEY, KeyProviderForTesting.class.getName());
     conf.set(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, "hbase");
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMultiTenantBloomFilterDelegation.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMultiTenantBloomFilterDelegation.java
@@ -1,0 +1,120 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.BloomFilterMetrics;
+import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.HFile;
+import org.apache.hadoop.hbase.io.hfile.HFileContext;
+import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
+import org.apache.hadoop.hbase.io.hfile.MultiTenantBloomSupport;
+import org.apache.hadoop.hbase.io.hfile.MultiTenantHFileWriter;
+import org.apache.hadoop.hbase.io.hfile.ReaderContext;
+import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.BloomFilterFactory;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+
+@Category(SmallTests.class)
+public class TestMultiTenantBloomFilterDelegation {
+
+  @Test
+  public void testRowBloomDelegation() throws Exception {
+    Configuration conf = HBaseConfiguration.create();
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    conf.setBoolean(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, true);
+    conf.setBoolean(BloomFilterFactory.IO_STOREFILE_BLOOM_ENABLED, true);
+
+    FileSystem fs = FileSystem.getLocal(conf);
+    Path baseDir = new Path(Files.createTempDirectory("multi-tenant-bloom").toUri());
+    Path file = StoreFileWriter.getUniqueFile(fs, baseDir);
+
+    CacheConfig cacheConfig = new CacheConfig(conf);
+
+    Map<String, String> tableProps = new HashMap<>();
+    tableProps.put(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+    tableProps.put(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH, "2");
+    tableProps.put("BLOOMFILTER", "ROW");
+
+    HFileContext context = new HFileContextBuilder().withBlockSize(4096)
+      .withColumnFamily(Bytes.toBytes("cf")).withTableName(Bytes.toBytes("tbl")).build();
+
+    MultiTenantHFileWriter writer = MultiTenantHFileWriter.create(fs, file, conf, cacheConfig,
+      tableProps, context, BloomType.ROW, BloomType.ROW, null, true);
+
+    long ts = EnvironmentEdgeManager.currentTime();
+    KeyValue tenantOneRow = new KeyValue(Bytes.toBytes("aa-0001"), Bytes.toBytes("cf"),
+      Bytes.toBytes("q"), ts, Bytes.toBytes("value"));
+    KeyValue tenantTwoRow = new KeyValue(Bytes.toBytes("bb-0001"), Bytes.toBytes("cf"),
+      Bytes.toBytes("q"), ts, Bytes.toBytes("value"));
+
+    writer.append(tenantOneRow);
+    writer.append(tenantTwoRow);
+    writer.close();
+
+    ReaderContext contextReader =
+      new ReaderContextBuilder().withFileSystemAndPath(fs, file).build();
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, file, true);
+    storeFileInfo.initHFileInfo(contextReader);
+    StoreFileReader reader = storeFileInfo.createReader(contextReader, cacheConfig);
+    try {
+      storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+      reader.loadFileInfo();
+      reader.loadBloomfilter(BlockType.GENERAL_BLOOM_META, new BloomFilterMetrics());
+      reader.loadBloomfilter(BlockType.DELETE_FAMILY_BLOOM_META, new BloomFilterMetrics());
+
+      byte[] presentRow = Bytes.toBytes("bb-0001");
+      byte[] absentRow = Bytes.toBytes("bb-zzzz");
+
+      HFile.Reader hfileReader = reader.getHFileReader();
+      assertTrue(hfileReader instanceof MultiTenantBloomSupport);
+      MultiTenantBloomSupport bloomSupport = (MultiTenantBloomSupport) hfileReader;
+
+      boolean expectedPresent =
+        bloomSupport.passesGeneralRowBloomFilter(presentRow, 0, presentRow.length);
+      assertTrue(expectedPresent);
+      Scan present = new Scan(new Get(presentRow));
+      assertEquals(expectedPresent, reader.passesBloomFilter(present, null));
+
+      boolean expectedAbsent =
+        bloomSupport.passesGeneralRowBloomFilter(absentRow, 0, absentRow.length);
+      Scan absent = new Scan(new Get(absentRow));
+      assertEquals(expectedAbsent, reader.passesBloomFilter(absent, null));
+    } finally {
+      reader.close(false);
+      fs.delete(baseDir, true);
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMultiTenantBloomFilterMultiSection.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMultiTenantBloomFilterMultiSection.java
@@ -1,0 +1,568 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.regionserver;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.nio.file.Files;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.TreeSet;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.ExtendedCell;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.KeyValue;
+import org.apache.hadoop.hbase.PrivateCellUtil;
+import org.apache.hadoop.hbase.client.Get;
+import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.BloomFilterMetrics;
+import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.HFile;
+import org.apache.hadoop.hbase.io.hfile.HFileContext;
+import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
+import org.apache.hadoop.hbase.io.hfile.MultiTenantBloomSupport;
+import org.apache.hadoop.hbase.io.hfile.MultiTenantHFileWriter;
+import org.apache.hadoop.hbase.io.hfile.ReaderContext;
+import org.apache.hadoop.hbase.io.hfile.ReaderContextBuilder;
+import org.apache.hadoop.hbase.testclassification.MediumTests;
+import org.apache.hadoop.hbase.util.BloomFilterUtil;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * Tests bloom filter correctness for HFile v4 multi-tenant files with multiple tenant sections.
+ * Covers all bloom filter types: ROW, ROWCOL, and ROWPREFIX_FIXED_LENGTH. Validates that:
+ * <ul>
+ * <li>Present keys in each tenant section pass the bloom filter</li>
+ * <li>Absent keys in each tenant section are filtered out</li>
+ * <li>Keys belonging to one tenant do not pass bloom checks routed through another tenant's
+ * section</li>
+ * <li>Both the per-section (MultiTenantBloomSupport) and StoreFileReader paths agree</li>
+ * </ul>
+ */
+@Category(MediumTests.class)
+public class TestMultiTenantBloomFilterMultiSection {
+  private static final Logger LOG =
+    LoggerFactory.getLogger(TestMultiTenantBloomFilterMultiSection.class);
+
+  private static final int NUM_TENANTS = 10;
+  private static final int TENANT_PREFIX_LENGTH = 4;
+  private static final int ROWS_PER_TENANT = 50;
+  private static final byte[] CF = Bytes.toBytes("cf");
+  private static final byte[] QUALIFIER = Bytes.toBytes("q");
+
+  private Configuration conf;
+  private FileSystem fs;
+  private Path baseDir;
+  private CacheConfig cacheConfig;
+
+  @Before
+  public void setUp() throws Exception {
+    conf = HBaseConfiguration.create();
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MIN_FORMAT_VERSION_WITH_MULTI_TENANT);
+    conf.setBoolean(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, true);
+    fs = FileSystem.getLocal(conf);
+    baseDir = new Path(Files.createTempDirectory("mt-bloom-multi-section").toUri());
+    cacheConfig = new CacheConfig(conf);
+  }
+
+  @After
+  public void tearDown() throws Exception {
+    if (fs != null && baseDir != null) {
+      fs.delete(baseDir, true);
+    }
+  }
+
+  /** Generate a 4-character tenant prefix like "t00_", "t01_", ... "t09_". */
+  private static String tenantPrefix(int tenantIndex) {
+    return String.format("t%02d_", tenantIndex);
+  }
+
+  /** Generate a row key: {tenantPrefix}{rowSuffix} */
+  private static byte[] rowKey(int tenantIndex, int rowIndex) {
+    return Bytes.toBytes(tenantPrefix(tenantIndex) + String.format("row%04d", rowIndex));
+  }
+
+  /** Generate a row key guaranteed absent from any tenant section. */
+  private static byte[] absentRowKey(int tenantIndex) {
+    return Bytes.toBytes(tenantPrefix(tenantIndex) + "zzz_absent");
+  }
+
+  /** Generate a row key with a prefix that matches no tenant. */
+  private static byte[] unknownTenantRowKey() {
+    return Bytes.toBytes("zzzz_no_such_tenant");
+  }
+
+  private Map<String, String> createTableProps(String bloomType) {
+    Map<String, String> props = new HashMap<>();
+    props.put(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "true");
+    props.put(MultiTenantHFileWriter.TABLE_TENANT_PREFIX_LENGTH,
+      String.valueOf(TENANT_PREFIX_LENGTH));
+    props.put("BLOOMFILTER", bloomType);
+    return props;
+  }
+
+  private Path writeMultiTenantHFile(BloomType bloomType, Map<String, String> tableProps)
+    throws IOException {
+    Path file = StoreFileWriter.getUniqueFile(fs, baseDir);
+    HFileContext context = new HFileContextBuilder().withBlockSize(4096).withColumnFamily(CF)
+      .withTableName(Bytes.toBytes("test_table")).build();
+    MultiTenantHFileWriter writer = MultiTenantHFileWriter.create(fs, file, conf, cacheConfig,
+      tableProps, context, bloomType, bloomType, null, true);
+    long ts = EnvironmentEdgeManager.currentTime();
+    for (int t = 0; t < NUM_TENANTS; t++) {
+      for (int r = 0; r < ROWS_PER_TENANT; r++) {
+        byte[] row = rowKey(t, r);
+        KeyValue kv = new KeyValue(row, CF, QUALIFIER, ts, Bytes.toBytes("val"));
+        writer.append(kv);
+      }
+    }
+    writer.close();
+    return file;
+  }
+
+  private StoreFileReader openReader(Path file) throws IOException {
+    ReaderContext readerContext =
+      new ReaderContextBuilder().withFileSystemAndPath(fs, file).build();
+    StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, file, true);
+    storeFileInfo.initHFileInfo(readerContext);
+    StoreFileReader reader = storeFileInfo.createReader(readerContext, cacheConfig);
+    storeFileInfo.getHFileInfo().initMetaAndIndex(reader.getHFileReader());
+    reader.loadFileInfo();
+    reader.loadBloomfilter(BlockType.GENERAL_BLOOM_META, new BloomFilterMetrics());
+    reader.loadBloomfilter(BlockType.DELETE_FAMILY_BLOOM_META, new BloomFilterMetrics());
+    return reader;
+  }
+
+  @Test
+  public void testRowBloomWithMultipleTenants() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROW");
+    Path file = writeMultiTenantHFile(BloomType.ROW, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      HFile.Reader hfileReader = reader.getHFileReader();
+      assertTrue("v4 reader must implement MultiTenantBloomSupport",
+        hfileReader instanceof MultiTenantBloomSupport);
+      MultiTenantBloomSupport bloomSupport = (MultiTenantBloomSupport) hfileReader;
+
+      LOG.info("ROW bloom: verifying {} tenants x {} rows", NUM_TENANTS, ROWS_PER_TENANT);
+      for (int t = 0; t < NUM_TENANTS; t++) {
+        for (int r = 0; r < ROWS_PER_TENANT; r++) {
+          byte[] row = rowKey(t, r);
+          assertTrue("ROW bloom must pass for present key tenant=" + t + " row=" + r,
+            bloomSupport.passesGeneralRowBloomFilter(row, 0, row.length));
+
+          Scan getScan = new Scan(new Get(row));
+          assertTrue("StoreFileReader.passesBloomFilter must pass for present key",
+            reader.passesBloomFilter(getScan, null));
+        }
+
+        byte[] absent = absentRowKey(t);
+        boolean directResult = bloomSupport.passesGeneralRowBloomFilter(absent, 0, absent.length);
+        Scan absentScan = new Scan(new Get(absent));
+        boolean storeReaderResult = reader.passesBloomFilter(absentScan, null);
+        LOG.info("ROW bloom absent key tenant={}: direct={} storeReader={}", t, directResult,
+          storeReaderResult);
+        // Both paths must agree (both should filter the absent key)
+        assertFalse("ROW bloom should filter absent key in tenant " + t, directResult);
+        assertFalse("StoreFileReader should filter absent key in tenant " + t, storeReaderResult);
+      }
+
+      byte[] unknownRow = unknownTenantRowKey();
+      assertFalse("ROW bloom should filter key with unknown tenant prefix",
+        bloomSupport.passesGeneralRowBloomFilter(unknownRow, 0, unknownRow.length));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  @Test
+  public void testRowColBloomWithMultipleTenants() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROWCOL");
+    Path file = writeMultiTenantHFile(BloomType.ROWCOL, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      HFile.Reader hfileReader = reader.getHFileReader();
+      assertTrue(hfileReader instanceof MultiTenantBloomSupport);
+      MultiTenantBloomSupport bloomSupport = (MultiTenantBloomSupport) hfileReader;
+
+      LOG.info("ROWCOL bloom: verifying {} tenants x {} rows", NUM_TENANTS, ROWS_PER_TENANT);
+      for (int t = 0; t < NUM_TENANTS; t++) {
+        for (int r = 0; r < ROWS_PER_TENANT; r++) {
+          byte[] row = rowKey(t, r);
+          ExtendedCell presentCell =
+            PrivateCellUtil.createFirstOnRow(row, HConstants.EMPTY_BYTE_ARRAY, QUALIFIER);
+          assertTrue("ROWCOL bloom must pass for present cell tenant=" + t + " row=" + r,
+            bloomSupport.passesGeneralRowColBloomFilter(presentCell));
+
+          TreeSet<byte[]> columns = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+          columns.add(QUALIFIER);
+          Scan getScan = new Scan(new Get(row));
+          assertTrue("StoreFileReader ROWCOL must pass for present key",
+            reader.passesBloomFilter(getScan, columns));
+        }
+
+        byte[] absent = absentRowKey(t);
+        ExtendedCell absentCell =
+          PrivateCellUtil.createFirstOnRow(absent, HConstants.EMPTY_BYTE_ARRAY, QUALIFIER);
+        boolean directResult = bloomSupport.passesGeneralRowColBloomFilter(absentCell);
+        TreeSet<byte[]> columns = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+        columns.add(QUALIFIER);
+        Scan absentScan = new Scan(new Get(absent));
+        boolean storeReaderResult = reader.passesBloomFilter(absentScan, columns);
+        LOG.info("ROWCOL bloom absent key tenant={}: direct={} storeReader={}", t, directResult,
+          storeReaderResult);
+        assertFalse("ROWCOL bloom should filter absent cell in tenant " + t, directResult);
+        assertFalse("StoreFileReader ROWCOL should filter absent cell in tenant " + t,
+          storeReaderResult);
+      }
+
+      byte[] unknownRow = unknownTenantRowKey();
+      ExtendedCell unknownCell =
+        PrivateCellUtil.createFirstOnRow(unknownRow, HConstants.EMPTY_BYTE_ARRAY, QUALIFIER);
+      assertFalse("ROWCOL bloom should filter cell with unknown tenant prefix",
+        bloomSupport.passesGeneralRowColBloomFilter(unknownCell));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  @Test
+  public void testRowPrefixBloomWithMultipleTenants() throws Exception {
+    int bloomPrefixLength = TENANT_PREFIX_LENGTH + 3; // "t00_row" = 7 chars
+    conf.set(BloomFilterUtil.PREFIX_LENGTH_KEY, String.valueOf(bloomPrefixLength));
+    Map<String, String> tableProps = createTableProps("ROWPREFIX_FIXED_LENGTH");
+    Path file = writeMultiTenantHFile(BloomType.ROWPREFIX_FIXED_LENGTH, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      HFile.Reader hfileReader = reader.getHFileReader();
+      assertTrue(hfileReader instanceof MultiTenantBloomSupport);
+      MultiTenantBloomSupport bloomSupport = (MultiTenantBloomSupport) hfileReader;
+
+      LOG.info("ROWPREFIX bloom (prefixLen={}): verifying {} tenants", bloomPrefixLength,
+        NUM_TENANTS);
+      for (int t = 0; t < NUM_TENANTS; t++) {
+        byte[] presentRow = rowKey(t, 0);
+        byte[] prefix = Bytes.copy(presentRow, 0, Math.min(bloomPrefixLength, presentRow.length));
+        assertTrue("ROWPREFIX bloom must pass for present prefix tenant=" + t,
+          bloomSupport.passesGeneralRowPrefixBloomFilter(prefix, 0, prefix.length));
+
+        Scan getScan = new Scan(new Get(presentRow));
+        assertTrue("StoreFileReader ROWPREFIX must pass for present key",
+          reader.passesBloomFilter(getScan, null));
+      }
+
+      for (int t = 0; t < NUM_TENANTS; t++) {
+        byte[] absentRow = Bytes.toBytes(tenantPrefix(t) + "zzz_absent");
+        byte[] absentPrefix =
+          Bytes.copy(absentRow, 0, Math.min(bloomPrefixLength, absentRow.length));
+        boolean directResult =
+          bloomSupport.passesGeneralRowPrefixBloomFilter(absentPrefix, 0, absentPrefix.length);
+        Scan absentScan = new Scan(new Get(absentRow));
+        boolean storeReaderResult = reader.passesBloomFilter(absentScan, null);
+        LOG.info("ROWPREFIX bloom absent key tenant={}: direct={} storeReader={}", t, directResult,
+          storeReaderResult);
+        assertFalse("ROWPREFIX bloom should filter absent prefix in tenant " + t, directResult);
+        assertFalse("StoreFileReader ROWPREFIX should filter absent prefix in tenant " + t,
+          storeReaderResult);
+      }
+
+      byte[] unknownRow = unknownTenantRowKey();
+      byte[] unknownPrefix =
+        Bytes.copy(unknownRow, 0, Math.min(bloomPrefixLength, unknownRow.length));
+      assertFalse("ROWPREFIX bloom should filter prefix with unknown tenant",
+        bloomSupport.passesGeneralRowPrefixBloomFilter(unknownPrefix, 0, unknownPrefix.length));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  @Test
+  public void testCrossTenantIsolation() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROW");
+    Path file = writeMultiTenantHFile(BloomType.ROW, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      MultiTenantBloomSupport bloomSupport = (MultiTenantBloomSupport) reader.getHFileReader();
+
+      LOG.info("Cross-tenant isolation: verifying keys unique to one tenant "
+        + "are not found via another tenant's bloom section");
+      for (int t = 0; t < NUM_TENANTS; t++) {
+        byte[] presentInT = rowKey(t, 0);
+        assertTrue("Key must pass bloom for its own tenant section",
+          bloomSupport.passesGeneralRowBloomFilter(presentInT, 0, presentInT.length));
+      }
+
+      // A row prefix from tenant 0 with a suffix that only tenant 5 has
+      byte[] crossRow = Bytes.toBytes(tenantPrefix(0) + "row_only_in_t5");
+      assertFalse("Cross-tenant key must be filtered by bloom",
+        bloomSupport.passesGeneralRowBloomFilter(crossRow, 0, crossRow.length));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  @Test
+  public void testMultiSectionBloomNotCachedLocally() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROW");
+    Path file = writeMultiTenantHFile(BloomType.ROW, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      assertNull("Multi-section v4 file must NOT have a locally cached generalBloomFilter "
+        + "(per-section routing required for correctness)", reader.getGeneralBloomFilter());
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  /**
+   * Validates the StoreFileReader fast path: for a single-section v4 file the bloom filter is
+   * cached locally in {@code generalBloomFilter}, avoiding the per-call multi-tenant overhead.
+   */
+  @Test
+  public void testSingleSectionBloomCachedLocally() throws Exception {
+    Configuration singleConf = HBaseConfiguration.create(conf);
+    singleConf.setBoolean(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, false);
+
+    Path file = StoreFileWriter.getUniqueFile(fs, baseDir);
+    HFileContext context = new HFileContextBuilder().withBlockSize(4096).withColumnFamily(CF)
+      .withTableName(Bytes.toBytes("single_tenant")).build();
+
+    Map<String, String> singleProps = new HashMap<>();
+    singleProps.put(MultiTenantHFileWriter.TABLE_MULTI_TENANT_ENABLED, "false");
+    singleProps.put("BLOOMFILTER", "ROW");
+
+    MultiTenantHFileWriter writer = MultiTenantHFileWriter.create(fs, file, singleConf, cacheConfig,
+      singleProps, context, BloomType.ROW, BloomType.ROW, null, true);
+    long ts = EnvironmentEdgeManager.currentTime();
+    for (int r = 0; r < 100; r++) {
+      byte[] row = Bytes.toBytes(String.format("row%04d", r));
+      writer.append(new KeyValue(row, CF, QUALIFIER, ts, Bytes.toBytes("val")));
+    }
+    writer.close();
+
+    StoreFileReader reader = openReader(file);
+    try {
+      assertTrue(reader.getHFileReader() instanceof MultiTenantBloomSupport);
+      assertNotNull("Single-section v4 file MUST have bloom cached locally for fast path",
+        reader.getGeneralBloomFilter());
+
+      byte[] present = Bytes.toBytes("row0050");
+      Scan getScan = new Scan(new Get(present));
+      assertTrue("Local bloom must pass for present key", reader.passesBloomFilter(getScan, null));
+
+      byte[] absent = Bytes.toBytes("row9999");
+      Scan absentScan = new Scan(new Get(absent));
+      assertFalse("Local bloom must filter absent key", reader.passesBloomFilter(absentScan, null));
+
+      byte[] afterLast = Bytes.toBytes("zzz_after_all_keys");
+      Scan afterLastScan = new Scan(new Get(afterLast));
+      assertFalse("Local bloom must filter key beyond lastBloomKey",
+        reader.passesBloomFilter(afterLastScan, null));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  /** ROW and ROWCOL blooms must bypass (return true) for non-get scans. */
+  @Test
+  public void testNonGetScanBypassesRowAndRowColBloom() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROW");
+    Path rowFile = writeMultiTenantHFile(BloomType.ROW, tableProps);
+    StoreFileReader rowReader = openReader(rowFile);
+    try {
+      byte[] absent = absentRowKey(0);
+      Scan rangeScan = new Scan().withStartRow(absent).withStopRow(Bytes.toBytes("t01_"));
+      assertTrue("ROW bloom must be bypassed for non-get scans",
+        rowReader.passesBloomFilter(rangeScan, null));
+    } finally {
+      rowReader.close(false);
+    }
+
+    Map<String, String> rowColProps = createTableProps("ROWCOL");
+    Path rowColFile = writeMultiTenantHFile(BloomType.ROWCOL, rowColProps);
+    StoreFileReader rowColReader = openReader(rowColFile);
+    try {
+      byte[] absent = absentRowKey(0);
+      Scan rangeScan = new Scan().withStartRow(absent).withStopRow(Bytes.toBytes("t01_"));
+      TreeSet<byte[]> columns = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+      columns.add(QUALIFIER);
+      assertTrue("ROWCOL bloom must be bypassed for non-get scans",
+        rowColReader.passesBloomFilter(rangeScan, columns));
+    } finally {
+      rowColReader.close(false);
+    }
+  }
+
+  /** ROWCOL bloom should filter when the row exists but the qualifier does not. */
+  @Test
+  public void testRowColBloomFiltersAbsentQualifier() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROWCOL");
+    Path file = writeMultiTenantHFile(BloomType.ROWCOL, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      MultiTenantBloomSupport bloomSupport = (MultiTenantBloomSupport) reader.getHFileReader();
+      byte[] presentRow = rowKey(3, 10);
+      byte[] absentQualifier = Bytes.toBytes("no_such_qualifier");
+
+      ExtendedCell absentCell =
+        PrivateCellUtil.createFirstOnRow(presentRow, HConstants.EMPTY_BYTE_ARRAY, absentQualifier);
+      assertFalse("ROWCOL bloom must filter present row with absent qualifier",
+        bloomSupport.passesGeneralRowColBloomFilter(absentCell));
+
+      TreeSet<byte[]> columns = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+      columns.add(absentQualifier);
+      Scan getScan = new Scan(new Get(presentRow));
+      assertFalse("StoreFileReader ROWCOL must filter present row with absent qualifier",
+        reader.passesBloomFilter(getScan, columns));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  /** ROWCOL passesBloomFilter returns true when columns is null or has more than 1 column. */
+  @Test
+  public void testRowColBloomBypassesMultiColumnAndNullColumns() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROWCOL");
+    Path file = writeMultiTenantHFile(BloomType.ROWCOL, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      byte[] absent = absentRowKey(0);
+      Scan getScan = new Scan(new Get(absent));
+
+      assertTrue("ROWCOL bloom must bypass when columns is null",
+        reader.passesBloomFilter(getScan, null));
+
+      TreeSet<byte[]> multiCols = new TreeSet<>(Bytes.BYTES_COMPARATOR);
+      multiCols.add(Bytes.toBytes("col1"));
+      multiCols.add(Bytes.toBytes("col2"));
+      assertTrue("ROWCOL bloom must bypass when columns.size() > 1",
+        reader.passesBloomFilter(getScan, multiCols));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  /**
+   * Row keys shorter than the tenant prefix length cannot be routed to a section.
+   * {@code extractTenantSectionId} returns null, so bloom should pass through (return true).
+   */
+  @Test
+  public void testShortRowKeyPassesThroughBloom() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROW");
+    Path file = writeMultiTenantHFile(BloomType.ROW, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      MultiTenantBloomSupport bloomSupport = (MultiTenantBloomSupport) reader.getHFileReader();
+
+      byte[] shortRow = Bytes.toBytes("ab");
+      assertTrue("Row shorter than prefix length must pass through (ROW)",
+        bloomSupport.passesGeneralRowBloomFilter(shortRow, 0, shortRow.length));
+
+      byte[] emptyRow = new byte[0];
+      assertTrue("Empty row must pass through (ROW)",
+        bloomSupport.passesGeneralRowBloomFilter(emptyRow, 0, emptyRow.length));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  /** ROWPREFIX bloom does NOT bypass for range scans — it checks prefix overlap. */
+  @Test
+  public void testRowPrefixBloomWithRangeScan() throws Exception {
+    int bloomPrefixLength = TENANT_PREFIX_LENGTH + 3;
+    conf.set(BloomFilterUtil.PREFIX_LENGTH_KEY, String.valueOf(bloomPrefixLength));
+    Map<String, String> tableProps = createTableProps("ROWPREFIX_FIXED_LENGTH");
+    Path file = writeMultiTenantHFile(BloomType.ROWPREFIX_FIXED_LENGTH, tableProps);
+    StoreFileReader reader = openReader(file);
+    try {
+      byte[] startRow = rowKey(2, 0);
+      byte[] stopRow = rowKey(2, 10);
+      Scan rangeScan = new Scan().withStartRow(startRow).withStopRow(stopRow);
+      assertTrue("ROWPREFIX bloom must pass for range scan within existing prefix",
+        reader.passesBloomFilter(rangeScan, null));
+
+      byte[] absentStart = Bytes.toBytes(tenantPrefix(2) + "zzz0000");
+      byte[] absentStop = Bytes.toBytes(tenantPrefix(2) + "zzz9999");
+      Scan absentRange = new Scan().withStartRow(absentStart).withStopRow(absentStop);
+      assertFalse("ROWPREFIX bloom must filter range scan for absent prefix",
+        reader.passesBloomFilter(absentRange, null));
+
+      byte[] t0Start = Bytes.toBytes(tenantPrefix(0) + "row0000");
+      byte[] t5Stop = Bytes.toBytes(tenantPrefix(5) + "row0000");
+      Scan crossTenantScan = new Scan().withStartRow(t0Start).withStopRow(t5Stop);
+      assertTrue(
+        "ROWPREFIX bloom must bypass when start/stop prefix diverges before " + "bloomPrefixLength",
+        reader.passesBloomFilter(crossTenantScan, null));
+    } finally {
+      reader.close(false);
+    }
+  }
+
+  /** Validates delete-family bloom filter with multi-section routing. */
+  @Test
+  public void testDeleteFamilyBloomWithMultipleTenants() throws Exception {
+    Map<String, String> tableProps = createTableProps("ROW");
+    Path file = StoreFileWriter.getUniqueFile(fs, baseDir);
+    HFileContext context = new HFileContextBuilder().withBlockSize(4096).withColumnFamily(CF)
+      .withTableName(Bytes.toBytes("test_delete_bloom")).build();
+    MultiTenantHFileWriter writer = MultiTenantHFileWriter.create(fs, file, conf, cacheConfig,
+      tableProps, context, BloomType.ROW, BloomType.ROW, null, true);
+
+    long ts = EnvironmentEdgeManager.currentTime();
+    for (int t = 0; t < NUM_TENANTS; t++) {
+      for (int r = 0; r < 10; r++) {
+        byte[] row = rowKey(t, r);
+        if (r == 5) {
+          writer.append(new KeyValue(row, CF, null, ts, KeyValue.Type.DeleteFamily));
+        }
+        writer.append(new KeyValue(row, CF, QUALIFIER, ts, Bytes.toBytes("val")));
+      }
+    }
+    writer.close();
+
+    StoreFileReader reader = openReader(file);
+    try {
+      MultiTenantBloomSupport bloomSupport = (MultiTenantBloomSupport) reader.getHFileReader();
+      for (int t = 0; t < NUM_TENANTS; t++) {
+        byte[] deletedRow = rowKey(t, 5);
+        assertTrue("Delete family bloom must pass for row with delete marker in tenant " + t,
+          bloomSupport.passesDeleteFamilyBloomFilter(deletedRow, 0, deletedRow.length));
+
+        assertTrue("StoreFileReader delete bloom must pass for row with delete marker",
+          reader.passesDeleteFamilyBloomFilter(deletedRow, 0, deletedRow.length));
+      }
+    } finally {
+      reader.close(false);
+    }
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileScannerWithTagCompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreFileScannerWithTagCompression.java
@@ -63,7 +63,7 @@ public class TestStoreFileScannerWithTagCompression {
 
   @BeforeClass
   public static void setUp() throws IOException {
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt("hfile.format.version", 4);
     fs = FileSystem.get(conf);
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestTags.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestTags.java
@@ -56,6 +56,7 @@ import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.RegionObserver;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -80,7 +81,7 @@ public class TestTags {
   @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     Configuration conf = TEST_UTIL.getConfiguration();
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     conf.setStrings(CoprocessorHost.USER_REGION_COPROCESSOR_CONF_KEY,
       TestCoprocessorForTags.class.getName());
     TEST_UTIL.startMiniCluster(2);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithTags.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithTags.java
@@ -55,6 +55,7 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.RegionObserver;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -100,7 +101,7 @@ public class TestReplicationWithTags {
 
   @BeforeClass
   public static void setUpBeforeClass() throws Exception {
-    conf1.setInt("hfile.format.version", 3);
+    conf1.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     conf1.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/1");
     conf1.setInt("replication.source.size.capacity", 10240);
     conf1.setLong("replication.source.sleepforretries", 100);
@@ -125,7 +126,7 @@ public class TestReplicationWithTags {
 
     // Base conf2 on conf1 so it gets the right zk cluster.
     conf2 = HBaseConfiguration.create(conf1);
-    conf2.setInt("hfile.format.version", 3);
+    conf2.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     conf2.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/2");
     conf2.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 6);
     conf2.setBoolean("hbase.tests.use.shortcircuit.reads", false);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithWALExtendedAttributes.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestReplicationWithWALExtendedAttributes.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hbase.coprocessor.RegionObserver;
 import org.apache.hadoop.hbase.coprocessor.RegionServerCoprocessor;
 import org.apache.hadoop.hbase.coprocessor.RegionServerCoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.RegionServerObserver;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.regionserver.MiniBatchOperationInProgress;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.ReplicationTests;
@@ -125,7 +126,7 @@ public class TestReplicationWithWALExtendedAttributes {
 
     // Base conf2 on conf1 so it gets the right zk cluster.
     Configuration conf2 = HBaseConfiguration.create(conf1);
-    conf2.setInt("hfile.format.version", 3);
+    conf2.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     conf2.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/2");
     conf2.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 6);
     conf2.setBoolean("hbase.tests.use.shortcircuit.reads", false);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/SecureTestUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/SecureTestUtil.java
@@ -103,7 +103,7 @@ public class SecureTestUtil {
     conf.set(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY, AccessController.class.getName());
     conf.set(CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY, AccessController.class.getName());
     // Need HFile V3 for tags for security features
-    conf.setInt(HFile.FORMAT_VERSION_KEY, 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, 4);
     conf.set(User.HBASE_SECURITY_AUTHORIZATION_CONF_KEY, "true");
     configureSuperuser(conf);
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/visibility/TestVisibilityLabelReplicationWithExpAsString.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/visibility/TestVisibilityLabelReplicationWithExpAsString.java
@@ -42,6 +42,7 @@ import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.codec.KeyValueCodecWithTags;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
@@ -69,7 +70,7 @@ public class TestVisibilityLabelReplicationWithExpAsString extends TestVisibilit
       + "\u0027&\\\\" + "\")";
     // setup configuration
     conf = HBaseConfiguration.create();
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     conf.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/1");
     conf.setInt("replication.source.size.capacity", 10240);
     conf.setLong("replication.source.sleepforretries", 100);
@@ -104,7 +105,7 @@ public class TestVisibilityLabelReplicationWithExpAsString extends TestVisibilit
 
     // Base conf2 on conf1 so it gets the right zk cluster.
     conf1 = HBaseConfiguration.create(conf);
-    conf1.setInt("hfile.format.version", 3);
+    conf1.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     conf1.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/2");
     conf1.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 6);
     conf1.setBoolean("hbase.tests.use.shortcircuit.reads", false);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/visibility/TestVisibilityLabelsReplication.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/visibility/TestVisibilityLabelsReplication.java
@@ -59,6 +59,7 @@ import org.apache.hadoop.hbase.coprocessor.ObserverContext;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessor;
 import org.apache.hadoop.hbase.coprocessor.RegionCoprocessorEnvironment;
 import org.apache.hadoop.hbase.coprocessor.RegionObserver;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.protobuf.generated.VisibilityLabelsProtos.VisibilityLabelsResponse;
 import org.apache.hadoop.hbase.replication.ReplicationEndpoint;
 import org.apache.hadoop.hbase.replication.ReplicationPeerConfig;
@@ -121,7 +122,7 @@ public class TestVisibilityLabelsReplication {
   protected void setUpTest() throws Exception {
     // setup configuration
     conf = HBaseConfiguration.create();
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     conf.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/1");
     conf.setInt("replication.source.size.capacity", 10240);
     conf.setLong("replication.source.sleepforretries", 100);
@@ -155,7 +156,7 @@ public class TestVisibilityLabelsReplication {
 
     // Base conf2 on conf1 so it gets the right zk cluster.
     conf1 = HBaseConfiguration.create(conf);
-    conf1.setInt("hfile.format.version", 3);
+    conf1.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     conf1.set(HConstants.ZOOKEEPER_ZNODE_PARENT, "/2");
     conf1.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 6);
     conf1.setBoolean("hbase.tests.use.shortcircuit.reads", false);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/visibility/VisibilityTestUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/visibility/VisibilityTestUtil.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.security.visibility;
 import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.security.User;
 
 /**
@@ -28,7 +29,7 @@ import org.apache.hadoop.hbase.security.User;
 public class VisibilityTestUtil {
 
   public static void enableVisiblityLabels(Configuration conf) throws IOException {
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
     conf.setBoolean(User.HBASE_SECURITY_AUTHORIZATION_CONF_KEY, true);
     appendCoprocessor(conf, CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY,
       VisibilityController.class.getName());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestHBaseFsckEncryption.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/util/TestHBaseFsckEncryption.java
@@ -67,7 +67,9 @@ public class TestHBaseFsckEncryption {
   @BeforeEach
   public void setUp() throws Exception {
     conf = TEST_UTIL.getConfiguration();
-    conf.setInt("hfile.format.version", 3);
+    // hfile.format.version is now strictly enforced as MAX_FORMAT_VERSION (v4) at
+    // RegionServer startup; using v3 here would fail HFile.checkHFileVersion.
+    conf.setInt("hfile.format.version", HFile.MAX_FORMAT_VERSION);
     conf.set(HConstants.CRYPTO_KEYPROVIDER_CONF_KEY, KeyProviderForTesting.class.getName());
     conf.set(HConstants.CRYPTO_MASTERKEY_NAME_CONF_KEY, "hbase");
 

--- a/hbase-shell/src/test/java/org/apache/hadoop/hbase/client/RubyShellTest.java
+++ b/hbase-shell/src/test/java/org/apache/hadoop/hbase/client/RubyShellTest.java
@@ -26,6 +26,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtility;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.security.access.SecureTestUtil;
 import org.apache.hadoop.hbase.security.visibility.VisibilityTestUtil;
 import org.jruby.embed.PathType;
@@ -59,7 +60,7 @@ public interface RubyShellTest {
     conf.setBoolean("hbase.quota.enabled", true);
     conf.setInt(HConstants.HBASE_CLIENT_RETRIES_NUMBER, 6);
     conf.setBoolean(CoprocessorHost.ABORT_ON_ERROR_KEY, false);
-    conf.setInt("hfile.format.version", 3);
+    conf.setInt(HFile.FORMAT_VERSION_KEY, HFile.MAX_FORMAT_VERSION);
 
     // Below settings are necessary for task monitor test.
     conf.setInt(HConstants.MASTER_INFO_PORT, 0);


### PR DESCRIPTION


Cherry-picked the entire PR #7296 from master/HBASE-29588-feature onto branch-2. This squashes the 99 commits + 8 master merges from the PR into one commit.

Conflicts resolved manually in 13 files (mostly imports, encryption test KeyProvider classes that differ between branches, FixedFileTrailer KEK fields, BucketCache notifyFileCachingCompleted retry-loop refactor, and the hbase-protocol-shaded HFile.proto location which differs between branch-2 and master).