### PR TITLE
HBASE-30205 Optimize Bloom Filter bit operations by replacing array lookup with bitwise shift

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/BloomFilterChunk.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/BloomFilterChunk.java
@@ -203,12 +203,12 @@ public class BloomFilterChunk implements BloomFilterBase {
    * @param pos index of bit
    */
   void set(long pos) {
-    int bytePos = (int) (pos / 8);
-    int bitPos = (int) (pos % 8);
+    int bytePos = (int) (pos >> 3);
+    int bitPos = (int) (pos & 7);
     byte curByte = bloom.get(bytePos);
-    curByte |= BloomFilterUtil.bitvals[bitPos];
+    curByte |= (1 << bitPos);  
     bloom.put(bytePos, curByte);
-  }
+}
 
   /**
    * Check if bit at specified index is 1.
@@ -216,13 +216,11 @@ public class BloomFilterChunk implements BloomFilterBase {
    * @return true if bit at specified index is 1, false if 0.
    */
   static boolean get(int pos, ByteBuffer bloomBuf, int bloomOffset) {
-    int bytePos = pos >> 3; // pos / 8
-    int bitPos = pos & 0x7; // pos % 8
-    // TODO access this via Util API which can do Unsafe access if possible(?)
+    int bytePos = pos >> 3;
+    int bitPos = pos & 0x7;
     byte curByte = bloomBuf.get(bloomOffset + bytePos);
-    curByte &= BloomFilterUtil.bitvals[bitPos];
-    return (curByte != 0);
-  }
+    return (curByte & (1 << bitPos)) != 0;
+}
 
   @Override
   public long getKeyCount() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/BloomFilterUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/BloomFilterUtil.java
@@ -49,10 +49,6 @@ public final class BloomFilterUtil {
 
   public static final String PREFIX_LENGTH_KEY = "RowPrefixBloomFilter.prefix_length";
 
-  /** Bit-value lookup array to prevent doing the same work over and over */
-  public static final byte[] bitvals = { (byte) 0x01, (byte) 0x02, (byte) 0x04, (byte) 0x08,
-    (byte) 0x10, (byte) 0x20, (byte) 0x40, (byte) 0x80 };
-
   /**
    * Private constructor to keep this class from being instantiated.
    */
@@ -221,8 +217,7 @@ public final class BloomFilterUtil {
     int bytePos = pos >> 3; // pos / 8
     int bitPos = pos & 0x7; // pos % 8
     byte curByte = bloomBuf.get(bloomOffset + bytePos);
-    curByte &= bitvals[bitPos];
-    return (curByte != 0);
+    return (curByte & (1 << bitPos)) != 0;
   }
 
   /**


### PR DESCRIPTION
Optimize Bloom Filter bit operations by replacing array lookup with bitwise shift

While this is functional, it introduces unnecessary overhead in the read path, which is highly performance-sensitive:

Array Bounds Checking: The JVM must perform bounds checking for every array access to prevent ArrayIndexOutOfBoundsException, which adds minor but cumulative overhead.
Memory Access: Even though bitvals is likely cached in L1/L2 CPU cache, it still requires a memory load instruction.
Division/Modulo Overhead: In BloomFilterChunk#set(long pos), the code uses / 8 and % 8 which compiles to relatively expensive division instructions.
Solution
This PR optimizes the Bloom Filter bit operations by replacing the array lookup with direct bitwise shifts and optimizing the division/modulo operations:

Direct Bitwise Shift: Replaced BloomFilterUtil.bitvals[bitPos] with (1 << bitPos).
This eliminates array bounds checks completely.
The JIT compiler can optimize 1 << bitPos into a single, extremely fast CPU instruction (SHL), executing entirely within CPU registers with zero memory access latency.
Remove Unused Array: Removed the BloomFilterUtil.bitvals array completely to clean up the code.
Division to Shift Optimization: In BloomFilterChunk#set(long pos), replaced pos / 8 and pos % 8 with pos >> 3 and pos & 7. Since pos is always non-negative in this context, this is a safe and much faster alternative to division instructions.
Proposed Changes