### PR TITLE
HBASE-30181 Add SECURITY.md pointing at security-model + reporting flow

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -183,10 +183,15 @@ LLM context ingestion.
 
 ## Security Model
 
-The project's security model is documented at
-`hbase-website/app/pages/_landing/security-model/content.md`
-(published at https://hbase.apache.org/security-model).
-Read that document for the full security model including trust boundaries,
+The project's security model is the entry point for any security analysis
+of this codebase. The canonical chain for discovering it is:
+
+  AGENTS.md  ->  SECURITY.md  ->  https://hbase.apache.org/security-model/
+
+`SECURITY.md` at the repo root is a short pointer to the published model
+and the `security@apache.org` reporting flow. The full model (source at
+`hbase-website/app/pages/_landing/security-model/content.md`, published
+at <https://hbase.apache.org/security-model/>) details trust boundaries,
 what constitutes a valid vulnerability, and what does not.
 
 When performing security analysis of this codebase, use the navigation

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,46 @@
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+-->
+
+# Security Policy
+
+## Reporting a Vulnerability
+
+To report a security vulnerability in Apache HBase, please send a
+private email to <security@apache.org> — the Apache Software
+Foundation security team. Do **not** open a public GitHub issue or
+pull request, as that risks disclosure before a fix is available.
+
+The Apache HBase PMC is looped in privately as part of the standard
+ASF disclosure process. See <https://www.apache.org/security/> for
+the overall ASF vulnerability handling flow.
+
+## Threat Model
+
+Apache HBase's security model — trust boundaries, what constitutes a
+valid vulnerability report, and what does not — is documented at:
+
+  <https://hbase.apache.org/security-model/>
+
+Please read that document before filing a report so the PMC can triage
+quickly and accurately.
+
+## Tooling notes
+
+Agents and automated security tools analyzing this repository should
+also consult [`AGENTS.md`](./AGENTS.md), which references the same
+security model as the authoritative scope document.


### PR DESCRIPTION
## Summary

Makes the canonical discovery chain for the security model explicit
and conventional:

```
AGENTS.md  ->  SECURITY.md  ->  https://hbase.apache.org/security-model/
```

Two files changed:

- **New `SECURITY.md`** at the repo root — short pointer to the
  published model at <https://hbase.apache.org/security-model/>
  and to the `security@apache.org` reporting flow. Intentionally
  doesn't restate the model; the published page stays the source
  of truth.

- **`AGENTS.md` — Security Model section updated** — previously
  linked the published page directly; now routes through
  `SECURITY.md` so the discovery chain is canonical. Same target
  URL on the other end.

## Why

Two practical drivers:

1. **GitHub UI affordance.** GitHub's "Report a vulnerability"
   link surfaces the contents of `SECURITY.md` at the repo root.
   Without one, well-meaning reporters file public issues or PRs
   against what they perceive as security gaps. Having a one-page
   pointer to the threat model + `security@apache.org` reduces
   that risk.

2. **Agent-driven security tooling discovery.** The ASF Security
   team's tooling looks for threat-model references through the
   `AGENTS.md` → `SECURITY.md` → published model chain.
   Apache HBase already had the first and third pieces (the
   `AGENTS.md` Security Model section + the
   `/security-model/` page); this commit adds the middle pointer
   so the chain is mechanically followable for anything that
   expects the conventional shape.

This is requested as part of the HBase opt-in to the ASF
Security team's coordinated scan onboarding (the May 2026
`[GLASSWING]` thread on `private@hbase.apache.org`); the
request to open this specifically came from Andrew Purtell on
that thread.

## What this PR does NOT do

- It does **not** change the threat model itself. The canonical
  model stays at <https://hbase.apache.org/security-model/>
  (sourced from `hbase-website/app/pages/_landing/security-model/`).
- It does **not** introduce a new reporting alias. Reports
  continue to flow through `security@apache.org` as the published
  page already documents.
- It does **not** touch the multi-paragraph navigation /
  conventions content in `AGENTS.md` — only the Security Model
  section's wording.

## Test plan

- [ ] Render `SECURITY.md` on GitHub — confirm the model link
      and `security@apache.org` mailto resolve.
- [ ] Confirm GitHub's "Report a vulnerability" UI affordance
      now surfaces the contents of `SECURITY.md`.
- [ ] Verify `AGENTS.md` Security Model section reads as a
      canonical chain (`AGENTS.md → SECURITY.md → /security-model/`).
- [ ] `git log --oneline -2` on the branch shows the two
      logically-separate commits (one per file) so reviewers
      can read them independently.
