### PR TITLE
HBASE-30169 Split completed parent region added to RIT list on host RS and master crash

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -2081,10 +2081,6 @@ public class AssignmentManager {
     return regionInTransitionTracker.getRegionsInTransition();
   }
 
-  public boolean isRegionInTransition(final RegionInfo regionInfo) {
-    return regionInTransitionTracker.isRegionInTransition(regionInfo);
-  }
-
   public int getRegionTransitScheduledCount() {
     return regionStates.getRegionTransitScheduledCount();
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -1871,9 +1871,10 @@ public class AssignmentManager {
       }
       // add regions to RIT while visiting the meta
       regionInTransitionTracker.handleRegionStateNodeOperation(regionNode);
-      // If region location of region belongs to a dead server mark the region crashed
+      // If region is supposed to be serve traffic (NOT split and merged) and location of region
+      // belongs to a dead server mark the region crashed
       if (
-        regionNode.getRegionLocation() != null
+        regionNode.getRegionLocation() != null && !AssignmentManagerUtil.isSplitOrMerged(regionNode)
           && master.getServerManager().isServerDead(regionNode.getRegionLocation())
       ) {
         long timeOfCrash = master.getServerManager().getDeadServers()

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManagerUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManagerUtil.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.favored.FavoredNodesManager;
 import org.apache.hadoop.hbase.ipc.HBaseRpcController;
+import org.apache.hadoop.hbase.master.RegionState;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
 import org.apache.hadoop.hbase.wal.WALSplitUtil;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -307,5 +308,17 @@ final class AssignmentManagerUtil {
       throw new IOException("Recovered.edits are found in Region: " + regionInfo
         + ", abort split/merge to prevent data loss");
     }
+  }
+
+  /**
+   * For splitting, need to test both region info and state, and will return true if either of the
+   * test returns true. Please see the comments in
+   * {@link AssignmentManager#markRegionAsSplit(RegionInfo, ServerName, RegionInfo, RegionInfo)} for
+   * more details on why we need to test two conditions.
+   */
+  static boolean isSplitOrMerged(RegionStateNode regionStateNode) {
+    return regionStateNode.getState() == RegionState.State.SPLIT
+      || regionStateNode.getRegionInfo().isSplit()
+      || regionStateNode.getState() == RegionState.State.MERGED;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionInTransitionTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionInTransitionTracker.java
@@ -44,7 +44,7 @@ public class RegionInTransitionTracker {
   private final List<RegionState.State> ENABLE_TABLE_REGION_STATE =
     Collections.singletonList(RegionState.State.OPEN);
 
-  // DO NOT USE containsKey() on regionInTransition map as MutableRegionInfo.hashCode() considers
+  // DO NOT USE containsKey() on regionInTransition map as MutableRegionInfo.COMPARATOR considers
   // offline/split flags.
   private final ConcurrentSkipListMap<RegionInfo, RegionStateNode> regionInTransition =
     new ConcurrentSkipListMap<>(RegionInfo.COMPARATOR);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionInTransitionTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionInTransitionTracker.java
@@ -44,14 +44,12 @@ public class RegionInTransitionTracker {
   private final List<RegionState.State> ENABLE_TABLE_REGION_STATE =
     Collections.singletonList(RegionState.State.OPEN);
 
+  // DO NOT USE containsKey() on regionInTransition map as MutableRegionInfo.hashCode() considers
+  // offline/split flags.
   private final ConcurrentSkipListMap<RegionInfo, RegionStateNode> regionInTransition =
     new ConcurrentSkipListMap<>(RegionInfo.COMPARATOR);
 
   private TableStateManager tableStateManager;
-
-  public boolean isRegionInTransition(final RegionInfo regionInfo) {
-    return regionInTransition.containsKey(regionInfo);
-  }
 
   /**
    * Handles a region whose hosting RegionServer has crashed. When a RegionServer fails, all regions

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionInTransitionTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionInTransitionTracker.java
@@ -59,7 +59,7 @@ public class RegionInTransitionTracker {
    * other servers.
    */
   public void regionCrashed(RegionStateNode regionStateNode) {
-    if (regionStateNode.getRegionInfo().getReplicaId() != RegionInfo.DEFAULT_REPLICA_ID) {
+    if (isReplica(regionStateNode) || isSplitOrMerged(regionStateNode)) {
       return;
     }
 
@@ -79,7 +79,7 @@ public class RegionInTransitionTracker {
    */
   public void handleRegionStateNodeOperation(RegionStateNode regionStateNode) {
     // only consider default replica for availability
-    if (regionStateNode.getRegionInfo().getReplicaId() != RegionInfo.DEFAULT_REPLICA_ID) {
+    if (isReplica(regionStateNode)) {
       return;
     }
 
@@ -89,10 +89,7 @@ public class RegionInTransitionTracker {
       tableEnabled ? ENABLE_TABLE_REGION_STATE : DISABLE_TABLE_REGION_STATE;
 
     // if region is merged or split it should not be in RIT list
-    if (
-      currentState == RegionState.State.SPLIT || currentState == RegionState.State.MERGED
-        || regionStateNode.getRegionInfo().isSplit()
-    ) {
+    if (isSplitOrMerged(regionStateNode)) {
       if (removeRegionInTransition(regionStateNode.getRegionInfo())) {
         LOG.debug("Removed {} from RIT list as it is split or merged",
           regionStateNode.getRegionInfo().getEncodedName());
@@ -108,6 +105,12 @@ public class RegionInTransitionTracker {
           regionStateNode.getRegionInfo().getEncodedName(), currentState);
       }
     }
+  }
+
+  private static boolean isSplitOrMerged(RegionStateNode regionStateNode) {
+    return regionStateNode.getState() == RegionState.State.SPLIT
+      || regionStateNode.getState() == RegionState.State.MERGED
+      || regionStateNode.getRegionInfo().isSplit();
   }
 
   private boolean isTableEnabled(TableName tableName) {
@@ -156,4 +159,9 @@ public class RegionInTransitionTracker {
   public void setTableStateManager(TableStateManager tableStateManager) {
     this.tableStateManager = tableStateManager;
   }
+
+  private static boolean isReplica(RegionStateNode regionStateNode) {
+    return regionStateNode.getRegionInfo().getReplicaId() != RegionInfo.DEFAULT_REPLICA_ID;
+  }
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionInTransitionTracker.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionInTransitionTracker.java
@@ -44,8 +44,10 @@ public class RegionInTransitionTracker {
   private final List<RegionState.State> ENABLE_TABLE_REGION_STATE =
     Collections.singletonList(RegionState.State.OPEN);
 
-  // DO NOT USE containsKey() on regionInTransition map as MutableRegionInfo.COMPARATOR considers
-  // offline/split flags.
+  // DO NOT USE containsKey()/remove() on regionInTransition with a different RegionInfo instance:
+  // this map is ordered by RegionInfo.COMPARATOR, and that comparator includes the offline flag.
+  // Lookups can therefore fail if the RegionInfo used as the key has a different offline value,
+  // even when it refers to the same region. Offline value changes with splitting.
   private final ConcurrentSkipListMap<RegionInfo, RegionStateNode> regionInTransition =
     new ConcurrentSkipListMap<>(RegionInfo.COMPARATOR);
 
@@ -57,7 +59,7 @@ public class RegionInTransitionTracker {
    * other servers.
    */
   public void regionCrashed(RegionStateNode regionStateNode) {
-    if (isReplica(regionStateNode) || isSplitOrMerged(regionStateNode)) {
+    if (isReplica(regionStateNode)) {
       return;
     }
 
@@ -87,7 +89,7 @@ public class RegionInTransitionTracker {
       tableEnabled ? ENABLE_TABLE_REGION_STATE : DISABLE_TABLE_REGION_STATE;
 
     // if region is merged or split it should not be in RIT list
-    if (isSplitOrMerged(regionStateNode)) {
+    if (AssignmentManagerUtil.isSplitOrMerged(regionStateNode)) {
       if (removeRegionInTransition(regionStateNode.getRegionInfo())) {
         LOG.debug("Removed {} from RIT list as it is split or merged",
           regionStateNode.getRegionInfo().getEncodedName());
@@ -103,12 +105,6 @@ public class RegionInTransitionTracker {
           regionStateNode.getRegionInfo().getEncodedName(), currentState);
       }
     }
-  }
-
-  private static boolean isSplitOrMerged(RegionStateNode regionStateNode) {
-    return regionStateNode.getState() == RegionState.State.SPLIT
-      || regionStateNode.getState() == RegionState.State.MERGED
-      || regionStateNode.getRegionInfo().isSplit();
   }
 
   private boolean isTableEnabled(TableName tableName) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/AssignmentTestingUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/AssignmentTestingUtil.java
@@ -49,10 +49,15 @@ public final class AssignmentTestingUtil {
   }
 
   public static void waitForRegionToBeInTransition(final HBaseTestingUtility util,
-    final RegionInfo hri) throws Exception {
-    while (!getMaster(util).getAssignmentManager().isRegionInTransition(hri)) {
+    final RegionInfo hri) {
+    while (!isRegionInTransition(hri, getMaster(util).getAssignmentManager())) {
       Threads.sleep(10);
     }
+  }
+
+  public static boolean isRegionInTransition(RegionInfo hri, AssignmentManager am) {
+    return am.getRegionsInTransition().stream()
+      .anyMatch(rsn -> rsn.getRegionInfo().getEncodedName().equals(hri.getEncodedName()));
   }
 
   public static void waitForRsToBeDead(final HBaseTestingUtility util, final ServerName serverName)

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionSplit.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionSplit.java
@@ -21,6 +21,7 @@ import static org.apache.hadoop.hbase.master.assignment.AssignmentTestingUtil.in
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -168,8 +169,8 @@ public class TestRegionSplit {
 
     assertNotNull(regions, "not able to find a splittable region");
     assertEquals(1, regions.length, "not able to find a splittable region");
-    assertEquals(0,
-      UTIL.getHBaseCluster().getMaster().getAssignmentManager().getRegionsInTransitionCount());
+    assertFalse(AssignmentTestingUtil.isRegionInTransition(regions[0],
+      UTIL.getHBaseCluster().getMaster().getAssignmentManager()));
 
     ServerName targetRS = UTIL.getHBaseCluster().getMaster().getAssignmentManager()
       .getRegionStates().getRegionServerOfRegion(regions[0]);
@@ -181,22 +182,25 @@ public class TestRegionSplit {
     ProcedureTestingUtility.assertProcNotFailed(procExec, procId);
 
     assertEquals(2, UTIL.getHBaseCluster().getRegions(tableName).size(), "not able to split table");
-    assertEquals(0,
-      UTIL.getHBaseCluster().getMaster().getAssignmentManager().getRegionsInTransitionCount());
+    assertFalse(AssignmentTestingUtil.isRegionInTransition(regions[0],
+      UTIL.getHBaseCluster().getMaster().getAssignmentManager()));
     // As there are only 3 RS, start one more RS before expiring one
     UTIL.getHBaseCluster().startRegionServer();
 
-    // stop RS holding split parent
+    // We don't want SCP to complete so kill PR it after store update
+    ProcedureTestingUtility
+      .toggleKillAfterStoreUpdate(UTIL.getHBaseCluster().getMaster().getMasterProcedureExecutor());
+    // stop RS holding split parent to create SCP and add RS into deadServerList
     UTIL.getHBaseCluster().getMaster().getServerManager().expireServer(targetRS);
 
     // stop master
     UTIL.getHBaseCluster().stopMaster(0);
     UTIL.getHBaseCluster().waitOnMaster(0);
-    Thread.sleep(500);
 
     // restart master
-    JVMClusterUtil.MasterThread t = UTIL.getHBaseCluster().startMaster();
-    UTIL.getHBaseCluster().waitForActiveAndReadyMaster(10000);
+    UTIL.getHBaseCluster().startMaster();
+    assertTrue(UTIL.getHBaseCluster().waitForActiveAndReadyMaster(30000),
+      "Master failed to initialize in in 30 seconds");
     UTIL.invalidateConnection();
 
     assertFalse(AssignmentTestingUtil.isRegionInTransition(regions[0],

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionSplit.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionSplit.java
@@ -19,8 +19,8 @@ package org.apache.hadoop.hbase.master.assignment;
 
 import static org.apache.hadoop.hbase.master.assignment.AssignmentTestingUtil.insertData;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
-import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
 import java.util.Map;
@@ -117,8 +117,8 @@ public class TestRegionSplit {
     int splitRowNum = startRowNum + rowCount / 2;
     byte[] splitKey = Bytes.toBytes("" + splitRowNum);
 
-    assertTrue(regions != null, "not able to find a splittable region");
-    assertTrue(regions.length == 1, "not able to find a splittable region");
+    assertNotNull(regions, "not able to find a splittable region");
+    assertEquals(1, regions.length, "not able to find a splittable region");
 
     // Split region of the table
     long procId = procExec.submitProcedure(
@@ -127,7 +127,7 @@ public class TestRegionSplit {
     ProcedureTestingUtility.waitProcedure(procExec, procId);
     ProcedureTestingUtility.assertProcNotFailed(procExec, procId);
 
-    assertTrue(UTIL.getHBaseCluster().getRegions(tableName).size() == 2, "not able to split table");
+    assertEquals(2, UTIL.getHBaseCluster().getRegions(tableName).size(), "not able to split table");
 
     // disable table
     UTIL.getAdmin().disableTable(tableName);
@@ -153,6 +153,54 @@ public class TestRegionSplit {
       .getAssignmentManager().getRegionStates().getRegionAssignments();
     assertEquals(regionInfoMap.get(tableRegions.get(0).getRegionInfo()),
       regionInfoMap.get(tableRegions.get(1).getRegionInfo()));
+  }
+
+  @Test
+  public void testRITWithSplitTableRegion() throws Exception {
+    final TableName tableName = TableName.valueOf(testMethodName);
+    final ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+
+    RegionInfo[] regions =
+      MasterProcedureTestingUtility.createTable(procExec, tableName, null, columnFamilyName);
+    insertData(UTIL, tableName, rowCount, startRowNum, columnFamilyName);
+    int splitRowNum = startRowNum + rowCount / 2;
+    byte[] splitKey = Bytes.toBytes("" + splitRowNum);
+
+    assertNotNull(regions, "not able to find a splittable region");
+    assertEquals(1, regions.length, "not able to find a splittable region");
+    assertEquals(0,
+      UTIL.getHBaseCluster().getMaster().getAssignmentManager().getRegionsInTransitionCount());
+
+    ServerName targetRS = UTIL.getHBaseCluster().getMaster().getAssignmentManager()
+      .getRegionStates().getRegionServerOfRegion(regions[0]);
+    // Split region of the table
+    long procId = procExec.submitProcedure(
+      new SplitTableRegionProcedure(procExec.getEnvironment(), regions[0], splitKey));
+    // Wait the completion
+    ProcedureTestingUtility.waitProcedure(procExec, procId);
+    ProcedureTestingUtility.assertProcNotFailed(procExec, procId);
+
+    assertEquals(2, UTIL.getHBaseCluster().getRegions(tableName).size(), "not able to split table");
+    assertEquals(0,
+      UTIL.getHBaseCluster().getMaster().getAssignmentManager().getRegionsInTransitionCount());
+    // As there are only 3 RS, start one more RS before expiring one
+    UTIL.getHBaseCluster().startRegionServer();
+
+    // stop RS holding split parent
+    UTIL.getHBaseCluster().getMaster().getServerManager().expireServer(targetRS);
+
+    // stop master
+    UTIL.getHBaseCluster().stopMaster(0);
+    UTIL.getHBaseCluster().waitOnMaster(0);
+    Thread.sleep(500);
+
+    // restart master
+    JVMClusterUtil.MasterThread t = UTIL.getHBaseCluster().startMaster();
+    UTIL.getHBaseCluster().waitForActiveAndReadyMaster(10000);
+    UTIL.invalidateConnection();
+
+    assertFalse(AssignmentTestingUtil.isRegionInTransition(regions[0],
+      UTIL.getHBaseCluster().getMaster().getAssignmentManager()));
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionSplit.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRegionSplit.java
@@ -160,6 +160,8 @@ public class TestRegionSplit {
   public void testRITWithSplitTableRegion() throws Exception {
     final TableName tableName = TableName.valueOf(testMethodName);
     final ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    // Disable CatalogJanitor to keep the split region in hbase:meta throughout the test
+    UTIL.getHBaseCluster().getMaster().getCatalogJanitor().setEnabled(false);
 
     RegionInfo[] regions =
       MasterProcedureTestingUtility.createTable(procExec, tableName, null, columnFamilyName);
@@ -184,6 +186,8 @@ public class TestRegionSplit {
     assertEquals(2, UTIL.getHBaseCluster().getRegions(tableName).size(), "not able to split table");
     assertFalse(AssignmentTestingUtil.isRegionInTransition(regions[0],
       UTIL.getHBaseCluster().getMaster().getAssignmentManager()));
+    assertTrue(UTIL.getHBaseCluster().getMaster().getAssignmentManager().getRegionStates()
+      .getOrCreateRegionStateNode(regions[0]).isSplit());
     // As there are only 3 RS, start one more RS before expiring one
     UTIL.getHBaseCluster().startRegionServer();
 
@@ -205,6 +209,8 @@ public class TestRegionSplit {
 
     assertFalse(AssignmentTestingUtil.isRegionInTransition(regions[0],
       UTIL.getHBaseCluster().getMaster().getAssignmentManager()));
+    assertTrue(UTIL.getHBaseCluster().getMaster().getAssignmentManager().getRegionStates()
+      .getOrCreateRegionStateNode(regions[0]).isSplit());
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSplitTransactionOnCluster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSplitTransactionOnCluster.java
@@ -906,7 +906,8 @@ public class TestSplitTransactionOnCluster {
       } catch (DoNotRetryIOException e) {
         // Expected
       }
-      assertFalse(am.isRegionInTransition(hri), "Split region can't be assigned");
+      assertFalse(AssignmentTestingUtil.isRegionInTransition(hri, am),
+        "Split region can't be assigned");
       assertTrue(regionStates.isRegionInState(hri, State.SPLIT));
 
       // We should not be able to unassign it either
@@ -916,7 +917,8 @@ public class TestSplitTransactionOnCluster {
       } catch (DoNotRetryIOException e) {
         // Expected
       }
-      assertFalse(am.isRegionInTransition(hri), "Split region can't be unassigned");
+      assertFalse(AssignmentTestingUtil.isRegionInTransition(hri, am),
+        "Split region can't be unassigned");
       assertTrue(regionStates.isRegionInState(hri, State.SPLIT));
     } finally {
       admin.balancerSwitch(true, false);


### PR DESCRIPTION
Bug: When a host RegionServer and master crashes, regionCrashed() blindly added all hosted regions to RIT, including split-completed parent regions that should never be reassigned.

Fix: Added isSplitOrMerged() guard in regionCrashed() to skip split/merged regions. Extracted isSplitOrMerged() and isReplica() helpers to reduce duplication with handleRegionStateNodeOperation().

- Removed broken isRegionInTransition(RegionInfo) API — RegionInfo.COMPARATOR considers offline/split flags, so lookups failed when those flags differed between the query and stored instance. Replaced
with encoded-name-based lookup in test utility.
- Added test testRITWithSplitTableRegion — splits a region, crashes the hosting RS, restarts the master, and verifies the split parent is NOT in the RIT list.