### PR TITLE
HBASE-30212 Netty should allow every supported TLS ciphers by default

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/crypto/tls/X509Util.java
@@ -47,6 +47,7 @@ import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hbase.thirdparty.io.netty.handler.ssl.IdentityCipherSuiteFilter;
 import org.apache.hbase.thirdparty.io.netty.handler.ssl.OpenSsl;
 import org.apache.hbase.thirdparty.io.netty.handler.ssl.SslContext;
 import org.apache.hbase.thirdparty.io.netty.handler.ssl.SslContextBuilder;
@@ -210,7 +211,14 @@ public final class X509Util {
       sslContextBuilder.protocols(enabledProtocols);
     }
     String[] cipherSuites = getCipherSuites(config);
-    if (cipherSuites != null) {
+    if (cipherSuites == null) {
+      /*
+       * if cipher list is not explicitly defined, we use the most inclusive cipher list at the
+       * client side
+       */
+      sslContextBuilder.ciphers(null,
+        IdentityCipherSuiteFilter.INSTANCE_DEFAULTING_TO_SUPPORTED_CIPHERS);
+    } else {
       sslContextBuilder.ciphers(Arrays.asList(cipherSuites));
     }
 


### PR DESCRIPTION
Netty will allow to use every supported cipher at the client side by default, so clients can use the widest range of ciphers.