### PR TITLE
HBASE-30023 Refactor write path, prefetch, and compaction cache popul…

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -365,7 +365,7 @@ public class HalfStoreFileReader extends StoreFileReader {
           long offset = s.getCurBlock().getOffset();
           LOG.trace("Seeking to split cell in reader: {} for file: {} top: {}, split offset: {}",
             this, reference, top, offset);
-          ((HFileReaderImpl) reader).getCacheConf().getBlockCache().ifPresent(cache -> {
+          ((HFileReaderImpl) reader).getCacheConf().getCacheAccessService().ifEnabled(cache -> {
             int numEvictedReferred = top
               ? cache.evictBlocksRangeByHfileName(referred, offset, Long.MAX_VALUE)
               : cache.evictBlocksRangeByHfileName(referred, 0, offset);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -309,8 +309,8 @@ public class CacheConfig implements PropagatingConfigurationObserver {
     Configuration conf) {
     Optional<Boolean> cacheFileBlock = Optional.of(true);
     // For DATA blocks only, if BucketCache is in use, we don't need to cache block again
-    if (getBlockCache().isPresent() && category.equals(BlockCategory.DATA)) {
-      Optional<Boolean> result = getBlockCache().get().shouldCacheFile(hFileInfo, conf);
+    if (category.equals(BlockCategory.DATA)) {
+      Optional<Boolean> result = getCacheAccessService().shouldCacheFile(hFileInfo, conf);
       if (result.isPresent()) {
         cacheFileBlock = result;
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
@@ -1075,7 +1075,7 @@ public class HFileBlockIndex {
         if (midKeyMetadata != null) blockStream.write(midKeyMetadata);
         blockWriter.writeHeaderAndData(out);
         if (cacheConf != null) {
-          cacheConf.getBlockCache().ifPresent(cache -> {
+          cacheConf.getCacheAccessService().ifEnabled(cache -> {
             HFileBlock blockForCaching = blockWriter.getBlockForCaching(cacheConf);
             cache.cacheBlock(new BlockCacheKey(nameForCaching, rootLevelIndexPos, true,
               blockForCaching.getBlockType()), blockForCaching);
@@ -1169,7 +1169,7 @@ public class HFileBlockIndex {
       blockWriter.writeHeaderAndData(out);
 
       if (getCacheOnWrite()) {
-        cacheConf.getBlockCache().ifPresent(cache -> {
+        cacheConf.getCacheAccessService().ifEnabled(cache -> {
           HFileBlock blockForCaching = blockWriter.getBlockForCaching(cacheConf);
           try {
             cache.cacheBlock(

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -42,7 +42,7 @@ public class HFilePreadReader extends HFileReaderImpl {
     fileInfo.initMetaAndIndex(this);
     // master hosted regions, like the master procedures store wouldn't have a block cache
     // Prefetch file blocks upon open if requested
-    if (cacheConf.getBlockCache().isPresent() && cacheConf.shouldPrefetchOnOpen()) {
+    if (cacheConf.getCacheAccessService().isCacheEnabled() && cacheConf.shouldPrefetchOnOpen()) {
       PrefetchExecutor.request(path, new Runnable() {
         @Override
         public void run() {
@@ -50,7 +50,7 @@ public class HFilePreadReader extends HFileReaderImpl {
           long end = 0;
           HFile.Reader prefetchStreamReader = null;
           try {
-            cacheConf.getBlockCache().ifPresent(
+            cacheConf.getCacheAccessService().ifEnabled(
               cache -> cache.waitForCacheInitialization(WAIT_TIME_FOR_CACHE_INITIALIZATION));
             ReaderContext streamReaderContext = ReaderContextBuilder.newBuilder(context)
               .withReaderType(ReaderContext.ReaderType.STREAM)
@@ -185,7 +185,7 @@ public class HFilePreadReader extends HFileReaderImpl {
     // Deallocate blocks in load-on-open section
     this.fileInfo.close();
     // Deallocate data blocks
-    cacheConf.getBlockCache().ifPresent(cache -> {
+    cacheConf.getCacheAccessService().ifEnabled(cache -> {
       if (evictOnClose) {
         int numEvicted = cache.evictBlocksByHfileName(name);
         if (LOG.isTraceEnabled()) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -1271,7 +1271,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
 
       // Cache the block
       if (cacheBlock) {
-        cacheConf.getBlockCache().ifPresent(
+        cacheConf.getCacheAccessService().ifEnabled(
           cache -> cache.cacheBlock(cacheKey, uncompressedBlock, cacheConf.isInMemory()));
       }
       return uncompressedBlock;
@@ -1290,7 +1290,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
    *      boolean, boolean)
    */
   private boolean shouldUseHeap(BlockType expectedBlockType, boolean cacheBlock) {
-    if (!cacheConf.getBlockCache().isPresent()) {
+    if (!cacheConf.getCacheAccessService().isCacheEnabled()) {
       return false;
     }
 
@@ -1411,7 +1411,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
         // Don't need the unpacked block back and we're storing the block in the cache compressed
         if (cacheOnly && cacheCompressed && cacheOnRead) {
           HFileBlock blockNoChecksum = BlockCacheUtil.getBlockForCaching(cacheConf, hfileBlock);
-          cacheConf.getBlockCache().ifPresent(cache -> {
+          cacheConf.getCacheAccessService().ifEnabled(cache -> {
             LOG.debug("Skipping decompression of block {} in prefetch", cacheKey);
             // Cache the block if necessary
             if (cacheBlock && cacheOnRead) {
@@ -1427,7 +1427,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
         HFileBlock unpacked = hfileBlock.unpack(hfileContext, fsBlockReader);
         HFileBlock unpackedNoChecksum = BlockCacheUtil.getBlockForCaching(cacheConf, unpacked);
         // Cache the block if necessary
-        cacheConf.getBlockCache().ifPresent(cache -> {
+        cacheConf.getCacheAccessService().ifEnabled(cache -> {
           if (cacheBlock && cacheOnRead) {
             // Using the wait on cache during compaction and prefetching.
             cache.cacheBlock(cacheKey,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hbase.io.crypto.Encryption;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock.BlockWritable;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.regionserver.TimeRangeTracker;
 import org.apache.hadoop.hbase.security.EncryptionUtil;
 import org.apache.hadoop.hbase.security.User;
@@ -576,7 +577,7 @@ public class HFileWriterImpl implements HFile.Writer {
    * @param offset the offset of the block we want to cache. Used to determine the cache key.
    */
   private void doCacheOnWrite(long offset) {
-    cacheConf.getBlockCache().ifPresent(cache -> {
+    cacheConf.getCacheAccessService().ifEnabled(cache -> {
       HFileBlock cacheFormatBlock = blockWriter.getBlockForCaching(cacheConf);
       try {
         BlockCacheKey key = buildCacheBlockKey(offset, cacheFormatBlock.getBlockType());
@@ -598,7 +599,7 @@ public class HFileWriterImpl implements HFile.Writer {
     return new BlockCacheKey(name, offset, true, blockType);
   }
 
-  private boolean shouldCacheBlock(BlockCache cache, BlockCacheKey key) {
+  private boolean shouldCacheBlock(CacheAccessService cache, BlockCacheKey key) {
     Optional<Boolean> result =
       cache.shouldCacheBlock(key, timeRangeTrackerForTiering.get().getMax(), conf);
     return result.orElse(true);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -304,5 +305,20 @@ public class BlockCacheBackedCacheAccessService implements CacheAccessService {
     long size) {
     Objects.requireNonNull(fileName, "fileName must not be null");
     blockCache.notifyFileCachingCompleted(fileName, totalBlockCount, dataBlockCount, size);
+  }
+
+  @Override
+  public Optional<Boolean> shouldCacheFile(HFileInfo hFileInfo, Configuration conf) {
+    Objects.requireNonNull(hFileInfo, "hFileInfo must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return blockCache.shouldCacheFile(hFileInfo, conf);
+  }
+
+  @Override
+  public Optional<Boolean> shouldCacheBlock(BlockCacheKey key, long maxTimestamp,
+    Configuration conf) {
+    Objects.requireNonNull(key, "key must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return blockCache.shouldCacheBlock(key, maxTimestamp, conf);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
@@ -17,7 +17,9 @@
  */
 package org.apache.hadoop.hbase.io.hfile.cache;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
@@ -25,6 +27,7 @@ import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -119,8 +122,8 @@ public interface CacheAccessService {
    */
   default Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
     boolean updateCacheMetrics) {
-    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(caching)
-      .setRepeat(repeat).setUpdateCacheMetrics(updateCacheMetrics).build();
+    CacheRequestContext context = CacheRequestContext.newBuilder().withCaching(caching)
+      .withRepeat(repeat).withUpdateCacheMetrics(updateCacheMetrics).build();
     return getBlock(cacheKey, context);
   }
 
@@ -140,8 +143,9 @@ public interface CacheAccessService {
    */
   default Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
     boolean updateCacheMetrics, BlockType blockType) {
-    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(caching)
-      .setRepeat(repeat).setUpdateCacheMetrics(updateCacheMetrics).setBlockType(blockType).build();
+    CacheRequestContext context =
+      CacheRequestContext.newBuilder().withCaching(caching).withRepeat(repeat)
+        .withUpdateCacheMetrics(updateCacheMetrics).withBlockType(blockType).build();
     return getBlock(cacheKey, context);
   }
 
@@ -178,7 +182,7 @@ public interface CacheAccessService {
    * @param inMemory whether the block should be treated as in-memory
    */
   default void cacheBlock(BlockCacheKey cacheKey, Cacheable block, boolean inMemory) {
-    CacheWriteContext context = CacheWriteContext.newBuilder().setInMemory(inMemory).build();
+    CacheWriteContext context = CacheWriteContext.newBuilder().withInMemory(inMemory).build();
     cacheBlock(cacheKey, block, context);
   }
 
@@ -196,8 +200,8 @@ public interface CacheAccessService {
    */
   default void cacheBlock(BlockCacheKey cacheKey, Cacheable block, boolean inMemory,
     boolean waitWhenCache) {
-    CacheWriteContext context =
-      CacheWriteContext.newBuilder().setInMemory(inMemory).setWaitWhenCache(waitWhenCache).build();
+    CacheWriteContext context = CacheWriteContext.newBuilder().withInMemory(inMemory)
+      .withWaitWhenCache(waitWhenCache).build();
     cacheBlock(cacheKey, block, context);
   }
 
@@ -443,5 +447,73 @@ public interface CacheAccessService {
   default void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
     long size) {
     // noop
+  }
+
+  /**
+   * Executes the supplied action when this cache service is enabled.
+   * <p>
+   * This helper is intended to preserve the old {@code getBlockCache().ifPresent(...)} style for
+   * call sites that should do nothing when block cache is disabled. It keeps callers independent of
+   * concrete implementations such as {@code NoOpCacheAccessService} while still allowing disabled
+   * cache wiring to behave like an absent cache.
+   * </p>
+   * <p>
+   * Implementations normally do not need to override this method. The default implementation checks
+   * {@link #isCacheEnabled()} and invokes the supplied action only when cache access is enabled.
+   * </p>
+   * @param action action to execute with this cache service when enabled
+   */
+  default void ifEnabled(Consumer<CacheAccessService> action) {
+    Objects.requireNonNull(action, "action must not be null");
+    if (isCacheEnabled()) {
+      action.accept(this);
+    }
+  }
+
+  /**
+   * Returns whether blocks from the given HFile should be cached. TODO: this method is a temporary
+   * adapter for file-level admission decisions. It will be removed and replaced by a more general
+   * admission API in the future.
+   * <p>
+   * This is a file-level admission hook used by cache population paths. Implementations may use
+   * file metadata, configuration, data tiering state, or implementation-specific bookkeeping to
+   * decide whether the file should be admitted into cache.
+   * </p>
+   * <p>
+   * The returned {@link Optional} is empty when the cache service does not support file-level
+   * admission decisions. In that case, callers should preserve existing default behavior, typically
+   * treating the result as "no opinion" rather than as a rejection.
+   * </p>
+   * @param hFileInfo HFile metadata used for the admission decision
+   * @param conf      configuration
+   * @return empty if unsupported; otherwise whether the file should be cached
+   */
+  default Optional<Boolean> shouldCacheFile(HFileInfo hFileInfo, Configuration conf) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns whether the block represented by the given key and timestamp should be cached. TODO:
+   * this method is a temporary adapter for file-level admission decisions. It will be removed and
+   * replaced by a more general admission API in the future.
+   * <p>
+   * <p>
+   * This is a block-level admission hook used by cache population paths. Implementations may use
+   * block identity, maximum timestamp, configuration, data tiering state, or
+   * implementation-specific policy to decide whether the block should be admitted into cache.
+   * </p>
+   * <p>
+   * The returned {@link Optional} is empty when the cache service does not support block-level
+   * admission decisions. In that case, callers should preserve existing default behavior, typically
+   * treating the result as "no opinion" rather than as a rejection.
+   * </p>
+   * @param key          block cache key
+   * @param maxTimestamp maximum timestamp associated with the block
+   * @param conf         configuration
+   * @return empty if unsupported; otherwise whether the block should be cached
+   */
+  default Optional<Boolean> shouldCacheBlock(BlockCacheKey key, long maxTimestamp,
+    Configuration conf) {
+    return Optional.empty();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheRequestContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheRequestContext.java
@@ -122,7 +122,7 @@ public final class CacheRequestContext {
      * @param caching true when caching is enabled
      * @return this builder
      */
-    public Builder setCaching(boolean caching) {
+    public Builder withCaching(boolean caching) {
       this.caching = caching;
       return this;
     }
@@ -132,7 +132,7 @@ public final class CacheRequestContext {
      * @param repeat true when this is a repeated lookup
      * @return this builder
      */
-    public Builder setRepeat(boolean repeat) {
+    public Builder withRepeat(boolean repeat) {
       this.repeat = repeat;
       return this;
     }
@@ -142,7 +142,7 @@ public final class CacheRequestContext {
      * @param updateCacheMetrics true when metrics should be updated
      * @return this builder
      */
-    public Builder setUpdateCacheMetrics(boolean updateCacheMetrics) {
+    public Builder withUpdateCacheMetrics(boolean updateCacheMetrics) {
       this.updateCacheMetrics = updateCacheMetrics;
       return this;
     }
@@ -152,7 +152,7 @@ public final class CacheRequestContext {
      * @param blockType expected block type
      * @return this builder
      */
-    public Builder setBlockType(BlockType blockType) {
+    public Builder withBlockType(BlockType blockType) {
       this.blockType = blockType;
       return this;
     }
@@ -162,7 +162,7 @@ public final class CacheRequestContext {
      * @param compaction true when compaction-related
      * @return this builder
      */
-    public Builder setCompaction(boolean compaction) {
+    public Builder withCompaction(boolean compaction) {
       this.compaction = compaction;
       return this;
     }
@@ -172,7 +172,7 @@ public final class CacheRequestContext {
      * @param prefetch true when prefetch-related
      * @return this builder
      */
-    public Builder setPrefetch(boolean prefetch) {
+    public Builder withPrefetch(boolean prefetch) {
       this.prefetch = prefetch;
       return this;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteContext.java
@@ -110,7 +110,7 @@ public final class CacheWriteContext {
      * @param inMemory true when in-memory treatment is requested
      * @return this builder
      */
-    public Builder setInMemory(boolean inMemory) {
+    public Builder withInMemory(boolean inMemory) {
       this.inMemory = inMemory;
       return this;
     }
@@ -120,7 +120,7 @@ public final class CacheWriteContext {
      * @param waitWhenCache true when insertion should wait
      * @return this builder
      */
-    public Builder setWaitWhenCache(boolean waitWhenCache) {
+    public Builder withWaitWhenCache(boolean waitWhenCache) {
       this.waitWhenCache = waitWhenCache;
       return this;
     }
@@ -130,7 +130,7 @@ public final class CacheWriteContext {
      * @param cacheCompressed true when compressed caching is requested
      * @return this builder
      */
-    public Builder setCacheCompressed(boolean cacheCompressed) {
+    public Builder withCacheCompressed(boolean cacheCompressed) {
       this.cacheCompressed = cacheCompressed;
       return this;
     }
@@ -140,7 +140,7 @@ public final class CacheWriteContext {
      * @param blockCategory block category
      * @return this builder
      */
-    public Builder setBlockCategory(BlockCategory blockCategory) {
+    public Builder withBlockCategory(BlockCategory blockCategory) {
       this.blockCategory = blockCategory;
       return this;
     }
@@ -150,7 +150,7 @@ public final class CacheWriteContext {
      * @param source cache write source
      * @return this builder
      */
-    public Builder setSource(CacheWriteSource source) {
+    public Builder withSource(CacheWriteSource source) {
       this.source = source;
       return this;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteSource.java
@@ -36,6 +36,16 @@ public enum CacheWriteSource {
   READ_MISS,
 
   /**
+   * Block was inserted from the HFile write/cache-on-write path.
+   * <p>
+   * This source covers write-side population where the caller does not expose whether the HFile is
+   * being produced by flush, compaction, bulk load, or another writer. More specific write-side
+   * sources can be added later when that context is available at the call site.
+   * </p>
+   */
+  WRITE_PATH,
+
+  /**
    * Cache population during flush output generation.
    */
   FLUSH,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -289,5 +290,20 @@ public final class NoOpCacheAccessService implements CacheAccessService {
   public void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
     long size) {
     Objects.requireNonNull(fileName, "fileName must not be null");
+  }
+
+  @Override
+  public Optional<Boolean> shouldCacheFile(HFileInfo hFileInfo, Configuration conf) {
+    Objects.requireNonNull(hFileInfo, "hFileInfo must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Boolean> shouldCacheBlock(BlockCacheKey key, long maxTimestamp,
+    Configuration conf) {
+    Objects.requireNonNull(key, "key must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return Optional.empty();
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/FromClientSideTest5.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/FromClientSideTest5.java
@@ -64,8 +64,8 @@ import org.apache.hadoop.hbase.filter.InclusiveStopFilter;
 import org.apache.hadoop.hbase.filter.RowFilter;
 import org.apache.hadoop.hbase.filter.SubstringComparator;
 import org.apache.hadoop.hbase.filter.ValueFilter;
-import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.regionserver.HStore;
@@ -650,7 +650,7 @@ public class FromClientSideTest5 extends FromClientSideTestBase {
       CacheConfig cacheConf = store.getCacheConfig();
       cacheConf.setCacheDataOnWrite(true);
       cacheConf.setEvictOnClose(true);
-      BlockCache cache = cacheConf.getBlockCache().get();
+      CacheAccessService cache = cacheConf.getCacheAccessService();
 
       // establish baseline stats
       long startBlockCount = cache.getBlockCount();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
@@ -219,6 +219,7 @@ public class TestHFile {
     BlockCache cache = Mockito.mock(BlockCache.class);
     Mockito.when(cache.shouldCacheBlock(Mockito.any(), Mockito.anyLong(), Mockito.any()))
       .thenReturn(Optional.of(false));
+    Mockito.when(cache.isCacheEnabled()).thenReturn(true);
     Path hfilePath = new Path(TEST_UTIL.getDataTestDir(), "testWriterCacheOnWriteSkipDoesNotLeak");
     HFileContext context = new HFileContextBuilder().withBlockSize(blockSize).build();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlock.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlock.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -65,6 +64,7 @@ import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.compress.Compression.Algorithm;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.io.hfile.cache.NoOpCacheAccessService;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.MultiByteBuff;
 import org.apache.hadoop.hbase.nio.SingleByteBuff;
@@ -288,7 +288,7 @@ public class TestHFileBlock {
   @TestTemplate
   public void testNoCompression() throws IOException {
     CacheConfig cacheConf = Mockito.mock(CacheConfig.class);
-    Mockito.when(cacheConf.getBlockCache()).thenReturn(Optional.empty());
+    Mockito.when(cacheConf.getCacheAccessService()).thenReturn(new NoOpCacheAccessService());
 
     HFileBlock block =
       createTestV2Block(NONE, includesMemstoreTS, false).getBlockForCaching(cacheConf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.HFile.Writer;
 import org.apache.hadoop.hbase.io.hfile.HFileBlockIndex.BlockIndexReader;
 import org.apache.hadoop.hbase.io.hfile.NoOpIndexBlockEncoder.NoOpEncodedSeeker;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.MultiByteBuff;
 import org.apache.hadoop.hbase.nio.RefCnt;
@@ -619,9 +620,9 @@ public class TestHFileBlockIndex {
     // should open hfile.block.index.cacheonwrite
     conf.setBoolean(CacheConfig.CACHE_INDEX_BLOCKS_ON_WRITE_KEY, true);
     CacheConfig cacheConf = new CacheConfig(conf, BlockCacheFactory.createBlockCache(conf));
-    BlockCache blockCache = cacheConf.getBlockCache().get();
+    CacheAccessService cache = cacheConf.getCacheAccessService();
     // Evict all blocks that were cached-on-write by the previous invocation.
-    blockCache.evictBlocksByHfileName(hfilePath.getName());
+    cache.evictBlocksByHfileName(hfilePath.getName());
     // Write the HFile
     HFileContext meta = new HFileContextBuilder().withBlockSize(SMALL_BLOCK_SIZE)
       .withCompression(Algorithm.NONE).withDataBlockEncoding(DataBlockEncoding.NONE).build();
@@ -671,14 +672,14 @@ public class TestHFileBlockIndex {
   public void testHFileWriterAndReader() throws IOException {
     Path hfilePath = new Path(TEST_UTIL.getDataTestDir(), "hfile_for_block_index");
     CacheConfig cacheConf = new CacheConfig(conf, BlockCacheFactory.createBlockCache(conf));
-    BlockCache blockCache = cacheConf.getBlockCache().get();
+    CacheAccessService cache = cacheConf.getCacheAccessService();
 
     for (int testI = 0; testI < INDEX_CHUNK_SIZES.length; ++testI) {
       int indexBlockSize = INDEX_CHUNK_SIZES[testI];
       int expectedNumLevels = EXPECTED_NUM_LEVELS[testI];
       LOG.info("Index block size: " + indexBlockSize + ", compression: " + compr);
       // Evict all blocks that were cached-on-write by the previous invocation.
-      blockCache.evictBlocksByHfileName(hfilePath.getName());
+      cache.evictBlocksByHfileName(hfilePath.getName());
 
       conf.setInt(HFileBlockIndex.MAX_CHUNK_SIZE_KEY, indexBlockSize);
       Set<String> keyStrSet = new HashSet<>();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestLazyDataBlockDecompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestLazyDataBlockDecompression.java
@@ -132,6 +132,10 @@ public class TestLazyDataBlockDecompression {
     reader.close();
   }
 
+  /*
+   * TODO: migrate this test to use new HBASE-30018 APIs and remove the need to cast to
+   * LruBlockCache
+   */
   @TestTemplate
   public void testCompressionIncreasesEffectiveBlockCacheSize() throws Exception {
     // enough room for 2 uncompressed block

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestBlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestBlockCacheBackedCacheAccessService.java
@@ -69,8 +69,8 @@ public class TestBlockCacheBackedCacheAccessService {
 
     when(blockCache.getBlock(key, true, true, false, BlockType.DATA)).thenReturn(block);
 
-    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(true).setRepeat(true)
-      .setUpdateCacheMetrics(false).setBlockType(BlockType.DATA).build();
+    CacheRequestContext context = CacheRequestContext.newBuilder().withCaching(true)
+      .withRepeat(true).withUpdateCacheMetrics(false).withBlockType(BlockType.DATA).build();
 
     assertSame(block, service.getBlock(key, context));
     verify(blockCache).getBlock(key, true, true, false, BlockType.DATA);
@@ -88,8 +88,8 @@ public class TestBlockCacheBackedCacheAccessService {
 
     when(blockCache.getBlock(key, true, false, true)).thenReturn(block);
 
-    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(true).setRepeat(false)
-      .setUpdateCacheMetrics(true).build();
+    CacheRequestContext context = CacheRequestContext.newBuilder().withCaching(true)
+      .withRepeat(false).withUpdateCacheMetrics(true).build();
 
     assertSame(block, service.getBlock(key, context));
     verify(blockCache).getBlock(key, true, false, true);
@@ -105,8 +105,8 @@ public class TestBlockCacheBackedCacheAccessService {
     BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
     Cacheable block = mock(Cacheable.class);
 
-    CacheWriteContext context = CacheWriteContext.newBuilder().setInMemory(true)
-      .setWaitWhenCache(true).setSource(CacheWriteSource.READ_MISS).build();
+    CacheWriteContext context = CacheWriteContext.newBuilder().withInMemory(true)
+      .withWaitWhenCache(true).withSource(CacheWriteSource.READ_MISS).build();
 
     service.cacheBlock(key, block, context);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestNoOpCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestNoOpCacheAccessService.java
@@ -52,10 +52,10 @@ public class TestNoOpCacheAccessService {
   void testNoOpCacheAccessService() {
     CacheAccessService service = new NoOpCacheAccessService(new CacheStats("noop"));
     BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
-    CacheRequestContext requestContext = CacheRequestContext.newBuilder().setCaching(true)
-      .setRepeat(false).setUpdateCacheMetrics(true).build();
-    CacheWriteContext writeContext = CacheWriteContext.newBuilder().setInMemory(true)
-      .setWaitWhenCache(true).setSource(CacheWriteSource.READ_MISS).build();
+    CacheRequestContext requestContext = CacheRequestContext.newBuilder().withCaching(true)
+      .withRepeat(false).withUpdateCacheMetrics(true).build();
+    CacheWriteContext writeContext = CacheWriteContext.newBuilder().withInMemory(true)
+      .withWaitWhenCache(true).withSource(CacheWriteSource.READ_MISS).build();
     Cacheable block = mock(Cacheable.class);
     Configuration conf = new Configuration(false);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestTopologyBackedCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestTopologyBackedCacheAccessService.java
@@ -463,12 +463,12 @@ public class TestTopologyBackedCacheAccessService {
   }
 
   private static CacheRequestContext requestContext() {
-    return CacheRequestContext.newBuilder().setCaching(true).setRepeat(false)
-      .setUpdateCacheMetrics(true).setBlockType(BlockType.DATA).build();
+    return CacheRequestContext.newBuilder().withCaching(true).withRepeat(false)
+      .withUpdateCacheMetrics(true).withBlockType(BlockType.DATA).build();
   }
 
   private static CacheWriteContext writeContext() {
-    return CacheWriteContext.newBuilder().setInMemory(true).setWaitWhenCache(true)
-      .setSource(CacheWriteSource.READ_MISS).build();
+    return CacheWriteContext.newBuilder().withInMemory(true).withWaitWhenCache(true)
+      .withSource(CacheWriteSource.READ_MISS).build();
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestAtomicOperation.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestAtomicOperation.java
@@ -63,8 +63,8 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.filter.BinaryComparator;
 import org.apache.hadoop.hbase.io.HeapSize;
-import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.VerySlowRegionServerTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -115,7 +115,7 @@ public class TestAtomicOperation {
       if (wal != null) {
         wal.close();
       }
-      cacheConfig.getBlockCache().ifPresent(BlockCache::shutdown);
+      cacheConfig.getCacheAccessService().ifEnabled(CacheAccessService::shutdown);
       region = null;
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCacheOnWriteInSchema.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCacheOnWriteInSchema.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.fs.HFileSystem;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
-import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheFactory;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
@@ -46,6 +45,7 @@ import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
 import org.apache.hadoop.hbase.io.hfile.RandomKeyValueUtil;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -201,7 +201,7 @@ public class TestCacheOnWriteInSchema {
 
   private void readStoreFile(Path path) throws IOException {
     CacheConfig cacheConf = store.getCacheConfig();
-    BlockCache cache = cacheConf.getBlockCache().get();
+    CacheAccessService cache = cacheConf.getCacheAccessService();
     StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, path, true);
     HStoreFile sf = new HStoreFile(storeFileInfo, BloomType.ROWCOL, cacheConf);
     sf.initReader();


### PR DESCRIPTION
### Summary

This PR continues the pluggable block cache refactoring by migrating cache population paths to use CacheAccessService instead of calling BlockCache directly where the code is part of HFile cache access behavior.

The change keeps the runtime behavior legacy-compatible. Existing BlockCache implementations are still used through BlockCacheBackedCacheAccessService. This PR does not refactor BlockCacheFactory, does not introduce CacheEngine-backed runtime wiring, and does not attempt to migrate all remaining BlockCache references.

The main goal is to make CacheAccessService the HBase-facing facade for cache lookup, insertion, invalidation, admission checks, and related cache operations while preserving existing behavior.

### Changes

* Migrates additional cache population code paths from direct BlockCache usage to CacheAccessService.
* Preserves simple cacheBlock(...) overloads on CacheAccessService so legacy-style call sites do not need to construct CacheWriteContext manually.
* Keeps CacheWriteContext available for future richer policy-aware cache insertion paths.
* Adds/uses compatibility forwarding for cache admission hooks such as shouldCacheBlock(...) and shouldCacheFile(...) where existing paths depend on them.
* Adds/uses CacheAccessService.ifEnabled(...) for call sites that need the old Optional#ifPresent(...) style behavior when cache is disabled.
* Preserves disabled-cache behavior through NoOpCacheAccessService.
* Updates affected tests.

### Compatibility notes

This PR intentionally does not force every cache insertion call site to specify a precise CacheWriteSource.

Existing HBase cache population code does not always expose whether a block insertion comes from flush, compaction, bulk load, or another writer path. Guessing that source could introduce incorrect policy behavior later. Therefore, this PR keeps compatibility-oriented overloads and uses richer context only where the information is already available and meaningful.

### Out of scope

* No BlockCacheFactory refactoring.
* No CacheEngine adapter migration.
* No migration of LruBlockCache, LruAdaptiveBlockCache, TinyLfuBlockCache, or BucketCache to CacheEngine.
* No removal of BlockCache from CacheConfig.
* No removal of getBlockCache().
* No migration of BlockCache.iterator().
* No diagnostic JSP/admin page migration.
* No broad migration of implementation-specific cache tests.
* No topology-backed runtime wiring.

### Testing

Ran the affected HFile cache-on-write test successfully:

bash mvn -pl hbase-server -Dtest=TestHFile#testWriterCacheOnWriteSkipDoesNotLeak test 

Also verified build/package after resolving a stale local class output issue unrelated to this PR.