### PR TITLE
HBASE-28659 Fix NPE in hmaster RegionStates.setServerState when the ServerStateNode is missing

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
@@ -376,6 +376,17 @@ public class RegionStates {
 
   private void setServerState(ServerName serverName, ServerState state) {
     ServerStateNode serverNode = getServerNode(serverName);
+    if (serverNode == null) {
+      // The ServerStateNode is only kept in memory and is rebuilt on Master startup just for the
+      // 'live' servers. A ServerCrashProcedure persisted before a Master restart can resume for a
+      // server that is no longer 'live' (already splitting and only referenced by the SCP), so no
+      // node was recreated for it. See HBASE-28659. The split state we set here is bookkeeping
+      // only, so if the node is gone there is nothing to update; skip rather than NPE (NPE would
+      // fail the SCP and trigger an unsupported rollback).
+      LOG.warn("Can not set state {} for {} as the ServerStateNode does not exist", state,
+        serverName);
+      return;
+    }
     synchronized (serverNode) {
       serverNode.setState(state);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
@@ -375,18 +375,15 @@ public class RegionStates {
   // ============================================================================================
 
   private void setServerState(ServerName serverName, ServerState state) {
-    ServerStateNode serverNode = getServerNode(serverName);
-    if (serverNode == null) {
-      // The ServerStateNode is only kept in memory and is rebuilt on Master startup just for the
-      // 'live' servers. A ServerCrashProcedure persisted before a Master restart can resume for a
-      // server that is no longer 'live' (already splitting and only referenced by the SCP), so no
-      // node was recreated for it. See HBASE-28659. The split state we set here is bookkeeping
-      // only, so if the node is gone there is nothing to update; skip rather than NPE (NPE would
-      // fail the SCP and trigger an unsupported rollback).
-      LOG.warn("Can not set state {} for {} as the ServerStateNode does not exist", state,
-        serverName);
-      return;
-    }
+    // The ServerStateNode is only kept in memory and is rebuilt on Master startup for the 'live'
+    // servers (RegionServerTracker#upgrade) and for servers still referenced as a region location
+    // in hbase:meta (AssignmentManager#loadMeta). A ServerCrashProcedure persisted before a Master
+    // restart can resume for a server that is no longer 'live' and is not referenced by any region
+    // in meta, so no node was recreated for it. See HBASE-28659. These split helpers only ever run
+    // for a crashed server inside an SCP, so recreate the node rather than NPE; the SCP will remove
+    // it again via removeServer at SERVER_CRASH_FINISH.
+    ServerStateNode serverNode =
+      serverMap.computeIfAbsent(serverName, key -> new ServerStateNode(key));
     synchronized (serverNode) {
       serverNode.setState(state);
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
@@ -382,8 +382,7 @@ public class RegionStates {
     // in meta, so no node was recreated for it. See HBASE-28659. These split helpers only ever run
     // for a crashed server inside an SCP, so recreate the node rather than NPE; the SCP will remove
     // it again via removeServer at SERVER_CRASH_FINISH.
-    ServerStateNode serverNode =
-      serverMap.computeIfAbsent(serverName, key -> new ServerStateNode(key));
+    ServerStateNode serverNode = createServer(serverName);
     synchronized (serverNode) {
       serverNode.setState(state);
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionStates.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionStates.java
@@ -17,13 +17,11 @@
  */
 package org.apache.hadoop.hbase.master.assignment;
 
-import static org.junit.jupiter.api.Assertions.assertEquals;
-
 import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
-
-import org.apache.hadoop.hbase.ServerName;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.concurrent.Callable;
@@ -32,6 +30,7 @@ import java.util.concurrent.Future;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
@@ -227,11 +226,12 @@ public class TestRegionStates {
    * recreated for it. When the resumed SCP reaches SERVER_CRASH_SPLIT_LOGS it calls
    * {@link RegionStates#logSplitting(ServerName)} -> setServerState -> getServerNode, which returns
    * null. Before the fix, {@code synchronized (serverNode)} threw NPE (failing the SCP and
-   * triggering an unsupported rollback). After the fix, setServerState skips the missing node, so
-   * logSplitting (and the other split helpers) are safe no-ops.
+   * triggering an unsupported rollback). After the fix, setServerState recreates the missing node
+   * (these helpers only ever run for a crashed server inside an SCP), so the split helpers proceed
+   * without throwing and the state is recorded.
    */
   @Test
-  public void testLogSplittingNoOpWhenServerNodeMissing() {
+  public void testLogSplittingCreatesNodeWhenServerNodeMissing() {
     final RegionStates stateMap = new RegionStates();
     // The crashed server from the JIRA log: hregion1,16020,1715424228375
     final ServerName crashedServer = ServerName.valueOf("hregion1", 16020, 1715424228375L);
@@ -241,15 +241,17 @@ public class TestRegionStates {
     assertNull(stateMap.getServerNode(crashedServer),
       "precondition: no ServerStateNode should exist for the crashed server after restart");
 
-    // The resumed SCP advances through the split states. None of these should throw now; they are
-    // no-ops because the ServerStateNode is gone. Exercise every entry point into setServerState.
+    // The resumed SCP advances through the split states. None of these should throw now; the node
+    // is recreated on demand. Exercise every entry point into setServerState.
     assertDoesNotThrow(() -> stateMap.metaLogSplitting(crashedServer));
     assertDoesNotThrow(() -> stateMap.metaLogSplit(crashedServer));
     assertDoesNotThrow(() -> stateMap.logSplitting(crashedServer));
     assertDoesNotThrow(() -> stateMap.logSplit(crashedServer));
 
-    // And the node is still absent (we must not implicitly create it).
-    assertNull(stateMap.getServerNode(crashedServer));
+    // The node was recreated and reflects the last split state set above.
+    ServerStateNode serverNode = stateMap.getServerNode(crashedServer);
+    assertNotNull(serverNode, "the ServerStateNode should be recreated by setServerState");
+    assertTrue(serverNode.isInState(ServerState.OFFLINE));
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionStates.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionStates.java
@@ -19,6 +19,12 @@ package org.apache.hadoop.hbase.master.assignment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+
+import org.apache.hadoop.hbase.ServerName;
+
 import java.util.List;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutorCompletionService;
@@ -207,5 +213,58 @@ public class TestRegionStates {
     long et = EnvironmentEdgeManager.currentTime();
     LOG.info(String.format("PERF SingleThread: %s %s/sec", StringUtils.humanTimeDiff(et - st),
       StringUtils.humanSize(NRUNS / ((et - st) / 1000.0f))));
+  }
+
+  // ==========================================================================
+  // HBASE-28659: NPE in setServerState when the ServerStateNode is missing
+  // ==========================================================================
+
+  /**
+   * Regression test for HBASE-28659. After a Master restart, the serverMap inside RegionStates is
+   * rebuilt only for the "live" servers (RegionServerTracker#upgrade -> createServer) and for
+   * servers that re-register / are loaded from meta. A ServerCrashProcedure that was persisted
+   * before the restart resumes for the *old* crashed ServerName, but no ServerStateNode was ever
+   * recreated for it. When the resumed SCP reaches SERVER_CRASH_SPLIT_LOGS it calls
+   * {@link RegionStates#logSplitting(ServerName)} -> setServerState -> getServerNode, which returns
+   * null. Before the fix, {@code synchronized (serverNode)} threw NPE (failing the SCP and
+   * triggering an unsupported rollback). After the fix, setServerState skips the missing node, so
+   * logSplitting (and the other split helpers) are safe no-ops.
+   */
+  @Test
+  public void testLogSplittingNoOpWhenServerNodeMissing() {
+    final RegionStates stateMap = new RegionStates();
+    // The crashed server from the JIRA log: hregion1,16020,1715424228375
+    final ServerName crashedServer = ServerName.valueOf("hregion1", 16020, 1715424228375L);
+
+    // Simulate the post-restart state: the ServerStateNode for the crashed server was never
+    // recreated (it was not in liveServersBeforeRestart and the RS came back with a new startcode).
+    assertNull(stateMap.getServerNode(crashedServer),
+      "precondition: no ServerStateNode should exist for the crashed server after restart");
+
+    // The resumed SCP advances through the split states. None of these should throw now; they are
+    // no-ops because the ServerStateNode is gone. Exercise every entry point into setServerState.
+    assertDoesNotThrow(() -> stateMap.metaLogSplitting(crashedServer));
+    assertDoesNotThrow(() -> stateMap.metaLogSplit(crashedServer));
+    assertDoesNotThrow(() -> stateMap.logSplitting(crashedServer));
+    assertDoesNotThrow(() -> stateMap.logSplit(crashedServer));
+
+    // And the node is still absent (we must not implicitly create it).
+    assertNull(stateMap.getServerNode(crashedServer));
+  }
+
+  /**
+   * Sanity check / contrast: when the ServerStateNode exists (the normal case, where the RS
+   * registered and createServer was called), logSplitting works without throwing.
+   */
+  @Test
+  public void testLogSplittingOkWhenServerNodePresent() {
+    final RegionStates stateMap = new RegionStates();
+    final ServerName crashedServer = ServerName.valueOf("hregion1", 16020, 1715424228375L);
+
+    stateMap.createServer(crashedServer);
+    assertNotNull(stateMap.getServerNode(crashedServer));
+
+    // Should not throw now that the ServerStateNode exists.
+    stateMap.logSplitting(crashedServer);
   }
 }


### PR DESCRIPTION
## Problem statement

A ServerCrashProcedure (SCP) can crash the PEWorker with a NullPointerException while processing a dead RegionServer, after a Master restart:

```
ERROR [PEWorker-15] procedure2.ProcedureExecutor: CODE-BUG: Uncaught runtime exception:
  pid=48, state=RUNNABLE:SERVER_CRASH_SPLIT_LOGS, hasLock=true;
  ServerCrashProcedure hregion1,16020,1715424228375, splitWal=true, meta=true
java.lang.NullPointerException: null
  at o.a.h.h.master.assignment.RegionStates.setServerState(RegionStates.java:409)
  at o.a.h.h.master.assignment.RegionStates.logSplitting(RegionStates.java:435)
  at o.a.h.h.master.procedure.ServerCrashProcedure.executeFromState(ServerCrashProcedure.java:226)
```

`setServerState` dereferences the result of `getServerNode(serverName)` inside `synchronized (serverNode)`, but `getServerNode` is documented to return **null** when no node exists:

```java
private void setServerState(ServerName serverName, ServerState state) {
  ServerStateNode serverNode = getServerNode(serverName);
  synchronized (serverNode) {   // NPE when serverNode == null
    serverNode.setState(state);
  }
}
```

This is worse than a single failed procedure: the SCP does not support rollback, so the uncaught exception triggers an unsupported rollback (`... does not support rollback but the execution failed and try to rollback, code bug?`). The crashed server's WAL split and region reassignment never complete — and since this SCP carried meta, meta recovery is abandoned, which can wedge the cluster until manual intervention.

## Root cause

`ServerStateNode`s live only in the in-memory `RegionStates.serverMap`; they are never persisted. On Master startup the map is rebuilt only from:

* `RegionServerTracker.upgrade()` -> `createServer()` for the live set: `rsListStorage.getAll()` ∪ `MasterWalManager.getLiveServersFromWALDir()` (WAL dirs that do not end in `-splitting`),
* RegionServers re-registering (`ServerManager.recordNewServerWithLock`),
* region locations loaded from `hbase:meta` (`AssignmentManager.loadMeta` -> `createServer(regionLocation)` for any region whose persisted location is that server).

Servers that only have an outstanding SCP are added to the **deadservers** list by `findDeadServersAndProcess`, but no `ServerStateNode` is created for them. So if a persisted SCP resumes for a server that:

1. has its WAL dir already renamed to `-splitting` (counted as "splitting", explicitly excluded from "live"),
2. has come back with a new start code (so re-registration creates a node for a different `ServerName`), and
3. is no longer referenced by any region in meta (so `loadMeta` does not recreate the node),

…then `getServerNode(oldServerName)` returns **null**, and the next `setServerState` call (`logSplitting` at `SERVER_CRASH_SPLIT_LOGS`) NPEs.

This is deterministic given that on-disk/in-memory state — it is not a timing race. It is "rare" only because reaching that state requires a Master restart to land inside an SCP's WAL-splitting window. A 2.5.8 -> 3.0 upgrade (rolling Master failovers while RegionServers bounce) widens that window dramatically, which is why the reporter only saw it during migration.

#### Timeline (from the attached hbase--master log)

| Time (UTC) | Event |
| ---------- | ----- |
| 10:43:51 | hregion1,16020,1715424228375 registers -> createServer() -> ServerStateNode created |
| 10:45:02 | hregion1 znode deleted -> expiration -> SCP pid=48 scheduled (carrying meta); runs through SERVER_CRASH_SPLIT_META_LOGS while the node still exists |
| 10:45:05 | hregion2 (now hosting meta) aborts: Failed to open region hbase:meta ... can not recover -> SCP pid=51 scheduled |
| 10:45:08 | Terminating master — the Master process itself goes down (external/harness event, unrelated to the SCP) |
| 10:45:11 | STARTING service HMaster — fresh Master boots; in-memory serverMap is empty |
| 10:45:42 | Upgrading RegionServerTracker ... 2 existing ServerCrashProcedures, 0 possibly 'live' servers, and 2 'splitting' — old hregion1 is in the splitting set, not live, so no node is recreated |
| 10:45:49 | hregion1 re-registers with a new start code ...343997 -> node created for the new name only |
| 10:45:57 | SCP pid=48 resumes for old ...228375 -> logSplitting -> getServerNode returns null -> NPE -> SCP fails -> unsupported rollback |

The Master restart and the SCP are independently triggered events (a RegionServer crash created the SCP; the Master process was terminated separately). The bug is the coincidence of the two.

## Solution

Recreate the `ServerStateNode` in `setServerState` when it is missing, instead of NPEing:

```java
private void setServerState(ServerName serverName, ServerState state) {
  ServerStateNode serverNode =
    serverMap.computeIfAbsent(serverName, key -> new ServerStateNode(key));
  synchronized (serverNode) {
    serverNode.setState(state);
  }
}
```

This single change covers all four split helpers that route through `setServerState`: `metaLogSplitting`, `metaLogSplit`, `logSplitting`, and `logSplit`.

These split helpers are only ever called from `ServerCrashProcedure` for a crashed server, and the SCP removes the node again via `removeServer` at `SERVER_CRASH_FINISH`. So creating the node on demand is the correct, self-cleaning behavior: the resumed SCP records its split state as usual, and the node is torn down when the SCP completes. This also follows the reviewer's suggestion — a missing node here is not an error condition, so a warning would only confuse operators; instead we just (re)create it, consistent with how `createServer` already builds nodes with the same `computeIfAbsent`.

#### Impact

* Eliminates the NullPointerException in `setServerState` during SCP replay after a Master restart/failover.
* Prevents the more damaging downstream effect: an SCP failure -> unsupported rollback -> abandoned WAL split / meta recovery -> stuck regions requiring manual recovery.
* No behavior change on the normal path (when the `ServerStateNode` exists). When it is absent, the node is recreated and cleaned up by the SCP at `SERVER_CRASH_FINISH`.
* Low-risk and easily backportable (single localized change), which matters because this bug surfaces during version upgrades.

#### Testing

* Updated the regression test in `TestRegionStates`:
  * `testLogSplittingCreatesNodeWhenServerNodeMissing` — reproduces the post-restart scenario (a server with no `ServerStateNode`) and asserts all four split helpers (`metaLogSplitting`, `metaLogSplit`, `logSplitting`, `logSplit`) run without throwing, recreate the node, and record the final split state. Before the fix this threw NPE.
  * `testLogSplittingOkWhenServerNodePresent` — contrast case confirming normal behavior when the node already exists.
* Verified the SCP integration suites pass: `TestSCP`, `TestSCPWithMeta` (meta-carrying scenario from the JIRA), `TestRollbackSCP`.
