### PR TITLE
HBASE-30193 Exclude transitive jakarta.mail dependency (CVE-2025-7962)

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -1886,6 +1886,10 @@
             <groupId>com.sun.xml.ws</groupId>
             <artifactId>samples</artifactId>
           </exclusion>
+          <exclusion>
+            <groupId>com.sun.mail</groupId>
+            <artifactId>jakarta.mail</artifactId>
+          </exclusion>
         </exclusions>
       </dependency>
       <dependency>


### PR DESCRIPTION
**com.sun.mail:jakarta.mail** is a transitive dependency pulled in via **com.sun.xml.ws:jaxws-rt:2.3.7**. It is not used anywhere in HBase.

jaxws-rt itself is only used in two modules (hbase-it and hbase-dev-generate-classpath), and the only class referenced from its dependency chain is javax.xml.ws.http.HTTPException (which comes from jakarta.xml.ws-api, not from jakarta.mail).

Since jakarta.mail is unused and brings in CVE-2025-7962 (SMTP Injection), it is safe to exclude it from jaxws-rt.