### PR TITLE
HBASE-29555 TestRollbackSCP.testFailAndRollback fails sometimes because non empty Scheduler queue

### DIFF
--- a/hbase-procedure/src/test/java/org/apache/hadoop/hbase/procedure2/ProcedureTestingUtility.java
+++ b/hbase-procedure/src/test/java/org/apache/hadoop/hbase/procedure2/ProcedureTestingUtility.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -125,14 +127,50 @@ public final class ProcedureTestingUtility {
       stopAction.call();
     }
     procExecutor.join();
-    procExecutor.getScheduler().clear();
+    // HBASE-29555: Callbacks that wake up a procedure after an async operation (such as updating
+    // meta) run on the asyncTaskExecutor, not on a PEWorker thread. ProcedureExecutor.stop() shuts
+    // the asyncTaskExecutor down, but ProcedureExecutor.join() only waits a bounded amount of time
+    // for it to terminate before giving up. If such a wake up task is still pending, it can call
+    // scheduler.addFront() after we clear the scheduler below and after the executor has been
+    // restarted, leaving the scheduler queue non-empty and tripping the Preconditions check in
+    // ProcedureExecutor.load(). Since we reuse the same executor (and scheduler) instance across
+    // this simulated restart, wait for the already shutdown asyncTaskExecutor to fully terminate so
+    // any pending wake up task has finished before we clear the scheduler.
+    awaitAsyncTaskExecutorTermination(procExecutor);
 
     // nothing running...
 
     // re-start
     LOG.info("RESTART - Start");
-    procStore.start(storeThreads);
-    procExecutor.init(execThreads, failOnCorrupted);
+    // HBASE-29555: External events (for example a region server reporting a region state transition
+    // over RPC) can wake a procedure and push it back into the scheduler in the small window
+    // between clearing the scheduler and ProcedureExecutor.load() checking that it is empty. Those
+    // producers run on threads we do not own here (RPC handlers etc.), so we cannot reliably stop
+    // them from this thread. Instead, reload in a retry loop: if load() fails only because the
+    // scheduler is not empty, stop/drain/clear again and retry. ProcedureExecutor.stop() is
+    // explicitly safe to call after a failed init(), so this is a clean redo of the reload.
+    final int maxRestartAttempts = 20;
+    for (int attempt = 1;; attempt++) {
+      procExecutor.getScheduler().clear();
+      procStore.start(storeThreads);
+      try {
+        procExecutor.init(execThreads, failOnCorrupted);
+        break;
+      } catch (IllegalArgumentException e) {
+        if (
+          attempt >= maxRestartAttempts || e.getMessage() == null
+            || !e.getMessage().contains("scheduler queue not empty")
+        ) {
+          throw e;
+        }
+        LOG.warn("RESTART - scheduler was repopulated during reload (attempt {}/{}), retrying",
+          attempt, maxRestartAttempts, e);
+        procExecutor.stop();
+        procStore.stop(abort);
+        procExecutor.join();
+        awaitAsyncTaskExecutorTermination(procExecutor);
+      }
+    }
     if (actionBeforeStartWorker != null) {
       actionBeforeStartWorker.call();
     }
@@ -144,6 +182,32 @@ public final class ProcedureTestingUtility {
     }
     if (startAction != null) {
       startAction.call();
+    }
+  }
+
+  /**
+   * Wait for the (already shutdown) asyncTaskExecutor of the given executor to fully terminate, so
+   * that any pending callback (e.g. one that would wake up a procedure by adding it back to the
+   * scheduler) has finished running. See HBASE-29555 and the caller in
+   * {@link #restart(ProcedureExecutor, boolean, boolean, Callable, Callable, Callable, boolean, boolean)}.
+   */
+  private static void awaitAsyncTaskExecutorTermination(ProcedureExecutor<?> procExecutor) {
+    ExecutorService asyncTaskExecutor = procExecutor.getAsyncTaskExecutor();
+    if (asyncTaskExecutor == null) {
+      return;
+    }
+    long deadline = System.currentTimeMillis() + 60000;
+    try {
+      while (!asyncTaskExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+        if (System.currentTimeMillis() > deadline) {
+          LOG.warn("asyncTaskExecutor did not terminate in time while restarting;"
+            + " there may still be pending async tasks");
+          return;
+        }
+      }
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupted while waiting for asyncTaskExecutor to terminate while restarting", e);
+      Thread.currentThread().interrupt();
     }
   }
 


### PR DESCRIPTION
## Summary

`TestRollbackSCP.testFailAndRollback` is flaky: it intermittently fails with
`java.lang.IllegalArgumentException: scheduler queue not empty` from
`ProcedureExecutor.load()` while restarting the master procedure executor.

The test restarts the `ProcedureExecutor` **in place**, reusing the same
executor and `MasterProcedureScheduler` instances to simulate a failover. While
the executor is being reloaded, other still-running threads of the live
mini-cluster master can push a procedure back into the shared scheduler in the
small window between `scheduler.clear()` and `ProcedureExecutor.load()`'s
`Preconditions.checkArgument(scheduler.size() == 0, ...)`.

Two producers were identified:
- the `asyncTaskExecutor` callback that wakes a procedure after an async meta
  update (e.g. `AssignmentManager.persistToMeta`), and
- an incoming `reportRegionStateTransition` RPC from a live region server,
  handled on an `RpcServer` handler thread, which wakes a procedure through
  `ProcedureEvent.wake` -> `scheduler.addFront`.

This is a test-infrastructure issue: a real master failover starts a fresh
process with a fresh executor/scheduler, so the production `load()` precondition
is not affected. The fix is therefore confined to test code.

## Changes (`ProcedureTestingUtility.restart()`, test-only)

- Wait for the already shut-down `asyncTaskExecutor` to fully terminate before
  clearing the scheduler, so any pending async wake-up callback has finished
  (closes the dominant, async producer deterministically).
- Reload (`clear` -> `procStore.start` -> `init`) in a bounded retry loop,
  retrying only when `load()` fails specifically with `scheduler queue not
  empty`. `ProcedureExecutor.stop()` is explicitly safe to call after a failed
  `init()`, so this is a clean redo and is robust to any external producer.

## Test plan

- [x] Ran `TestRollbackSCP` 100x consecutively with the fix: 100/100 passed (twice).
- [x] Control: reverted the fix and reran: reproduced the failure within a few iterations.
- [x] Regression: ran affected `hbase-procedure` tests and a representative
      `hbase-server` subset (TestSCP, TestProcedureAdmin,
      TestTransitRegionStateProcedure, TestCreateTableProcedure): all pass.

