### PR TITLE
HBASE-30226 Avoid same-row reverse FuzzyRowFilter hints

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/FuzzyRowFilter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/FuzzyRowFilter.java
@@ -644,9 +644,13 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
 
     byte[] trailingZerosTrimmed = trimTrailingZeroes(result, fuzzyKeyMeta, toInc);
     if (reverse) {
-      // In the reverse case we increase last non-max byte to make sure that the proper row is
-      // selected next.
-      return PrivateCellUtil.increaseLastNonMaxByte(trailingZerosTrimmed);
+      // In the reverse case we usually increase last non-max byte to make sure that the proper row
+      // is selected next.
+      byte[] nextRowKeyCandidate = PrivateCellUtil.increaseLastNonMaxByte(trailingZerosTrimmed);
+      // If the adjusted hint is the current row, return the unadjusted candidate so the hint moves.
+      return Bytes.equals(row, offset, length, nextRowKeyCandidate, 0, nextRowKeyCandidate.length)
+        ? trailingZerosTrimmed
+        : nextRowKeyCandidate;
     } else {
       return trailingZerosTrimmed;
     }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/FuzzyRowFilter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/FuzzyRowFilter.java
@@ -87,7 +87,7 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
   private int lastFoundIndex = -1;
 
   /**
-   * Row tracker (keeps all next rows after SEEK_NEXT_USING_HINT was returned)
+   * Row tracker for next row hints and reverse same-row hint detection.
    */
   private final RowTracker tracker;
 
@@ -216,9 +216,14 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
         return ReturnCode.INCLUDE;
       }
     }
-    // NOT FOUND -> seek next using hint
+    // NOT FOUND -> seek next using hint or skip the current row.
     lastFoundIndex = -1;
     filterRow = true;
+    // For reverse scans, a non-matching row can recreate itself as the next hint. Since fuzzy
+    // matching is row-key based, skip the whole non-matching row instead of seeking to it again.
+    if (isReversed() && tracker.updateTracker(c) && tracker.isNextRowSameAs(c)) {
+      return ReturnCode.NEXT_ROW;
+    }
     return ReturnCode.SEEK_NEXT_USING_HINT;
 
   }
@@ -232,10 +237,9 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
     }
     byte[] nextRowKey = tracker.nextRow();
     if (isReversed() && !tracker.lessThan(currentCell, nextRowKey)) {
-      // StoreScanner only seeks on reverse hints that compare before the current cell.
-      // createLastOnRow(currentCell) creates the last possible cell on the current row, which does
-      // not satisfy that condition. StoreScanner then falls back to heap.next() and moves past the
-      // current cell instead of seeking back to the same row candidate.
+      // filterCell normally handles same-row reverse hints with NEXT_ROW. If a non-progressing
+      // hint still reaches here, keep the current-row boundary to avoid skipping matching rows
+      // under it, but return a non-seeking hint so StoreScanner advances normally.
       return PrivateCellUtil.createLastOnRow(currentCell);
     }
     return PrivateCellUtil.createFirstOnRow(nextRowKey, 0, (short) nextRowKey.length);
@@ -288,7 +292,7 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
           byte[] nextRowKeyCandidate = updateWith(currentCell, fuzzyData);
           if (nextRowKeyCandidate != null && !lessThan(currentCell, nextRowKeyCandidate)) {
             // The candidate still does not make progress for this row. Keep it in the queue so
-            // getNextCellHint can return a non-seeking hint and move past the current cell.
+            // filterCell can skip the row or getNextCellHint can return a non-seeking hint.
             break;
           }
         }
@@ -300,6 +304,15 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
       int compareResult =
         CellComparator.getInstance().compareRows(currentCell, nextRowKey, 0, nextRowKey.length);
       return (!isReversed() && compareResult < 0) || (isReversed() && compareResult > 0);
+    }
+
+    boolean isNextRowSameAs(Cell currentCell) {
+      if (nextRows.isEmpty()) {
+        return false;
+      }
+      byte[] candidateRowKey = nextRows.peek().getFirst();
+      return CellComparator.getInstance().compareRows(currentCell, candidateRowKey, 0,
+        candidateRowKey.length) == 0;
     }
 
     byte[] updateWith(Cell currentCell, Pair<byte[], byte[]> fuzzyData) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/FuzzyRowFilter.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/filter/FuzzyRowFilter.java
@@ -231,6 +231,13 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
       return null;
     }
     byte[] nextRowKey = tracker.nextRow();
+    if (isReversed() && !tracker.lessThan(currentCell, nextRowKey)) {
+      // StoreScanner only seeks on reverse hints that compare before the current cell.
+      // createLastOnRow(currentCell) creates the last possible cell on the current row, which does
+      // not satisfy that condition. StoreScanner then falls back to heap.next() and moves past the
+      // current cell instead of seeking back to the same row candidate.
+      return PrivateCellUtil.createLastOnRow(currentCell);
+    }
     return PrivateCellUtil.createFirstOnRow(nextRowKey, 0, (short) nextRowKey.length);
   }
 
@@ -278,7 +285,12 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
         while (!nextRows.isEmpty() && !lessThan(currentCell, nextRows.peek().getFirst())) {
           Pair<byte[], Pair<byte[], byte[]>> head = nextRows.poll();
           Pair<byte[], byte[]> fuzzyData = head.getSecond();
-          updateWith(currentCell, fuzzyData);
+          byte[] nextRowKeyCandidate = updateWith(currentCell, fuzzyData);
+          if (nextRowKeyCandidate != null && !lessThan(currentCell, nextRowKeyCandidate)) {
+            // The candidate still does not make progress for this row. Keep it in the queue so
+            // getNextCellHint can return a non-seeking hint and move past the current cell.
+            break;
+          }
         }
       }
       return !nextRows.isEmpty();
@@ -290,13 +302,14 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
       return (!isReversed() && compareResult < 0) || (isReversed() && compareResult > 0);
     }
 
-    void updateWith(Cell currentCell, Pair<byte[], byte[]> fuzzyData) {
+    byte[] updateWith(Cell currentCell, Pair<byte[], byte[]> fuzzyData) {
       byte[] nextRowKeyCandidate =
         getNextForFuzzyRule(isReversed(), currentCell.getRowArray(), currentCell.getRowOffset(),
           currentCell.getRowLength(), fuzzyData.getFirst(), fuzzyData.getSecond());
       if (nextRowKeyCandidate != null) {
         nextRows.add(new Pair<>(nextRowKeyCandidate, fuzzyData));
       }
+      return nextRowKeyCandidate;
     }
 
   }
@@ -644,13 +657,9 @@ public class FuzzyRowFilter extends FilterBase implements HintingFilter {
 
     byte[] trailingZerosTrimmed = trimTrailingZeroes(result, fuzzyKeyMeta, toInc);
     if (reverse) {
-      // In the reverse case we usually increase last non-max byte to make sure that the proper row
-      // is selected next.
-      byte[] nextRowKeyCandidate = PrivateCellUtil.increaseLastNonMaxByte(trailingZerosTrimmed);
-      // If the adjusted hint is the current row, return the unadjusted candidate so the hint moves.
-      return Bytes.equals(row, offset, length, nextRowKeyCandidate, 0, nextRowKeyCandidate.length)
-        ? trailingZerosTrimmed
-        : nextRowKeyCandidate;
+      // In the reverse case we increase last non-max byte to make sure that the proper row is
+      // selected next.
+      return PrivateCellUtil.increaseLastNonMaxByte(trailingZerosTrimmed);
     } else {
       return trailingZerosTrimmed;
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
@@ -265,7 +265,7 @@ public class TestFuzzyRowFilter {
     assertNext(true, new byte[] { 0, 1, 0, 0 }, // fuzzy row
       new byte[] { 0, -1, 0, 0 }, // mask
       new byte[] { 5, 1, (byte) 255, 1 }, // current
-      new byte[] { 5, 1, (byte) 255, 1 }); // expected next
+      new byte[] { 5, 1, (byte) 255, 0 }); // expected next
 
     assertNext(true, new byte[] { 0, 1, 0, 1 }, // fuzzy row
       new byte[] { 0, -1, 0, -1 }, // mask
@@ -305,27 +305,27 @@ public class TestFuzzyRowFilter {
     assertNext(true, new byte[] { 1, 0, 1 }, // fuzzy row
       new byte[] { -1, 0, -1 }, // mask
       new byte[] { 1, (byte) 128, 2 }, // row to check
-      new byte[] { 1, (byte) 128, 2 }); // expected next
+      new byte[] { 1, (byte) 128, 1 }); // expected next
 
     assertNext(true, new byte[] { 0, 1, 0, 1 }, // fuzzy row
       new byte[] { 0, -1, 0, -1 }, // mask
       new byte[] { 5, 1, 0, 2 }, // row to check
-      new byte[] { 5, 1, 0, 2 }); // expected next
+      new byte[] { 5, 1, 0, 1 }); // expected next
 
     assertNext(true, new byte[] { 5, 1, 1, 0 }, // fuzzy row
       new byte[] { -1, -1, 0, 0 }, // mask
       new byte[] { 5, 1, (byte) 0xFF, 1 }, // row to check
-      new byte[] { 5, 1, (byte) 0xFF, 1 }); // expected next
+      new byte[] { 5, 1, (byte) 0xFF, 0 }); // expected next
 
     assertNext(true, new byte[] { 1, 1, 1, 1 }, // fuzzy row
       new byte[] { -1, -1, 0, 0 }, // mask
       new byte[] { 1, 1, 2, 2 }, // row to check
-      new byte[] { 1, 1, 2, 2 }); // expected next
+      new byte[] { 1, 1, 2, 1 }); // expected next
 
     assertNext(true, new byte[] { 1, 1, 1, 1 }, // fuzzy row
       new byte[] { 0, 0, 0, 0 }, // mask
       new byte[] { 1, 1, 2, 3 }, // row to check
-      new byte[] { 1, 1, 2, 3 }); // expected next
+      new byte[] { 1, 1, 2, 2 }); // expected next
 
     // no before cell than current which satisfies the fuzzy row -> null
     assertNull(FuzzyRowFilter.getNextForFuzzyRule(true, new byte[] { 1, 1, 1, 3, 0 },

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
@@ -307,7 +307,7 @@ public class TestFuzzyRowFilter {
       new byte[] { 2, 1, 1, 1, 0 }, // row to check
       new byte[] { 1, 2, (byte) 255, 4 }); // expected next
 
-    // no before cell than current which satisfies the fuzzy row -> null
+    // No cell before the current one satisfies the fuzzy row -> null.
     assertNull(FuzzyRowFilter.getNextForFuzzyRule(true, new byte[] { 1, 1, 1, 3, 0 },
       new byte[] { 1, 2, 0, 3 }, new byte[] { -1, -1, 0, -1 }));
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
@@ -377,8 +377,8 @@ public class TestFuzzyRowFilter {
 
   @Test
   public void testReverseFilterListSkipsSameRowFuzzyHint() throws IOException {
-    for (FilterList.Operator operator :
-      Arrays.asList(FilterList.Operator.MUST_PASS_ALL, FilterList.Operator.MUST_PASS_ONE)) {
+    for (FilterList.Operator operator : Arrays.asList(FilterList.Operator.MUST_PASS_ALL,
+      FilterList.Operator.MUST_PASS_ONE)) {
       FilterList filterList =
         new FilterList(operator, newReverseFuzzyRowFilter(), newReverseFuzzyRowFilter());
 
@@ -392,14 +392,14 @@ public class TestFuzzyRowFilter {
   }
 
   private static FuzzyRowFilter newReverseFuzzyRowFilter() {
-    FuzzyRowFilter filter = new FuzzyRowFilter(Arrays.asList(
-      new Pair<>(Bytes.toBytes("aaa"), new byte[] { 0, 1, 0 })));
+    FuzzyRowFilter filter =
+      new FuzzyRowFilter(Arrays.asList(new Pair<>(Bytes.toBytes("aaa"), new byte[] { 0, 1, 0 })));
     filter.setReversed(true);
     return filter;
   }
 
   private static void assertRow(String expected, Cell cell) {
-    assertEquals(expected, Bytes.toString(cell.getRowArray(), cell.getRowOffset(),
-      cell.getRowLength()));
+    assertEquals(expected,
+      Bytes.toString(cell.getRowArray(), cell.getRowOffset(), cell.getRowLength()));
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
@@ -262,11 +262,6 @@ public class TestFuzzyRowFilter {
       new byte[] { 5, 1, 0, 2, 1 }, // current
       new byte[] { 5, 1, 0, 2 }); // expected next
 
-    assertNext(true, new byte[] { 0, 1, 0, 0 }, // fuzzy row
-      new byte[] { 0, -1, 0, 0 }, // mask
-      new byte[] { 5, 1, (byte) 255, 1 }, // current
-      new byte[] { 5, 1, (byte) 255, 0 }); // expected next
-
     assertNext(true, new byte[] { 0, 1, 0, 1 }, // fuzzy row
       new byte[] { 0, -1, 0, -1 }, // mask
       new byte[] { 5, 1, 0, 1 }, // current
@@ -302,6 +297,20 @@ public class TestFuzzyRowFilter {
       new byte[] { 2, 1, 1, 1, 0 }, // row to check
       new byte[] { 1, 2, (byte) 255, 4 }); // expected next
 
+    // no before cell than current which satisfies the fuzzy row -> null
+    assertNull(FuzzyRowFilter.getNextForFuzzyRule(true, new byte[] { 1, 1, 1, 3, 0 },
+      new byte[] { 1, 2, 0, 3 }, new byte[] { -1, -1, 0, -1 }));
+  }
+
+  // Same-row adjusted reverse hints should fall back to the unadjusted candidate, so the hint keeps
+  // moving before the current row.
+  @Test
+  public void testGetNextForFuzzyRuleReverseAvoidsSameRowHint() {
+    assertNext(true, new byte[] { 0, 1, 0, 0 }, // fuzzy row
+      new byte[] { 0, -1, 0, 0 }, // mask
+      new byte[] { 5, 1, (byte) 255, 1 }, // current
+      new byte[] { 5, 1, (byte) 255, 0 }); // expected next
+
     assertNext(true, new byte[] { 1, 0, 1 }, // fuzzy row
       new byte[] { -1, 0, -1 }, // mask
       new byte[] { 1, (byte) 128, 2 }, // row to check
@@ -326,10 +335,6 @@ public class TestFuzzyRowFilter {
       new byte[] { 0, 0, 0, 0 }, // mask
       new byte[] { 1, 1, 2, 3 }, // row to check
       new byte[] { 1, 1, 2, 2 }); // expected next
-
-    // no before cell than current which satisfies the fuzzy row -> null
-    assertNull(FuzzyRowFilter.getNextForFuzzyRule(true, new byte[] { 1, 1, 1, 3, 0 },
-      new byte[] { 1, 2, 0, 3 }, new byte[] { -1, -1, 0, -1 }));
   }
 
   private static void assertNext(boolean reverse, byte[] fuzzyRow, byte[] mask, byte[] current,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
@@ -262,6 +262,11 @@ public class TestFuzzyRowFilter {
       new byte[] { 5, 1, 0, 2, 1 }, // current
       new byte[] { 5, 1, 0, 2 }); // expected next
 
+    assertNext(true, new byte[] { 0, 1, 0, 0 }, // fuzzy row
+      new byte[] { 0, -1, 0, 0 }, // mask
+      new byte[] { 5, 1, (byte) 255, 1 }, // current
+      new byte[] { 5, 1, (byte) 255, 1 }); // expected next
+
     assertNext(true, new byte[] { 0, 1, 0, 1 }, // fuzzy row
       new byte[] { 0, -1, 0, -1 }, // mask
       new byte[] { 5, 1, 0, 1 }, // current
@@ -297,44 +302,34 @@ public class TestFuzzyRowFilter {
       new byte[] { 2, 1, 1, 1, 0 }, // row to check
       new byte[] { 1, 2, (byte) 255, 4 }); // expected next
 
-    // no before cell than current which satisfies the fuzzy row -> null
-    assertNull(FuzzyRowFilter.getNextForFuzzyRule(true, new byte[] { 1, 1, 1, 3, 0 },
-      new byte[] { 1, 2, 0, 3 }, new byte[] { -1, -1, 0, -1 }));
-  }
-
-  // Same-row adjusted reverse hints should fall back to the unadjusted candidate, so the hint keeps
-  // moving before the current row.
-  @Test
-  public void testGetNextForFuzzyRuleReverseAvoidsSameRowHint() {
-    assertNext(true, new byte[] { 0, 1, 0, 0 }, // fuzzy row
-      new byte[] { 0, -1, 0, 0 }, // mask
-      new byte[] { 5, 1, (byte) 255, 1 }, // current
-      new byte[] { 5, 1, (byte) 255, 0 }); // expected next
-
     assertNext(true, new byte[] { 1, 0, 1 }, // fuzzy row
       new byte[] { -1, 0, -1 }, // mask
       new byte[] { 1, (byte) 128, 2 }, // row to check
-      new byte[] { 1, (byte) 128, 1 }); // expected next
+      new byte[] { 1, (byte) 128, 2 }); // expected next
 
     assertNext(true, new byte[] { 0, 1, 0, 1 }, // fuzzy row
       new byte[] { 0, -1, 0, -1 }, // mask
       new byte[] { 5, 1, 0, 2 }, // row to check
-      new byte[] { 5, 1, 0, 1 }); // expected next
+      new byte[] { 5, 1, 0, 2 }); // expected next
 
     assertNext(true, new byte[] { 5, 1, 1, 0 }, // fuzzy row
       new byte[] { -1, -1, 0, 0 }, // mask
       new byte[] { 5, 1, (byte) 0xFF, 1 }, // row to check
-      new byte[] { 5, 1, (byte) 0xFF, 0 }); // expected next
+      new byte[] { 5, 1, (byte) 0xFF, 1 }); // expected next
 
     assertNext(true, new byte[] { 1, 1, 1, 1 }, // fuzzy row
       new byte[] { -1, -1, 0, 0 }, // mask
       new byte[] { 1, 1, 2, 2 }, // row to check
-      new byte[] { 1, 1, 2, 1 }); // expected next
+      new byte[] { 1, 1, 2, 2 }); // expected next
 
     assertNext(true, new byte[] { 1, 1, 1, 1 }, // fuzzy row
       new byte[] { 0, 0, 0, 0 }, // mask
       new byte[] { 1, 1, 2, 3 }, // row to check
-      new byte[] { 1, 1, 2, 2 }); // expected next
+      new byte[] { 1, 1, 2, 3 }); // expected next
+
+    // no before cell than current which satisfies the fuzzy row -> null
+    assertNull(FuzzyRowFilter.getNextForFuzzyRule(true, new byte[] { 1, 1, 1, 3, 0 },
+      new byte[] { 1, 2, 0, 3 }, new byte[] { -1, -1, 0, -1 }));
   }
 
   private static void assertNext(boolean reverse, byte[] fuzzyRow, byte[] mask, byte[] current,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilter.java
@@ -20,11 +20,15 @@ package org.apache.hadoop.hbase.filter;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
+import java.io.IOException;
+import java.util.Arrays;
+import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.KeyValueUtil;
 import org.apache.hadoop.hbase.testclassification.FilterTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Pair;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
 
@@ -247,6 +251,12 @@ public class TestFuzzyRowFilter {
       new byte[] { 1, 2, 1, 0, 1 }, // current
       new byte[] { 1, 1, 3 }); // expected next
 
+    // Preserve HBASE-28634 boundary hints. Lowering 1115 to 1114 would skip rows such as 111444.
+    assertNext(true, Bytes.toBytes("111433"), // fuzzy row
+      new byte[] { -1, -1, -1, -1, 0, 0 }, // mask
+      Bytes.toBytes("1115"), // current
+      Bytes.toBytes("1115")); // expected next
+
     assertNext(true, new byte[] { 0, 1, 0, 2, 0 }, // fuzzy row
       new byte[] { 0, -1, 0, -1, 0 }, // mask
       new byte[] { 1, 2, 1, 3, 1 }, // current
@@ -261,11 +271,6 @@ public class TestFuzzyRowFilter {
       new byte[] { 0, -1, 0, -1 }, // mask
       new byte[] { 5, 1, 0, 2, 1 }, // current
       new byte[] { 5, 1, 0, 2 }); // expected next
-
-    assertNext(true, new byte[] { 0, 1, 0, 0 }, // fuzzy row
-      new byte[] { 0, -1, 0, 0 }, // mask
-      new byte[] { 5, 1, (byte) 255, 1 }, // current
-      new byte[] { 5, 1, (byte) 255, 1 }); // expected next
 
     assertNext(true, new byte[] { 0, 1, 0, 1 }, // fuzzy row
       new byte[] { 0, -1, 0, -1 }, // mask
@@ -302,6 +307,24 @@ public class TestFuzzyRowFilter {
       new byte[] { 2, 1, 1, 1, 0 }, // row to check
       new byte[] { 1, 2, (byte) 255, 4 }); // expected next
 
+    // no before cell than current which satisfies the fuzzy row -> null
+    assertNull(FuzzyRowFilter.getNextForFuzzyRule(true, new byte[] { 1, 1, 1, 3, 0 },
+      new byte[] { 1, 2, 0, 3 }, new byte[] { -1, -1, 0, -1 }));
+  }
+
+  @Test
+  public void testGetNextForFuzzyRuleReverseCanReturnCurrentRow() {
+    // HBASE-28634 reverse adjustment can intentionally return the current row as a boundary hint.
+    assertNext(true, new byte[] { 'a', 'a', 'a' }, // fuzzy row
+      new byte[] { -1, 0, -1 }, // mask
+      new byte[] { 'a', 'b', 'b' }, // current
+      new byte[] { 'a', 'b', 'b' }); // expected next
+
+    assertNext(true, new byte[] { 0, 1, 0, 0 }, // fuzzy row
+      new byte[] { 0, -1, 0, 0 }, // mask
+      new byte[] { 5, 1, (byte) 255, 1 }, // current
+      new byte[] { 5, 1, (byte) 255, 1 }); // expected next
+
     assertNext(true, new byte[] { 1, 0, 1 }, // fuzzy row
       new byte[] { -1, 0, -1 }, // mask
       new byte[] { 1, (byte) 128, 2 }, // row to check
@@ -326,10 +349,6 @@ public class TestFuzzyRowFilter {
       new byte[] { 0, 0, 0, 0 }, // mask
       new byte[] { 1, 1, 2, 3 }, // row to check
       new byte[] { 1, 1, 2, 3 }); // expected next
-
-    // no before cell than current which satisfies the fuzzy row -> null
-    assertNull(FuzzyRowFilter.getNextForFuzzyRule(true, new byte[] { 1, 1, 1, 3, 0 },
-      new byte[] { 1, 2, 0, 3 }, new byte[] { -1, -1, 0, -1 }));
   }
 
   private static void assertNext(boolean reverse, byte[] fuzzyRow, byte[] mask, byte[] current,
@@ -338,5 +357,49 @@ public class TestFuzzyRowFilter {
     byte[] nextForFuzzyRule = FuzzyRowFilter.getNextForFuzzyRule(reverse, kv.getRowArray(),
       kv.getRowOffset(), kv.getRowLength(), fuzzyRow, mask);
     assertEquals(Bytes.toStringBinary(expected), Bytes.toStringBinary(nextForFuzzyRule));
+  }
+
+  @Test
+  public void testReverseFilterCellSkipsSameRowHint() {
+    // The first non-matching row can seek to abb, but abb would recreate abb as its reverse hint.
+    // The scanner should skip that non-matching row instead of seeking to the same row again.
+    FuzzyRowFilter filter = newReverseFuzzyRowFilter();
+
+    KeyValue abc = KeyValueUtil.createFirstOnRow(Bytes.toBytes("abc"));
+    assertEquals(Filter.ReturnCode.SEEK_NEXT_USING_HINT, filter.filterCell(abc));
+    Cell hint = filter.getNextCellHint(abc);
+    assertRow("abb", hint);
+
+    KeyValue abb = KeyValueUtil.createFirstOnRow(Bytes.toBytes("abb"));
+    // filterCell handles the same-row hint by skipping the current non-matching row.
+    assertEquals(Filter.ReturnCode.NEXT_ROW, filter.filterCell(abb));
+  }
+
+  @Test
+  public void testReverseFilterListSkipsSameRowFuzzyHint() throws IOException {
+    for (FilterList.Operator operator :
+      Arrays.asList(FilterList.Operator.MUST_PASS_ALL, FilterList.Operator.MUST_PASS_ONE)) {
+      FilterList filterList =
+        new FilterList(operator, newReverseFuzzyRowFilter(), newReverseFuzzyRowFilter());
+
+      KeyValue abc = KeyValueUtil.createFirstOnRow(Bytes.toBytes("abc"));
+      assertEquals(Filter.ReturnCode.SEEK_NEXT_USING_HINT, filterList.filterCell(abc));
+      assertRow("abb", filterList.getNextCellHint(abc));
+
+      KeyValue abb = KeyValueUtil.createFirstOnRow(Bytes.toBytes("abb"));
+      assertEquals(Filter.ReturnCode.NEXT_ROW, filterList.filterCell(abb));
+    }
+  }
+
+  private static FuzzyRowFilter newReverseFuzzyRowFilter() {
+    FuzzyRowFilter filter = new FuzzyRowFilter(Arrays.asList(
+      new Pair<>(Bytes.toBytes("aaa"), new byte[] { 0, 1, 0 })));
+    filter.setReversed(true);
+    return filter;
+  }
+
+  private static void assertRow(String expected, Cell cell) {
+    assertEquals(expected, Bytes.toString(cell.getRowArray(), cell.getRowOffset(),
+      cell.getRowLength()));
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilterEndToEnd.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilterEndToEnd.java
@@ -373,6 +373,52 @@ public class TestFuzzyRowFilterEndToEnd {
   }
 
   @Test
+  public void testReverseScanMovesPastSameRowFuzzyHintAcrossMultipleCells(TestInfo testInfo)
+    throws IOException {
+    final String cf = "f";
+
+    String name = testInfo.getTestMethod().orElseThrow(AssertionError::new).getName();
+    try (Table ht = TEST_UTIL.createTable(TableName.valueOf(name), Bytes.toBytes(cf))) {
+      List<Put> puts = Lists.newArrayList();
+      puts.add(new Put(Bytes.toBytes("aaa")).addColumn(Bytes.toBytes(cf), Bytes.toBytes("q1"),
+        Bytes.toBytes("v")));
+      puts.add(new Put(Bytes.toBytes("aba")).addColumn(Bytes.toBytes(cf), Bytes.toBytes("q1"),
+        Bytes.toBytes("v")));
+      // The same-row reverse hint is recreated for each cell on this non-matching row. Before the
+      // fix, the first cell could loop inside RowTracker and never return to StoreScanner. After the
+      // fix, StoreScanner advances cell by cell until it reaches the next matching row.
+      puts.add(new Put(Bytes.toBytes("abb"))
+        .addColumn(Bytes.toBytes(cf), Bytes.toBytes("q1"), Bytes.toBytes("v1"))
+        .addColumn(Bytes.toBytes(cf), Bytes.toBytes("q2"), Bytes.toBytes("v2"))
+        .addColumn(Bytes.toBytes(cf), Bytes.toBytes("q3"), Bytes.toBytes("v3")));
+      puts.add(new Put(Bytes.toBytes("abc")).addColumn(Bytes.toBytes(cf), Bytes.toBytes("q1"),
+        Bytes.toBytes("v")));
+      ht.put(puts);
+
+      TEST_UTIL.flush();
+
+      List<Pair<byte[], byte[]>> fuzzyList = new LinkedList<>();
+      fuzzyList.add(new Pair<>(Bytes.toBytes("aaa"), new byte[] { 0, 1, 0 }));
+
+      Scan scan = new Scan();
+      scan.setReversed(true);
+      scan.setFilter(new FuzzyRowFilter(fuzzyList));
+
+      try (ResultScanner scanner = ht.getScanner(scan)) {
+        Result result = scanner.next();
+        assertNotNull(result);
+        assertEquals("aba", Bytes.toString(result.getRow()));
+        result = scanner.next();
+        assertNotNull(result);
+        assertEquals("aaa", Bytes.toString(result.getRow()));
+        assertNull(scanner.next());
+      }
+    }
+
+    TEST_UTIL.deleteTable(TableName.valueOf(name));
+  }
+
+  @Test
   public void testHBASE28634(TestInfo testInfo) throws IOException {
     final String CF = "f";
     final String CQ = "name";
@@ -392,8 +438,11 @@ public class TestFuzzyRowFilterEndToEnd {
       Bytes.toBytes("a4")));
     puts.add(new Put(Bytes.toBytes("111446")).addColumn(Bytes.toBytes(CF), Bytes.toBytes(CQ),
       Bytes.toBytes("a5")));
-    puts.add(new Put(Bytes.toBytes("111777")).addColumn(Bytes.toBytes(CF), Bytes.toBytes(CQ),
+    // Keep a real boundary row at the reverse hint target so this test also guards HBASE-28634.
+    puts.add(new Put(Bytes.toBytes("1115")).addColumn(Bytes.toBytes(CF), Bytes.toBytes(CQ),
       Bytes.toBytes("a6")));
+    puts.add(new Put(Bytes.toBytes("111777")).addColumn(Bytes.toBytes(CF), Bytes.toBytes(CQ),
+      Bytes.toBytes("a7")));
     puts.add(new Put(Bytes.toBytes("111777")).addColumn(Bytes.toBytes(CF), Bytes.toBytes(CQ),
       Bytes.toBytes("a")));
     ht.put(puts);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilterEndToEnd.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilterEndToEnd.java
@@ -343,6 +343,8 @@ public class TestFuzzyRowFilterEndToEnd {
         Bytes.toBytes("v")));
       puts.add(new Put(Bytes.toBytes("aba")).addColumn(Bytes.toBytes(cf), Bytes.toBytes(cq),
         Bytes.toBytes("v")));
+      puts.add(new Put(Bytes.toBytes("abaa")).addColumn(Bytes.toBytes(cf), Bytes.toBytes(cq),
+        Bytes.toBytes("v")));
       puts.add(new Put(Bytes.toBytes("abb")).addColumn(Bytes.toBytes(cf), Bytes.toBytes(cq),
         Bytes.toBytes("v")));
       puts.add(new Put(Bytes.toBytes("abc")).addColumn(Bytes.toBytes(cf), Bytes.toBytes(cq),
@@ -360,6 +362,9 @@ public class TestFuzzyRowFilterEndToEnd {
 
       try (ResultScanner scanner = ht.getScanner(scan)) {
         Result result = scanner.next();
+        assertNotNull(result);
+        assertEquals("abaa", Bytes.toString(result.getRow()));
+        result = scanner.next();
         assertNotNull(result);
         assertEquals("aba", Bytes.toString(result.getRow()));
         result = scanner.next();
@@ -384,9 +389,11 @@ public class TestFuzzyRowFilterEndToEnd {
         Bytes.toBytes("v")));
       puts.add(new Put(Bytes.toBytes("aba")).addColumn(Bytes.toBytes(cf), Bytes.toBytes("q1"),
         Bytes.toBytes("v")));
-      // The same-row reverse hint is recreated for each cell on this non-matching row. Before the
-      // fix, the first cell could loop inside RowTracker and never return to StoreScanner. After the
-      // fix, StoreScanner advances cell by cell until it reaches the next matching row.
+      puts.add(new Put(Bytes.toBytes("abaa")).addColumn(Bytes.toBytes(cf), Bytes.toBytes("q1"),
+        Bytes.toBytes("v")));
+      // The same-row reverse hint can be recreated for each cell on this non-matching row.
+      // Before the fix, the first cell could loop inside RowTracker and never return to
+      // StoreScanner. After the fix, NEXT_ROW skips the whole row without skipping abaa.
       puts.add(new Put(Bytes.toBytes("abb"))
         .addColumn(Bytes.toBytes(cf), Bytes.toBytes("q1"), Bytes.toBytes("v1"))
         .addColumn(Bytes.toBytes(cf), Bytes.toBytes("q2"), Bytes.toBytes("v2"))
@@ -406,6 +413,9 @@ public class TestFuzzyRowFilterEndToEnd {
 
       try (ResultScanner scanner = ht.getScanner(scan)) {
         Result result = scanner.next();
+        assertNotNull(result);
+        assertEquals("abaa", Bytes.toString(result.getRow()));
+        result = scanner.next();
         assertNotNull(result);
         assertEquals("aba", Bytes.toString(result.getRow()));
         result = scanner.next();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilterEndToEnd.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilterEndToEnd.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.filter;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 
 import java.io.IOException;
@@ -326,6 +327,47 @@ public class TestFuzzyRowFilterEndToEnd {
 
     // Only one row who's rowKey=1
     assertNull(scanner.next());
+
+    TEST_UTIL.deleteTable(TableName.valueOf(name));
+  }
+
+  @Test
+  public void testReverseScanMovesPastSameRowFuzzyHint(TestInfo testInfo) throws IOException {
+    final String cf = "f";
+    final String cq = "q";
+
+    String name = testInfo.getTestMethod().orElseThrow(AssertionError::new).getName();
+    try (Table ht = TEST_UTIL.createTable(TableName.valueOf(name), Bytes.toBytes(cf))) {
+      List<Put> puts = Lists.newArrayList();
+      puts.add(new Put(Bytes.toBytes("aaa")).addColumn(Bytes.toBytes(cf), Bytes.toBytes(cq),
+        Bytes.toBytes("v")));
+      puts.add(new Put(Bytes.toBytes("aba")).addColumn(Bytes.toBytes(cf), Bytes.toBytes(cq),
+        Bytes.toBytes("v")));
+      puts.add(new Put(Bytes.toBytes("abb")).addColumn(Bytes.toBytes(cf), Bytes.toBytes(cq),
+        Bytes.toBytes("v")));
+      puts.add(new Put(Bytes.toBytes("abc")).addColumn(Bytes.toBytes(cf), Bytes.toBytes(cq),
+        Bytes.toBytes("v")));
+      ht.put(puts);
+
+      TEST_UTIL.flush();
+
+      List<Pair<byte[], byte[]>> fuzzyList = new LinkedList<>();
+      fuzzyList.add(new Pair<>(Bytes.toBytes("aaa"), new byte[] { 0, 1, 0 }));
+
+      Scan scan = new Scan();
+      scan.setReversed(true);
+      scan.setFilter(new FuzzyRowFilter(fuzzyList));
+
+      try (ResultScanner scanner = ht.getScanner(scan)) {
+        Result result = scanner.next();
+        assertNotNull(result);
+        assertEquals("aba", Bytes.toString(result.getRow()));
+        result = scanner.next();
+        assertNotNull(result);
+        assertEquals("aaa", Bytes.toString(result.getRow()));
+        assertNull(scanner.next());
+      }
+    }
 
     TEST_UTIL.deleteTable(TableName.valueOf(name));
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilterEndToEnd.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/filter/TestFuzzyRowFilterEndToEnd.java
@@ -467,6 +467,8 @@ public class TestFuzzyRowFilterEndToEnd {
     }
 
     assertEquals(2, actualRowsList.size());
+    assertEquals("111444", Bytes.toString(actualRowsList.get(0)));
+    assertEquals("111446", Bytes.toString(actualRowsList.get(1)));
 
     // Reverse scan
     scan = new Scan();
@@ -481,6 +483,8 @@ public class TestFuzzyRowFilterEndToEnd {
     }
 
     assertEquals(2, actualRowsList.size());
+    assertEquals("111446", Bytes.toString(actualRowsList.get(0)));
+    assertEquals("111444", Bytes.toString(actualRowsList.get(1)));
 
     TEST_UTIL.deleteTable(TableName.valueOf(name));
   }


### PR DESCRIPTION
  ## Why

  Reverse `FuzzyRowFilter` can stop making progress when the reverse seek hint is equal to the current row. See [HBASE-30226](https://issues.apache.org/jira/browse/HBASE-30226) for the detailed reproduction and analysis.

  ## What

  This PR keeps the HBASE-28634 reverse hint adjustment for the normal case, but avoids returning the adjusted hint when it is equal to the current row.

  It also adds an end-to-end regression test for the `abc -> abb -> aaa` reverse scan case.

  ## Test plan

  ```text
  mvn -pl hbase-server -am
  -Dtest=TestFuzzyRowFilter,TestFuzzyRowFilterEndToEnd,TestFuzzyRowFilterEndToEndLarge,TestFuzzyRowAndColumnRangeFilter,TestFilterSerialization
  -DexcludedGroups=slow -Dwarbucks.skip=true test

  Result: Tests run: 68, Failures: 0, Errors: 0, Skipped: 0

  mvn -pl hbase-rest -am -Dtest=TestScannersWithFilters -DexcludedGroups=slow -Dwarbucks.skip=true test

  Result: Tests run: 12, Failures: 0, Errors: 0, Skipped: 0