### PR TITLE
HBASE-30220: A replica cluster can have read-only mode disabled even when another active cluster already exists

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ReadOnlyTransitionException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ReadOnlyTransitionException.java
@@ -28,8 +28,11 @@ public class ReadOnlyTransitionException extends DoNotRetryIOException {
 
   private static final long serialVersionUID = 1L;
 
+  private final String activeClusterId;
+
   public ReadOnlyTransitionException() {
     super();
+    this.activeClusterId = null;
   }
 
   /**
@@ -37,6 +40,16 @@ public class ReadOnlyTransitionException extends DoNotRetryIOException {
    */
   public ReadOnlyTransitionException(String message) {
     super(message);
+    this.activeClusterId = null;
+  }
+
+  /**
+   * @param message         the message for this exception
+   * @param activeClusterId the ID of the cluster that is currently active
+   */
+  public ReadOnlyTransitionException(String message, String activeClusterId) {
+    super(message);
+    this.activeClusterId = activeClusterId;
   }
 
   /**
@@ -45,6 +58,7 @@ public class ReadOnlyTransitionException extends DoNotRetryIOException {
    */
   public ReadOnlyTransitionException(String message, Throwable throwable) {
     super(message, throwable);
+    this.activeClusterId = null;
   }
 
   /**
@@ -52,5 +66,19 @@ public class ReadOnlyTransitionException extends DoNotRetryIOException {
    */
   public ReadOnlyTransitionException(Throwable throwable) {
     super(throwable);
+    this.activeClusterId = null;
+  }
+
+  /** Returns the ID of the cluster that is currently active, or null if unknown */
+  public String getActiveClusterId() {
+    return activeClusterId;
+  }
+
+  @Override
+  public String getMessage() {
+    if (activeClusterId != null) {
+      return super.getMessage() + " Current active cluster ID: " + activeClusterId;
+    }
+    return super.getMessage();
   }
 }

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/ReadOnlyTransitionException.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/ReadOnlyTransitionException.java
@@ -1,0 +1,56 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Thrown when a replica cluster attempts to disable read-only mode while another active cluster
+ * already exists on the same storage location.
+ */
+@InterfaceAudience.Public
+public class ReadOnlyTransitionException extends DoNotRetryIOException {
+
+  private static final long serialVersionUID = 1L;
+
+  public ReadOnlyTransitionException() {
+    super();
+  }
+
+  /**
+   * @param message the message for this exception
+   */
+  public ReadOnlyTransitionException(String message) {
+    super(message);
+  }
+
+  /**
+   * @param message   the message for this exception
+   * @param throwable the {@link Throwable} to use for this exception
+   */
+  public ReadOnlyTransitionException(String message, Throwable throwable) {
+    super(message, throwable);
+  }
+
+  /**
+   * @param throwable the {@link Throwable} to use for this exception
+   */
+  public ReadOnlyTransitionException(Throwable throwable) {
+    super(throwable);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -667,7 +667,7 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
       HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME, this.blockingActiveClusterId.get(),
       HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
     this.readOnlyTransitionBlocked.set(true);
-    return ConfigurationUtil.getReadOnlyEnabledConfigurationCopy(updatedConf);
+    return ConfigurationUtil.copyWithReadOnlyModeEnabled(updatedConf);
   }
 
   protected void checkForBlockedReadOnlyTransition() throws ReadOnlyTransitionException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -73,6 +73,7 @@ import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.unsafe.HBasePlatformDependent;
 import org.apache.hadoop.hbase.util.Addressing;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.ConfigurationUtil;
 import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSTableDescriptors;
@@ -102,15 +103,19 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
   protected final AtomicBoolean abortRequested = new AtomicBoolean(false);
 
   // Set when a report to the master comes back with a message asking us to
-  // shutdown. Also set by call to stop when debugging or running unit tests
+  // shut down. Also set by call to stop when debugging or running unit tests
   // of HRegionServer in isolation.
   protected volatile boolean stopped = false;
+
+  // Flag set when a read-only to read-write transition is blocked because another active cluster
+  // exists
+  protected volatile boolean readOnlyTransitionBlocked = false;
 
   // Only for testing
   private boolean isShutdownHookInstalled = false;
 
   /**
-   * This servers startcode.
+   * This server's startcode.
    */
   protected final long startcode;
 
@@ -639,9 +644,28 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
     LOG.info("Reloading the configuration from disk.");
     // Reload the configuration from disk.
     preUpdateConfiguration();
+    this.readOnlyTransitionBlocked = false;
     conf.reloadConfiguration();
     configurationManager.notifyAllObservers(conf);
+    this.checkForBlockedReadOnlyTransition();
     postUpdateConfiguration();
+  }
+
+  protected Configuration blockReadOnlyTransition(Configuration updatedConf) {
+    LOG.error(
+      "Cannot disable read-only mode. The {} file contains a different cluster ID, which means "
+        + "that cluster is already the active cluster. Reverting {} to true",
+      HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME, HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
+    this.readOnlyTransitionBlocked = true;
+    return ConfigurationUtil.getReadOnlyEnabledConfigurationCopy(updatedConf);
+  }
+
+  protected void checkForBlockedReadOnlyTransition() throws ReadOnlyTransitionException {
+    if (this.readOnlyTransitionBlocked) {
+      throw new ReadOnlyTransitionException(
+        "Cannot disable read-only mode because another active cluster already exists on this "
+          + "storage location. The read-only coprocessors have not been removed.");
+    }
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/HBaseServerBase.java
@@ -32,6 +32,7 @@ import java.net.BindException;
 import java.net.InetAddress;
 import java.net.InetSocketAddress;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
 import javax.servlet.http.HttpServlet;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.SystemUtils;
@@ -109,7 +110,10 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
 
   // Flag set when a read-only to read-write transition is blocked because another active cluster
   // exists
-  protected volatile boolean readOnlyTransitionBlocked = false;
+  protected final AtomicBoolean readOnlyTransitionBlocked;
+
+  // Tracks the active cluster in a read-replica setup when a ReadOnlyTransitionException occurs
+  private final AtomicReference<String> blockingActiveClusterId;
 
   // Only for testing
   private boolean isShutdownHookInstalled = false;
@@ -254,6 +258,8 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
 
   public HBaseServerBase(Configuration conf, String name) throws IOException {
     super(name); // thread name
+    this.readOnlyTransitionBlocked = new AtomicBoolean(false);
+    this.blockingActiveClusterId = new AtomicReference<>(null);
     final Span span = TraceUtil.createSpan("HBaseServerBase.cxtor");
     try (Scope ignored = span.makeCurrent()) {
       this.conf = conf;
@@ -644,27 +650,32 @@ public abstract class HBaseServerBase<R extends HBaseRpcServicesBase<?>> extends
     LOG.info("Reloading the configuration from disk.");
     // Reload the configuration from disk.
     preUpdateConfiguration();
-    this.readOnlyTransitionBlocked = false;
+    this.readOnlyTransitionBlocked.set(false);
+    this.blockingActiveClusterId.set(null);
     conf.reloadConfiguration();
     configurationManager.notifyAllObservers(conf);
     this.checkForBlockedReadOnlyTransition();
     postUpdateConfiguration();
   }
 
-  protected Configuration blockReadOnlyTransition(Configuration updatedConf) {
+  protected Configuration blockReadOnlyTransition(Configuration updatedConf,
+    String activeClusterId) {
+    this.blockingActiveClusterId.set(activeClusterId);
     LOG.error(
-      "Cannot disable read-only mode. The {} file contains a different cluster ID, which means "
+      "Cannot disable read-only mode. The {} file contains a different cluster ID ({}), which means "
         + "that cluster is already the active cluster. Reverting {} to true",
-      HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME, HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
-    this.readOnlyTransitionBlocked = true;
+      HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME, this.blockingActiveClusterId.get(),
+      HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
+    this.readOnlyTransitionBlocked.set(true);
     return ConfigurationUtil.getReadOnlyEnabledConfigurationCopy(updatedConf);
   }
 
   protected void checkForBlockedReadOnlyTransition() throws ReadOnlyTransitionException {
-    if (this.readOnlyTransitionBlocked) {
+    if (this.readOnlyTransitionBlocked.get()) {
       throw new ReadOnlyTransitionException(
         "Cannot disable read-only mode because another active cluster already exists on this "
-          + "storage location. The read-only coprocessors have not been removed.");
+          + "storage location. The read-only coprocessors have not been removed.",
+        this.blockingActiveClusterId.get());
     }
   }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -261,6 +261,7 @@ import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
 import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.FSTableDescriptors;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.util.FutureUtils;
 import org.apache.hadoop.hbase.util.HBaseFsck;
 import org.apache.hadoop.hbase.util.HFileArchiveUtil;
@@ -4543,8 +4544,10 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
         AbstractReadOnlyController.isAnotherClusterActive(mfs.getFileSystem(), mfs.getRootDir(),
           mfs.getActiveClusterSuffix())
       ) {
+        String activeClusterId =
+          FSUtils.getClusterIdFromActiveClusterFile(mfs.getFileSystem(), mfs.getRootDir());
         // Revert read-only mode here
-        confForCoprocessors = this.blockReadOnlyTransition(updatedConf);
+        confForCoprocessors = this.blockReadOnlyTransition(updatedConf, activeClusterId);
       }
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/HMaster.java
@@ -4528,11 +4528,31 @@ public class HMaster extends HBaseServerBase<MasterRpcServices> implements Maste
 
     boolean originalIsReadOnlyEnabled = CoprocessorConfigurationUtil
       .areReadOnlyCoprocessorsLoaded(this.conf, CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY);
+    boolean newReadOnlyEnabled = ConfigurationUtil.isReadOnlyModeEnabledInConf(updatedConf);
 
-    // updatedConf and this.conf reference the same Configuration object in an actual HBase
-    // deployment. However, in unit test cases they reference different Configuration objects, so
-    // this.conf needs to be updated.
-    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(updatedConf, this.conf,
+    // The updatedConf is potentially a shared Configuration object, so we do not want to directly
+    // revert its read-only value if another active cluster already exists. For now, we reference
+    // updatedConf and create a copy for modification below if necessary.
+    Configuration confForCoprocessors = updatedConf;
+
+    if (originalIsReadOnlyEnabled && !newReadOnlyEnabled) {
+      // Changing this cluster from a replica to an active cluster. There should not be another
+      // active cluster already.
+      MasterFileSystem mfs = this.getMasterFileSystem();
+      if (
+        AbstractReadOnlyController.isAnotherClusterActive(mfs.getFileSystem(), mfs.getRootDir(),
+          mfs.getActiveClusterSuffix())
+      ) {
+        // Revert read-only mode here
+        confForCoprocessors = this.blockReadOnlyTransition(updatedConf);
+      }
+    }
+
+    // In a real HBase deployment, confForCoprocessors may reference the same object as this.conf.
+    // This is assuming confForCoprocessors still references updatedConf, as mentioned in a previous
+    // comment. For unit tests, this Configuration object is not shared, so we need to make sure to
+    // update the coprocessors specifically for this.conf.
+    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(confForCoprocessors, this.conf,
       originalIsReadOnlyEnabled, this.cpHost, CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY,
       this.maintenanceMode, this.toString(), this::initializeCoprocessorHost);
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -9023,8 +9023,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
                 + "the active cluster on this storage location. Reverting {} to true.",
               this, activeClusterId, HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
             // Revert read-only mode here
-            confForCoprocessors =
-              ConfigurationUtil.copyWithReadOnlyModeEnabled(updatedConf);
+            confForCoprocessors = ConfigurationUtil.copyWithReadOnlyModeEnabled(updatedConf);
             newReadOnlyEnabled = true;
           }
         }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -78,12 +78,14 @@ import org.apache.hadoop.fs.FileStatus;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.ActiveClusterSuffix;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellBuilderType;
 import org.apache.hadoop.hbase.CellComparator;
 import org.apache.hadoop.hbase.CellComparatorImpl;
 import org.apache.hadoop.hbase.CellScanner;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.ClusterId;
 import org.apache.hadoop.hbase.CompareOperator;
 import org.apache.hadoop.hbase.CompoundConfiguration;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
@@ -172,6 +174,7 @@ import org.apache.hadoop.hbase.regionserver.wal.WALUtil;
 import org.apache.hadoop.hbase.replication.ReplicationUtils;
 import org.apache.hadoop.hbase.replication.regionserver.ReplicationObserver;
 import org.apache.hadoop.hbase.security.User;
+import org.apache.hadoop.hbase.security.access.AbstractReadOnlyController;
 import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.SnapshotManifest;
 import org.apache.hadoop.hbase.trace.TraceUtil;
@@ -8997,20 +9000,54 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
 
     boolean originalIsReadOnlyEnabled = CoprocessorConfigurationUtil
       .areReadOnlyCoprocessorsLoaded(this.conf, CoprocessorHost.REGION_COPROCESSOR_CONF_KEY);
+    boolean newReadOnlyEnabled = ConfigurationUtil.isReadOnlyModeEnabledInConf(updatedConf);
+
+    // The updatedConf is potentially a shared Configuration object, so we do not want to directly
+    // revert its read-only value if another active cluster already exists. For now, we reference
+    // updatedConf and create a copy for modification below if necessary.
+    Configuration confForCoprocessors = updatedConf;
+
+    if (originalIsReadOnlyEnabled && !newReadOnlyEnabled) {
+      // Changing this cluster from a replica to an active cluster. There should not be another
+      // active cluster already.
+      try {
+        FileSystem regionFs = getFilesystem();
+        Path rootDir = CommonFSUtils.getRootDir(this.conf);
+        ClusterId clusterId = FSUtils.getClusterIdFile(regionFs, rootDir, new ClusterId.Parser());
+        if (clusterId != null) {
+          ActiveClusterSuffix localSuffix = ActiveClusterSuffix.fromConfig(updatedConf, clusterId);
+          if (AbstractReadOnlyController.isAnotherClusterActive(regionFs, rootDir, localSuffix)) {
+            LOG.error(
+              "Cannot disable read-only mode for region {}. Another cluster is already "
+                + "the active cluster on this storage location. Reverting {} to true.",
+              this, HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
+            // Revert read-only mode here
+            confForCoprocessors =
+              ConfigurationUtil.getReadOnlyEnabledConfigurationCopy(updatedConf);
+            newReadOnlyEnabled = true;
+          }
+        }
+      } catch (IOException e) {
+        LOG.error("Failed to check active cluster status for region {}. "
+          + "Blocking read-only mode transition to prevent potential data corruption.", this, e);
+        // Revert read-only mode here
+        confForCoprocessors = ConfigurationUtil.getReadOnlyEnabledConfigurationCopy(updatedConf);
+        newReadOnlyEnabled = true;
+      }
+    }
 
     // HRegion's this.conf is a special Configuration type called CompoundConfiguration. This means
-    // we don't want to use the updatedConf provided in onConfigurationChange() for creating a new
+    // we don't want to use the confForCoprocessors Configuration for creating a new
     // RegionCoprocessorHost. Instead, we update this.conf and use that for decorating the region
     // config and updating this.coprocessorHost.
-    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(updatedConf, this.conf,
+    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(confForCoprocessors, this.conf,
       originalIsReadOnlyEnabled, this.coprocessorHost, CoprocessorHost.REGION_COPROCESSOR_CONF_KEY,
       false, this.toString(), conf -> {
         decorateRegionConfiguration(conf);
         this.coprocessorHost = new RegionCoprocessorHost(this, rsServices, conf);
       });
 
-    boolean newReadOnlyEnabled = ConfigurationUtil.isReadOnlyModeEnabledInConf(updatedConf);
-
+    // Changing this cluster from a replica to an active cluster
     if (originalIsReadOnlyEnabled && !newReadOnlyEnabled) {
       LOG.info("Cluster Read Only mode disabled");
       for (HStore store : stores.values()) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -9024,7 +9024,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
               this, activeClusterId, HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
             // Revert read-only mode here
             confForCoprocessors =
-              ConfigurationUtil.getReadOnlyEnabledConfigurationCopy(updatedConf);
+              ConfigurationUtil.copyWithReadOnlyModeEnabled(updatedConf);
             newReadOnlyEnabled = true;
           }
         }
@@ -9032,7 +9032,7 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
         LOG.error("Failed to check active cluster status for region {}. "
           + "Blocking read-only mode transition to prevent potential data corruption.", this, e);
         // Revert read-only mode here
-        confForCoprocessors = ConfigurationUtil.getReadOnlyEnabledConfigurationCopy(updatedConf);
+        confForCoprocessors = ConfigurationUtil.copyWithReadOnlyModeEnabled(updatedConf);
         newReadOnlyEnabled = true;
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegion.java
@@ -9017,10 +9017,11 @@ public class HRegion implements HeapSize, PropagatingConfigurationObserver, Regi
         if (clusterId != null) {
           ActiveClusterSuffix localSuffix = ActiveClusterSuffix.fromConfig(updatedConf, clusterId);
           if (AbstractReadOnlyController.isAnotherClusterActive(regionFs, rootDir, localSuffix)) {
+            String activeClusterId = FSUtils.getClusterIdFromActiveClusterFile(regionFs, rootDir);
             LOG.error(
-              "Cannot disable read-only mode for region {}. Another cluster is already "
+              "Cannot disable read-only mode for region {}. Another cluster with ID {} is already "
                 + "the active cluster on this storage location. Reverting {} to true.",
-              this, HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
+              this, activeClusterId, HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY);
             // Revert read-only mode here
             confForCoprocessors =
               ConfigurationUtil.getReadOnlyEnabledConfigurationCopy(updatedConf);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -3532,8 +3532,10 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
         AbstractReadOnlyController.isAnotherClusterActive(getFileSystem(), getDataRootDir(),
           localSuffix)
       ) {
+        String activeClusterId =
+          FSUtils.getClusterIdFromActiveClusterFile(getFileSystem(), getDataRootDir());
         // Revert read-only mode here
-        confForCoprocessors = this.blockReadOnlyTransition(updatedConf);
+        confForCoprocessors = this.blockReadOnlyTransition(updatedConf, activeClusterId);
       }
     }
 

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -74,9 +74,11 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.Abortable;
+import org.apache.hadoop.hbase.ActiveClusterSuffix;
 import org.apache.hadoop.hbase.CacheEvictionStats;
 import org.apache.hadoop.hbase.CallQueueTooBigException;
 import org.apache.hadoop.hbase.ClockOutOfSyncException;
+import org.apache.hadoop.hbase.ClusterId;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.ExecutorStatusChore;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -155,9 +157,11 @@ import org.apache.hadoop.hbase.security.SecurityConstants;
 import org.apache.hadoop.hbase.security.Superusers;
 import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.security.UserProvider;
+import org.apache.hadoop.hbase.security.access.AbstractReadOnlyController;
 import org.apache.hadoop.hbase.trace.TraceUtil;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CompressionTest;
+import org.apache.hadoop.hbase.util.ConfigurationUtil;
 import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
 import org.apache.hadoop.hbase.util.DNS;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
@@ -316,7 +320,6 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
   private LeaseManager leaseManager;
 
   private volatile boolean dataFsOk;
-  private volatile boolean isGlobalReadOnlyEnabled;
 
   static final String ABORT_TIMEOUT = "hbase.regionserver.abort.timeout";
   // Default abort timeout is 1200 seconds for safe
@@ -3513,11 +3516,32 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
 
     boolean originalIsReadOnlyEnabled = CoprocessorConfigurationUtil
       .areReadOnlyCoprocessorsLoaded(this.conf, CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY);
+    boolean newReadOnlyEnabled = ConfigurationUtil.isReadOnlyModeEnabledInConf(updatedConf);
 
-    // updatedConf and this.conf reference the same Configuration object in an actual HBase
-    // deployment. However, in unit test cases they reference different Configuration objects, so
-    // this.conf needs to be updated.
-    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(updatedConf, this.conf,
+    // The updatedConf is potentially a shared Configuration object, so we do not want to directly
+    // revert its read-only value if another active cluster already exists. For now, we reference
+    // updatedConf and create a copy for modification below if necessary.
+    Configuration confForCoprocessors = updatedConf;
+
+    if (originalIsReadOnlyEnabled && !newReadOnlyEnabled) {
+      // Changing this cluster from a replica to an active cluster. There should not be another
+      // active cluster already.
+      ActiveClusterSuffix localSuffix =
+        ActiveClusterSuffix.fromConfig(this.conf, new ClusterId(getClusterId()));
+      if (
+        AbstractReadOnlyController.isAnotherClusterActive(getFileSystem(), getDataRootDir(),
+          localSuffix)
+      ) {
+        // Revert read-only mode here
+        confForCoprocessors = this.blockReadOnlyTransition(updatedConf);
+      }
+    }
+
+    // In a real HBase deployment, confForCoprocessors may reference the same object as this.conf.
+    // This is assuming confForCoprocessors still references updatedConf, as mentioned in a previous
+    // comment. For unit tests, this Configuration object is not shared, so we need to make sure to
+    // update the coprocessors specifically for this.conf.
+    CoprocessorConfigurationUtil.maybeUpdateCoprocessors(confForCoprocessors, this.conf,
       originalIsReadOnlyEnabled, this.rsHost, CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY,
       false, this.toString(), conf -> this.rsHost = new RegionServerCoprocessorHost(this, conf));
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AbstractReadOnlyController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AbstractReadOnlyController.java
@@ -87,7 +87,7 @@ public abstract class AbstractReadOnlyController implements Coprocessor {
       }
       return !localClusterSuffix.equals(fileData);
     } catch (IOException e) {
-      LOG.error(
+      LOG.warn(
         "Failed to read active cluster suffix file from {} at {}. "
           + "Assuming another cluster is active to prevent potential data corruption.",
         HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME, rootDir, e);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AbstractReadOnlyController.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/security/access/AbstractReadOnlyController.java
@@ -68,6 +68,33 @@ public abstract class AbstractReadOnlyController implements Coprocessor {
   public void stop(CoprocessorEnvironment env) {
   }
 
+  /**
+   * Checks whether another cluster is currently active on this storage location by reading the
+   * {@value HConstants#ACTIVE_CLUSTER_SUFFIX_FILE_NAME} file on the filesystem.
+   * @param fs                 the filesystem to read from
+   * @param rootDir            the HBase root directory
+   * @param localClusterSuffix the local cluster's ActiveClusterSuffix identity
+   * @return true if the active cluster file exists and belongs to a different cluster; false if the
+   *         file does not exist or belongs to this cluster
+   */
+  public static boolean isAnotherClusterActive(FileSystem fs, Path rootDir,
+    ActiveClusterSuffix localClusterSuffix) {
+    try {
+      ActiveClusterSuffix fileData =
+        FSUtils.getClusterIdFile(fs, rootDir, new ActiveClusterSuffix.Parser());
+      if (fileData == null) {
+        return false;
+      }
+      return !localClusterSuffix.equals(fileData);
+    } catch (IOException e) {
+      LOG.error(
+        "Failed to read active cluster suffix file from {} at {}. "
+          + "Assuming another cluster is active to prevent potential data corruption.",
+        HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME, rootDir, e);
+      return true;
+    }
+  }
+
   public static void manageActiveClusterIdFile(boolean readOnlyEnabled, MasterFileSystem mfs) {
     FileSystem fs = mfs.getFileSystem();
     Path rootDir = mfs.getRootDir();
@@ -110,8 +137,23 @@ public abstract class AbstractReadOnlyController implements Coprocessor {
           FSUtils.setClusterIdFile(fs, rootDir, HConstants.ACTIVE_CLUSTER_SUFFIX_FILE_NAME,
             mfs.getActiveClusterSuffix(), wait);
         } else {
-          LOG.debug("Active cluster file already exists at: {}. No need to create it again.",
-            activeClusterFile);
+          try (FSDataInputStream in = fs.open(activeClusterFile)) {
+            ActiveClusterSuffix existingData = ActiveClusterSuffix.parseFrom(in.readAllBytes());
+            ActiveClusterSuffix localData = mfs.getActiveClusterSuffix();
+            if (localData.equals(existingData)) {
+              LOG.debug("Active cluster file already exists at {} and belongs to this cluster. "
+                + "No need to create it again.", activeClusterFile);
+            } else {
+              LOG.error(
+                "Active cluster file at {} belongs to a different cluster. "
+                  + "ID from active cluster file: {}, ID of this cluster: {}. "
+                  + "Another cluster is already the active cluster.",
+                activeClusterFile, existingData, localData);
+            }
+          } catch (DeserializationException e) {
+            LOG.error("Failed to deserialize ActiveClusterSuffix from file {}", activeClusterFile,
+              e);
+          }
         }
       }
     } catch (IOException e) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ConfigurationUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ConfigurationUtil.java
@@ -116,8 +116,22 @@ public final class ConfigurationUtil {
     return rtn;
   }
 
+  /**
+   * Returns true if the provided Configuration object has
+   * {@link HConstants#HBASE_GLOBAL_READONLY_ENABLED_KEY} set to true; false otherwise.
+   */
   public static boolean isReadOnlyModeEnabledInConf(Configuration conf) {
     return conf.getBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY,
       HConstants.HBASE_GLOBAL_READONLY_ENABLED_DEFAULT);
+  }
+
+  /**
+   * Returns a copied version of the provided Configuration object that has
+   * {@link HConstants#HBASE_GLOBAL_READONLY_ENABLED_KEY} set to true.
+   */
+  public static Configuration getReadOnlyEnabledConfigurationCopy(Configuration conf) {
+    Configuration readOnlyConf = new Configuration(conf);
+    readOnlyConf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+    return readOnlyConf;
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ConfigurationUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ConfigurationUtil.java
@@ -129,7 +129,7 @@ public final class ConfigurationUtil {
    * Returns a copied version of the provided Configuration object that has
    * {@link HConstants#HBASE_GLOBAL_READONLY_ENABLED_KEY} set to true.
    */
-  public static Configuration getReadOnlyEnabledConfigurationCopy(Configuration conf) {
+  public static Configuration copyWithReadOnlyModeEnabled(Configuration conf) {
     Configuration readOnlyConf = new Configuration(conf);
     readOnlyConf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
     return readOnlyConf;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/FSUtils.java
@@ -65,6 +65,7 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.PathFilter;
 import org.apache.hadoop.fs.StorageType;
 import org.apache.hadoop.fs.permission.FsPermission;
+import org.apache.hadoop.hbase.ActiveClusterSuffix;
 import org.apache.hadoop.hbase.ClusterIdFile;
 import org.apache.hadoop.hbase.ClusterIdFileParser;
 import org.apache.hadoop.hbase.HConstants;
@@ -608,6 +609,20 @@ public final class FSUtils {
       LOG.warn("Cluster file does not exist at {}", idPath);
     }
     return cs;
+  }
+
+  public static String getClusterIdFromActiveClusterFile(FileSystem fs, Path rootDir) {
+    String activeClusterId = null;
+    try {
+      ActiveClusterSuffix parsedClusterIdFile =
+        FSUtils.getClusterIdFile(fs, rootDir, new ActiveClusterSuffix.Parser());
+      if (parsedClusterIdFile != null) {
+        activeClusterId = parsedClusterIdFile.toString();
+      }
+    } catch (IOException e) {
+      LOG.debug("Failed to read active cluster ID from file", e);
+    }
+    return activeClusterId;
   }
 
   private static <T extends ClusterIdFile> void rewriteAsPb(final FileSystem fs, final Path rootdir,

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyManageActiveClusterFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/security/access/TestReadOnlyManageActiveClusterFile.java
@@ -17,21 +17,41 @@
  */
 package org.apache.hadoop.hbase.security.access;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
+import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.ActiveClusterSuffix;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.ReadOnlyTransitionException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.coprocessor.CoprocessorHost;
+import org.apache.hadoop.hbase.coprocessor.SimpleRegionObserver;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.master.MasterFileSystem;
+import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
+import org.apache.hadoop.hbase.regionserver.NoOpScanPolicyObserver;
+import org.apache.hadoop.hbase.regionserver.RegionCoprocessorHost;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.SecurityTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CoprocessorConfigurationUtil;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
@@ -145,5 +165,177 @@ public class TestReadOnlyManageActiveClusterFile {
     // As Active cluster file is not owned by the cluster, it should not be deleted even when
     // switching to readonly mode
     assertTrue(activeClusterIdFileExists());
+  }
+
+  @Test
+  public void testCannotDisableReadOnlyWhenAnotherClusterIsActive() throws Exception {
+    // First enable read-only mode (simulating a replica cluster)
+    setReadOnlyMode(true);
+    assertFalse(activeClusterIdFileExists());
+
+    // Now write an active cluster file with a DIFFERENT cluster's data (simulating another active
+    // cluster owning the storage)
+    overwriteExistingFile();
+    assertTrue(activeClusterIdFileExists());
+
+    // Attempt to disable read-only mode, but get an exception because another active cluster
+    // already exists.
+    master.getConfiguration().setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+
+    // Master's updateConfiguration should throw because another cluster is active
+    assertThrows(ReadOnlyTransitionException.class, () -> master.updateConfiguration());
+
+    // Verify read-only coprocessors are still loaded on the master
+    assertTrue(CoprocessorConfigurationUtil.areReadOnlyCoprocessorsLoaded(master.getConfiguration(),
+      CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY));
+
+    // Verify read-only coprocessors are still loaded on the region server
+    assertTrue(CoprocessorConfigurationUtil.areReadOnlyCoprocessorsLoaded(
+      regionServer.getConfiguration(), CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY));
+  }
+
+  @Test
+  public void testCanDisableReadOnlyWhenOwnClusterIsActive() throws Exception {
+    // Enable read-only mode
+    setReadOnlyMode(true);
+    assertFalse(activeClusterIdFileExists());
+
+    // Verify read-only coprocessors are loaded
+    assertTrue(CoprocessorConfigurationUtil.areReadOnlyCoprocessorsLoaded(master.getConfiguration(),
+      CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY));
+
+    // Disable read-only mode (our own cluster, no conflicting active cluster file)
+    setReadOnlyMode(false);
+
+    // Active cluster file should be recreated
+    assertTrue(activeClusterIdFileExists());
+
+    // Verify read-only coprocessors are removed
+    assertFalse(CoprocessorConfigurationUtil.areReadOnlyCoprocessorsLoaded(
+      master.getConfiguration(), CoprocessorHost.MASTER_COPROCESSOR_CONF_KEY));
+  }
+
+  @Test
+  public void testRegionCoprocessorsStillLoadWhenReadOnlyTransitionBlocked() throws Exception {
+    // Create a table so we have a region to work with
+    TableName tableName = TableName.valueOf("testCoprocessorLoadTable");
+    TableDescriptor desc = TableDescriptorBuilder.newBuilder(tableName)
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.of("cf")).build();
+    TEST_UTIL.getAdmin().createTable(desc);
+    List<HRegion> regions = regionServer.getRegions(tableName);
+    assertFalse(regions.isEmpty());
+    HRegion region = regions.get(0);
+
+    // Enable read-only mode to load ReadOnly coprocessors on the region
+    Configuration readOnlyConf = new Configuration(conf);
+    readOnlyConf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, true);
+    region.onConfigurationChange(readOnlyConf);
+
+    // Verify ReadOnly coprocessors are loaded
+    RegionCoprocessorHost regionCPHost = region.getCoprocessorHost();
+    assertNotNull(regionCPHost.findCoprocessor(RegionReadOnlyController.class.getName()),
+      "RegionReadOnlyController should be loaded after enabling read-only mode");
+
+    // Simulate another active cluster by writing a foreign cluster ID to the active cluster file
+    overwriteExistingFile();
+    assertTrue(activeClusterIdFileExists());
+
+    // Build a config that attempts to disable read-only AND adds new coprocessors
+    Configuration newConf = new Configuration(conf);
+    newConf.setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+
+    // Add a system and user region coprocessors
+    newConf.set(CoprocessorHost.REGION_COPROCESSOR_CONF_KEY, SimpleRegionObserver.class.getName());
+    newConf.set(CoprocessorHost.USER_REGION_COPROCESSOR_CONF_KEY,
+      NoOpScanPolicyObserver.class.getName());
+
+    // Trigger dynamic configuration change on the region
+    region.onConfigurationChange(newConf);
+
+    // Verify ReadOnly coprocessors are still loaded since the read-only transition was blocked
+    regionCPHost = region.getCoprocessorHost();
+    assertTrue(
+      CoprocessorConfigurationUtil.areReadOnlyCoprocessorsLoaded(region.getConfiguration(),
+        CoprocessorHost.REGION_COPROCESSOR_CONF_KEY),
+      "ReadOnly coprocessors should remain in the region configuration");
+
+    // Verify new system and user coprocessors were loaded despite the blocked read-only transition
+    assertNotNull(regionCPHost.findCoprocessor(SimpleRegionObserver.class.getName()),
+      "SimpleRegionObserver should be loaded even when read-only transition is blocked");
+    assertNotNull(regionCPHost.findCoprocessor(NoOpScanPolicyObserver.class.getName()),
+      "NoOpScanPolicyObserver should be loaded even when read-only transition is blocked");
+  }
+
+  @Test
+  public void testRegionServerCannotDisableReadOnlyWhenAnotherClusterIsActive() throws Exception {
+    // First enable read-only mode
+    setReadOnlyMode(true);
+    assertFalse(activeClusterIdFileExists());
+
+    // Write an active cluster file with a different cluster's data
+    overwriteExistingFile();
+    assertTrue(activeClusterIdFileExists());
+
+    // Attempt to disable read-only mode, but get an exception because another active cluster
+    // already exists
+    regionServer.getConfiguration().setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+
+    // RegionServer's updateConfiguration should throw because another cluster is active
+    assertThrows(ReadOnlyTransitionException.class, () -> regionServer.updateConfiguration());
+
+    // Verify read-only coprocessors are still loaded on the region server
+    assertTrue(CoprocessorConfigurationUtil.areReadOnlyCoprocessorsLoaded(
+      regionServer.getConfiguration(), CoprocessorHost.REGIONSERVER_COPROCESSOR_CONF_KEY));
+  }
+
+  @Test
+  public void testBlockedThenSuccessfulReadOnlyTransition() throws Exception {
+    // Put cluster in read-only mode with a foreign active cluster file
+    setReadOnlyMode(true);
+    assertFalse(activeClusterIdFileExists());
+    overwriteExistingFile();
+    assertTrue(activeClusterIdFileExists());
+
+    // Attempt to disable read-only mode. This should fail because another cluster is active.
+    // We need to run updateConfiguration() to ensure the readOnlyTransitionBlocked boolean in
+    // HBaseServerBase gets set.
+    master.getConfiguration().setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+    assertThrows(ReadOnlyTransitionException.class, () -> master.updateConfiguration());
+    regionServer.getConfiguration().setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+    assertThrows(ReadOnlyTransitionException.class, () -> regionServer.updateConfiguration());
+
+    // Try to create a table. This should fail because the cluster is still in read-only mode
+    TableName tableName = TableName.valueOf("testBlockedTransitionTable");
+    TableDescriptor desc = TableDescriptorBuilder.newBuilder(tableName)
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.of("cf")).build();
+    assertThrows(IOException.class, () -> TEST_UTIL.getAdmin().createTable(desc));
+
+    // Delete the foreign active cluster file
+    fs.delete(activeClusterFile, false);
+    assertFalse(activeClusterIdFileExists());
+
+    // Disable read-only mode again. This should succeed now that no foreign active cluster file
+    // exists. We need to run updateConfiguration() to ensure the readOnlyTransitionBlocked boolean
+    // in HBaseServerBase was reset.
+    master.getConfiguration().setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+    master.updateConfiguration();
+    regionServer.getConfiguration().setBoolean(HConstants.HBASE_GLOBAL_READONLY_ENABLED_KEY, false);
+    regionServer.updateConfiguration();
+
+    // Verify the active.cluster.suffix.id file contains this cluster's ID
+    assertTrue(activeClusterIdFileExists());
+    try (FSDataInputStream in = fs.open(activeClusterFile)) {
+      ActiveClusterSuffix actual = ActiveClusterSuffix.parseFrom(in.readAllBytes());
+      ActiveClusterSuffix expected = ActiveClusterSuffix.fromConfig(conf, mfs.getClusterId());
+      assertEquals(expected, actual);
+    }
+
+    // Create a table and add a row to verify read-only mode has been disabled
+    TEST_UTIL.getAdmin().createTable(desc);
+    try (Table table = TEST_UTIL.getConnection().getTable(tableName)) {
+      Put put = new Put(Bytes.toBytes("row1"));
+      put.addColumn(Bytes.toBytes("cf"), Bytes.toBytes("q1"), Bytes.toBytes("value1"));
+      table.put(put);
+    }
   }
 }

--- a/hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/read-replica-cluster.mdx
+++ b/hbase-website/app/pages/_docs/docs/_mdx/(multi-page)/read-replica-cluster.mdx
@@ -51,8 +51,8 @@ sharing the same `hbase.rootdir` must be configured with a distinct suffix so it
 | Class                            | Coprocessor host | Blocks                                                                                                |
 | -------------------------------- | ---------------- | ----------------------------------------------------------------------------------------------------- |
 | `MasterReadOnlyController`       | Master           | DDL, snapshots, splits, merges, namespace ops, ACL/quota ops, replication-peer ops                    |
-| `RegionReadOnlyController`       | Region           | put, delete, batchMutate, checkAnd\*, append, increment, flush, compaction, WAL append, commit/replay |
 | `RegionServerReadOnlyController` | RegionServer     | WAL roll, replication sink mutations, log replay                                                      |
+| `RegionReadOnlyController`       | Region           | put, delete, batchMutate, checkAnd\*, append, increment, flush, compaction, WAL append, commit/replay |
 | `BulkLoadReadOnlyController`     | Region           | bulk-load prepare/cleanup                                                                             |
 | `EndpointReadOnlyController`     | Region           | all coprocessor endpoint invocations                                                                  |
 
@@ -187,6 +187,52 @@ mutations.
    store). The new active master will refuse to start while a foreign sentinel file is in place.
 3. Set `hbase.global.readonly.enabled=false` on the replica and apply the change (dynamic update or
    restart). The master writes a fresh sentinel file with this cluster's identity.
+
+### Case 5. Recover from a blocked read-only transition
+
+If you attempt to promote a replica to active (`hbase.global.readonly.enabled=false` + `update_all_config`)
+while a different cluster's `active.cluster.suffix.id` file is still present, the transition is blocked. The
+shell returns a `ReadOnlyTransitionException` and the cluster remains in read-only mode — writes continue to be
+rejected with `WriteAttemptedOnReadOnlyClusterException`.
+
+The server ERROR log includes the foreign cluster's ID:
+
+```
+Cannot disable read-only mode. The active.cluster.suffix.id file contains a different
+cluster ID (<foreign-id>), which means that cluster is already the active cluster.
+Reverting hbase.global.readonly.enabled to true.
+```
+
+<Callout type="info">
+  A cluster whose promotion was blocked is still a replica — the read-only coprocessors remain loaded and
+  writes are still rejected — even though its `hbase-site.xml` has `hbase.global.readonly.enabled=false`.
+</Callout>
+
+To recover, choose one of the following paths depending on whether the existing active cluster is still
+running.
+
+**Path A — the active cluster is still running:**
+
+1. On the currently active cluster, set `hbase.global.readonly.enabled=true` in `hbase-site.xml` and run
+   `update_all_config`. This converts it to a replica and deletes its `active.cluster.suffix.id` file.
+2. On the cluster you want to promote, re-run `update_all_config`. The transition will now succeed — the
+   cluster writes a fresh sentinel file with its own identity and unloads the read-only coprocessors.
+
+**Path B — the active cluster is down or has already been converted to a replica:**
+
+1. Confirm the cluster that owns the sentinel file is fully stopped or has already been converted to a replica.
+2. Remove the foreign sentinel file:
+   ```bash
+   hdfs dfs -rm <hbase.rootdir>/active.cluster.suffix.id
+   ```
+3. On the cluster you want to promote, re-run `update_all_config`. The transition will now succeed — the
+   cluster writes a fresh sentinel file with its own identity and unloads the read-only coprocessors.
+
+<Callout type="warning">
+  **Do not remove the sentinel file while the cluster that wrote it is still running as an active cluster.**
+  Doing so would allow two clusters to write to the same shared storage simultaneously, risking data
+  corruption.
+</Callout>
 
 ## Configurations and Commands
 


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-30220

## AI Usage

These changes were generated using Claude Opus 4.6 and then modified by hand.

## Summary

In a Read-Replica cluster setup, the active cluster allows both reads and writes, while the replica clusters only allow reads. In this type of setup, only one cluster should be an active cluster at a time. Although the current code prevents starting an active cluster while another one exists, it is still possible to simple turn a running replica into an active cluster despite another active cluster already existing. The changes in this pull request prevent this behavior.

A cluster is promoted from replica to active by changing the `hbase.global.readonly.enabled` variable from `true` to `false` in `hbase-site.xml` and then running `update_all_config` in the HBase shell.  The current active cluster is tracked by having the cluster's ID in a file called `active.cluster.suffix.id`.  This file does not exist when all clusters are replicas.

## Key Changes

1. Adds a `volatile boolean` flag called `readOnlyTransitionBlocked` to HBaseServerBase. This is used to track whether a cluster was prevented from becoming an active cluster due to another active cluster already existing.
    - If another active cluster exists when changing read-only from `false` to `true`, then `readOnlyTransitionBlocked` is set to `true`, and a new exception called `ReadOnlyTransitionException` is thrown in the HBase shell.
2. Adds a `static` method to `AbstractReadOnlyController` called `isAnotherClusterActive()`.  This returns true when the cluster ID in `active.cluster.suffix.id` does not match the current cluster.
3. Adds logic to `onConfigurationChange()` in `HMaster`, `HRegionServer`, and `HRegion` to prevent the replica cluster from being promoted to an active cluster when another active cluster exists.
    - These methods does not return early when the read-only transition is blocked in case other coprocessors or variables need to be dynamically loaded.
4. Read-only mode is still active and the ReadOnlyController coprocessors are still loaded if a cluster is blocked from becoming an active cluster.