### PR TITLE
HBASE-30168 Remove webkit from Playwright e2e tests; it crashes on CI

### DIFF
--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -78,8 +78,10 @@ RUN curl -fsSL "https://nodejs.org/dist/$NODE_VERSION/node-$NODE_VERSION-linux-x
     && tar -xzf node.tar.gz -C /usr/local --strip-components=1 \
     && rm node.tar.gz
 
-# Install Playwright dependencies. Needed for docs PDF export and docs UI e2e tests.
-RUN npx -y playwright install --with-deps
+# Install OS-level dependencies for Playwright browsers used in CI.
+# Only chromium and firefox — webkit crashes on Ubuntu 22.04 due to
+# libsoup2/libsoup3 conflict (HBASE-30168).
+RUN npx -y playwright install-deps chromium firefox
 
 ##
 # download sundry dependencies

--- a/dev-support/generate-website/generate-hbase-website.Jenkinsfile
+++ b/dev-support/generate-website/generate-hbase-website.Jenkinsfile
@@ -50,7 +50,7 @@ pipeline {
           user=$(whoami)
           docker build -t hbase-build-website -f "${WORKSPACE}/component/dev-support/docker/Dockerfile" .
           docker run --rm -v "${WORKSPACE}":/home/${user} -v /etc/passwd:/etc/passwd:ro -v /etc/group:/etc/group:ro \
-            -u `id -u`:`id -g` -e JAVA_HOME="/usr/lib/jvm/java-17" -e GIT_AUTHOR_NAME="HBase" \
+            -u `id -u`:`id -g` -e CI=true -e JAVA_HOME="/usr/lib/jvm/java-17" -e GIT_AUTHOR_NAME="HBase" \
             -e GIT_AUTHOR_EMAIL="dev@hbase.apache.org" -e GIT_COMMITTER_NAME="HBase" \
             -e GIT_COMMITTER_EMAIL="dev@hbase.apache.org" --workdir=/home/${user} hbase-build-website \
             "component/dev-support/generate-website/build-hbase-website.sh" \

--- a/hbase-website/package.json
+++ b/hbase-website/package.json
@@ -28,8 +28,8 @@
     "export-pdf": "playwright test e2e-tests/export-pdf.spec.ts --project=chromium --workers=1",
     "fumadocs-init": "fumadocs-mdx",
     "copy-pdf-to-build": "cp -r public/books build/client",
-    "ci": "npm run extract-all && npm run fumadocs-init && npm run lint && npm run typecheck && npm run test:unit:run && npm run build && npx playwright install && npm run test:e2e && npm run copy-pdf-to-build",
-    "ci-skip-tests": "npm run extract-all && npm run fumadocs-init && npm run build && npx playwright install && npm run export-pdf && npm run copy-pdf-to-build"
+    "ci": "npm run extract-all && npm run fumadocs-init && npm run lint && npm run typecheck && npm run test:unit:run && npm run build && npx playwright install chromium firefox && npm run test:e2e && npm run copy-pdf-to-build",
+    "ci-skip-tests": "npm run extract-all && npm run fumadocs-init && npm run build && npx playwright install chromium && npm run export-pdf && npm run copy-pdf-to-build"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/hbase-website/playwright.config.ts
+++ b/hbase-website/playwright.config.ts
@@ -52,11 +52,6 @@ export default defineConfig({
     {
       name: "firefox",
       use: { ...devices["Desktop Firefox"] }
-    },
-
-    {
-      name: "webkit",
-      use: { ...devices["Desktop Safari"] }
     }
   ],
 


### PR DESCRIPTION
Webkit's MiniBrowser aborts on Ubuntu 22.04 due to a libsoup2/libsoup3 conflict introduced by `playwright install --with-deps`. Drop webkit from the Playwright config and Dockerfile, and pass CI=true into the Docker container so the existing Playwright CI-mode settings take effect.