### PR TITLE
Revert "HBASE-30157 Bump urllib3 from 2.6.3 to 2.7.0 in /dev-support/git-jira-release-audit"

### DIFF
--- a/dev-support/git-jira-release-audit/requirements.txt
+++ b/dev-support/git-jira-release-audit/requirements.txt
@@ -35,5 +35,5 @@ requests-oauthlib==1.3.0
 requests-toolbelt==0.9.1
 six==1.14.0
 smmap2==2.0.5
-urllib3==2.7.0
+urllib3==2.6.3
 wcwidth==0.1.8


### PR DESCRIPTION
Reverts apache/hbase#8220 for the incorrect commit message