### PR TITLE
HBASE-29912 Codel lifoThreshold should be applied on soft queue limit

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java
@@ -44,7 +44,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
   private LinkedBlockingDeque<CallRunner> queue;
 
   // so we can calculate actual threshold to switch to LIFO under load
-  private int maxCapacity;
+  private int currentQueueLimit;
 
   // metrics (shared across all queues)
   private LongAdder numGeneralCallsDropped;
@@ -71,14 +71,15 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
   private AtomicBoolean isOverloaded = new AtomicBoolean(false);
 
   public AdaptiveLifoCoDelCallQueue(int capacity, int targetDelay, int interval,
-    double lifoThreshold, LongAdder numGeneralCallsDropped, LongAdder numLifoModeSwitches) {
-    this.maxCapacity = capacity;
+    double lifoThreshold, LongAdder numGeneralCallsDropped, LongAdder numLifoModeSwitches,
+    int currentQueueLimit) {
     this.queue = new LinkedBlockingDeque<>(capacity);
     this.codelTargetDelay = targetDelay;
     this.codelInterval = interval;
     this.lifoThreshold = lifoThreshold;
     this.numGeneralCallsDropped = numGeneralCallsDropped;
     this.numLifoModeSwitches = numLifoModeSwitches;
+    this.currentQueueLimit = currentQueueLimit;
   }
 
   /**
@@ -86,12 +87,14 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
    * @param newCodelTargetDelay new CoDel target delay
    * @param newCodelInterval    new CoDel interval
    * @param newLifoThreshold    new Adaptive Lifo threshold
+   * @param currentQueueLimit   new limit of queue
    */
-  public void updateTunables(int newCodelTargetDelay, int newCodelInterval,
-    double newLifoThreshold) {
+  public void updateTunables(int newCodelTargetDelay, int newCodelInterval, double newLifoThreshold,
+    int currentQueueLimit) {
     this.codelTargetDelay = newCodelTargetDelay;
     this.codelInterval = newCodelInterval;
     this.lifoThreshold = newLifoThreshold;
+    this.currentQueueLimit = currentQueueLimit;
   }
 
   /**
@@ -104,7 +107,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
   public CallRunner take() throws InterruptedException {
     CallRunner cr;
     while (true) {
-      if (((double) queue.size() / this.maxCapacity) > lifoThreshold) {
+      if (((double) queue.size() / this.currentQueueLimit) > lifoThreshold) {
         numLifoModeSwitches.increment();
         cr = queue.takeLast();
       } else {
@@ -124,7 +127,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
     CallRunner cr;
     boolean switched = false;
     while (true) {
-      if (((double) queue.size() / this.maxCapacity) > lifoThreshold) {
+      if (((double) queue.size() / this.currentQueueLimit) > lifoThreshold) {
         // Only count once per switch.
         if (!switched) {
           switched = true;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java
@@ -44,7 +44,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
   private LinkedBlockingDeque<CallRunner> queue;
 
   // so we can calculate actual threshold to switch to LIFO under load
-  private int currentQueueLimit;
+  private volatile int currentQueueLimit;
 
   // metrics (shared across all queues)
   private LongAdder numGeneralCallsDropped;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java
@@ -44,7 +44,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
   private LinkedBlockingDeque<CallRunner> queue;
 
   // so we can calculate actual threshold to switch to LIFO under load
-  private volatile int currentQueueLimit;
+  private volatile int softLimit;
 
   // metrics (shared across all queues)
   private LongAdder numGeneralCallsDropped;
@@ -79,7 +79,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
     this.lifoThreshold = lifoThreshold;
     this.numGeneralCallsDropped = numGeneralCallsDropped;
     this.numLifoModeSwitches = numLifoModeSwitches;
-    this.currentQueueLimit = currentQueueLimit;
+    this.softLimit = currentQueueLimit;
   }
 
   /**
@@ -94,7 +94,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
     this.codelTargetDelay = newCodelTargetDelay;
     this.codelInterval = newCodelInterval;
     this.lifoThreshold = newLifoThreshold;
-    this.currentQueueLimit = currentQueueLimit;
+    this.softLimit = currentQueueLimit;
   }
 
   /**
@@ -107,7 +107,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
   public CallRunner take() throws InterruptedException {
     CallRunner cr;
     while (true) {
-      if (((double) queue.size() / this.currentQueueLimit) > lifoThreshold) {
+      if (((double) queue.size() / this.softLimit) > lifoThreshold) {
         numLifoModeSwitches.increment();
         cr = queue.takeLast();
       } else {
@@ -127,7 +127,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
     CallRunner cr;
     boolean switched = false;
     while (true) {
-      if (((double) queue.size() / this.currentQueueLimit) > lifoThreshold) {
+      if (((double) queue.size() / this.softLimit) > lifoThreshold) {
         // Only count once per switch.
         if (!switched) {
           switched = true;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/AdaptiveLifoCoDelCallQueue.java
@@ -87,7 +87,7 @@ public class AdaptiveLifoCoDelCallQueue implements BlockingQueue<CallRunner> {
    * @param newCodelTargetDelay new CoDel target delay
    * @param newCodelInterval    new CoDel interval
    * @param newLifoThreshold    new Adaptive Lifo threshold
-   * @param currentQueueLimit   new limit of queue
+   * @param currentQueueLimit   new soft limit of queue
    */
   public void updateTunables(int newCodelTargetDelay, int newCodelInterval, double newLifoThreshold,
     int currentQueueLimit) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
@@ -107,6 +107,7 @@ public abstract class RpcExecutor {
   private final Class<? extends BlockingQueue> queueClass;
   private final Object[] queueInitArgs;
 
+  // this is soft limit of the queue, while initializing we will use hard limit as the size of queue
   protected volatile int currentQueueLimit;
 
   private final AtomicInteger activeHandlerCount = new AtomicInteger(0);
@@ -161,11 +162,13 @@ public abstract class RpcExecutor {
       int handlerCountPerQueue = this.handlerCount / this.numCallQueues;
       maxQueueLength = handlerCountPerQueue * RpcServer.DEFAULT_MAX_CALLQUEUE_LENGTH_PER_HANDLER;
     }
+    currentQueueLimit = maxQueueLength;
+    int queueHardLimit = Math.max(maxQueueLength, DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT);
 
     if (isDeadlineQueueType(callQueueType)) {
       this.name += ".Deadline";
       this.queueInitArgs =
-        new Object[] { maxQueueLength, new CallPriorityComparator(conf, priority) };
+        new Object[] { queueHardLimit, new CallPriorityComparator(conf, priority) };
       this.queueClass = BoundedPriorityBlockingQueue.class;
     } else if (isCodelQueueType(callQueueType)) {
       this.name += ".Codel";
@@ -174,8 +177,8 @@ public abstract class RpcExecutor {
       int codelInterval = conf.getInt(CALL_QUEUE_CODEL_INTERVAL, CALL_QUEUE_CODEL_DEFAULT_INTERVAL);
       double codelLifoThreshold =
         conf.getDouble(CALL_QUEUE_CODEL_LIFO_THRESHOLD, CALL_QUEUE_CODEL_DEFAULT_LIFO_THRESHOLD);
-      this.queueInitArgs = new Object[] { maxQueueLength, codelTargetDelay, codelInterval,
-        codelLifoThreshold, numGeneralCallsDropped, numLifoModeSwitches };
+      this.queueInitArgs = new Object[] { queueHardLimit, codelTargetDelay, codelInterval,
+        codelLifoThreshold, numGeneralCallsDropped, numLifoModeSwitches, currentQueueLimit };
       this.queueClass = AdaptiveLifoCoDelCallQueue.class;
     } else if (isPluggableQueueType(callQueueType)) {
       Optional<Class<? extends BlockingQueue<CallRunner>>> pluggableQueueClass =
@@ -185,12 +188,12 @@ public abstract class RpcExecutor {
         throw new PluggableRpcQueueNotFound(
           "Pluggable call queue failed to load and selected call" + " queue type required");
       } else {
-        this.queueInitArgs = new Object[] { maxQueueLength, priority, conf };
+        this.queueInitArgs = new Object[] { queueHardLimit, priority, conf };
         this.queueClass = pluggableQueueClass.get();
       }
     } else {
       this.name += ".Fifo";
-      this.queueInitArgs = new Object[] { maxQueueLength };
+      this.queueInitArgs = new Object[] { queueHardLimit };
       this.queueClass = LinkedBlockingQueue.class;
     }
 
@@ -231,20 +234,7 @@ public abstract class RpcExecutor {
       .collect(Collectors.groupingBy(Pair::getFirst, Collectors.summingLong(Pair::getSecond)));
   }
 
-  // This method can only be called ONCE per executor instance.
-  // Before calling: queueInitArgs[0] contains the soft limit (desired queue capacity)
-  // After calling: queueInitArgs[0] is set to hard limit and currentQueueLimit stores the original
-  // soft limit.
-  // Multiple calls would incorrectly use the hard limit as the soft limit.
-  // As all the queues has same initArgs and queueClass, there should be no need to call this again.
   protected void initializeQueues(final int numQueues) {
-    if (!queues.isEmpty()) {
-      throw new RuntimeException("Queues are already initialized");
-    }
-    if (queueInitArgs.length > 0) {
-      currentQueueLimit = (int) queueInitArgs[0];
-      queueInitArgs[0] = Math.max((int) queueInitArgs[0], DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT);
-    }
     for (int i = 0; i < numQueues; ++i) {
       queues.add(ReflectionUtils.newInstance(queueClass, queueInitArgs));
     }
@@ -479,8 +469,10 @@ public abstract class RpcExecutor {
 
     for (BlockingQueue<CallRunner> queue : queues) {
       if (queue instanceof AdaptiveLifoCoDelCallQueue) {
+        // current queue Limit for executor is already updated as part of resizeQueues, we need to
+        // let codel queue also make aware of it
         ((AdaptiveLifoCoDelCallQueue) queue).updateTunables(codelTargetDelay, codelInterval,
-          codelLifoThreshold);
+          codelLifoThreshold, currentQueueLimit);
       } else if (queue instanceof ConfigurationObserver) {
         ((ConfigurationObserver) queue).onConfigurationChange(conf);
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
@@ -107,9 +107,11 @@ public abstract class RpcExecutor {
   private final Class<? extends BlockingQueue> queueClass;
   private final Object[] queueInitArgs;
 
-  // this is soft limit of the queue, not size. While initializing we will use hard limit as the
-  // size of queue, it will let us dynamically change the queue size
+  // this is soft limit of the queue, not size/capacity.
   protected volatile int currentQueueLimit;
+  // While initializing we will use hard limit as the capacity of queue, it will let us dynamically
+  // change the queue limit
+  protected int queueHardLimit;
 
   private final AtomicInteger activeHandlerCount = new AtomicInteger(0);
   private final List<RpcHandler> handlers;
@@ -164,7 +166,7 @@ public abstract class RpcExecutor {
       maxQueueLength = handlerCountPerQueue * RpcServer.DEFAULT_MAX_CALLQUEUE_LENGTH_PER_HANDLER;
     }
     currentQueueLimit = maxQueueLength;
-    int queueHardLimit = Math.max(maxQueueLength, DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT);
+    queueHardLimit = Math.max(maxQueueLength, DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT);
 
     if (isDeadlineQueueType(callQueueType)) {
       this.name += ".Deadline";
@@ -458,11 +460,11 @@ public abstract class RpcExecutor {
     }
     final int queueLimit = currentQueueLimit;
     int newQueueLimit = conf.getInt(configKey, queueLimit);
-    if (newQueueLimit > DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT) {
+    if (newQueueLimit > queueHardLimit) {
       LOG.warn(
-        "Requested soft limit {} exceeds dynamic-resize ceiling {}. "
+        "Requested soft limit {} exceeds queue hard limit/capacity {}. "
           + "A region server restart is required to grow the underlying queue.",
-        newQueueLimit, DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT);
+        newQueueLimit, queueHardLimit);
       newQueueLimit = DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT;
     }
     currentQueueLimit = newQueueLimit;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
@@ -111,7 +111,7 @@ public abstract class RpcExecutor {
   protected volatile int currentQueueLimit;
   // While initializing we will use hard limit as the capacity of queue, it will let us dynamically
   // change the queue limit
-  protected int queueHardLimit;
+  protected final int queueHardLimit;
 
   private final AtomicInteger activeHandlerCount = new AtomicInteger(0);
   private final List<RpcHandler> handlers;
@@ -465,7 +465,7 @@ public abstract class RpcExecutor {
         "Requested soft limit {} exceeds queue hard limit/capacity {}. "
           + "A region server restart is required to grow the underlying queue.",
         newQueueLimit, queueHardLimit);
-      newQueueLimit = DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT;
+      newQueueLimit = currentQueueLimit;
     }
     currentQueueLimit = newQueueLimit;
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
@@ -90,7 +90,7 @@ public abstract class RpcExecutor {
   public static final String CALL_QUEUE_CODEL_LIFO_THRESHOLD =
     "hbase.ipc.server.callqueue.codel.lifo.threshold";
 
-  public static final int CALL_QUEUE_CODEL_DEFAULT_TARGET_DELAY = 100;
+  public static final int CALL_QUEUE_CODEL_DEFAULT_TARGET_DELAY = 5;
   public static final int CALL_QUEUE_CODEL_DEFAULT_INTERVAL = 100;
   public static final double CALL_QUEUE_CODEL_DEFAULT_LIFO_THRESHOLD = 0.8;
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/ipc/RpcExecutor.java
@@ -107,7 +107,8 @@ public abstract class RpcExecutor {
   private final Class<? extends BlockingQueue> queueClass;
   private final Object[] queueInitArgs;
 
-  // this is soft limit of the queue, while initializing we will use hard limit as the size of queue
+  // this is soft limit of the queue, not size. While initializing we will use hard limit as the
+  // size of queue, it will let us dynamically change the queue size
   protected volatile int currentQueueLimit;
 
   private final AtomicInteger activeHandlerCount = new AtomicInteger(0);
@@ -456,7 +457,15 @@ public abstract class RpcExecutor {
       }
     }
     final int queueLimit = currentQueueLimit;
-    currentQueueLimit = conf.getInt(configKey, queueLimit);
+    int newQueueLimit = conf.getInt(configKey, queueLimit);
+    if (newQueueLimit > DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT) {
+      LOG.warn(
+        "Requested soft limit {} exceeds dynamic-resize ceiling {}. "
+          + "A region server restart is required to grow the underlying queue.",
+        newQueueLimit, DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT);
+      newQueueLimit = DEFAULT_CALL_QUEUE_SIZE_HARD_LIMIT;
+    }
+    currentQueueLimit = newQueueLimit;
   }
 
   public void onConfigurationChange(Configuration conf) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.ipc;
 
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
@@ -34,6 +35,7 @@ import java.io.IOException;
 import java.lang.reflect.Field;
 import java.net.InetSocketAddress;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -41,6 +43,7 @@ import java.util.Set;
 import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Abortable;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -807,4 +810,166 @@ public class TestSimpleRpcScheduler {
       }
     };
   }
+
+  /**
+   * Test LIFO switching behavior through actual RPC calls. This test verifies that when the queue
+   * fills beyond the LIFO threshold, newer calls are processed before older calls (LIFO mode).
+   */
+  @Test
+  public void testCoDelLifoWithRpcCalls() throws Exception {
+    Configuration testConf = HBaseConfiguration.create();
+    testConf.set(RpcExecutor.CALL_QUEUE_TYPE_CONF_KEY,
+      RpcExecutor.CALL_QUEUE_TYPE_CODEL_CONF_VALUE);
+    int maxCallQueueLength = 50;
+    double codelLifoThreshold = 0.8;
+    testConf.setInt(RpcScheduler.IPC_SERVER_MAX_CALLQUEUE_LENGTH, maxCallQueueLength);
+    testConf.setDouble(RpcExecutor.CALL_QUEUE_CODEL_LIFO_THRESHOLD, codelLifoThreshold);
+    testConf.setInt(RpcExecutor.CALL_QUEUE_CODEL_TARGET_DELAY, 100);
+    testConf.setInt(RpcExecutor.CALL_QUEUE_CODEL_INTERVAL, 100);
+    testConf.setInt(HConstants.REGION_SERVER_HANDLER_COUNT, 1); // Single handler to control
+                                                                // processing
+
+    PriorityFunction priority = mock(PriorityFunction.class);
+    when(priority.getPriority(any(), any(), any())).thenReturn(HConstants.NORMAL_QOS);
+    SimpleRpcScheduler scheduler =
+      new SimpleRpcScheduler(testConf, 1, 0, 0, priority, HConstants.QOS_THRESHOLD);
+
+    try {
+      scheduler.init(CONTEXT);
+      scheduler.start();
+
+      // Track completion order
+      final List<Integer> completedCalls = Collections.synchronizedList(new ArrayList<>());
+
+      // Dispatch many slow calls rapidly to fill the queue beyond 80% threshold
+      // With queue limit of 50, we need > 40 calls to cross 80%
+      int numCalls = 48;
+      for (int i = 0; i < numCalls; i++) {
+        final int callId = i;
+        CallRunner call = createMockTask(HConstants.NORMAL_QOS);
+        call.setStatus(new MonitoredRPCHandlerImpl("test"));
+        doAnswer(invocation -> {
+          completedCalls.add(callId);
+          Thread.sleep(100); // Slow processing to allow queue to build up
+          return null;
+        }).when(call).run();
+        scheduler.dispatch(call);
+        // No delay between dispatches - rapidly fill the queue
+      }
+
+      // Wait for some calls to complete
+      await().atMost(1, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 2);
+
+      // Check that we had LIFO switches
+      long lifoSwitches = scheduler.getNumLifoModeSwitches();
+      assertTrue("Should have switched to LIFO mode at least once, but got: " + lifoSwitches,
+        lifoSwitches > 0);
+
+      // Verify LIFO behavior: Among first completed calls, we should see higher call IDs
+      // (indicating later dispatched calls completed first)
+      int maxCallIdCompleted = -1;
+      for (int i = 0; i < 5 && i < completedCalls.size(); i++) {
+        maxCallIdCompleted = Math.max(maxCallIdCompleted, completedCalls.get(i));
+      }
+      // At least one of the early completed calls should have a high ID (>20)
+      // indicating LIFO processing
+      assertTrue(
+        "Expected LIFO behavior: early completed calls should include call arrived after threshold "
+          + "maxCallIdCompleted: " + maxCallIdCompleted,
+        maxCallIdCompleted > maxCallQueueLength * codelLifoThreshold);
+
+    } finally {
+      scheduler.stop();
+    }
+  }
+
+  /**
+   * Test that CoDel queue returns to FIFO mode after draining below threshold.
+   */
+  @Test
+  public void testCoDelQueueDrainAndFifoReturn() throws Exception {
+    Configuration testConf = HBaseConfiguration.create();
+    testConf.set(RpcExecutor.CALL_QUEUE_TYPE_CONF_KEY,
+      RpcExecutor.CALL_QUEUE_TYPE_CODEL_CONF_VALUE);
+    testConf.setInt(RpcScheduler.IPC_SERVER_MAX_CALLQUEUE_LENGTH, 50);
+    testConf.setDouble(RpcExecutor.CALL_QUEUE_CODEL_LIFO_THRESHOLD, 0.8);
+    testConf.setInt(HConstants.REGION_SERVER_HANDLER_COUNT, 2);
+
+    PriorityFunction priority = mock(PriorityFunction.class);
+    when(priority.getPriority(any(), any(), any())).thenReturn(HConstants.NORMAL_QOS);
+    SimpleRpcScheduler scheduler =
+      new SimpleRpcScheduler(testConf, 2, 0, 0, priority, HConstants.QOS_THRESHOLD);
+
+    try {
+      scheduler.init(CONTEXT);
+      scheduler.start();
+
+      final List<Integer> completedCalls = Collections.synchronizedList(new ArrayList<>());
+
+      // Phase 1: Fill queue rapidly to trigger LIFO (>40 calls for 80% of 50)
+      for (int i = 0; i < 48; i++) {
+        final int callId = i;
+        CallRunner call = createMockTask(HConstants.NORMAL_QOS);
+        call.setStatus(new MonitoredRPCHandlerImpl("test"));
+        doAnswer(invocation -> {
+          completedCalls.add(callId);
+          Thread.sleep(80);
+          return null;
+        }).when(call).run();
+        scheduler.dispatch(call);
+      }
+
+      // Wait for calls to complete
+      await().atMost(1, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 2);
+      long lifoSwitchesPhase1 = scheduler.getNumLifoModeSwitches();
+      assertTrue("Should have entered LIFO mode", lifoSwitchesPhase1 > 0);
+
+      // Phase 2: Let queue drain
+      await().atMost(2, TimeUnit.SECONDS).until(() -> scheduler.getGeneralQueueLength() <= 0);
+      int queueLength = scheduler.getGeneralQueueLength();
+      assertTrue("Queue should have drained significantly, but got: " + queueLength,
+        queueLength < 25);
+
+      // Phase 3: Send new calls - should process in FIFO order
+      completedCalls.clear();
+      for (int i = 100; i < 105; i++) {
+        final int callId = i;
+        CallRunner call = createMockTask(HConstants.NORMAL_QOS);
+        call.setStatus(new MonitoredRPCHandlerImpl("test"));
+        doAnswer(invocation -> {
+          completedCalls.add(callId);
+          Thread.sleep(80);
+          return null;
+        }).when(call).run();
+        scheduler.dispatch(call);
+      }
+
+      // Wait for these calls to complete
+      await().atMost(2, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 2);
+
+      // Verify FIFO behavior: calls should complete in order (100, 101, 102, 103, 104)
+      assertTrue(
+        "Should have completed test calls, but count of completed calls: " + completedCalls.size(),
+        completedCalls.size() >= 2);
+      // Check that calls completed roughly in order (allowing some variance due to threading with 2
+      // handlers)
+      // With 2 handlers, we expect general FIFO order but some interleaving is possible
+      // Just verify the general trend is increasing
+      int violations = 0;
+      for (int i = 0; i < completedCalls.size() - 1; i++) {
+        int current = completedCalls.get(i);
+        int next = completedCalls.get(i + 1);
+        if (next < current) {
+          violations++;
+        }
+      }
+      // Allow at most 1 violation due to concurrent execution by 2 handlers
+      assertTrue("Calls should complete in approximate FIFO order, violations: " + violations
+        + ", order: " + completedCalls, violations <= 1);
+
+    } finally {
+      scheduler.stop();
+    }
+  }
+
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
@@ -953,6 +953,7 @@ public class TestSimpleRpcScheduler {
       await().atMost(2, TimeUnit.SECONDS).until(
         () -> scheduler.getGeneralQueueLength() == 0 && scheduler.getActiveRpcHandlerCount() == 0);
 
+      long pastNumLifoModeSwitches = scheduler.getNumLifoModeSwitches();
       // Send new calls - should process in FIFO order
       completedCalls.clear();
       for (int i = 100; i < 105; i++) {
@@ -970,25 +971,11 @@ public class TestSimpleRpcScheduler {
       // Wait for these calls to complete
       await().atMost(2, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 2);
 
-      // Verify FIFO behavior: calls should complete in order (100, 101, 102..)
-      assertTrue(completedCalls.size() >= 2,
-        "Should have completed test calls, but count of completed calls: " + completedCalls.size());
-      // Check that calls completed roughly in order (allowing some variance due to threading with 2
-      // handlers)
-      // With 2 handlers, we expect general FIFO order but some interleaving is possible
-      // Just verify the general trend is increasing
-      int violations = 0;
-      for (int i = 0; i < completedCalls.size() - 1; i++) {
-        int current = completedCalls.get(i);
-        int next = completedCalls.get(i + 1);
-        if (next < current) {
-          violations++;
-        }
-      }
+      long newLifoSwitch = scheduler.getNumLifoModeSwitches() - pastNumLifoModeSwitches;
       // Allow at most 1 violation due to concurrent execution by 2 handlers
-      assertTrue(violations <= 1, "Calls should complete in approximate FIFO order, violations: "
-        + violations + ", order: " + completedCalls);
-
+      assertEquals(0, newLifoSwitch,
+        "Queue should not switch to LIFO last 5 calls but number of LIFO switch are : "
+          + newLifoSwitch);
     } finally {
       scheduler.stop();
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
@@ -89,7 +89,7 @@ public class TestSimpleRpcScheduler {
   };
   private Configuration conf;
   private String testMethodName;
-  private static final AtomicInteger requestProcessed = new AtomicInteger(0);
+  private final AtomicInteger requestProcessed = new AtomicInteger(0);
 
   @BeforeEach
   public void setUp(TestInfo testInfo) {
@@ -582,7 +582,7 @@ public class TestSimpleRpcScheduler {
     }
   }
 
-  private static final class CoDelEnvironmentEdge implements EnvironmentEdge {
+  private final class CoDelEnvironmentEdge implements EnvironmentEdge {
 
     private long perRequestOffset;
     private long gapInRequests;
@@ -628,6 +628,7 @@ public class TestSimpleRpcScheduler {
       this.perRequestOffset = requestProcessingTime;
       this.gapInRequests = 1000L / arrivalRatePerSecond;
       this.requestCount = 0;
+      requestProcessed.set(0);
       this.testStartTime = System.currentTimeMillis();
     }
   }
@@ -651,7 +652,6 @@ public class TestSimpleRpcScheduler {
       scheduler.start();
       EnvironmentEdgeManager.injectEdge(envEdge);
 
-      requestProcessed.set(0);
       // incoming traffic < capacity
       envEdge.startTestFor(20, 40);
       for (int i = 0; i < 100; i++) {
@@ -667,7 +667,6 @@ public class TestSimpleRpcScheduler {
       assertEquals(0, scheduler.getNumGeneralCallsDropped(),
         "None of these calls should have been discarded");
 
-      requestProcessed.set(0);
       // incoming traffic = capacity
       envEdge.startTestFor(20, 50);
       for (int i = 0; i < 20; i++) {
@@ -685,7 +684,6 @@ public class TestSimpleRpcScheduler {
       assertEquals(0, scheduler.getNumGeneralCallsDropped(),
         "None of these calls should have been discarded");
 
-      requestProcessed.set(0);
       // incoming traffic > capacity
       envEdge.startTestFor(20, 60);
       // now slow calls and the ones to be dropped
@@ -849,9 +847,9 @@ public class TestSimpleRpcScheduler {
     testConf.set(RpcExecutor.CALL_QUEUE_TYPE_CONF_KEY,
       RpcExecutor.CALL_QUEUE_TYPE_CODEL_CONF_VALUE);
     int maxCallQueueLength = 50;
-    double codelLifoThreshold = 0.8;
+    double coDelLifoThreshold = 0.8;
     testConf.setInt(RpcScheduler.IPC_SERVER_MAX_CALLQUEUE_LENGTH, maxCallQueueLength);
-    testConf.setDouble(RpcExecutor.CALL_QUEUE_CODEL_LIFO_THRESHOLD, codelLifoThreshold);
+    testConf.setDouble(RpcExecutor.CALL_QUEUE_CODEL_LIFO_THRESHOLD, coDelLifoThreshold);
     testConf.setInt(RpcExecutor.CALL_QUEUE_CODEL_TARGET_DELAY, 100);
     testConf.setInt(RpcExecutor.CALL_QUEUE_CODEL_INTERVAL, 100);
     testConf.setInt(HConstants.REGION_SERVER_HANDLER_COUNT, 1); // Single handler to control
@@ -886,7 +884,7 @@ public class TestSimpleRpcScheduler {
       }
 
       // Wait for some calls to complete
-      await().atMost(1, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 3);
+      await().atMost(2, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 3);
 
       // Check that we had LIFO switches
       long lifoSwitches = scheduler.getNumLifoModeSwitches();
@@ -901,7 +899,7 @@ public class TestSimpleRpcScheduler {
       }
       // At least one of the early completed calls should have a high ID (>20)
       // indicating LIFO processing
-      assertTrue(maxCallIdCompleted > maxCallQueueLength * codelLifoThreshold,
+      assertTrue(maxCallIdCompleted > maxCallQueueLength * coDelLifoThreshold,
         "Expected LIFO behavior: early completed calls should include call arrived after threshold "
           + "maxCallIdCompleted: " + maxCallIdCompleted);
 
@@ -934,7 +932,7 @@ public class TestSimpleRpcScheduler {
 
       final List<Integer> completedCalls = Collections.synchronizedList(new ArrayList<>());
 
-      // Phase 1: Fill queue rapidly to trigger LIFO (>40 calls for 80% of 50)
+      // Fill queue rapidly to trigger LIFO (>40 calls for 80% of 50)
       for (int i = 0; i < 48; i++) {
         final int callId = i;
         CallRunner call = createMockTask(HConstants.NORMAL_QOS);
@@ -949,13 +947,12 @@ public class TestSimpleRpcScheduler {
 
       // Wait for calls to complete
       await().atMost(1, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 3);
-      long lifoSwitchesPhase1 = scheduler.getNumLifoModeSwitches();
-      assertTrue(lifoSwitchesPhase1 > 0, "Should have entered LIFO mode");
+      assertTrue(scheduler.getNumLifoModeSwitches() > 0, "Should have entered LIFO mode");
 
-      // Phase 2: Let queue drain
-      await().atMost(2, TimeUnit.SECONDS).until(() -> scheduler.getGeneralQueueLength() == 0);
+      await().atMost(2, TimeUnit.SECONDS).until(
+        () -> scheduler.getGeneralQueueLength() == 0 && scheduler.getActiveRpcHandlerCount() == 0);
 
-      // Phase 3: Send new calls - should process in FIFO order
+      // Send new calls - should process in FIFO order
       completedCalls.clear();
       for (int i = 100; i < 105; i++) {
         final int callId = i;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
@@ -40,10 +40,9 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.BlockingQueue;
 import java.util.concurrent.CountDownLatch;
-import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.Abortable;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -90,6 +89,7 @@ public class TestSimpleRpcScheduler {
   };
   private Configuration conf;
   private String testMethodName;
+  private static final AtomicInteger requestProcessed = new AtomicInteger(0);
 
   @BeforeEach
   public void setUp(TestInfo testInfo) {
@@ -229,6 +229,7 @@ public class TestSimpleRpcScheduler {
     RequestHeader header = RequestHeader.newBuilder().setPriority(priority).build();
     when(task.getRpcCall()).thenReturn(call);
     when(call.getHeader()).thenReturn(header);
+    when(call.getReceiveTime()).thenReturn(EnvironmentEdgeManager.currentTime());
     return task;
   }
 
@@ -583,42 +584,60 @@ public class TestSimpleRpcScheduler {
 
   private static final class CoDelEnvironmentEdge implements EnvironmentEdge {
 
-    private final BlockingQueue<Long> timeQ = new LinkedBlockingQueue<>();
+    private long perRequestOffset;
+    private long gapInRequests;
+    private long testStartTime = 0;
 
-    private long offset;
+    private int requestCount = 0;
 
-    private final Set<String> threadNamePrefixs = new HashSet<>();
+    private final Set<String> threadNamePrefixes = new HashSet<>();
+    private final String testThread = Thread.currentThread().getName();
 
     @Override
     public long currentTime() {
-      for (String threadNamePrefix : threadNamePrefixs) {
-        String threadName = Thread.currentThread().getName();
+      String threadName = Thread.currentThread().getName();
+      if (threadName.equals(testThread)) {
+        // test thread will create a request and add that to scheduler
+        // Replicating a constant rate of request arrival.
+        long requestStartTime = testStartTime + requestCount * gapInRequests;
+        requestCount++;
+        return requestStartTime;
+      }
+      // handler thread will pick the request from queue, this time will depend on processing time
+      // of handler
+      for (String threadNamePrefix : threadNamePrefixes) {
         if (threadName.startsWith(threadNamePrefix)) {
-          if (timeQ != null) {
-            Long qTime = timeQ.poll();
-            if (qTime != null) {
-              return qTime.longValue() + offset;
-            }
+          long requestPickTime;
+          if (gapInRequests >= perRequestOffset) {
+            // it means handler can complete the processing of last request and will be free when it
+            // will come to serve next request. We don't need it in fast path but just in case for
+            // other tests
+            requestPickTime = testStartTime + requestProcessed.get() * gapInRequests;
+          } else {
+            // this means handler will still be busy processing the last requests when new request
+            // will come in queue
+            requestPickTime = testStartTime + requestProcessed.get() * perRequestOffset;
           }
+          return requestPickTime;
         }
       }
       return System.currentTimeMillis();
     }
+
+    public void startTestFor(int arrivalRatePerSecond, long requestProcessingTime) {
+      this.perRequestOffset = requestProcessingTime;
+      this.gapInRequests = 1000L / arrivalRatePerSecond;
+      this.requestCount = 0;
+      this.testStartTime = System.currentTimeMillis();
+    }
   }
 
-  // FIX. I don't get this test (St.Ack). When I time this test, the minDelay is > 2 * codel delay
-  // from the get go. So we are always overloaded. The test below would seem to complete the
-  // queuing of all the CallRunners inside the codel check interval. I don't think we are skipping
-  // codel checking. Second, I think this test has been broken since HBASE-16089 Add on FastPath for
-  // CoDel went in. The thread name we were looking for was the name BEFORE we updated: i.e.
-  // "RpcServer.CodelBQ.default.handler". But same patch changed the name of the codel fastpath
-  // thread to: new FastPathBalancedQueueRpcExecutor("CodelFPBQ.default", handlerCount,
-  // numCallQueues... Codel is hard to test. This test is going to be flakey given it all
-  // timer-based. Disabling for now till chat with authors.
+  // This test is fixing the processing time and arrival rate of the request and checking if CoDel
+  // can utilize the maximum capacity of system
   @Test
   public void testCoDelScheduling() throws Exception {
     CoDelEnvironmentEdge envEdge = new CoDelEnvironmentEdge();
-    envEdge.threadNamePrefixs.add("RpcServer.default.FPBQ.Codel.handler");
+    envEdge.threadNamePrefixes.add("RpcServer.default.FPBQ.Codel.handler");
     Configuration schedConf = HBaseConfiguration.create();
     schedConf.setInt(RpcScheduler.IPC_SERVER_MAX_CALLQUEUE_LENGTH, 250);
     schedConf.set(RpcExecutor.CALL_QUEUE_TYPE_CONF_KEY,
@@ -627,20 +646,19 @@ public class TestSimpleRpcScheduler {
     when(priority.getPriority(any(), any(), any())).thenReturn(HConstants.NORMAL_QOS);
     SimpleRpcScheduler scheduler =
       new SimpleRpcScheduler(schedConf, 1, 1, 1, priority, HConstants.QOS_THRESHOLD);
+
     try {
-      // Loading mocked call runner can take a good amount of time the first time through
-      // (haven't looked why). Load it for first time here outside of the timed loop.
-      getMockedCallRunner(EnvironmentEdgeManager.currentTime(), 2);
       scheduler.start();
       EnvironmentEdgeManager.injectEdge(envEdge);
-      envEdge.offset = 5;
-      // Calls faster than min delay
-      // LOG.info("Start");
+
+      requestProcessed.set(0);
+      // incoming traffic < capacity
+      envEdge.startTestFor(20, 40);
       for (int i = 0; i < 100; i++) {
         long time = EnvironmentEdgeManager.currentTime();
-        envEdge.timeQ.put(time);
         CallRunner cr = getMockedCallRunner(time, 2);
         scheduler.dispatch(cr);
+        Thread.sleep(50);
       }
       // LOG.info("Loop done");
       // make sure fast calls are handled
@@ -649,13 +667,16 @@ public class TestSimpleRpcScheduler {
       assertEquals(0, scheduler.getNumGeneralCallsDropped(),
         "None of these calls should have been discarded");
 
-      envEdge.offset = 151;
-      // calls slower than min delay, but not individually slow enough to be dropped
+      requestProcessed.set(0);
+      // incoming traffic = capacity
+      envEdge.startTestFor(20, 50);
       for (int i = 0; i < 20; i++) {
         long time = EnvironmentEdgeManager.currentTime();
-        envEdge.timeQ.put(time);
         CallRunner cr = getMockedCallRunner(time, 2);
         scheduler.dispatch(cr);
+        // We have mocked the arrival time and the time request get picked from queue but we need to
+        // also make sure that queue fill at the arrival rate
+        Thread.sleep(50);
       }
 
       // make sure somewhat slow calls are handled
@@ -664,21 +685,29 @@ public class TestSimpleRpcScheduler {
       assertEquals(0, scheduler.getNumGeneralCallsDropped(),
         "None of these calls should have been discarded");
 
-      envEdge.offset = 2000;
+      requestProcessed.set(0);
+      // incoming traffic > capacity
+      envEdge.startTestFor(20, 60);
       // now slow calls and the ones to be dropped
       for (int i = 0; i < 60; i++) {
         long time = EnvironmentEdgeManager.currentTime();
-        envEdge.timeQ.put(time);
         CallRunner cr = getMockedCallRunner(time, 100);
         scheduler.dispatch(cr);
+        Thread.sleep(50);
       }
 
       // make sure somewhat slow calls are handled
       waitUntilQueueEmpty(scheduler);
       Thread.sleep(100);
-      assertTrue(scheduler.getNumGeneralCallsDropped() > 12,
-        "There should have been at least 12 calls dropped however there were "
+      // 60 calls will take 3 second with 20 rps. And in 3 second with 60 processing time we can
+      // only serve 50 request
+      assertTrue(requestProcessed.get() >= 48,
+        "Number of processed requests should be greater then 90% of capacity"
+          + requestProcessed.get());
+      assertTrue(scheduler.getNumGeneralCallsDropped() >= 9,
+        "There should have been at least 9 calls dropped however there were "
           + scheduler.getNumGeneralCallsDropped());
+
     } finally {
       scheduler.stop();
     }
@@ -793,9 +822,8 @@ public class TestSimpleRpcScheduler {
           return;
         }
         try {
-          LOG.warn("Sleeping for " + sleepTime);
           Thread.sleep(sleepTime);
-          LOG.warn("Done Sleeping for " + sleepTime);
+          requestProcessed.incrementAndGet();
         } catch (InterruptedException e) {
         }
       }
@@ -858,12 +886,12 @@ public class TestSimpleRpcScheduler {
       }
 
       // Wait for some calls to complete
-      await().atMost(1, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 2);
+      await().atMost(1, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 3);
 
       // Check that we had LIFO switches
       long lifoSwitches = scheduler.getNumLifoModeSwitches();
-      assertTrue("Should have switched to LIFO mode at least once, but got: " + lifoSwitches,
-        lifoSwitches > 0);
+      assertTrue(lifoSwitches > 0,
+        "Should have switched to LIFO mode at least once, but got: " + lifoSwitches);
 
       // Verify LIFO behavior: Among first completed calls, we should see higher call IDs
       // (indicating later dispatched calls completed first)
@@ -873,10 +901,9 @@ public class TestSimpleRpcScheduler {
       }
       // At least one of the early completed calls should have a high ID (>20)
       // indicating LIFO processing
-      assertTrue(
+      assertTrue(maxCallIdCompleted > maxCallQueueLength * codelLifoThreshold,
         "Expected LIFO behavior: early completed calls should include call arrived after threshold "
-          + "maxCallIdCompleted: " + maxCallIdCompleted,
-        maxCallIdCompleted > maxCallQueueLength * codelLifoThreshold);
+          + "maxCallIdCompleted: " + maxCallIdCompleted);
 
     } finally {
       scheduler.stop();
@@ -891,6 +918,7 @@ public class TestSimpleRpcScheduler {
     Configuration testConf = HBaseConfiguration.create();
     testConf.set(RpcExecutor.CALL_QUEUE_TYPE_CONF_KEY,
       RpcExecutor.CALL_QUEUE_TYPE_CODEL_CONF_VALUE);
+    testConf.setLong(RpcExecutor.CALL_QUEUE_CODEL_TARGET_DELAY, 100);
     testConf.setInt(RpcScheduler.IPC_SERVER_MAX_CALLQUEUE_LENGTH, 50);
     testConf.setDouble(RpcExecutor.CALL_QUEUE_CODEL_LIFO_THRESHOLD, 0.8);
     testConf.setInt(HConstants.REGION_SERVER_HANDLER_COUNT, 2);
@@ -920,15 +948,12 @@ public class TestSimpleRpcScheduler {
       }
 
       // Wait for calls to complete
-      await().atMost(1, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 2);
+      await().atMost(1, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 3);
       long lifoSwitchesPhase1 = scheduler.getNumLifoModeSwitches();
-      assertTrue("Should have entered LIFO mode", lifoSwitchesPhase1 > 0);
+      assertTrue(lifoSwitchesPhase1 > 0, "Should have entered LIFO mode");
 
       // Phase 2: Let queue drain
-      await().atMost(2, TimeUnit.SECONDS).until(() -> scheduler.getGeneralQueueLength() <= 0);
-      int queueLength = scheduler.getGeneralQueueLength();
-      assertTrue("Queue should have drained significantly, but got: " + queueLength,
-        queueLength < 25);
+      await().atMost(2, TimeUnit.SECONDS).until(() -> scheduler.getGeneralQueueLength() == 0);
 
       // Phase 3: Send new calls - should process in FIFO order
       completedCalls.clear();
@@ -938,7 +963,7 @@ public class TestSimpleRpcScheduler {
         call.setStatus(new MonitoredRPCHandlerImpl("test"));
         doAnswer(invocation -> {
           completedCalls.add(callId);
-          Thread.sleep(80);
+          Thread.sleep(50);
           return null;
         }).when(call).run();
         scheduler.dispatch(call);
@@ -947,10 +972,9 @@ public class TestSimpleRpcScheduler {
       // Wait for these calls to complete
       await().atMost(2, TimeUnit.SECONDS).until(() -> completedCalls.size() >= 2);
 
-      // Verify FIFO behavior: calls should complete in order (100, 101, 102, 103, 104)
-      assertTrue(
-        "Should have completed test calls, but count of completed calls: " + completedCalls.size(),
-        completedCalls.size() >= 2);
+      // Verify FIFO behavior: calls should complete in order (100, 101, 102..)
+      assertTrue(completedCalls.size() >= 2,
+        "Should have completed test calls, but count of completed calls: " + completedCalls.size());
       // Check that calls completed roughly in order (allowing some variance due to threading with 2
       // handlers)
       // With 2 handlers, we expect general FIFO order but some interleaving is possible
@@ -964,8 +988,8 @@ public class TestSimpleRpcScheduler {
         }
       }
       // Allow at most 1 violation due to concurrent execution by 2 handlers
-      assertTrue("Calls should complete in approximate FIFO order, violations: " + violations
-        + ", order: " + completedCalls, violations <= 1);
+      assertTrue(violations <= 1, "Calls should complete in approximate FIFO order, violations: "
+        + violations + ", order: " + completedCalls);
 
     } finally {
       scheduler.stop();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/ipc/TestSimpleRpcScheduler.java
@@ -643,6 +643,7 @@ public class TestSimpleRpcScheduler {
     schedConf.setInt(RpcScheduler.IPC_SERVER_MAX_CALLQUEUE_LENGTH, 250);
     schedConf.set(RpcExecutor.CALL_QUEUE_TYPE_CONF_KEY,
       RpcExecutor.CALL_QUEUE_TYPE_CODEL_CONF_VALUE);
+    schedConf.setInt(RpcExecutor.CALL_QUEUE_CODEL_TARGET_DELAY, 5);
     PriorityFunction priority = mock(PriorityFunction.class);
     when(priority.getPriority(any(), any(), any())).thenReturn(HConstants.NORMAL_QOS);
     SimpleRpcScheduler scheduler =
@@ -894,7 +895,7 @@ public class TestSimpleRpcScheduler {
       // Verify LIFO behavior: Among first completed calls, we should see higher call IDs
       // (indicating later dispatched calls completed first)
       int maxCallIdCompleted = -1;
-      for (int i = 0; i < 5 && i < completedCalls.size(); i++) {
+      for (int i = 0; i < completedCalls.size(); i++) {
         maxCallIdCompleted = Math.max(maxCallIdCompleted, completedCalls.get(i));
       }
       // At least one of the early completed calls should have a high ID (>20)


### PR DESCRIPTION
After [HBASE-16089](https://issues.apache.org/jira/browse/HBASE-16089) codel target delay was changed to 100, that is not standard for CoDel ([patch](https://issues.apache.org/jira/secure/attachment/12813161/HBASE-16089.v3.patch)). I have changed it back.
To visualize why we should have 5 target delay with 100 interval, I used the [model](https://github.com/Umeshkumar9414/hbase/blob/0056886fb540ca1cfd9035aec489a3106c47bc09/hbase-server/src/main/resources/hbase-webapps/queue-simulator/adaptive-lifo-codel-simulator.html), With target delay 100 and interval 100 we are more prone the queue being full, although CoDel will be still helpful in LIFO mode but a full queue is problem as it can cause OOM.