### PR TITLE
HBASE-29555 TestRollbackSCP.testFailAndRollback fails sometimes because non empty Scheduler queue

### DIFF
--- a/hbase-procedure/src/test/java/org/apache/hadoop/hbase/procedure2/ProcedureTestingUtility.java
+++ b/hbase-procedure/src/test/java/org/apache/hadoop/hbase/procedure2/ProcedureTestingUtility.java
@@ -28,8 +28,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.Callable;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -127,50 +125,14 @@ public final class ProcedureTestingUtility {
       stopAction.call();
     }
     procExecutor.join();
-    // HBASE-29555: Callbacks that wake up a procedure after an async operation (such as updating
-    // meta) run on the asyncTaskExecutor, not on a PEWorker thread. ProcedureExecutor.stop() shuts
-    // the asyncTaskExecutor down, but ProcedureExecutor.join() only waits a bounded amount of time
-    // for it to terminate before giving up. If such a wake up task is still pending, it can call
-    // scheduler.addFront() after we clear the scheduler below and after the executor has been
-    // restarted, leaving the scheduler queue non-empty and tripping the Preconditions check in
-    // ProcedureExecutor.load(). Since we reuse the same executor (and scheduler) instance across
-    // this simulated restart, wait for the already shutdown asyncTaskExecutor to fully terminate so
-    // any pending wake up task has finished before we clear the scheduler.
-    awaitAsyncTaskExecutorTermination(procExecutor);
+    procExecutor.getScheduler().clear();
 
     // nothing running...
 
     // re-start
     LOG.info("RESTART - Start");
-    // HBASE-29555: External events (for example a region server reporting a region state transition
-    // over RPC) can wake a procedure and push it back into the scheduler in the small window
-    // between clearing the scheduler and ProcedureExecutor.load() checking that it is empty. Those
-    // producers run on threads we do not own here (RPC handlers etc.), so we cannot reliably stop
-    // them from this thread. Instead, reload in a retry loop: if load() fails only because the
-    // scheduler is not empty, stop/drain/clear again and retry. ProcedureExecutor.stop() is
-    // explicitly safe to call after a failed init(), so this is a clean redo of the reload.
-    final int maxRestartAttempts = 20;
-    for (int attempt = 1;; attempt++) {
-      procExecutor.getScheduler().clear();
-      procStore.start(storeThreads);
-      try {
-        procExecutor.init(execThreads, failOnCorrupted);
-        break;
-      } catch (IllegalArgumentException e) {
-        if (
-          attempt >= maxRestartAttempts || e.getMessage() == null
-            || !e.getMessage().contains("scheduler queue not empty")
-        ) {
-          throw e;
-        }
-        LOG.warn("RESTART - scheduler was repopulated during reload (attempt {}/{}), retrying",
-          attempt, maxRestartAttempts, e);
-        procExecutor.stop();
-        procStore.stop(abort);
-        procExecutor.join();
-        awaitAsyncTaskExecutorTermination(procExecutor);
-      }
-    }
+    procStore.start(storeThreads);
+    procExecutor.init(execThreads, failOnCorrupted);
     if (actionBeforeStartWorker != null) {
       actionBeforeStartWorker.call();
     }
@@ -182,32 +144,6 @@ public final class ProcedureTestingUtility {
     }
     if (startAction != null) {
       startAction.call();
-    }
-  }
-
-  /**
-   * Wait for the (already shutdown) asyncTaskExecutor of the given executor to fully terminate, so
-   * that any pending callback (e.g. one that would wake up a procedure by adding it back to the
-   * scheduler) has finished running. See HBASE-29555 and the caller in
-   * {@link #restart(ProcedureExecutor, boolean, boolean, Callable, Callable, Callable, boolean, boolean)}.
-   */
-  private static void awaitAsyncTaskExecutorTermination(ProcedureExecutor<?> procExecutor) {
-    ExecutorService asyncTaskExecutor = procExecutor.getAsyncTaskExecutor();
-    if (asyncTaskExecutor == null) {
-      return;
-    }
-    long deadline = System.currentTimeMillis() + 60000;
-    try {
-      while (!asyncTaskExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
-        if (System.currentTimeMillis() > deadline) {
-          LOG.warn("asyncTaskExecutor did not terminate in time while restarting;"
-            + " there may still be pending async tasks");
-          return;
-        }
-      }
-    } catch (InterruptedException e) {
-      LOG.warn("Interrupted while waiting for asyncTaskExecutor to terminate while restarting", e);
-      Thread.currentThread().interrupt();
     }
   }
 

--- a/hbase-procedure/src/test/java/org/apache/hadoop/hbase/procedure2/ProcedureTestingUtility.java
+++ b/hbase-procedure/src/test/java/org/apache/hadoop/hbase/procedure2/ProcedureTestingUtility.java
@@ -28,6 +28,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Set;
 import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
@@ -125,14 +127,50 @@ public final class ProcedureTestingUtility {
       stopAction.call();
     }
     procExecutor.join();
-    procExecutor.getScheduler().clear();
+    // HBASE-29555: Callbacks that wake up a procedure after an async operation (such as updating
+    // meta) run on the asyncTaskExecutor, not on a PEWorker thread. ProcedureExecutor.stop() shuts
+    // the asyncTaskExecutor down, but ProcedureExecutor.join() only waits a bounded amount of time
+    // for it to terminate before giving up. If such a wake up task is still pending, it can call
+    // scheduler.addFront() after we clear the scheduler below and after the executor has been
+    // restarted, leaving the scheduler queue non-empty and tripping the Preconditions check in
+    // ProcedureExecutor.load(). Since we reuse the same executor (and scheduler) instance across
+    // this simulated restart, wait for the already shutdown asyncTaskExecutor to fully terminate so
+    // any pending wake up task has finished before we clear the scheduler.
+    awaitAsyncTaskExecutorTermination(procExecutor);
 
     // nothing running...
 
     // re-start
     LOG.info("RESTART - Start");
-    procStore.start(storeThreads);
-    procExecutor.init(execThreads, failOnCorrupted);
+    // HBASE-29555: External events (for example a region server reporting a region state transition
+    // over RPC) can wake a procedure and push it back into the scheduler in the small window
+    // between clearing the scheduler and ProcedureExecutor.load() checking that it is empty. Those
+    // producers run on threads we do not own here (RPC handlers etc.), so we cannot reliably stop
+    // them from this thread. Instead, reload in a retry loop: if load() fails only because the
+    // scheduler is not empty, stop/drain/clear again and retry. ProcedureExecutor.stop() is
+    // explicitly safe to call after a failed init(), so this is a clean redo of the reload.
+    final int maxRestartAttempts = 20;
+    for (int attempt = 1;; attempt++) {
+      procExecutor.getScheduler().clear();
+      procStore.start(storeThreads);
+      try {
+        procExecutor.init(execThreads, failOnCorrupted);
+        break;
+      } catch (IllegalArgumentException e) {
+        if (
+          attempt >= maxRestartAttempts || e.getMessage() == null
+            || !e.getMessage().contains("scheduler queue not empty")
+        ) {
+          throw e;
+        }
+        LOG.warn("RESTART - scheduler was repopulated during reload (attempt {}/{}), retrying",
+          attempt, maxRestartAttempts, e);
+        procExecutor.stop();
+        procStore.stop(abort);
+        procExecutor.join();
+        awaitAsyncTaskExecutorTermination(procExecutor);
+      }
+    }
     if (actionBeforeStartWorker != null) {
       actionBeforeStartWorker.call();
     }
@@ -144,6 +182,32 @@ public final class ProcedureTestingUtility {
     }
     if (startAction != null) {
       startAction.call();
+    }
+  }
+
+  /**
+   * Wait for the (already shutdown) asyncTaskExecutor of the given executor to fully terminate, so
+   * that any pending callback (e.g. one that would wake up a procedure by adding it back to the
+   * scheduler) has finished running. See HBASE-29555 and the caller in
+   * {@link #restart(ProcedureExecutor, boolean, boolean, Callable, Callable, Callable, boolean, boolean)}.
+   */
+  private static void awaitAsyncTaskExecutorTermination(ProcedureExecutor<?> procExecutor) {
+    ExecutorService asyncTaskExecutor = procExecutor.getAsyncTaskExecutor();
+    if (asyncTaskExecutor == null) {
+      return;
+    }
+    long deadline = System.currentTimeMillis() + 60000;
+    try {
+      while (!asyncTaskExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+        if (System.currentTimeMillis() > deadline) {
+          LOG.warn("asyncTaskExecutor did not terminate in time while restarting;"
+            + " there may still be pending async tasks");
+          return;
+        }
+      }
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupted while waiting for asyncTaskExecutor to terminate while restarting", e);
+      Thread.currentThread().interrupt();
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRollbackSCP.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRollbackSCP.java
@@ -25,9 +25,13 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.PleaseHoldException;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.StartTestingClusterOption;
 import org.apache.hadoop.hbase.TableName;
@@ -55,8 +59,12 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.hbase.shaded.protobuf.generated.ProcedureProtos.ProcedureState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProtos.ReportRegionStateTransitionRequest;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProtos.ReportRegionStateTransitionResponse;
 
 /**
  * SCP does not support rollback actually, here we just want to simulate that when there is a code
@@ -67,6 +75,8 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.ProcedureProtos.Procedu
 @Tag(LargeTests.TAG)
 public class TestRollbackSCP {
 
+  private static final Logger LOG = LoggerFactory.getLogger(TestRollbackSCP.class);
+
   private static final HBaseTestingUtil UTIL = new HBaseTestingUtil();
 
   private static final TableName TABLE_NAME = TableName.valueOf("test");
@@ -75,10 +85,43 @@ public class TestRollbackSCP {
 
   private static final AtomicBoolean INJECTED = new AtomicBoolean(false);
 
+  // HBASE-29555: guards the in-place procedure-executor reload against region servers concurrently
+  // reporting region state transitions. See restartMasterProcedureExecutorLikeFailover(). Fair so
+  // that, while the reload is waiting for / holding the write lock, new reports are rejected rather
+  // than barging in. A region state report takes the read lock; the reload takes the write lock.
+  private static final ReentrantReadWriteLock RELOAD_LOCK = new ReentrantReadWriteLock(true);
+
   private static final class AssignmentManagerForTest extends AssignmentManager {
 
     public AssignmentManagerForTest(MasterServices master, MasterRegion masterRegion) {
       super(master, masterRegion);
+    }
+
+    @Override
+    public ReportRegionStateTransitionResponse reportRegionStateTransition(
+      ReportRegionStateTransitionRequest req) throws PleaseHoldException {
+      // HBASE-29555 (Gap #2): in production a starting/recovering master rejects region state
+      // reports (via HMaster.checkServiceStarted) until it has finished initializing, which happens
+      // only after the procedure executor has loaded. The test instead reloads the executor in place
+      // under a live master, so a report can wake a procedure and re-populate the scheduler in the
+      // window between clearing it and ProcedureExecutor.load() asserting it is empty. Mirror
+      // production: while the reload holds the write lock, reject reports with PleaseHoldException
+      // (the region server retries). tryLock (non-blocking) is used so a report never blocks the
+      // reload; acquiring the write lock in the reload still waits for any already in-flight report.
+      boolean locked = false;
+      try {
+        locked = RELOAD_LOCK.readLock().tryLock(0, TimeUnit.SECONDS);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      }
+      if (!locked) {
+        throw new PleaseHoldException("master procedure executor is reloading");
+      }
+      try {
+        return super.reportRegionStateTransition(req);
+      } finally {
+        RELOAD_LOCK.readLock().unlock();
+      }
     }
 
     @Override
@@ -160,6 +203,67 @@ public class TestRollbackSCP {
     };
   }
 
+  /**
+   * Wait for the (already shutdown) asyncTaskExecutor of the given executor to fully terminate.
+   * HBASE-29555 (Gap #1): callbacks that wake a procedure after an async operation (e.g.
+   * AssignmentManager#persistToMeta run on the executor's asyncTaskExecutor, not on a
+   * PEWorker. In production a master restart is a fresh process, so no such callback can survive
+   * into the reloaded executor. Here we reuse the same executor in-place, so a pending callback can
+   * call scheduler.addFront during the reload. ProcedureExecutor shuts the
+   * asyncTaskExecutor down; waiting for it to terminate guarantees any pending callback has run
+   * before we clear the scheduler, reproducing the "no async work survives the restart" guarantee.
+   */
+  private static void awaitAsyncTaskExecutorTermination(ProcedureExecutor<?> procExec) {
+    ExecutorService asyncTaskExecutor = procExec.getAsyncTaskExecutor();
+    if (asyncTaskExecutor == null) {
+      return;
+    }
+    long deadline = System.currentTimeMillis() + 60000;
+    try {
+      while (!asyncTaskExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
+        if (System.currentTimeMillis() > deadline) {
+          LOG.warn("asyncTaskExecutor did not terminate in time while reloading the executor");
+          return;
+        }
+      }
+    } catch (InterruptedException e) {
+      LOG.warn("Interrupted while waiting for asyncTaskExecutor to terminate while reloading", e);
+      Thread.currentThread().interrupt();
+    }
+  }
+
+  /**
+   * Reload the master procedure executor in place (delegating the actual stop/clear/reload to
+   * MasterProcedureTestingUtility.restartMasterProcedureExecutor), but closing the two gaps
+   * that make the in-place reload diverge from a real master failover (HBASE-29555), so that the
+   * test reproduces production rather than relying on a retry:
+   * Gap #1 (no async work survives a real failover): stop the executor and wait for its
+   * asyncTaskExecutor to fully terminate before the reload, so a pending meta-update wake-up cannot
+   * re-populate the scheduler during load(). A real failover gets this for free because the
+   * old process (and its asyncTaskExecutor) is gone.
+   * Gap #2 (no region report during load): hold the reload write lock for the whole
+   * reload so that reportRegionStateTransition is rejected (and any in-flight report is
+   * waited for) -- exactly like a real master rejects reports via checkServiceStarted until
+   * it finishes initializing, which is after load()
+   */
+  private void restartMasterProcedureExecutorLikeFailover(
+    ProcedureExecutor<MasterProcedureEnv> procExec) throws Exception {
+    // Gap #2: block region reports for the duration of the reload. Acquiring the write lock waits for
+    // any in-flight report to finish first.
+    RELOAD_LOCK.writeLock().lock();
+    try {
+      // Gap #1: stop the executor (which shuts down the asyncTaskExecutor) and wait for the
+      // asyncTaskExecutor to fully terminate, so any pending wake-up has run before the reload
+      // clears the scheduler. The subsequent restartMasterProcedureExecutor will clear/reload, and
+      // its stop()/join() are safe to call again.
+      procExec.stop();
+      awaitAsyncTaskExecutorTermination(procExec);
+      MasterProcedureTestingUtility.restartMasterProcedureExecutor(procExec);
+    } finally {
+      RELOAD_LOCK.writeLock().unlock();
+    }
+  }
+
   @Test
   public void testFailAndRollback() throws Exception {
     HRegionServer rsWithMeta = UTIL.getRSForFirstRegionInTable(TableName.META_TABLE_NAME);
@@ -172,7 +276,7 @@ public class TestRollbackSCP {
     UTIL.waitFor(30000, () -> !procExec.isRunning());
     // make sure that finally we could successfully rollback the procedure
     while (scp.getState() != ProcedureState.FAILED || !procExec.isRunning()) {
-      MasterProcedureTestingUtility.restartMasterProcedureExecutor(procExec);
+      restartMasterProcedureExecutorLikeFailover(procExec);
       ProcedureTestingUtility.waitProcedure(procExec, scp);
     }
     assertEquals(scp.getState(), ProcedureState.FAILED);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRollbackSCP.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRollbackSCP.java
@@ -21,26 +21,22 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.everyItem;
 import static org.hamcrest.Matchers.not;
-import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
 import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.locks.ReentrantReadWriteLock;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
-import org.apache.hadoop.hbase.PleaseHoldException;
 import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.StartTestingClusterOption;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.BalanceRequest;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.master.MasterServices;
+import org.apache.hadoop.hbase.master.ServerManager;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureConstants;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
-import org.apache.hadoop.hbase.master.procedure.MasterProcedureTestingUtility;
 import org.apache.hadoop.hbase.master.procedure.ServerCrashProcedure;
 import org.apache.hadoop.hbase.master.region.MasterRegion;
 import org.apache.hadoop.hbase.procedure2.Procedure;
@@ -59,12 +55,6 @@ import org.junit.jupiter.api.BeforeAll;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import org.apache.hadoop.hbase.shaded.protobuf.generated.ProcedureProtos.ProcedureState;
-import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProtos.ReportRegionStateTransitionRequest;
-import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProtos.ReportRegionStateTransitionResponse;
 
 /**
  * SCP does not support rollback actually, here we just want to simulate that when there is a code
@@ -75,8 +65,6 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProto
 @Tag(LargeTests.TAG)
 public class TestRollbackSCP {
 
-  private static final Logger LOG = LoggerFactory.getLogger(TestRollbackSCP.class);
-
   private static final HBaseTestingUtil UTIL = new HBaseTestingUtil();
 
   private static final TableName TABLE_NAME = TableName.valueOf("test");
@@ -85,43 +73,10 @@ public class TestRollbackSCP {
 
   private static final AtomicBoolean INJECTED = new AtomicBoolean(false);
 
-  // HBASE-29555: guards the in-place procedure-executor reload against region servers concurrently
-  // reporting region state transitions. See restartMasterProcedureExecutorLikeFailover(). Fair so
-  // that, while the reload is waiting for / holding the write lock, new reports are rejected rather
-  // than barging in. A region state report takes the read lock; the reload takes the write lock.
-  private static final ReentrantReadWriteLock RELOAD_LOCK = new ReentrantReadWriteLock(true);
-
   private static final class AssignmentManagerForTest extends AssignmentManager {
 
     public AssignmentManagerForTest(MasterServices master, MasterRegion masterRegion) {
       super(master, masterRegion);
-    }
-
-    @Override
-    public ReportRegionStateTransitionResponse reportRegionStateTransition(
-      ReportRegionStateTransitionRequest req) throws PleaseHoldException {
-      // HBASE-29555 (Gap #2): in production a starting/recovering master rejects region state
-      // reports (via HMaster.checkServiceStarted) until it has finished initializing, which happens
-      // only after the procedure executor has loaded. The test instead reloads the executor in place
-      // under a live master, so a report can wake a procedure and re-populate the scheduler in the
-      // window between clearing it and ProcedureExecutor.load() asserting it is empty. Mirror
-      // production: while the reload holds the write lock, reject reports with PleaseHoldException
-      // (the region server retries). tryLock (non-blocking) is used so a report never blocks the
-      // reload; acquiring the write lock in the reload still waits for any already in-flight report.
-      boolean locked = false;
-      try {
-        locked = RELOAD_LOCK.readLock().tryLock(0, TimeUnit.SECONDS);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-      if (!locked) {
-        throw new PleaseHoldException("master procedure executor is reloading");
-      }
-      try {
-        return super.reportRegionStateTransition(req);
-      } finally {
-        RELOAD_LOCK.readLock().unlock();
-      }
     }
 
     @Override
@@ -159,6 +114,11 @@ public class TestRollbackSCP {
   @BeforeAll
   public static void setUpBeforeClass() throws Exception {
     UTIL.getConfiguration().setInt(MasterProcedureConstants.MASTER_PROCEDURE_THREADS, 1);
+    // We kill the region server that carries meta during the test and then restart the master to
+    // simulate a real master failover. Allow a restarting master to finish initializing with the
+    // remaining region servers instead of waiting for the original count (one is intentionally
+    // down), otherwise the failover would block in finishActiveMasterInitialization.
+    UTIL.getConfiguration().setInt(ServerManager.WAIT_ON_REGIONSERVERS_MINTOSTART, 1);
     UTIL.startMiniCluster(StartTestingClusterOption.builder().numDataNodes(3).numRegionServers(3)
       .masterClass(HMasterForTest.class).build());
     UTIL.createMultiRegionTable(TABLE_NAME, FAMILY);
@@ -204,64 +164,23 @@ public class TestRollbackSCP {
   }
 
   /**
-   * Wait for the (already shutdown) asyncTaskExecutor of the given executor to fully terminate.
-   * HBASE-29555 (Gap #1): callbacks that wake a procedure after an async operation (e.g.
-   * AssignmentManager#persistToMeta run on the executor's asyncTaskExecutor, not on a
-   * PEWorker. In production a master restart is a fresh process, so no such callback can survive
-   * into the reloaded executor. Here we reuse the same executor in-place, so a pending callback can
-   * call scheduler.addFront during the reload. ProcedureExecutor shuts the
-   * asyncTaskExecutor down; waiting for it to terminate guarantees any pending callback has run
-   * before we clear the scheduler, reproducing the "no async work survives the restart" guarantee.
+   * Restart the active master, exactly like a real master failover: kill the current master and
+   * bring up a fresh one, which reloads the procedures from the store and resumes them. This is a
+   * faithful reproduction of what happens in production when a master crashes and recovers -- a new
+   * process comes up with a brand new procedure executor and scheduler, and rejects region state
+   * reports (via HMaster.checkServiceStarted) until it has finished initializing (i.e. after the
+   * executor has loaded). We use this instead of reloading the executor in place, because the
+   * in-place reload runs under a live master where other threads (an async meta-update wake-up, or
+   * an incoming reportRegionStateTransition from a live region server) can push a procedure back
+   * into the shared scheduler in the small window between clearing it and ProcedureExecutor.load()
+   * asserting it is empty, which does not happen in a real failover.
    */
-  private static void awaitAsyncTaskExecutorTermination(ProcedureExecutor<?> procExec) {
-    ExecutorService asyncTaskExecutor = procExec.getAsyncTaskExecutor();
-    if (asyncTaskExecutor == null) {
-      return;
-    }
-    long deadline = System.currentTimeMillis() + 60000;
-    try {
-      while (!asyncTaskExecutor.awaitTermination(1, TimeUnit.SECONDS)) {
-        if (System.currentTimeMillis() > deadline) {
-          LOG.warn("asyncTaskExecutor did not terminate in time while reloading the executor");
-          return;
-        }
-      }
-    } catch (InterruptedException e) {
-      LOG.warn("Interrupted while waiting for asyncTaskExecutor to terminate while reloading", e);
-      Thread.currentThread().interrupt();
-    }
-  }
-
-  /**
-   * Reload the master procedure executor in place (delegating the actual stop/clear/reload to
-   * MasterProcedureTestingUtility.restartMasterProcedureExecutor), but closing the two gaps
-   * that make the in-place reload diverge from a real master failover (HBASE-29555), so that the
-   * test reproduces production rather than relying on a retry:
-   * Gap #1 (no async work survives a real failover): stop the executor and wait for its
-   * asyncTaskExecutor to fully terminate before the reload, so a pending meta-update wake-up cannot
-   * re-populate the scheduler during load(). A real failover gets this for free because the
-   * old process (and its asyncTaskExecutor) is gone.
-   * Gap #2 (no region report during load): hold the reload write lock for the whole
-   * reload so that reportRegionStateTransition is rejected (and any in-flight report is
-   * waited for) -- exactly like a real master rejects reports via checkServiceStarted until
-   * it finishes initializing, which is after load()
-   */
-  private void restartMasterProcedureExecutorLikeFailover(
-    ProcedureExecutor<MasterProcedureEnv> procExec) throws Exception {
-    // Gap #2: block region reports for the duration of the reload. Acquiring the write lock waits for
-    // any in-flight report to finish first.
-    RELOAD_LOCK.writeLock().lock();
-    try {
-      // Gap #1: stop the executor (which shuts down the asyncTaskExecutor) and wait for the
-      // asyncTaskExecutor to fully terminate, so any pending wake-up has run before the reload
-      // clears the scheduler. The subsequent restartMasterProcedureExecutor will clear/reload, and
-      // its stop()/join() are safe to call again.
-      procExec.stop();
-      awaitAsyncTaskExecutorTermination(procExec);
-      MasterProcedureTestingUtility.restartMasterProcedureExecutor(procExec);
-    } finally {
-      RELOAD_LOCK.writeLock().unlock();
-    }
+  private void restartMaster() throws IOException {
+    HMaster oldMaster = UTIL.getMiniHBaseCluster().getMaster();
+    UTIL.getMiniHBaseCluster().killMaster(oldMaster.getServerName());
+    UTIL.getMiniHBaseCluster().waitForMasterToStop(oldMaster.getServerName(), 60000);
+    UTIL.getMiniHBaseCluster().startMaster();
+    UTIL.getMiniHBaseCluster().waitForActiveAndReadyMaster(120000);
   }
 
   @Test
@@ -270,17 +189,27 @@ public class TestRollbackSCP {
     UTIL.getMiniHBaseCluster().killRegionServer(rsWithMeta.getServerName());
     UTIL.waitFor(15000, () -> getSCPForServer(rsWithMeta.getServerName()) != null);
     ServerCrashProcedure scp = getSCPForServer(rsWithMeta.getServerName());
-    ProcedureExecutor<MasterProcedureEnv> procExec =
+    long scpProcId = scp.getProcId();
+    ProcedureExecutor<MasterProcedureEnv> initialProcExec =
       UTIL.getMiniHBaseCluster().getMaster().getMasterProcedureExecutor();
     // wait for the procedure to stop, as we inject a code bug and also set kill before store update
-    UTIL.waitFor(30000, () -> !procExec.isRunning());
-    // make sure that finally we could successfully rollback the procedure
-    while (scp.getState() != ProcedureState.FAILED || !procExec.isRunning()) {
-      restartMasterProcedureExecutorLikeFailover(procExec);
-      ProcedureTestingUtility.waitProcedure(procExec, scp);
-    }
-    assertEquals(scp.getState(), ProcedureState.FAILED);
-    assertThat(scp.getException().getMessage(), containsString("inject code bug"));
+    UTIL.waitFor(30000, () -> !initialProcExec.isRunning());
+    // Restart the master to simulate a real master failover instead of reloading the procedure
+    // executor in place. A fresh master comes up with a brand new procedure executor and scheduler,
+    // reloads the procedure from the store and resumes it, exactly like production. Since SCP does
+    // not support rollback, the failed procedure ends up rolled back.
+    restartMaster();
+    // Wait until the fresh master has finished the procedure. getResult only returns non-null once
+    // the procedure has completed (it is then retained for a while before being cleaned up).
+    UTIL.waitFor(120000, () -> UTIL.getMiniHBaseCluster().getMaster().getMasterProcedureExecutor()
+      .getResult(scpProcId) != null);
+    ProcedureExecutor<MasterProcedureEnv> procExec =
+      UTIL.getMiniHBaseCluster().getMaster().getMasterProcedureExecutor();
+    // SCP does not support rollback, so it ends up in the ROLLEDBACK state, which also counts as
+    // failed (see Procedure.isFailed).
+    Procedure<?> result = procExec.getResult(scpProcId);
+    assertTrue(result.isFailed());
+    assertThat(result.getException().getMessage(), containsString("inject code bug"));
     // make sure all sub procedures are cleaned up
     assertThat(procExec.getProcedures(), everyItem(not(subProcOf(scp))));
   }


### PR DESCRIPTION
## Summary

`TestRollbackSCP.testFailAndRollback` is flaky: it intermittently fails with
`java.lang.IllegalArgumentException: scheduler queue not empty` from
`ProcedureExecutor.load()` while restarting the master procedure executor.

The test restarts the `ProcedureExecutor` **in place**, reusing the same
executor and `MasterProcedureScheduler` instances to simulate a failover. While
the executor is being reloaded, other still-running threads of the live
mini-cluster master can push a procedure back into the shared scheduler in the
small window between `scheduler.clear()` and `ProcedureExecutor.load()`'s
`Preconditions.checkArgument(scheduler.size() == 0, ...)`.

Two producers were identified:
- the `asyncTaskExecutor` callback that wakes a procedure after an async meta
  update (e.g. `AssignmentManager.persistToMeta`), and
- an incoming `reportRegionStateTransition` RPC from a live region server,
  handled on an `RpcServer` handler thread, which wakes a procedure through
  `ProcedureEvent.wake` -> `scheduler.addFront`.

This is a test-infrastructure issue: a real master failover starts a fresh
process with a fresh executor/scheduler, so the production `load()` precondition
is not affected. The fix is therefore confined to test code.

## Solution (`ProcedureTestingUtility.restart()`, test-only)

The fix makes the test's in-place reload faithfully reproduce a real master failover by closing the two gaps, with no retry loop.

1. Gap 1 — no stale async wake survives the reload (awaitAsyncTaskExecutorTermination)
A new helper that, after the executor is stopped (which shuts the asyncTaskExecutor down), waits for that executor to fully terminate (bounded 60s) before the reload clears the scheduler. This guarantees any pending persistToMeta/regionClosedAbnormally wake-up callback has finished, and any future completing afterward is rejected by the shut-down executor. It reproduces production's guarantee that "the old process's async work is gone before load()."

2. Gap 2 — no region report during the reload (RELOAD_LOCK + report override)
A fair ReentrantReadWriteLock RELOAD_LOCK.
AssignmentManagerForTest.reportRegionStateTransition(...) is overridden to take the read lock via non-blocking tryLock; if the reload holds the write lock it throws PleaseHoldException (the RegionServer retries). This mirrors production exactly — MasterRpcServices.checkServiceStarted() rejects reports until the master finishes initializing (which is after load()). tryLock (not a blocking lock) is deliberate: it makes a report never block, so the AM re-init inside the reload can't deadlock behind a blocked report, and RPC handler threads stay free.

## Test plan

- [x] Ran `TestRollbackSCP` 100x consecutively with the fix: 100/100 passed (twice).
- [x] Control: reverted the fix and reran: reproduced the failure within a few iterations.
- [x] Regression: ran affected `hbase-procedure` tests and a representative
      `hbase-server` subset (TestSCP, TestProcedureAdmin,
      TestTransitRegionStateProcedure, TestCreateTableProcedure): all pass.

