### PR TITLE
HBase-30196 Add diagnostic cached-block iteration capability for pluggable cache engines

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/HalfStoreFileReader.java
@@ -365,7 +365,7 @@ public class HalfStoreFileReader extends StoreFileReader {
           long offset = s.getCurBlock().getOffset();
           LOG.trace("Seeking to split cell in reader: {} for file: {} top: {}, split offset: {}",
             this, reference, top, offset);
-          ((HFileReaderImpl) reader).getCacheConf().getBlockCache().ifPresent(cache -> {
+          ((HFileReaderImpl) reader).getCacheConf().getCacheAccessService().ifEnabled(cache -> {
             int numEvictedReferred = top
               ? cache.evictBlocksRangeByHfileName(referred, offset, Long.MAX_VALUE)
               : cache.evictBlocksRangeByHfileName(referred, 0, offset);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -24,6 +24,7 @@ import org.apache.hadoop.hbase.conf.ConfigurationManager;
 import org.apache.hadoop.hbase.conf.PropagatingConfigurationObserver;
 import org.apache.hadoop.hbase.io.ByteBuffAllocator;
 import org.apache.hadoop.hbase.io.hfile.BlockType.BlockCategory;
+import org.apache.hadoop.hbase.io.hfile.cache.BlockCacheBackedCacheAccessService;
 import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServices;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -190,11 +191,38 @@ public class CacheConfig implements PropagatingConfigurationObserver {
    * @param conf hbase configuration
    */
   public CacheConfig(Configuration conf) {
-    this(conf, null);
+    this(conf, (CacheAccessService) null);
   }
 
+  /**
+   * Create a cache configuration using the specified configuration object and block cache. Only use
+   * in tests
+   * @param conf       hbase configuration
+   * @param blockCache block cache to use for this configuration
+   */
   public CacheConfig(Configuration conf, BlockCache blockCache) {
     this(conf, null, blockCache, ByteBuffAllocator.HEAP);
+  }
+
+  /**
+   * Create a cache configuration using the specified configuration object and cache access service.
+   * Only use in tests
+   * @param conf    hbase configuration
+   * @param service cache access service to use for this configuration
+   */
+  public CacheConfig(Configuration conf, CacheAccessService service) {
+    this(conf, null, service, ByteBuffAllocator.HEAP);
+  }
+
+  public CacheConfig(Configuration conf, ColumnFamilyDescriptor family, CacheAccessService service,
+    ByteBuffAllocator byteBuffAllocator) {
+    initFromConf(conf, family);
+    this.byteBuffAllocator = byteBuffAllocator;
+    this.cacheAccessService = service != null ? service : CacheAccessServices.disabled();
+    this.blockCache = service instanceof BlockCacheBackedCacheAccessService
+      ? ((BlockCacheBackedCacheAccessService) service).getBlockCache()
+      : null;
+
   }
 
   /**
@@ -204,6 +232,15 @@ public class CacheConfig implements PropagatingConfigurationObserver {
    */
   public CacheConfig(Configuration conf, ColumnFamilyDescriptor family, BlockCache blockCache,
     ByteBuffAllocator byteBuffAllocator) {
+    initFromConf(conf, family);
+    this.blockCache = blockCache;
+    this.byteBuffAllocator = byteBuffAllocator;
+    this.cacheAccessService = blockCache != null
+      ? CacheAccessServices.fromBlockCache(blockCache)
+      : CacheAccessServices.disabled();
+  }
+
+  private void initFromConf(Configuration conf, ColumnFamilyDescriptor family) {
     if (family == null || family.isBlockCacheEnabled()) {
       this.cacheDataOnRead = conf.getBoolean(CACHE_DATA_ON_READ_KEY, DEFAULT_CACHE_DATA_ON_READ);
       this.inMemory = family == null ? DEFAULT_IN_MEMORY : family.isInMemory();
@@ -233,11 +270,6 @@ public class CacheConfig implements PropagatingConfigurationObserver {
       this.heapUsageThreshold =
         conf.getDouble(PREFETCH_HEAP_USAGE_THRESHOLD, DEFAULT_PREFETCH_HEAP_USAGE_THRESHOLD);
     }
-    this.blockCache = blockCache;
-    this.byteBuffAllocator = byteBuffAllocator;
-    this.cacheAccessService = blockCache != null
-      ? CacheAccessServices.fromBlockCache(blockCache)
-      : CacheAccessServices.disabled();
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -309,8 +309,8 @@ public class CacheConfig implements PropagatingConfigurationObserver {
     Configuration conf) {
     Optional<Boolean> cacheFileBlock = Optional.of(true);
     // For DATA blocks only, if BucketCache is in use, we don't need to cache block again
-    if (getBlockCache().isPresent() && category.equals(BlockCategory.DATA)) {
-      Optional<Boolean> result = getBlockCache().get().shouldCacheFile(hFileInfo, conf);
+    if (category.equals(BlockCategory.DATA)) {
+      Optional<Boolean> result = getCacheAccessService().shouldCacheFile(hFileInfo, conf);
       if (result.isPresent()) {
         cacheFileBlock = result;
       }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/CacheConfig.java
@@ -24,6 +24,8 @@ import org.apache.hadoop.hbase.conf.ConfigurationManager;
 import org.apache.hadoop.hbase.conf.PropagatingConfigurationObserver;
 import org.apache.hadoop.hbase.io.ByteBuffAllocator;
 import org.apache.hadoop.hbase.io.hfile.BlockType.BlockCategory;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServices;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -176,6 +178,8 @@ public class CacheConfig implements PropagatingConfigurationObserver {
   // Local reference to the block cache
   private final BlockCache blockCache;
 
+  private final CacheAccessService cacheAccessService;
+
   private final ByteBuffAllocator byteBuffAllocator;
 
   private double heapUsageThreshold;
@@ -231,6 +235,9 @@ public class CacheConfig implements PropagatingConfigurationObserver {
     }
     this.blockCache = blockCache;
     this.byteBuffAllocator = byteBuffAllocator;
+    this.cacheAccessService = blockCache != null
+      ? CacheAccessServices.fromBlockCache(blockCache)
+      : CacheAccessServices.disabled();
   }
 
   /**
@@ -252,6 +259,9 @@ public class CacheConfig implements PropagatingConfigurationObserver {
     this.blockCache = cacheConf.blockCache;
     this.byteBuffAllocator = cacheConf.byteBuffAllocator;
     this.heapUsageThreshold = cacheConf.heapUsageThreshold;
+    this.cacheAccessService = blockCache != null
+      ? CacheAccessServices.fromBlockCache(blockCache)
+      : CacheAccessServices.disabled();
   }
 
   private CacheConfig() {
@@ -270,6 +280,7 @@ public class CacheConfig implements PropagatingConfigurationObserver {
     this.blockCache = null;
     this.byteBuffAllocator = ByteBuffAllocator.HEAP;
     this.heapUsageThreshold = DEFAULT_PREFETCH_HEAP_USAGE_THRESHOLD;
+    this.cacheAccessService = CacheAccessServices.disabled();
   }
 
   /**
@@ -467,6 +478,20 @@ public class CacheConfig implements PropagatingConfigurationObserver {
    */
   public Optional<BlockCache> getBlockCache() {
     return Optional.ofNullable(this.blockCache);
+  }
+
+  /**
+   * Returns the cache access service used by HFile read/write path callers.
+   * <p>
+   * This service is the migration-facing cache abstraction. For now it is backed by the existing
+   * {@link BlockCache} when block cache is configured, or by a disabled no-op implementation when
+   * block cache is unavailable. This keeps cache construction unchanged while allowing callers such
+   * as {@code HFileReaderImpl} to depend on {@link CacheAccessService}.
+   * </p>
+   * @return cache access service
+   */
+  public CacheAccessService getCacheAccessService() {
+    return cacheAccessService;
   }
 
   public boolean isCombinedBlockCache() {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileBlockIndex.java
@@ -1075,7 +1075,7 @@ public class HFileBlockIndex {
         if (midKeyMetadata != null) blockStream.write(midKeyMetadata);
         blockWriter.writeHeaderAndData(out);
         if (cacheConf != null) {
-          cacheConf.getBlockCache().ifPresent(cache -> {
+          cacheConf.getCacheAccessService().ifEnabled(cache -> {
             HFileBlock blockForCaching = blockWriter.getBlockForCaching(cacheConf);
             cache.cacheBlock(new BlockCacheKey(nameForCaching, rootLevelIndexPos, true,
               blockForCaching.getBlockType()), blockForCaching);
@@ -1169,7 +1169,7 @@ public class HFileBlockIndex {
       blockWriter.writeHeaderAndData(out);
 
       if (getCacheOnWrite()) {
-        cacheConf.getBlockCache().ifPresent(cache -> {
+        cacheConf.getCacheAccessService().ifEnabled(cache -> {
           HFileBlock blockForCaching = blockWriter.getBlockForCaching(cacheConf);
           try {
             cache.cacheBlock(

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -42,7 +42,7 @@ public class HFilePreadReader extends HFileReaderImpl {
     fileInfo.initMetaAndIndex(this);
     // master hosted regions, like the master procedures store wouldn't have a block cache
     // Prefetch file blocks upon open if requested
-    if (cacheConf.getBlockCache().isPresent() && cacheConf.shouldPrefetchOnOpen()) {
+    if (cacheConf.getCacheAccessService().isCacheEnabled() && cacheConf.shouldPrefetchOnOpen()) {
       PrefetchExecutor.request(path, new Runnable() {
         @Override
         public void run() {
@@ -50,7 +50,7 @@ public class HFilePreadReader extends HFileReaderImpl {
           long end = 0;
           HFile.Reader prefetchStreamReader = null;
           try {
-            cacheConf.getBlockCache().ifPresent(
+            cacheConf.getCacheAccessService().ifEnabled(
               cache -> cache.waitForCacheInitialization(WAIT_TIME_FOR_CACHE_INITIALIZATION));
             ReaderContext streamReaderContext = ReaderContextBuilder.newBuilder(context)
               .withReaderType(ReaderContext.ReaderType.STREAM)
@@ -185,7 +185,7 @@ public class HFilePreadReader extends HFileReaderImpl {
     // Deallocate blocks in load-on-open section
     this.fileInfo.close();
     // Deallocate data blocks
-    cacheConf.getBlockCache().ifPresent(cache -> {
+    cacheConf.getCacheAccessService().ifEnabled(cache -> {
       if (evictOnClose) {
         int numEvicted = cache.evictBlocksByHfileName(name);
         if (LOG.isTraceEnabled()) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFilePreadReader.java
@@ -21,6 +21,7 @@ import java.io.IOException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -65,7 +66,7 @@ public class HFilePreadReader extends HFileReaderImpl {
             // Don't use BlockIterator here, because it's designed to read load-on-open section.
             long onDiskSizeOfNextBlock = -1;
             // if we are here, block cache is present anyways
-            BlockCache cache = cacheConf.getBlockCache().get();
+            CacheAccessService cacheAccessService = cacheConf.getCacheAccessService();
             boolean interrupted = false;
             int blockCount = 0;
             int dataBlockCount = 0;
@@ -78,10 +79,10 @@ public class HFilePreadReader extends HFileReaderImpl {
               // update the offset and move on to the next block without actually going read all
               // the way to the cache.
               BlockCacheKey cacheKey = new BlockCacheKey(name, offset);
-              if (cache.isAlreadyCached(cacheKey).orElse(false)) {
+              if (cacheAccessService.isAlreadyCached(cacheKey).orElse(false)) {
                 // Right now, isAlreadyCached is only supported by BucketCache, which should
                 // always cache data blocks.
-                int size = cache.getBlockSize(cacheKey).orElse(0);
+                int size = cacheAccessService.getBlockSize(cacheKey).orElse(0);
                 if (size > 0) {
                   offset += size;
                   LOG.debug("Found block of size {} for cache key {}. "
@@ -108,11 +109,12 @@ public class HFilePreadReader extends HFileReaderImpl {
                 /* cacheBlock= */true, /* pread= */false, false, false, null, null, true);
               try {
                 if (!cacheConf.isInMemory()) {
-                  if (!cache.blockFitsIntoTheCache(block).orElse(true)) {
+                  if (!cacheAccessService.blockFitsIntoTheCache(block).orElse(true)) {
                     LOG.warn(
                       "Interrupting prefetch for file {} because block {} of size {} "
                         + "doesn't fit in the available cache space. isCacheEnabled: {}",
-                      path, cacheKey, block.getOnDiskSizeWithHeader(), cache.isCacheEnabled());
+                      path, cacheKey, block.getOnDiskSizeWithHeader(),
+                      cacheAccessService.isCacheEnabled());
                     interrupted = true;
                     break;
                   }
@@ -139,8 +141,8 @@ public class HFilePreadReader extends HFileReaderImpl {
               }
             }
             if (!interrupted) {
-              cacheConf.getBlockCache().get().notifyFileCachingCompleted(path, blockCount,
-                dataBlockCount, offset);
+              cacheAccessService.notifyFileCachingCompleted(path, blockCount, dataBlockCount,
+                offset);
             }
           } catch (IOException e) {
             // IOExceptions are probably due to region closes (relocation, etc.)

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -47,6 +47,7 @@ import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoder;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.io.encoding.HFileBlockDecodingContext;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.monitoring.ThreadLocalServerSideScanMetrics;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.regionserver.KeyValueScanner;
@@ -1104,120 +1105,120 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
     boolean updateCacheMetrics, BlockType expectedBlockType,
     DataBlockEncoding expectedDataBlockEncoding) throws IOException {
     // Check cache for block. If found return.
-    BlockCache cache = cacheConf.getBlockCache().orElse(null);
+    CacheAccessService cacheAccessService = cacheConf.getCacheAccessService();
     long cachedBlockBytesRead = 0;
-    if (cache != null) {
-      HFileBlock cachedBlock = null;
-      boolean isScanMetricsEnabled = ThreadLocalServerSideScanMetrics.isScanMetricsEnabled();
-      try {
-        cachedBlock = (HFileBlock) cache.getBlock(cacheKey, cacheBlock, useLock, updateCacheMetrics,
-          expectedBlockType);
-        if (cachedBlock != null) {
-          if (cacheConf.shouldCacheCompressed(cachedBlock.getBlockType().getCategory())) {
-            HFileBlock compressedBlock = cachedBlock;
-            cachedBlock = compressedBlock.unpack(hfileContext, fsBlockReader);
-            // In case of compressed block after unpacking we can release the compressed block
-            if (compressedBlock != cachedBlock) {
-              compressedBlock.release();
-            }
+    HFileBlock cachedBlock = null;
+    boolean isScanMetricsEnabled = ThreadLocalServerSideScanMetrics.isScanMetricsEnabled();
+    try {
+      cachedBlock = (HFileBlock) cacheAccessService.getBlock(cacheKey, cacheBlock, useLock,
+        updateCacheMetrics, expectedBlockType);
+      if (cachedBlock != null) {
+        if (cacheConf.shouldCacheCompressed(cachedBlock.getBlockType().getCategory())) {
+          HFileBlock compressedBlock = cachedBlock;
+          cachedBlock = compressedBlock.unpack(hfileContext, fsBlockReader);
+          // In case of compressed block after unpacking we can release the compressed block
+          if (compressedBlock != cachedBlock) {
+            compressedBlock.release();
           }
-          try {
-            validateBlockType(cachedBlock, expectedBlockType);
-          } catch (IOException e) {
-            returnAndEvictBlock(cache, cacheKey, cachedBlock);
-            cachedBlock = null;
-            throw e;
-          }
+        }
+        try {
+          validateBlockType(cachedBlock, expectedBlockType);
+        } catch (IOException e) {
+          returnAndEvictBlock(cacheAccessService, cacheKey, cachedBlock);
+          cachedBlock = null;
+          throw e;
+        }
 
-          if (expectedDataBlockEncoding == null) {
-            return cachedBlock;
-          }
-          DataBlockEncoding actualDataBlockEncoding = cachedBlock.getDataBlockEncoding();
-          // Block types other than data blocks always have
-          // DataBlockEncoding.NONE. To avoid false negative cache misses, only
-          // perform this check if cached block is a data block.
-          if (
-            cachedBlock.getBlockType().isData()
-              && !actualDataBlockEncoding.equals(expectedDataBlockEncoding)
-          ) {
-            // This mismatch may happen if a Scanner, which is used for say a
-            // compaction, tries to read an encoded block from the block cache.
-            // The reverse might happen when an EncodedScanner tries to read
-            // un-encoded blocks which were cached earlier.
-            //
-            // Because returning a data block with an implicit BlockType mismatch
-            // will cause the requesting scanner to throw a disk read should be
-            // forced here. This will potentially cause a significant number of
-            // cache misses, so update so we should keep track of this as it might
-            // justify the work on a CompoundScanner.
-            if (
-              !expectedDataBlockEncoding.equals(DataBlockEncoding.NONE)
-                && !actualDataBlockEncoding.equals(DataBlockEncoding.NONE)
-            ) {
-              // If the block is encoded but the encoding does not match the
-              // expected encoding it is likely the encoding was changed but the
-              // block was not yet evicted. Evictions on file close happen async
-              // so blocks with the old encoding still linger in cache for some
-              // period of time. This event should be rare as it only happens on
-              // schema definition change.
-              LOG.info(
-                "Evicting cached block with key {} because data block encoding mismatch; "
-                  + "expected {}, actual {}, path={}",
-                cacheKey, actualDataBlockEncoding, expectedDataBlockEncoding, path);
-              // This is an error scenario. so here we need to release the block.
-              returnAndEvictBlock(cache, cacheKey, cachedBlock);
-            }
-            cachedBlock = null;
-            return null;
-          }
+        if (expectedDataBlockEncoding == null) {
           return cachedBlock;
         }
-      } catch (Exception e) {
-        if (cachedBlock != null) {
-          returnAndEvictBlock(cache, cacheKey, cachedBlock);
+        DataBlockEncoding actualDataBlockEncoding = cachedBlock.getDataBlockEncoding();
+        // Block types other than data blocks always have
+        // DataBlockEncoding.NONE. To avoid false negative cache misses, only
+        // perform this check if cached block is a data block.
+        if (
+          cachedBlock.getBlockType().isData()
+            && !actualDataBlockEncoding.equals(expectedDataBlockEncoding)
+        ) {
+          // This mismatch may happen if a Scanner, which is used for say a
+          // compaction, tries to read an encoded block from the block cache.
+          // The reverse might happen when an EncodedScanner tries to read
+          // un-encoded blocks which were cached earlier.
+          //
+          // Because returning a data block with an implicit BlockType mismatch
+          // will cause the requesting scanner to throw a disk read should be
+          // forced here. This will potentially cause a significant number of
+          // cache misses, so update so we should keep track of this as it might
+          // justify the work on a CompoundScanner.
+          if (
+            !expectedDataBlockEncoding.equals(DataBlockEncoding.NONE)
+              && !actualDataBlockEncoding.equals(DataBlockEncoding.NONE)
+          ) {
+            // If the block is encoded but the encoding does not match the
+            // expected encoding it is likely the encoding was changed but the
+            // block was not yet evicted. Evictions on file close happen async
+            // so blocks with the old encoding still linger in cache for some
+            // period of time. This event should be rare as it only happens on
+            // schema definition change.
+            LOG.info(
+              "Evicting cached block with key {} because data block encoding mismatch; "
+                + "expected {}, actual {}, path={}",
+              cacheKey, actualDataBlockEncoding, expectedDataBlockEncoding, path);
+            // This is an error scenario. so here we need to release the block.
+            returnAndEvictBlock(cacheAccessService, cacheKey, cachedBlock);
+          }
+          cachedBlock = null;
+          return null;
         }
-        LOG.warn("Failed retrieving block from cache with key {}. "
-          + "\n Evicting this block from cache and will read it from file system. "
-          + "\n Exception details: ", cacheKey, e);
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("Further tracing details for failed block cache retrieval:"
+        return cachedBlock;
+      }
+    } catch (Exception e) {
+      if (cachedBlock != null) {
+        returnAndEvictBlock(cacheAccessService, cacheKey, cachedBlock);
+      }
+      LOG.warn("Failed retrieving block from cache with key {}. "
+        + "\n Evicting this block from cache and will read it from file system. "
+        + "\n Exception details: ", cacheKey, e);
+      if (LOG.isDebugEnabled()) {
+        LOG.debug(
+          "Further tracing details for failed block cache retrieval:"
             + "\n Complete File path - {}," + "\n Expected Block Type - {}, Actual Block Type - {},"
             + "\n Cache compressed - {}" + "\n Header size (after deserialized from cache) - {}"
             + "\n Size with header - {}" + "\n Uncompressed size without header - {} "
-            + "\n Total byte buffer size - {}" + "\n Encoding code - {}", this.path,
-            expectedBlockType, (cachedBlock != null ? cachedBlock.getBlockType() : "N/A"),
-            (expectedBlockType != null
-              ? cacheConf.shouldCacheCompressed(expectedBlockType.getCategory())
-              : "N/A"),
-            (cachedBlock != null ? cachedBlock.headerSize() : "N/A"),
-            (cachedBlock != null ? cachedBlock.getOnDiskSizeWithHeader() : "N/A"),
-            (cachedBlock != null ? cachedBlock.getUncompressedSizeWithoutHeader() : "N/A"),
-            (cachedBlock != null ? cachedBlock.getBufferReadOnly().limit() : "N/A"),
-            (cachedBlock != null
-              ? cachedBlock.getBufferReadOnly().getShort(cachedBlock.headerSize())
-              : "N/A"));
+            + "\n Total byte buffer size - {}" + "\n Encoding code - {}",
+          this.path, expectedBlockType, (cachedBlock != null ? cachedBlock.getBlockType() : "N/A"),
+          (expectedBlockType != null
+            ? cacheConf.shouldCacheCompressed(expectedBlockType.getCategory())
+            : "N/A"),
+          (cachedBlock != null ? cachedBlock.headerSize() : "N/A"),
+          (cachedBlock != null ? cachedBlock.getOnDiskSizeWithHeader() : "N/A"),
+          (cachedBlock != null ? cachedBlock.getUncompressedSizeWithoutHeader() : "N/A"),
+          (cachedBlock != null ? cachedBlock.getBufferReadOnly().limit() : "N/A"),
+          (cachedBlock != null
+            ? cachedBlock.getBufferReadOnly().getShort(cachedBlock.headerSize())
+            : "N/A"));
+      }
+      return null;
+    } finally {
+      // Count bytes read as cached block is being returned
+      if (isScanMetricsEnabled && cachedBlock != null) {
+        cachedBlockBytesRead = cachedBlock.getOnDiskSizeWithHeader();
+        // Account for the header size of the next block if it exists
+        if (cachedBlock.getNextBlockOnDiskSize() > 0) {
+          cachedBlockBytesRead += cachedBlock.headerSize();
         }
-        return null;
-      } finally {
-        // Count bytes read as cached block is being returned
-        if (isScanMetricsEnabled && cachedBlock != null) {
-          cachedBlockBytesRead = cachedBlock.getOnDiskSizeWithHeader();
-          // Account for the header size of the next block if it exists
-          if (cachedBlock.getNextBlockOnDiskSize() > 0) {
-            cachedBlockBytesRead += cachedBlock.headerSize();
-          }
-        }
-        if (cachedBlockBytesRead > 0) {
-          ThreadLocalServerSideScanMetrics.addBytesReadFromBlockCache(cachedBlockBytesRead);
-        }
+      }
+      if (cachedBlockBytesRead > 0) {
+        ThreadLocalServerSideScanMetrics.addBytesReadFromBlockCache(cachedBlockBytesRead);
       }
     }
     return null;
   }
 
-  private void returnAndEvictBlock(BlockCache cache, BlockCacheKey cacheKey, Cacheable block) {
+  private void returnAndEvictBlock(CacheAccessService cacheAccessService, BlockCacheKey cacheKey,
+    Cacheable block) {
     block.release();
-    cache.evictBlock(cacheKey);
+    cacheAccessService.evictBlock(cacheKey);
   }
 
   /**
@@ -1373,9 +1374,8 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
               // type in the cache key, and we expect it to match on a cache hit.
               if (cachedBlock.getDataBlockEncoding() != dataBlockEncoder.getDataBlockEncoding()) {
                 // Remember to release the block when in exceptional path.
-                cacheConf.getBlockCache().ifPresent(cache -> {
-                  returnAndEvictBlock(cache, cacheKey, cachedBlock);
-                });
+                CacheAccessService cacheAccessService = cacheConf.getCacheAccessService();
+                returnAndEvictBlock(cacheAccessService, cacheKey, cachedBlock);
                 throw new IOException("Cached block under key " + cacheKey + " "
                   + "has wrong encoding: " + cachedBlock.getDataBlockEncoding() + " (expected: "
                   + dataBlockEncoder.getDataBlockEncoding() + "), path=" + path);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileReaderImpl.java
@@ -1271,7 +1271,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
 
       // Cache the block
       if (cacheBlock) {
-        cacheConf.getBlockCache().ifPresent(
+        cacheConf.getCacheAccessService().ifEnabled(
           cache -> cache.cacheBlock(cacheKey, uncompressedBlock, cacheConf.isInMemory()));
       }
       return uncompressedBlock;
@@ -1290,7 +1290,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
    *      boolean, boolean)
    */
   private boolean shouldUseHeap(BlockType expectedBlockType, boolean cacheBlock) {
-    if (!cacheConf.getBlockCache().isPresent()) {
+    if (!cacheConf.getCacheAccessService().isCacheEnabled()) {
       return false;
     }
 
@@ -1411,7 +1411,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
         // Don't need the unpacked block back and we're storing the block in the cache compressed
         if (cacheOnly && cacheCompressed && cacheOnRead) {
           HFileBlock blockNoChecksum = BlockCacheUtil.getBlockForCaching(cacheConf, hfileBlock);
-          cacheConf.getBlockCache().ifPresent(cache -> {
+          cacheConf.getCacheAccessService().ifEnabled(cache -> {
             LOG.debug("Skipping decompression of block {} in prefetch", cacheKey);
             // Cache the block if necessary
             if (cacheBlock && cacheOnRead) {
@@ -1427,7 +1427,7 @@ public abstract class HFileReaderImpl implements HFile.Reader, Configurable {
         HFileBlock unpacked = hfileBlock.unpack(hfileContext, fsBlockReader);
         HFileBlock unpackedNoChecksum = BlockCacheUtil.getBlockForCaching(cacheConf, unpacked);
         // Cache the block if necessary
-        cacheConf.getBlockCache().ifPresent(cache -> {
+        cacheConf.getCacheAccessService().ifEnabled(cache -> {
           if (cacheBlock && cacheOnRead) {
             // Using the wait on cache during compaction and prefetching.
             cache.cacheBlock(cacheKey,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/HFileWriterImpl.java
@@ -52,6 +52,7 @@ import org.apache.hadoop.hbase.io.crypto.Encryption;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock.BlockWritable;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.regionserver.TimeRangeTracker;
 import org.apache.hadoop.hbase.security.EncryptionUtil;
 import org.apache.hadoop.hbase.security.User;
@@ -576,7 +577,7 @@ public class HFileWriterImpl implements HFile.Writer {
    * @param offset the offset of the block we want to cache. Used to determine the cache key.
    */
   private void doCacheOnWrite(long offset) {
-    cacheConf.getBlockCache().ifPresent(cache -> {
+    cacheConf.getCacheAccessService().ifEnabled(cache -> {
       HFileBlock cacheFormatBlock = blockWriter.getBlockForCaching(cacheConf);
       try {
         BlockCacheKey key = buildCacheBlockKey(offset, cacheFormatBlock.getBlockType());
@@ -598,7 +599,7 @@ public class HFileWriterImpl implements HFile.Writer {
     return new BlockCacheKey(name, offset, true, blockType);
   }
 
-  private boolean shouldCacheBlock(BlockCache cache, BlockCacheKey key) {
+  private boolean shouldCacheBlock(CacheAccessService cache, BlockCacheKey key) {
     Optional<Boolean> result =
       cache.shouldCacheBlock(key, timeRangeTrackerForTiering.get().getMax(), conf);
     return result.orElse(true);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/AdmissionDecision.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/AdmissionDecision.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Result of cache admission evaluation.
+ */
+@InterfaceAudience.Private
+public final class AdmissionDecision {
+
+  private static final AdmissionDecision ADMIT = new AdmissionDecision(true, "ADMIT");
+
+  private static final AdmissionDecision REJECT = new AdmissionDecision(false, "REJECT");
+
+  private final boolean admit;
+  private final String reason;
+
+  private AdmissionDecision(boolean admit, String reason) {
+    this.admit = admit;
+    this.reason = reason;
+  }
+
+  /**
+   * Returns a normal-priority admission decision.
+   * @return admit decision
+   */
+  public static AdmissionDecision admit() {
+    return ADMIT;
+  }
+
+  /**
+   * Returns an admission decision with a reason.
+   * @param reason reason text
+   * @return admit decision
+   */
+  public static AdmissionDecision admit(String reason) {
+    return new AdmissionDecision(true, reason);
+  }
+
+  /**
+   * Returns a rejection decision. * @return reject decision
+   */
+  public static AdmissionDecision reject() {
+    return REJECT;
+  }
+
+  /**
+   * Returns a rejection decision with a reason.
+   * @param reason rejection reason
+   * @return reject decision
+   */
+  public static AdmissionDecision reject(String reason) {
+    return new AdmissionDecision(false, reason);
+  }
+
+  /**
+   * Returns whether the block should be admitted.
+   * @return true when admitted
+   */
+  public boolean isAdmitted() {
+    return admit;
+  }
+
+  /**
+   * Returns the decision reason.
+   * @return decision reason
+   */
+  public String getReason() {
+    return reason;
+  }
+
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/AdmissionPriority.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/AdmissionPriority.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Priority hint associated with an admitted cache block.
+ */
+@InterfaceAudience.Private
+public enum AdmissionPriority {
+
+  /**
+   * Low-priority admission, suitable for opportunistic insertions such as prefetch.
+   */
+  LOW,
+
+  /**
+   * Normal-priority admission.
+   */
+  NORMAL,
+
+  /**
+   * High-priority admission, suitable for metadata-heavy or latency-sensitive blocks.
+   */
+  HIGH
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
@@ -27,6 +27,7 @@ import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -304,5 +305,20 @@ public class BlockCacheBackedCacheAccessService implements CacheAccessService {
     long size) {
     Objects.requireNonNull(fileName, "fileName must not be null");
     blockCache.notifyFileCachingCompleted(fileName, totalBlockCount, dataBlockCount, size);
+  }
+
+  @Override
+  public Optional<Boolean> shouldCacheFile(HFileInfo hFileInfo, Configuration conf) {
+    Objects.requireNonNull(hFileInfo, "hFileInfo must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return blockCache.shouldCacheFile(hFileInfo, conf);
+  }
+
+  @Override
+  public Optional<Boolean> shouldCacheBlock(BlockCacheKey key, long maxTimestamp,
+    Configuration conf) {
+    Objects.requireNonNull(key, "key must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return blockCache.shouldCacheBlock(key, maxTimestamp, conf);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
@@ -1,0 +1,300 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCache;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * {@link CacheAccessService} implementation backed by an existing {@link BlockCache} instance.
+ * <p>
+ * This adapter is the compatibility bridge for the first migration step. It allows new callers to
+ * depend on {@link CacheAccessService} while the runtime implementation still uses the current
+ * {@link BlockCache} hierarchy, including LruBlockCache, BucketCache, CombinedBlockCache, and other
+ * existing implementations.
+ * </p>
+ * <p>
+ * The adapter should not introduce new policy, placement, admission, representation, promotion, or
+ * topology behavior. Its purpose is to translate the new context-based service API into the current
+ * {@code BlockCache} API with no intentional behavior change.
+ * </p>
+ * <p>
+ * A future topology-backed service can replace this adapter after call sites have migrated to
+ * {@link CacheAccessService}. That future implementation may use {@link CacheTopology},
+ * {@link CachePlacementAdmissionPolicy}, and {@link CacheEngine}; this adapter deliberately does
+ * not.
+ * </p>
+ */
+@InterfaceAudience.Private
+public class BlockCacheBackedCacheAccessService implements CacheAccessService {
+
+  private final BlockCache blockCache;
+
+  /**
+   * Creates a cache access service backed by the supplied legacy block cache.
+   * @param blockCache block cache to wrap
+   */
+  public BlockCacheBackedCacheAccessService(BlockCache blockCache) {
+    this.blockCache = Objects.requireNonNull(blockCache, "blockCache must not be null");
+  }
+
+  /**
+   * Returns the wrapped {@link BlockCache} instance.
+   * <p>
+   * This accessor is intended for tests and transitional wiring only. New read/write path code
+   * should use {@link CacheAccessService} methods instead of unwrapping the legacy cache.
+   * </p>
+   * @return wrapped block cache
+   */
+  public BlockCache getBlockCache() {
+    return blockCache;
+  }
+
+  /**
+   * Returns a human-readable service name.
+   * @return service name
+   */
+  @Override
+  public String getName() {
+    return blockCache.getClass().getSimpleName();
+  }
+
+  /**
+   * Fetches a block by delegating to the wrapped {@link BlockCache}.
+   * @param cacheKey block to fetch
+   * @param context  cache request context
+   * @return cached block, or {@code null} if not present
+   */
+  @Override
+  public Cacheable getBlock(BlockCacheKey cacheKey, CacheRequestContext context) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+
+    Optional<BlockType> blockType = context.getBlockType();
+    if (blockType.isPresent()) {
+      return blockCache.getBlock(cacheKey, context.isCaching(), context.isRepeat(),
+        context.isUpdateCacheMetrics(), blockType.get());
+    }
+    return blockCache.getBlock(cacheKey, context.isCaching(), context.isRepeat(),
+      context.isUpdateCacheMetrics());
+  }
+
+  /**
+   * Caches a block by delegating to the wrapped {@link BlockCache}.
+   * @param cacheKey block cache key
+   * @param block    block contents
+   * @param context  cache write context
+   */
+  @Override
+  public void cacheBlock(BlockCacheKey cacheKey, Cacheable block, CacheWriteContext context) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(block, "block must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+
+    blockCache.cacheBlock(cacheKey, block, context.isInMemory(), context.isWaitWhenCache());
+  }
+
+  /**
+   * Evicts a single block by delegating to the wrapped {@link BlockCache}.
+   * @param cacheKey block to remove
+   * @return {@code true} if the block existed and was removed, {@code false} otherwise
+   */
+  @Override
+  public boolean evictBlock(BlockCacheKey cacheKey) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    return blockCache.evictBlock(cacheKey);
+  }
+
+  /**
+   * Evicts all cached blocks for the given HFile by delegating to the wrapped {@link BlockCache}.
+   * @param hfileName HFile name
+   * @return number of blocks removed
+   */
+  @Override
+  public int evictBlocksByHfileName(String hfileName) {
+    Objects.requireNonNull(hfileName, "hfileName must not be null");
+    return blockCache.evictBlocksByHfileName(hfileName);
+  }
+
+  /**
+   * Evicts cached blocks for an HFile range if the wrapped cache supports it.
+   * @param hfileName  HFile name
+   * @param initOffset inclusive start offset
+   * @param endOffset  inclusive end offset
+   * @return number of blocks removed
+   */
+  @Override
+  public int evictBlocksRangeByHfileName(String hfileName, long initOffset, long endOffset) {
+    Objects.requireNonNull(hfileName, "hfileName must not be null");
+    return blockCache.evictBlocksRangeByHfileName(hfileName, initOffset, endOffset);
+  }
+
+  /**
+   * Evicts cached blocks for a region if the wrapped cache supports it.
+   * @param regionName region name
+   * @return number of blocks removed
+   */
+  @Override
+  public int evictBlocksByRegionName(String regionName) {
+    Objects.requireNonNull(regionName, "regionName must not be null");
+    // BlockCache does not support region-based eviction, so we return 0 to indicate no
+    // blocks removed
+    return 0;
+  }
+
+  /**
+   * Returns statistics from the wrapped {@link BlockCache}.
+   * @return cache statistics
+   */
+  @Override
+  public CacheStats getStats() {
+    return blockCache.getStats();
+  }
+
+  /**
+   * Shuts down the wrapped {@link BlockCache}.
+   */
+  @Override
+  public void shutdown() {
+    blockCache.shutdown();
+  }
+
+  /**
+   * Returns maximum configured cache size from the wrapped {@link BlockCache}.
+   * @return maximum cache size
+   */
+  @Override
+  public long getMaxSize() {
+    return blockCache.getMaxSize();
+  }
+
+  /**
+   * Returns free cache size from the wrapped {@link BlockCache}.
+   * @return free size
+   */
+  @Override
+  public long getFreeSize() {
+    return blockCache.getFreeSize();
+  }
+
+  /**
+   * Returns occupied cache size from the wrapped {@link BlockCache}.
+   * @return occupied cache size
+   */
+  @Override
+  public long size() {
+    return blockCache.size();
+  }
+
+  /**
+   * Returns occupied data-block size from the wrapped {@link BlockCache}.
+   * @return occupied data-block size
+   */
+  @Override
+  public long getCurrentDataSize() {
+    return blockCache.getCurrentDataSize();
+  }
+
+  /**
+   * Returns cached block count from the wrapped {@link BlockCache}.
+   * @return total block count
+   */
+  @Override
+  public long getBlockCount() {
+    return blockCache.getBlockCount();
+  }
+
+  /**
+   * Returns cached data block count from the wrapped {@link BlockCache}.
+   * @return data block count
+   */
+  @Override
+  public long getDataBlockCount() {
+    return blockCache.getDataBlockCount();
+  }
+
+  /**
+   * Delegates block fit check to the wrapped {@link BlockCache}.
+   * @param block block to check
+   * @return empty if unsupported; otherwise whether the block fits
+   */
+  @Override
+  public Optional<Boolean> blockFitsIntoTheCache(HFileBlock block) {
+    Objects.requireNonNull(block, "block must not be null");
+    return blockCache.blockFitsIntoTheCache(block);
+  }
+
+  /**
+   * Delegates already-cached check to the wrapped {@link BlockCache}.
+   * @param key block cache key
+   * @return empty if unsupported; otherwise whether the block is cached
+   */
+  @Override
+  public Optional<Boolean> isAlreadyCached(BlockCacheKey key) {
+    Objects.requireNonNull(key, "key must not be null");
+    return blockCache.isAlreadyCached(key);
+  }
+
+  /**
+   * Delegates per-block size lookup to the wrapped {@link BlockCache}.
+   * @param key block cache key
+   * @return empty if unsupported or not present; otherwise cached block size
+   */
+  @Override
+  public Optional<Integer> getBlockSize(BlockCacheKey key) {
+    Objects.requireNonNull(key, "key must not be null");
+    return blockCache.getBlockSize(key);
+  }
+
+  /**
+   * Returns whether the wrapped {@link BlockCache} is enabled.
+   * @return {@code true} if enabled, {@code false} otherwise
+   */
+  @Override
+  public boolean isCacheEnabled() {
+    return blockCache.isCacheEnabled();
+  }
+
+  /**
+   * Waits for wrapped cache initialization if supported.
+   * @param timeout maximum time to wait
+   * @return {@code true} if the cache is enabled and ready, {@code false} otherwise
+   */
+  @Override
+  public boolean waitForCacheInitialization(long timeout) {
+    return blockCache.waitForCacheInitialization(timeout);
+  }
+
+  /**
+   * Propagates configuration changes to the wrapped {@link BlockCache}.
+   * @param config new configuration
+   */
+  @Override
+  public void onConfigurationChange(Configuration config) {
+    Objects.requireNonNull(config, "config must not be null");
+    blockCache.onConfigurationChange(config);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.io.hfile.cache;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
@@ -296,5 +297,12 @@ public class BlockCacheBackedCacheAccessService implements CacheAccessService {
   public void onConfigurationChange(Configuration config) {
     Objects.requireNonNull(config, "config must not be null");
     blockCache.onConfigurationChange(config);
+  }
+
+  @Override
+  public void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
+    long size) {
+    Objects.requireNonNull(fileName, "fileName must not be null");
+    blockCache.notifyFileCachingCompleted(fileName, totalBlockCount, dataBlockCount, size);
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.io.hfile.cache;
 
+import java.util.Iterator;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
@@ -26,6 +27,7 @@ import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.CachedBlock;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
 import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -51,7 +53,8 @@ import org.apache.yetus.audience.InterfaceAudience;
  * </p>
  */
 @InterfaceAudience.Private
-public class BlockCacheBackedCacheAccessService implements CacheAccessService {
+public class BlockCacheBackedCacheAccessService
+  implements CacheAccessService, Iterable<CachedBlock> {
 
   private final BlockCache blockCache;
 
@@ -320,5 +323,15 @@ public class BlockCacheBackedCacheAccessService implements CacheAccessService {
     Objects.requireNonNull(key, "key must not be null");
     Objects.requireNonNull(conf, "conf must not be null");
     return blockCache.shouldCacheBlock(key, maxTimestamp, conf);
+  }
+
+  @Override
+  public Iterator<CachedBlock> iterator() {
+    return blockCache.iterator();
+  }
+
+  @Override
+  public long getCurrentSize() {
+    return blockCache.getCurrentSize();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
@@ -17,7 +17,9 @@
  */
 package org.apache.hadoop.hbase.io.hfile.cache;
 
+import java.util.Objects;
 import java.util.Optional;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
@@ -25,6 +27,7 @@ import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -119,8 +122,8 @@ public interface CacheAccessService {
    */
   default Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
     boolean updateCacheMetrics) {
-    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(caching)
-      .setRepeat(repeat).setUpdateCacheMetrics(updateCacheMetrics).build();
+    CacheRequestContext context = CacheRequestContext.newBuilder().withCaching(caching)
+      .withRepeat(repeat).withUpdateCacheMetrics(updateCacheMetrics).build();
     return getBlock(cacheKey, context);
   }
 
@@ -140,8 +143,9 @@ public interface CacheAccessService {
    */
   default Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
     boolean updateCacheMetrics, BlockType blockType) {
-    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(caching)
-      .setRepeat(repeat).setUpdateCacheMetrics(updateCacheMetrics).setBlockType(blockType).build();
+    CacheRequestContext context =
+      CacheRequestContext.newBuilder().withCaching(caching).withRepeat(repeat)
+        .withUpdateCacheMetrics(updateCacheMetrics).withBlockType(blockType).build();
     return getBlock(cacheKey, context);
   }
 
@@ -178,7 +182,7 @@ public interface CacheAccessService {
    * @param inMemory whether the block should be treated as in-memory
    */
   default void cacheBlock(BlockCacheKey cacheKey, Cacheable block, boolean inMemory) {
-    CacheWriteContext context = CacheWriteContext.newBuilder().setInMemory(inMemory).build();
+    CacheWriteContext context = CacheWriteContext.newBuilder().withInMemory(inMemory).build();
     cacheBlock(cacheKey, block, context);
   }
 
@@ -196,8 +200,8 @@ public interface CacheAccessService {
    */
   default void cacheBlock(BlockCacheKey cacheKey, Cacheable block, boolean inMemory,
     boolean waitWhenCache) {
-    CacheWriteContext context =
-      CacheWriteContext.newBuilder().setInMemory(inMemory).setWaitWhenCache(waitWhenCache).build();
+    CacheWriteContext context = CacheWriteContext.newBuilder().withInMemory(inMemory)
+      .withWaitWhenCache(waitWhenCache).build();
     cacheBlock(cacheKey, block, context);
   }
 
@@ -443,5 +447,73 @@ public interface CacheAccessService {
   default void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
     long size) {
     // noop
+  }
+
+  /**
+   * Executes the supplied action when this cache service is enabled.
+   * <p>
+   * This helper is intended to preserve the old {@code getBlockCache().ifPresent(...)} style for
+   * call sites that should do nothing when block cache is disabled. It keeps callers independent of
+   * concrete implementations such as {@code NoOpCacheAccessService} while still allowing disabled
+   * cache wiring to behave like an absent cache.
+   * </p>
+   * <p>
+   * Implementations normally do not need to override this method. The default implementation checks
+   * {@link #isCacheEnabled()} and invokes the supplied action only when cache access is enabled.
+   * </p>
+   * @param action action to execute with this cache service when enabled
+   */
+  default void ifEnabled(Consumer<CacheAccessService> action) {
+    Objects.requireNonNull(action, "action must not be null");
+    if (isCacheEnabled()) {
+      action.accept(this);
+    }
+  }
+
+  /**
+   * Returns whether blocks from the given HFile should be cached. TODO: this method is a temporary
+   * adapter for file-level admission decisions. It will be removed and replaced by a more general
+   * admission API in the future.
+   * <p>
+   * This is a file-level admission hook used by cache population paths. Implementations may use
+   * file metadata, configuration, data tiering state, or implementation-specific bookkeeping to
+   * decide whether the file should be admitted into cache.
+   * </p>
+   * <p>
+   * The returned {@link Optional} is empty when the cache service does not support file-level
+   * admission decisions. In that case, callers should preserve existing default behavior, typically
+   * treating the result as "no opinion" rather than as a rejection.
+   * </p>
+   * @param hFileInfo HFile metadata used for the admission decision
+   * @param conf      configuration
+   * @return empty if unsupported; otherwise whether the file should be cached
+   */
+  default Optional<Boolean> shouldCacheFile(HFileInfo hFileInfo, Configuration conf) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns whether the block represented by the given key and timestamp should be cached. TODO:
+   * this method is a temporary adapter for file-level admission decisions. It will be removed and
+   * replaced by a more general admission API in the future.
+   * <p>
+   * <p>
+   * This is a block-level admission hook used by cache population paths. Implementations may use
+   * block identity, maximum timestamp, configuration, data tiering state, or
+   * implementation-specific policy to decide whether the block should be admitted into cache.
+   * </p>
+   * <p>
+   * The returned {@link Optional} is empty when the cache service does not support block-level
+   * admission decisions. In that case, callers should preserve existing default behavior, typically
+   * treating the result as "no opinion" rather than as a rejection.
+   * </p>
+   * @param key          block cache key
+   * @param maxTimestamp maximum timestamp associated with the block
+   * @param conf         configuration
+   * @return empty if unsupported; otherwise whether the block should be cached
+   */
+  default Optional<Boolean> shouldCacheBlock(BlockCacheKey key, long maxTimestamp,
+    Configuration conf) {
+    return Optional.empty();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
@@ -1,0 +1,423 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * HBase-facing access layer for block cache operations.
+ * <p>
+ * {@code CacheAccessService} is the cache abstraction intended for HBase read and write path
+ * callers such as HFile readers, HFile writers, prefetch code, and file lifecycle code. It
+ * preserves the core operational shape of the existing {@code BlockCache} API so callers can be
+ * migrated incrementally, but it removes methods that are specific to a concrete cache engine,
+ * tiered topology implementation, or diagnostics-only use case.
+ * </p>
+ * <p>
+ * This interface is deliberately close to the hot-path subset of {@code BlockCache}:
+ * </p>
+ * <ul>
+ * <li>lookup a block</li>
+ * <li>cache a block</li>
+ * <li>explicitly evict or invalidate blocks</li>
+ * <li>report aggregate statistics and sizing information</li>
+ * <li>manage cache lifecycle</li>
+ * </ul>
+ * <p>
+ * The important difference from {@link CacheEngine} is the abstraction level. A {@code CacheEngine}
+ * is a storage back-end implemented by a concrete cache such as LruBlockCache, BucketCache, or a
+ * future CarrotCache engine. {@code CacheAccessService} is the HBase-facing facade above topology
+ * and engines. It receives request intent through {@link CacheRequestContext} and insertion intent
+ * through {@link CacheWriteContext}. A service implementation may initially delegate to an existing
+ * {@code BlockCache}; a later implementation may delegate to {@link CacheTopology},
+ * {@link CachePlacementAdmissionPolicy}, and one or more {@link CacheEngine} instances.
+ * </p>
+ * <p>
+ * Normal HBase read and write path code should depend on this interface rather than accessing
+ * {@link CacheTopology} or {@link CacheEngine} directly. Direct access to topology or engines is
+ * reserved for cache assembly, topology execution, policy code, diagnostics, and tests. This keeps
+ * placement, admission, representation, promotion, and engine-specific behavior outside of HFile
+ * read/write logic.
+ * </p>
+ * <p>
+ * This interface intentionally does not expose methods such as victim-cache wiring, backing-map
+ * inspection, per-engine iterators, file fully-cached diagnostics, or BucketCache-specific helper
+ * methods. Those concerns belong in lower-level engine APIs, topology views, metrics, or admin
+ * tooling rather than the main read/write path abstraction.
+ * </p>
+ */
+@InterfaceAudience.Private
+public interface CacheAccessService {
+
+  /**
+   * Returns a human-readable name for this cache access service instance.
+   * <p>
+   * The name is intended for logging, metrics, diagnostics, and configuration reporting. For a
+   * legacy adapter this may be derived from the wrapped cache. For a topology-backed service it may
+   * identify the configured topology or service implementation.
+   * </p>
+   * @return service name
+   */
+  String getName();
+
+  /**
+   * Fetches a block from the cache.
+   * <p>
+   * This is the main read-path lookup method. The supplied {@link CacheRequestContext} carries
+   * caller intent that used to be passed as individual boolean arguments to {@code BlockCache},
+   * such as whether caching is enabled for this request, whether this lookup is a repeated lookup
+   * for the same logical request, and whether cache metrics should be updated.
+   * </p>
+   * <p>
+   * The service is responsible for preserving the current HBase lookup semantics. A legacy
+   * implementation may translate this call directly to {@code BlockCache#getBlock}. A future
+   * topology-backed implementation may route the lookup through {@link CacheTopology}, apply
+   * hit-driven promotion decisions, and aggregate metrics across engines.
+   * </p>
+   * @param cacheKey block to fetch
+   * @param context  cache request context
+   * @return cached block, or {@code null} if not present
+   */
+  Cacheable getBlock(BlockCacheKey cacheKey, CacheRequestContext context);
+
+  /**
+   * Fetches a block from the cache using explicit lookup flags.
+   * <p>
+   * This compatibility helper mirrors the current {@code BlockCache#getBlock} call shape and builds
+   * a {@link CacheRequestContext} before delegating to
+   * {@link #getBlock(BlockCacheKey, CacheRequestContext)}. New call sites should prefer the context
+   * based method directly.
+   * </p>
+   * @param cacheKey           block to fetch
+   * @param caching            whether caching is enabled for the request; used for metrics
+   * @param repeat             whether this is a repeated lookup for the same logical request
+   * @param updateCacheMetrics whether cache metrics should be updated
+   * @return cached block, or {@code null} if not present
+   */
+  default Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
+    boolean updateCacheMetrics) {
+    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(caching)
+      .setRepeat(repeat).setUpdateCacheMetrics(updateCacheMetrics).build();
+    return getBlock(cacheKey, context);
+  }
+
+  /**
+   * Fetches a block from the cache using explicit lookup flags and a block type hint.
+   * <p>
+   * This compatibility helper mirrors the current {@code BlockCache#getBlock} overload that accepts
+   * a {@link BlockType}. The block type is a lookup hint and must not be treated as part of the
+   * cache key.
+   * </p>
+   * @param cacheKey           block to fetch
+   * @param caching            whether caching is enabled for the request; used for metrics
+   * @param repeat             whether this is a repeated lookup for the same logical request
+   * @param updateCacheMetrics whether cache metrics should be updated
+   * @param blockType          optional block type hint
+   * @return cached block, or {@code null} if not present
+   */
+  default Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
+    boolean updateCacheMetrics, BlockType blockType) {
+    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(caching)
+      .setRepeat(repeat).setUpdateCacheMetrics(updateCacheMetrics).setBlockType(blockType).build();
+    return getBlock(cacheKey, context);
+  }
+
+  /**
+   * Adds a block to the cache.
+   * <p>
+   * This is the main write-side cache population method. The supplied {@link CacheWriteContext}
+   * identifies the source and intent of the insertion, for example read-miss population, flush
+   * output, compaction output, prefetch, or promotion. Existing {@code CacheConfig} logic should
+   * decide whether cache population should be attempted before this method is called.
+   * </p>
+   * <p>
+   * A legacy implementation may translate this call directly to {@code BlockCache#cacheBlock}. A
+   * future topology-backed implementation may first ask {@link CachePlacementAdmissionPolicy} for
+   * admission, tier placement, and representation decisions, then execute the selected operation
+   * through {@link CacheTopology} and its engines.
+   * </p>
+   * @param cacheKey block cache key
+   * @param block    block contents
+   * @param context  cache write context
+   */
+  void cacheBlock(BlockCacheKey cacheKey, Cacheable block, CacheWriteContext context);
+
+  /**
+   * Adds a block to the cache using explicit insertion flags.
+   * <p>
+   * This compatibility helper mirrors the current {@code BlockCache#cacheBlock} call shape and
+   * builds a {@link CacheWriteContext} before delegating to
+   * {@link #cacheBlock(BlockCacheKey, Cacheable, CacheWriteContext)}. New call sites should prefer
+   * the context based method directly.
+   * </p>
+   * @param cacheKey block cache key
+   * @param block    block contents
+   * @param inMemory whether the block should be treated as in-memory
+   */
+  default void cacheBlock(BlockCacheKey cacheKey, Cacheable block, boolean inMemory) {
+    CacheWriteContext context = CacheWriteContext.newBuilder().setInMemory(inMemory).build();
+    cacheBlock(cacheKey, block, context);
+  }
+
+  /**
+   * Adds a block to the cache using explicit insertion flags.
+   * <p>
+   * This compatibility helper mirrors the current {@code BlockCache#cacheBlock} overload that
+   * carries {@code waitWhenCache}. The flag is useful for asynchronous cache backends such as
+   * BucketCache. New call sites should prefer the context based method directly.
+   * </p>
+   * @param cacheKey      block cache key
+   * @param block         block contents
+   * @param inMemory      whether the block should be treated as in-memory
+   * @param waitWhenCache whether to wait for the cache operation to be accepted/flushed
+   */
+  default void cacheBlock(BlockCacheKey cacheKey, Cacheable block, boolean inMemory,
+    boolean waitWhenCache) {
+    CacheWriteContext context =
+      CacheWriteContext.newBuilder().setInMemory(inMemory).setWaitWhenCache(waitWhenCache).build();
+    cacheBlock(cacheKey, block, context);
+  }
+
+  /**
+   * Adds a block to the cache, defaulting to non in-memory treatment.
+   * <p>
+   * This compatibility helper mirrors {@code BlockCache#cacheBlock(BlockCacheKey, Cacheable)}.
+   * </p>
+   * @param cacheKey block cache key
+   * @param block    block contents
+   */
+  default void cacheBlock(BlockCacheKey cacheKey, Cacheable block) {
+    cacheBlock(cacheKey, block, CacheWriteContext.newBuilder().build());
+  }
+
+  /**
+   * Explicitly removes a single block from the cache.
+   * <p>
+   * This method represents caller-requested invalidation/removal. It is not the normal replacement
+   * path used by a cache implementation under capacity pressure. A service implementation should
+   * propagate this operation to the appropriate topology or underlying cache implementation.
+   * </p>
+   * @param cacheKey block to remove
+   * @return {@code true} if the block existed and was removed, {@code false} otherwise
+   */
+  boolean evictBlock(BlockCacheKey cacheKey);
+
+  /**
+   * Explicitly removes all cached blocks for the given HFile.
+   * <p>
+   * This method is used for file-scoped invalidation during HFile lifecycle events. The method name
+   * intentionally follows the existing {@code BlockCache} API for migration compatibility, although
+   * the operation is better understood as explicit invalidation rather than replacement eviction.
+   * </p>
+   * @param hfileName HFile name
+   * @return number of blocks removed
+   */
+  int evictBlocksByHfileName(String hfileName);
+
+  /**
+   * Explicitly removes cached blocks for the given HFile within the specified offset range.
+   * <p>
+   * This optional method mirrors the storage-oriented range invalidation support in
+   * {@link CacheEngine}. Implementations that cannot perform efficient range invalidation may
+   * return {@code 0}. Callers must not rely on this method for correctness unless the specific
+   * service implementation documents support for it.
+   * </p>
+   * @param hfileName  HFile name
+   * @param initOffset inclusive start offset
+   * @param endOffset  inclusive end offset
+   * @return number of blocks removed
+   */
+  default int evictBlocksRangeByHfileName(String hfileName, long initOffset, long endOffset) {
+    return 0;
+  }
+
+  /**
+   * Explicitly removes cached blocks associated with the specified region.
+   * <p>
+   * This optional method supports region-scoped invalidation without requiring callers to enumerate
+   * files first. Implementations that cannot perform efficient region invalidation may return
+   * {@code 0}. Callers must not rely on this method for correctness unless the specific service
+   * implementation documents support for it.
+   * </p>
+   * @param regionName region name
+   * @return number of blocks removed
+   */
+  default int evictBlocksByRegionName(String regionName) {
+    return 0;
+  }
+
+  /**
+   * Returns aggregate cache statistics visible at the service level.
+   * <p>
+   * For a legacy adapter this may be the statistics object from the wrapped cache. For a
+   * topology-backed implementation this should represent aggregate statistics across all engines in
+   * the topology, preserving the semantics expected by existing HBase metrics and callers.
+   * </p>
+   * @return cache statistics
+   */
+  CacheStats getStats();
+
+  /**
+   * Shuts down the cache access service and releases owned resources.
+   * <p>
+   * A service implementation should also shut down any underlying topology, engines, or wrapped
+   * legacy cache it owns. If the service does not own the underlying cache lifecycle, the
+   * implementation should document that behavior.
+   * </p>
+   */
+  void shutdown();
+
+  /**
+   * Returns the maximum configured cache size visible through this service, in bytes.
+   * <p>
+   * For a topology-backed service this should normally be the aggregate configured capacity of the
+   * participating engines, unless the topology has a different externally visible capacity model.
+   * </p>
+   * @return maximum cache size
+   */
+  long getMaxSize();
+
+  /**
+   * Returns the amount of free cache space visible through this service, in bytes.
+   * <p>
+   * Free space may not always be exactly {@code getMaxSize() - size()} because engines may have
+   * fragmentation, reserved capacity, asynchronous insertion queues, or topology-specific capacity
+   * rules.
+   * </p>
+   * @return free size
+   */
+  long getFreeSize();
+
+  /**
+   * Returns the currently occupied cache size visible through this service, in bytes.
+   * <p>
+   * The method name follows the existing {@code BlockCache} and {@link CacheEngine} shape for
+   * migration compatibility.
+   * </p>
+   * @return occupied cache size
+   */
+  long size();
+
+  /**
+   * Returns the currently occupied size of cached data blocks, in bytes.
+   * <p>
+   * This is an aggregate service-level value. Implementations that cannot distinguish data-block
+   * occupancy should return the best value available from the underlying cache implementation.
+   * </p>
+   * @return occupied data-block size
+   */
+  long getCurrentDataSize();
+
+  /**
+   * Returns the total number of cached blocks visible through this service.
+   * @return total block count
+   */
+  long getBlockCount();
+
+  /**
+   * Returns the number of cached data blocks visible through this service.
+   * @return data block count
+   */
+  long getDataBlockCount();
+
+  /**
+   * Checks whether the given block can fit into the cache represented by this service.
+   * <p>
+   * This method is optional and exists primarily for migration compatibility with existing cache
+   * call sites. It should not be used as a general admission policy API. Admission and placement
+   * decisions belong to {@link CachePlacementAdmissionPolicy} in the topology-backed architecture.
+   * </p>
+   * @param block block to check
+   * @return empty if unsupported; otherwise whether the block fits
+   */
+  default Optional<Boolean> blockFitsIntoTheCache(HFileBlock block) {
+    return Optional.empty();
+  }
+
+  /**
+   * Checks whether the block represented by the given key is already cached.
+   * <p>
+   * This method is optional and exists primarily for migration compatibility and diagnostics. It is
+   * not required for the normal read/write path because callers should use
+   * {@link #getBlock(BlockCacheKey, CacheRequestContext)} for lookup.
+   * </p>
+   * @param key block cache key
+   * @return empty if unsupported; otherwise whether the block is cached
+   */
+  default Optional<Boolean> isAlreadyCached(BlockCacheKey key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the size of the cached block represented by the given key.
+   * <p>
+   * This method is optional because not all implementations expose per-block size cheaply. It is
+   * not part of the normal hot-path lookup contract.
+   * </p>
+   * @param key block cache key
+   * @return empty if unsupported or not present; otherwise cached block size
+   */
+  default Optional<Integer> getBlockSize(BlockCacheKey key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns whether cache access is enabled.
+   * <p>
+   * Implementations may override this when cache availability is controlled by initialization
+   * state, configuration, or a wrapped legacy cache. The default assumes the service is enabled.
+   * </p>
+   * @return {@code true} if enabled, {@code false} otherwise
+   */
+  default boolean isCacheEnabled() {
+    return true;
+  }
+
+  /**
+   * Waits for asynchronous cache initialization to complete.
+   * <p>
+   * Some cache implementations, especially those backed by persistent or asynchronous engines, may
+   * require initialization before they should be used. Services that do not require asynchronous
+   * initialization may return {@code true} immediately.
+   * </p>
+   * @param timeout maximum time to wait
+   * @return {@code true} if the cache is enabled and ready, {@code false} otherwise
+   */
+  default boolean waitForCacheInitialization(long timeout) {
+    return true;
+  }
+
+  /**
+   * Refreshes this service's configuration.
+   * <p>
+   * A service implementation may propagate this notification to the wrapped legacy cache, topology,
+   * policy, or engines. The default implementation is a no-op.
+   * </p>
+   * @param config new configuration
+   */
+  default void onConfigurationChange(Configuration config) {
+    // noop
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.io.hfile.cache;
 
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
@@ -418,6 +419,29 @@ public interface CacheAccessService {
    * @param config new configuration
    */
   default void onConfigurationChange(Configuration config) {
+    // noop
+  }
+
+  /**
+   * Notifies the cache service that cache population for an HFile has completed.
+   * <p>
+   * This callback is used for file-level cache lifecycle notifications. Some cache implementations
+   * may use it to finalize file-scoped metadata, update fully-cached-file tracking, publish cache
+   * population statistics, or trigger implementation-specific bookkeeping after a writer/prefetcher
+   * has finished caching blocks for an HFile.
+   * </p>
+   * <p>
+   * The default implementation is a no-op because not all cache implementations need
+   * file-completion notifications. Callers may invoke this method unconditionally after file-level
+   * cache population completes.
+   * </p>
+   * @param fileName        path of the HFile whose cache population completed
+   * @param totalBlockCount total number of cached blocks for the file
+   * @param dataBlockCount  number of cached data blocks for the file
+   * @param size            total cached size for the file, in bytes
+   */
+  default void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
+    long size) {
     // noop
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessService.java
@@ -22,6 +22,7 @@ import java.util.Optional;
 import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.conf.ConfigurationObserver;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
@@ -73,7 +74,7 @@ import org.apache.yetus.audience.InterfaceAudience;
  * </p>
  */
 @InterfaceAudience.Private
-public interface CacheAccessService {
+public interface CacheAccessService extends ConfigurationObserver {
 
   /**
    * Returns a human-readable name for this cache access service instance.
@@ -326,6 +327,12 @@ public interface CacheAccessService {
   long size();
 
   /**
+   * Returns the occupied size of the block cache, in bytes.
+   * @return occupied space in cache, in bytes
+   */
+  long getCurrentSize();
+
+  /**
    * Returns the currently occupied size of cached data blocks, in bytes.
    * <p>
    * This is an aggregate service-level value. Implementations that cannot distinguish data-block
@@ -422,6 +429,7 @@ public interface CacheAccessService {
    * </p>
    * @param config new configuration
    */
+  @Override
   default void onConfigurationChange(Configuration config) {
     // noop
   }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServices.java
@@ -18,7 +18,9 @@
 package org.apache.hadoop.hbase.io.hfile.cache;
 
 import java.util.Objects;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.hfile.BlockCache;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheFactory;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -54,6 +56,35 @@ public final class CacheAccessServices {
   public static CacheAccessService fromBlockCache(BlockCache blockCache) {
     return new BlockCacheBackedCacheAccessService(
       Objects.requireNonNull(blockCache, "blockCache must not be null"));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} from the block cache configuration.
+   * <p>
+   * This method is a compatibility factory for tests and transitional code paths that want to
+   * obtain a {@link CacheAccessService} directly from {@link Configuration}, while still using the
+   * existing {@link BlockCacheFactory} and legacy {@link BlockCache} implementations underneath.
+   * </p>
+   * <p>
+   * The method delegates block-cache construction to
+   * {@link BlockCacheFactory#createBlockCache(Configuration)}. If the legacy factory creates a
+   * {@link BlockCache}, the returned service is backed by that cache through
+   * {@link BlockCacheBackedCacheAccessService}. If the legacy factory does not create a cache, this
+   * method returns the disabled/no-op cache access service.
+   * </p>
+   * <p>
+   * This method does not introduce new cache-engine or topology-based runtime wiring. It is
+   * intended only as a bridge while existing HBase tests and integration paths migrate from direct
+   * {@link BlockCache} usage to {@link CacheAccessService}.
+   * </p>
+   * @param conf configuration used by {@link BlockCacheFactory}
+   * @return cache access service created from the configured legacy block cache, or disabled when
+   *         no block cache is configured
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessService fromConfiguration(Configuration conf) {
+    Objects.requireNonNull(conf, "conf must not be null");
+    return fromBlockCache(BlockCacheFactory.createBlockCache(conf));
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServices.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Objects;
+import org.apache.hadoop.hbase.io.hfile.BlockCache;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Utility methods for creating {@link CacheAccessService} instances.
+ * <p>
+ * This class keeps service construction centralized without introducing a full factory or plugin
+ * loader in the initial {@code CacheAccessService} ticket. The first supported construction modes
+ * are a legacy {@link BlockCache}-backed service, a topology-backed service, and a disabled no-op
+ * service.
+ * </p>
+ * <p>
+ * A later integration step can move construction into {@code BlockCacheFactory} once HBase runtime
+ * wiring starts returning {@link CacheAccessService} instead of, or alongside, raw
+ * {@link BlockCache}.
+ * </p>
+ */
+@InterfaceAudience.Private
+public final class CacheAccessServices {
+
+  private CacheAccessServices() {
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by an existing {@link BlockCache}.
+   * <p>
+   * This is the default compatibility path during migration from {@code BlockCache} to
+   * {@code CacheAccessService}. The returned service delegates to the supplied block cache and
+   * should preserve existing behavior.
+   * </p>
+   * @param blockCache block cache to wrap
+   * @return cache access service backed by {@code blockCache}
+   */
+  public static CacheAccessService fromBlockCache(BlockCache blockCache) {
+    return new BlockCacheBackedCacheAccessService(
+      Objects.requireNonNull(blockCache, "blockCache must not be null"));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by a {@link CacheTopology} and placement/admission
+   * policy.
+   * <p>
+   * The returned service uses the topology to resolve participating tiers and engines, uses the
+   * policy to make admission, placement, representation, and promotion decisions, and executes
+   * storage operations through {@link CacheEngine}.
+   * </p>
+   * @param topology cache topology
+   * @param policy   placement and admission policy
+   * @return topology-backed cache access service
+   */
+  public static CacheAccessService fromTopology(CacheTopology topology,
+    CachePlacementAdmissionPolicy policy) {
+    return new TopologyBackedCacheAccessService(
+      Objects.requireNonNull(topology, "topology must not be null"),
+      Objects.requireNonNull(policy, "policy must not be null"));
+  }
+
+  /**
+   * Creates a disabled no-op {@link CacheAccessService}.
+   * <p>
+   * The returned service never stores blocks and always reports zero capacity and occupancy. It is
+   * useful for callers that prefer a non-null service object even when block cache is disabled.
+   * </p>
+   * @return disabled no-op cache access service
+   */
+  public static CacheAccessService disabled() {
+    return new NoOpCacheAccessService();
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServices.java
@@ -18,9 +18,11 @@
 package org.apache.hadoop.hbase.io.hfile.cache;
 
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheFactory;
+import org.apache.hadoop.hbase.io.hfile.CachedBlock;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -117,4 +119,26 @@ public final class CacheAccessServices {
   public static CacheAccessService disabled() {
     return new NoOpCacheAccessService();
   }
+
+  /**
+   * Returns an iterable cached-block view for the supplied cache access service when available.
+   * <p>
+   * Cached-block iteration is intended for tests, diagnostics, and admin views only. It must not be
+   * used by normal read/write paths. Not every {@link CacheAccessService} implementation is
+   * required to expose cached-block iteration.
+   * </p>
+   * @param cacheAccessService cache access service
+   * @return optional iterable cached-block view
+   * @throws NullPointerException if {@code cacheAccessService} is {@code null}
+   */
+  @SuppressWarnings("unchecked")
+  public static Optional<Iterable<CachedBlock>>
+    asCachedBlockIterable(CacheAccessService cacheAccessService) {
+    Objects.requireNonNull(cacheAccessService, "cacheAccessService must not be null");
+    if (cacheAccessService instanceof Iterable) {
+      return Optional.of((Iterable<CachedBlock>) cacheAccessService);
+    }
+    return Optional.empty();
+  }
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheEngine.java
@@ -1,0 +1,292 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Storage abstraction for a concrete HBase block cache backend.
+ * <p>
+ * A {@code CacheEngine} represents the storage layer only. It is responsible for storing,
+ * retrieving, invalidating, and reporting statistics for cached blocks. It does not perform tier
+ * orchestration, admission control, placement decisions, or promotion/demotion across cache levels.
+ * </p>
+ * <p>
+ * This interface is intentionally aligned with the storage-oriented subset of the current
+ * {@code BlockCache} contract so that existing implementations such as LruBlockCache and
+ * BucketCache can be migrated incrementally with minimal behavioral risk.
+ * </p>
+ * <p>
+ * Responsibilities of a {@code CacheEngine} include:
+ * </p>
+ * <ul>
+ * <li>block lookup</li>
+ * <li>block insertion</li>
+ * <li>targeted invalidation / eviction</li>
+ * <li>capacity and occupancy reporting</li>
+ * <li>engine-local statistics</li>
+ * <li>optional implementation-specific fit/capability checks</li>
+ * </ul>
+ * <p>
+ * Non-responsibilities include:
+ * </p>
+ * <ul>
+ * <li>L1/L2 topology orchestration</li>
+ * <li>admission policy</li>
+ * <li>tier placement decisions</li>
+ * <li>promotion or demotion across tiers</li>
+ * </ul>
+ */
+@InterfaceAudience.Private
+public interface CacheEngine {
+
+  /**
+   * Returns a human-readable name for this cache engine instance.
+   * <p>
+   * The name is intended for logging, metrics, diagnostics, and configuration reporting. It should
+   * be stable for the lifetime of the engine instance.
+   * </p>
+   * @return engine name
+   */
+  String getName();
+
+  /**
+   * Adds a block to the cache.
+   * @param cacheKey block cache key
+   * @param buf      block contents
+   * @param inMemory whether the block should be treated as in-memory
+   */
+  void cacheBlock(BlockCacheKey cacheKey, Cacheable buf, boolean inMemory);
+
+  /**
+   * Adds a block to the cache, optionally waiting for asynchronous cache backends.
+   * <p>
+   * This is primarily useful for implementations such as BucketCache that may buffer writes
+   * asynchronously.
+   * </p>
+   * @param cacheKey      block cache key
+   * @param buf           block contents
+   * @param inMemory      whether the block should be treated as in-memory
+   * @param waitWhenCache whether to wait for the cache operation to be accepted/flushed
+   */
+  default void cacheBlock(BlockCacheKey cacheKey, Cacheable buf, boolean inMemory,
+    boolean waitWhenCache) {
+    cacheBlock(cacheKey, buf, inMemory);
+  }
+
+  /**
+   * Adds a block to the cache, defaulting to non in-memory treatment.
+   * @param cacheKey block cache key
+   * @param buf      block contents
+   */
+  void cacheBlock(BlockCacheKey cacheKey, Cacheable buf);
+
+  /**
+   * Fetches a block from the cache.
+   * @param cacheKey           block to fetch
+   * @param caching            whether caching is enabled for the request; used for metrics
+   * @param repeat             whether this is a repeated lookup for the same block; used to avoid
+   *                           double-counting misses
+   * @param updateCacheMetrics whether cache metrics should be updated
+   * @return cached block, or {@code null} if not present
+   */
+  Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
+    boolean updateCacheMetrics);
+
+  /**
+   * Fetches a block from the cache with an optional block type hint.
+   * <p>
+   * Implementations may ignore the block type if it is not needed.
+   * </p>
+   * @param cacheKey           block to fetch
+   * @param caching            whether caching is enabled for the request; used for metrics
+   * @param repeat             whether this is a repeated lookup for the same block; used to avoid
+   *                           double-counting misses
+   * @param updateCacheMetrics whether cache metrics should be updated
+   * @param blockType          optional block type hint
+   * @return cached block, or {@code null} if not present
+   */
+  default Cacheable getBlock(BlockCacheKey cacheKey, boolean caching, boolean repeat,
+    boolean updateCacheMetrics, BlockType blockType) {
+    return getBlock(cacheKey, caching, repeat, updateCacheMetrics);
+  }
+
+  /**
+   * Evicts a single block from the cache.
+   * @param cacheKey block to evict
+   * @return {@code true} if the block existed and was evicted, {@code false} otherwise
+   */
+  boolean evictBlock(BlockCacheKey cacheKey);
+
+  /**
+   * Evicts all cached blocks for the given HFile.
+   * @param hfileName HFile name
+   * @return number of blocks evicted
+   */
+  int evictBlocksByHfileName(String hfileName);
+
+  /**
+   * Evicts all cached blocks for the given HFile within the specified offset range.
+   * <p>
+   * This is useful for targeted invalidation during file lifecycle events where only a subset of
+   * blocks should be removed.
+   * </p>
+   * @param hfileName  HFile name
+   * @param initOffset inclusive start offset
+   * @param endOffset  inclusive end offset
+   * @return number of blocks evicted
+   */
+  default int evictBlocksRangeByHfileName(String hfileName, long initOffset, long endOffset) {
+    return 0;
+  }
+
+  /**
+   * Evicts all cached blocks associated with the specified region.
+   * <p>
+   * This is a new API intended to support region-scoped invalidation in a storage-oriented way,
+   * without requiring higher-level code to enumerate files first.
+   * </p>
+   * @param regionName region name
+   * @return number of blocks evicted
+   */
+  default int evictBlocksByRegionName(String regionName) {
+    return 0;
+  }
+
+  /**
+   * Returns engine statistics.
+   * @return cache statistics
+   */
+  CacheStats getStats();
+
+  /**
+   * Shuts down this cache engine and releases any owned resources.
+   */
+  void shutdown();
+
+  /**
+   * Returns the maximum configured cache size, in bytes.
+   * @return maximum cache size
+   */
+  long getMaxSize();
+
+  /**
+   * Returns the amount of free space available in the cache, in bytes.
+   * @return free size
+   */
+  long getFreeSize();
+
+  /**
+   * Returns the currently occupied cache size, in bytes.
+   * @return occupied size
+   */
+  long size();
+
+  /**
+   * Returns the currently occupied size of data blocks, in bytes.
+   * @return occupied data-block size
+   */
+  long getCurrentDataSize();
+
+  /**
+   * Returns the total number of cached blocks.
+   * @return total block count
+   */
+  long getBlockCount();
+
+  /**
+   * Returns the number of cached data blocks.
+   * @return data block count
+   */
+  long getDataBlockCount();
+
+  /**
+   * Checks whether the given block can fit into this cache engine.
+   * <p>
+   * This method is optional because not all engines expose a meaningful fit check.
+   * </p>
+   * @param block block to check
+   * @return empty if unsupported; otherwise whether the block fits
+   */
+  default Optional<Boolean> blockFitsIntoTheCache(HFileBlock block) {
+    return Optional.empty();
+  }
+
+  /**
+   * Checks whether the block represented by the given key is already cached.
+   * <p>
+   * This method is optional because not all engines can answer it efficiently.
+   * </p>
+   * @param key block cache key
+   * @return empty if unsupported; otherwise whether the block is cached
+   */
+  default Optional<Boolean> isAlreadyCached(BlockCacheKey key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns the size of the cached block represented by the given key.
+   * <p>
+   * This method is optional because not all engines expose per-block size cheaply.
+   * </p>
+   * @param key block cache key
+   * @return empty if unsupported or not present; otherwise cached block size
+   */
+  default Optional<Integer> getBlockSize(BlockCacheKey key) {
+    return Optional.empty();
+  }
+
+  /**
+   * Returns whether this cache engine is enabled.
+   * @return {@code true} if enabled, {@code false} otherwise
+   */
+  default boolean isCacheEnabled() {
+    return true;
+  }
+
+  /**
+   * Waits for asynchronous engine initialization to complete.
+   * <p>
+   * Some cache backends may perform initialization asynchronously. Engines that do not require this
+   * may simply return {@code true} immediately.
+   * </p>
+   * @param timeout maximum time to wait
+   * @return {@code true} if the cache is enabled, {@code false} otherwise
+   */
+  default boolean waitForCacheInitialization(long timeout) {
+    return true;
+  }
+
+  /**
+   * Refreshes this engine's configuration.
+   * <p>
+   * The default implementation is a no-op.
+   * </p>
+   * @param config new configuration
+   */
+  default void onConfigurationChange(Configuration config) {
+    // noop
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheEngine.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.io.hfile.cache;
 
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
@@ -287,6 +288,18 @@ public interface CacheEngine {
    * @param config new configuration
    */
   default void onConfigurationChange(Configuration config) {
+    // noop
+  }
+
+  /**
+   * Notifies the cache service that cache population for an HFile has completed.
+   * @param fileName        path of the HFile whose cache population completed
+   * @param totalBlockCount total number of cached blocks for the file
+   * @param dataBlockCount  number of cached data blocks for the file
+   * @param size            total cached size for the file, in bytes
+   */
+  default void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
+    long size) {
     // noop
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheEngineView.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheEngineView.java
@@ -1,0 +1,89 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Default read-only view over a {@link CacheEngine}.
+ */
+@InterfaceAudience.Private
+public final class CacheEngineView {
+
+  private final CacheEngine engine;
+
+  /** Create a new view over the given cache engine. */
+
+  CacheEngineView(CacheEngine engine) {
+    this.engine = engine;
+  }
+
+  /* Getters for cache engine properties. */
+  /**
+   * Returns the name of the cache engine.
+   * @return the name of the cache engine
+   */
+  public String getName() {
+    return engine.getName();
+  }
+
+  /**
+   * Returns the maximum size of the cache in bytes.
+   * @return the maximum size of the cache in bytes
+   */
+  public long getMaxSize() {
+    return engine.getMaxSize();
+  }
+
+  /**
+   * Returns the current size of the cache in bytes.
+   * @return the current size of the cache in bytes
+   */
+  public long size() {
+    return engine.size();
+  }
+
+  /**
+   * Returns the free size of the cache in bytes.
+   * @return the free size of the cache in bytes
+   */
+  public long getFreeSize() {
+    return engine.getFreeSize();
+  }
+
+  /**
+   * Returns the number of blocks currently stored in the cache.
+   * @return the number of blocks currently stored in the cache
+   */
+  public long getBlockCount() {
+    return engine.getBlockCount();
+  }
+
+  /**
+   * Is engine able to store this block.
+   * @return true - if yes, false - otherwise
+   */
+  public boolean canStore(Cacheable block) {
+    if (block instanceof HFileBlock) {
+      return engine.blockFitsIntoTheCache((HFileBlock) block).orElse(true);
+    }
+    return true;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CachePlacementAdmissionPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CachePlacementAdmissionPolicy.java
@@ -1,0 +1,88 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Policy interface for cache admission, tier placement, representation, and promotion.
+ * <p>
+ * This policy decides what should happen for a cache operation. It does not execute cache
+ * operations directly. Execution belongs to {@link CacheTopology} and storage belongs to
+ * {@link CacheEngine}.
+ * </p>
+ * <p>
+ * The policy may consult {@link CacheTopologyView} to inspect available tiers and engine capacity,
+ * but it must not mutate cache state.
+ * </p>
+ */
+@InterfaceAudience.Private
+public interface CachePlacementAdmissionPolicy {
+
+  /**
+   * Decides whether a block should be admitted into the cache.
+   * @param cacheKey     block cache key
+   * @param block        block to cache
+   * @param context      write context describing insertion source and hints
+   * @param priority     admission priority hint
+   * @param topologyView read-only topology view
+   * @return admission decision
+   */
+  AdmissionDecision shouldAdmit(BlockCacheKey cacheKey, Cacheable block, CacheWriteContext context,
+    AdmissionPriority priority, CacheTopologyView topologyView);
+
+  /**
+   * Selects the target tier for an admitted block.
+   * @param cacheKey     block cache key
+   * @param block        block to cache
+   * @param context      write context describing insertion source and hints
+   * @param topologyView read-only topology view
+   * @return tier decision
+   */
+  TierDecision selectTier(BlockCacheKey cacheKey, Cacheable block, CacheWriteContext context,
+    CacheTopologyView topologyView);
+
+  /**
+   * Selects the cached representation for an admitted block.
+   * <p>
+   * The initial compatibility policy should preserve the representation currently produced by
+   * existing HBase code paths.
+   * </p>
+   * @param cacheKey     block cache key
+   * @param block        block to cache
+   * @param context      write context describing insertion source and hints
+   * @param topologyView read-only topology view
+   * @return representation decision
+   */
+  RepresentationDecision selectRepresentation(BlockCacheKey cacheKey, Cacheable block,
+    CacheWriteContext context, CacheTopologyView topologyView);
+
+  /**
+   * Decides whether a cache hit should trigger promotion to another tier.
+   * @param cacheKey     block cache key
+   * @param block        cached block
+   * @param sourceTier   tier where the block was found
+   * @param context      read request context
+   * @param topologyView read-only topology view
+   * @return promotion decision
+   */
+  PromotionDecision shouldPromote(BlockCacheKey cacheKey, Cacheable block, CacheTier sourceTier,
+    CacheRequestContext context, CacheTopologyView topologyView);
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheRequestContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheRequestContext.java
@@ -1,0 +1,187 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Context for cache lookup.
+ * <p>
+ * This object carries read-path cache lookup intent. It mirrors the existing low-allocation
+ * BlockCache request parameters while allowing future call sites to pass structured context.
+ * </p>
+ */
+@InterfaceAudience.Private
+public final class CacheRequestContext {
+
+  private final boolean caching;
+  private final boolean repeat;
+  private final boolean updateCacheMetrics;
+  private final BlockType blockType;
+  private final boolean compaction;
+  private final boolean prefetch;
+
+  private CacheRequestContext(Builder builder) {
+    this.caching = builder.caching;
+    this.repeat = builder.repeat;
+    this.updateCacheMetrics = builder.updateCacheMetrics;
+    this.blockType = builder.blockType;
+    this.compaction = builder.compaction;
+    this.prefetch = builder.prefetch;
+  }
+
+  /**
+   * Creates a new builder.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns whether caching is enabled for this request.
+   * @return true when caching is enabled
+   */
+  public boolean isCaching() {
+    return caching;
+  }
+
+  /**
+   * Returns whether this is a repeated lookup for the same block.
+   * @return true when this is a repeated lookup
+   */
+  public boolean isRepeat() {
+    return repeat;
+  }
+
+  /**
+   * Returns whether cache metrics should be updated.
+   * @return true when metrics should be updated
+   */
+  public boolean isUpdateCacheMetrics() {
+    return updateCacheMetrics;
+  }
+
+  /**
+   * Returns the expected block type, if known.
+   * @return block type, or null if unknown
+   */
+  public BlockType getBlockType() {
+    return blockType;
+  }
+
+  /**
+   * Returns whether this request is associated with compaction.
+   * @return true when compaction-related
+   */
+  public boolean isCompaction() {
+    return compaction;
+  }
+
+  /**
+   * Returns whether this request is associated with prefetch.
+   * @return true when prefetch-related
+   */
+  public boolean isPrefetch() {
+    return prefetch;
+  }
+
+  /**
+   * Builder for {@link CacheRequestContext}.
+   */
+  public static final class Builder {
+
+    private boolean caching;
+    private boolean repeat;
+    private boolean updateCacheMetrics = true;
+    private BlockType blockType;
+    private boolean compaction;
+    private boolean prefetch;
+
+    private Builder() {
+    }
+
+    /**
+     * Sets whether caching is enabled.
+     * @param caching true when caching is enabled
+     * @return this builder
+     */
+    public Builder setCaching(boolean caching) {
+      this.caching = caching;
+      return this;
+    }
+
+    /**
+     * Sets repeated-lookup status.
+     * @param repeat true when this is a repeated lookup
+     * @return this builder
+     */
+    public Builder setRepeat(boolean repeat) {
+      this.repeat = repeat;
+      return this;
+    }
+
+    /**
+     * Sets whether cache metrics should be updated.
+     * @param updateCacheMetrics true when metrics should be updated
+     * @return this builder
+     */
+    public Builder setUpdateCacheMetrics(boolean updateCacheMetrics) {
+      this.updateCacheMetrics = updateCacheMetrics;
+      return this;
+    }
+
+    /**
+     * Sets the expected block type.
+     * @param blockType expected block type
+     * @return this builder
+     */
+    public Builder setBlockType(BlockType blockType) {
+      this.blockType = blockType;
+      return this;
+    }
+
+    /**
+     * Sets compaction request status.
+     * @param compaction true when compaction-related
+     * @return this builder
+     */
+    public Builder setCompaction(boolean compaction) {
+      this.compaction = compaction;
+      return this;
+    }
+
+    /**
+     * Sets prefetch request status.
+     * @param prefetch true when prefetch-related
+     * @return this builder
+     */
+    public Builder setPrefetch(boolean prefetch) {
+      this.prefetch = prefetch;
+      return this;
+    }
+
+    /**
+     * Builds the context.
+     * @return cache request context
+     */
+    public CacheRequestContext build() {
+      return new CacheRequestContext(this);
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheRequestContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheRequestContext.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.io.hfile.cache;
 
+import java.util.Optional;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
 import org.apache.yetus.audience.InterfaceAudience;
 
@@ -79,10 +80,10 @@ public final class CacheRequestContext {
 
   /**
    * Returns the expected block type, if known.
-   * @return block type, or null if unknown
+   * @return an {@link Optional} containing the block type, or empty if unknown
    */
-  public BlockType getBlockType() {
-    return blockType;
+  public Optional<BlockType> getBlockType() {
+    return Optional.ofNullable(blockType);
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheRequestContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheRequestContext.java
@@ -122,7 +122,7 @@ public final class CacheRequestContext {
      * @param caching true when caching is enabled
      * @return this builder
      */
-    public Builder setCaching(boolean caching) {
+    public Builder withCaching(boolean caching) {
       this.caching = caching;
       return this;
     }
@@ -132,7 +132,7 @@ public final class CacheRequestContext {
      * @param repeat true when this is a repeated lookup
      * @return this builder
      */
-    public Builder setRepeat(boolean repeat) {
+    public Builder withRepeat(boolean repeat) {
       this.repeat = repeat;
       return this;
     }
@@ -142,7 +142,7 @@ public final class CacheRequestContext {
      * @param updateCacheMetrics true when metrics should be updated
      * @return this builder
      */
-    public Builder setUpdateCacheMetrics(boolean updateCacheMetrics) {
+    public Builder withUpdateCacheMetrics(boolean updateCacheMetrics) {
       this.updateCacheMetrics = updateCacheMetrics;
       return this;
     }
@@ -152,7 +152,7 @@ public final class CacheRequestContext {
      * @param blockType expected block type
      * @return this builder
      */
-    public Builder setBlockType(BlockType blockType) {
+    public Builder withBlockType(BlockType blockType) {
       this.blockType = blockType;
       return this;
     }
@@ -162,7 +162,7 @@ public final class CacheRequestContext {
      * @param compaction true when compaction-related
      * @return this builder
      */
-    public Builder setCompaction(boolean compaction) {
+    public Builder withCompaction(boolean compaction) {
       this.compaction = compaction;
       return this;
     }
@@ -172,7 +172,7 @@ public final class CacheRequestContext {
      * @param prefetch true when prefetch-related
      * @return this builder
      */
-    public Builder setPrefetch(boolean prefetch) {
+    public Builder withPrefetch(boolean prefetch) {
       this.prefetch = prefetch;
       return this;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTier.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTier.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Logical cache tier used by topology and policy code.
+ * <p>
+ * This enum describes the role an engine plays inside a topology. It is intentionally separate from
+ * {@link CacheEngineType}, which describes the implementation family of an engine.
+ * </p>
+ */
+@InterfaceAudience.Private
+public enum CacheTier {
+
+  /**
+   * Single-tier topology engine.
+   */
+  SINGLE,
+
+  /**
+   * First-level cache, usually smaller and optimized for low latency.
+   */
+  L1,
+
+  /**
+   * Second-level cache, usually larger and optimized for capacity.
+   */
+  L2
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTopology.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTopology.java
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Describes orchestration of one or more cache engines.
+ * <p>
+ * {@code CacheTopology} is responsible for the structural relationship between cache engines, for
+ * example a single-engine cache, a tiered exclusive L1/L2 cache, or a tiered inclusive L1/L2 cache.
+ * </p>
+ * <p>
+ * This abstraction does not own storage. Storage belongs to {@link CacheEngine}. This abstraction
+ * also does not decide admission or write placement. Admission, placement, representation, and
+ * promotion decisions belong to the policy layer.
+ * </p>
+ * <p>
+ * Responsibilities of a cache topology include:
+ * </p>
+ * <ul>
+ * <li>exposing participating cache engines</li>
+ * <li>mapping engines to logical tiers such as L1 and L2</li>
+ * <li>providing aggregate cache statistics</li>
+ * <li>performing topology-specific promotion when requested by policy</li>
+ * <li>optionally performing topology-specific demotion</li>
+ * <li>coordinating shutdown of participating engines</li>
+ * </ul>
+ * <p>
+ * Non-responsibilities include:
+ * </p>
+ * <ul>
+ * <li>block storage</li>
+ * <li>local eviction algorithms</li>
+ * <li>cache admission control</li>
+ * <li>write routing / target tier selection</li>
+ * <li>HFile read/write path integration</li>
+ * </ul>
+ */
+@InterfaceAudience.Private
+public interface CacheTopology {
+
+  /**
+   * Returns a human-readable topology name.
+   * <p>
+   * The name is intended for logging, metrics, diagnostics, and configuration reporting. It should
+   * be stable for the lifetime of this topology instance.
+   * </p>
+   * @return topology name
+   */
+  String getName();
+
+  /**
+   * Returns the topology type.
+   * <p>
+   * The type identifies the topology family, such as single-engine, tiered exclusive, or tiered
+   * inclusive.
+   * </p>
+   * @return topology type
+   */
+  CacheTopologyType getType();
+
+  /**
+   * Returns the cache engines participating in this topology.
+   * <p>
+   * The returned list is primarily intended for diagnostics, metrics, and topology inspection.
+   * Callers should not use it to bypass topology and policy logic for normal cache operations.
+   * </p>
+   * @return participating cache engines
+   */
+  List<CacheEngine> getEngines();
+
+  /**
+   * Returns the logical cache tiers defined by this topology.
+   * <p>
+   * This method describes the structure of the topology in terms of {@link CacheTier} identifiers
+   * (for example, {@code SINGLE}, {@code L1}, {@code L2}). The returned list defines which tiers
+   * are present and can be used for lookup, placement, and promotion decisions.
+   * </p>
+   * <p>
+   * The ordering of tiers is significant and should reflect lookup priority (for example,
+   * {@code L1} before {@code L2}).
+   * </p>
+   * <p>
+   * This method must be explicitly implemented by each topology. Callers must not infer tier
+   * structure from {@link #getEngines()} or other properties.
+   * </p>
+   * @return ordered list of tiers defined by this topology
+   */
+  List<CacheTier> getTiers();
+
+  /**
+   * Returns the cache engine associated with the given logical tier, if one exists.
+   * <p>
+   * For example, a tiered topology may expose an L1 and L2 engine. A single-engine topology may
+   * return an engine for {@link CacheTier#SINGLE} and an empty result for L1/L2.
+   * </p>
+   * @param tier logical cache tier
+   * @return cache engine for the tier, or empty if this topology does not define that tier
+   */
+  Optional<CacheEngine> getEngine(CacheTier tier);
+
+  /**
+   * Returns aggregate topology-level cache statistics.
+   * <p>
+   * For a single-engine topology, this may simply return the underlying engine statistics. For a
+   * multi-engine topology, this should represent an aggregate view suitable for compatibility with
+   * existing HBase block cache metrics.
+   * </p>
+   * @return aggregate cache statistics
+   */
+  CacheStats getStats();
+
+  /**
+   * Promotes a cached block from one engine to another.
+   * <p>
+   * This method performs the topology-specific mechanics of promotion. The decision whether a block
+   * should be promoted belongs to the placement/admission policy layer. For example, a policy may
+   * decide that an index block found in L2 should be promoted to L1, and then call this method to
+   * perform the promotion.
+   * </p>
+   * <p>
+   * Implementations may either copy or move the block depending on topology semantics. For example:
+   * </p>
+   * <ul>
+   * <li>inclusive may copy the block into the target tier while retaining it in source</li>
+   * <li>exclusive may move the block into the target tier and remove it from source</li>
+   * </ul>
+   * @param cacheKey     block cache key
+   * @param block        cached block to promote
+   * @param sourceEngine engine where the block was found
+   * @param targetEngine engine where the block should be promoted
+   * @return {@code true} if promotion was performed, {@code false} otherwise
+   */
+  boolean promote(BlockCacheKey cacheKey, Cacheable block, CacheEngine sourceEngine,
+    CacheEngine targetEngine);
+
+  /**
+   * Demotes a cached block from one engine to another.
+   * <p>
+   * Demotion is optional because not all topologies or cache engines can support it efficiently. In
+   * many implementations, eviction does not expose the evicted block in a form that can be cheaply
+   * demoted. The default implementation therefore performs no action.
+   * </p>
+   * <p>
+   * The decision whether demotion should happen belongs to the policy layer or to a
+   * topology-specific eviction callback mechanism. This method only provides a standard hook for
+   * topologies that support demotion.
+   * </p>
+   * @param cacheKey     block cache key
+   * @param block        cached block to demote
+   * @param sourceEngine engine from which the block is being demoted
+   * @param targetEngine engine where the block should be demoted
+   * @return {@code true} if demotion was performed, {@code false} otherwise
+   */
+  default boolean demote(BlockCacheKey cacheKey, Cacheable block, CacheEngine sourceEngine,
+    CacheEngine targetEngine) {
+    return false;
+  }
+
+  /**
+   * Shuts down this topology and any cache engines owned by it.
+   * <p>
+   * If the topology does not own the life cycle of its engines, the implementation should document
+   * that behavior. The default expectation is that shutting down a topology shuts down
+   * participating engines.
+   * </p>
+   */
+  void shutdown();
+
+  /**
+   * Returns a read-only view of this topology.
+   * <p>
+   * The returned view is intended for policy implementations, diagnostics, and metrics. It should
+   * expose topology and engine state without allowing callers to mutate cache contents or bypass
+   * topology behavior.
+   * </p>
+   * @return read-only topology view
+   */
+  CacheTopologyView getView();
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTopology.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTopology.java
@@ -198,4 +198,5 @@ public interface CacheTopology {
    * @return read-only topology view
    */
   CacheTopologyView getView();
+
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTopologyType.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTopologyType.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Identifies the structural form of a cache topology.
+ */
+@InterfaceAudience.Private
+public enum CacheTopologyType {
+
+  /**
+   * A topology with a single cache engine.
+   */
+  SINGLE,
+
+  /**
+   * A tiered topology where a block normally resides in only one tier at a time.
+   */
+  TIERED_EXCLUSIVE,
+
+  /**
+   * A tiered topology where a block present in an upper tier may also remain in a lower tier.
+   */
+  TIERED_INCLUSIVE
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTopologyView.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheTopologyView.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Default immutable-style read-only view over a {@link CacheTopology}.
+ * <p>
+ * This view delegates to the topology and exposes only read-only engine views.
+ * </p>
+ */
+@InterfaceAudience.Private
+public final class CacheTopologyView {
+
+  private final CacheTopology topology;
+
+  /**
+   * Constructs a CacheTopologyView for the given CacheTopology.
+   */
+  CacheTopologyView(CacheTopology topology) {
+    this.topology = topology;
+  }
+
+  /**
+   * Delegating getters for topology properties and read-only engine views.
+   */
+
+  public String getName() {
+    return topology.getName();
+  }
+
+  /**
+   * Returns the cache topology type, which can be SINGLE, TIERED_EXCLUSIVE, or TIERED_INCLUSIVE.
+   * @return the cache topology type
+   */
+  public CacheTopologyType getType() {
+    return topology.getType();
+  }
+
+  /**
+   * Returns the list of cache tiers in this topology. For a single-tier topology, it returns a list
+   * containing only CacheTier.SINGLE. For a multi-tier topology, it returns a list containing
+   * CacheTier.L1 and CacheTier.L2.
+   * @return the list of cache tiers in this topology
+   */
+  public List<CacheTier> getTiers() {
+    return topology.getTiers();
+  }
+
+  /**
+   * Returns an Optional containing a CacheEngineView for the specified cache tier if it exists in
+   * the topology, or an empty Optional if the tier is not present.
+   * @param tier the cache tier for which to retrieve the engine view
+   * @return an Optional containing the CacheEngineView for the specified tier, or empty if not
+   *         present
+   */
+  public Optional<CacheEngineView> getEngine(CacheTier tier) {
+    return topology.getEngine(tier).map(CacheEngineView::new);
+  }
+
+  /**
+   * Returns a list of CacheEngineView objects representing all cache engines in this topology.
+   * @return a list of CacheEngineView objects for all engines in this topology
+   */
+  public List<CacheEngineView> getEngines() {
+    return topology.getEngines().stream().map(CacheEngineView::new).collect(Collectors.toList());
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteContext.java
@@ -1,0 +1,166 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.hadoop.hbase.io.hfile.BlockType.BlockCategory;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Context for cache insertion.
+ * <p>
+ * This object carries insertion intent from read-miss population, write path population, prefetch,
+ * compaction, or promotion. It is intentionally small and immutable.
+ * </p>
+ */
+@InterfaceAudience.Private
+public final class CacheWriteContext {
+
+  private final boolean inMemory;
+  private final boolean waitWhenCache;
+  private final boolean cacheCompressed;
+  private final BlockCategory blockCategory;
+  private final CacheWriteSource source;
+
+  private CacheWriteContext(Builder builder) {
+    this.inMemory = builder.inMemory;
+    this.waitWhenCache = builder.waitWhenCache;
+    this.cacheCompressed = builder.cacheCompressed;
+    this.blockCategory = builder.blockCategory;
+    this.source = builder.source;
+  }
+
+  /**
+   * Creates a new builder.
+   */
+  public static Builder newBuilder() {
+    return new Builder();
+  }
+
+  /**
+   * Returns whether this block should receive in-memory treatment.
+   * @return true when in-memory treatment is requested
+   */
+  public boolean isInMemory() {
+    return inMemory;
+  }
+
+  /**
+   * Returns whether insertion should wait for asynchronous cache acceptance.
+   * @return true when wait is requested
+   */
+  public boolean isWaitWhenCache() {
+    return waitWhenCache;
+  }
+
+  /**
+   * Returns whether compressed caching is requested.
+   * @return true when compressed caching is requested
+   */
+  public boolean isCacheCompressed() {
+    return cacheCompressed;
+  }
+
+  /**
+   * Returns the block category, if known.
+   * @return block category, or null if unknown
+   */
+  public BlockCategory getBlockCategory() {
+    return blockCategory;
+  }
+
+  /**
+   * Returns the source of this cache write.
+   * @return cache write source
+   */
+  public CacheWriteSource getSource() {
+    return source;
+  }
+
+  /**
+   * Builder for {@link CacheWriteContext}.
+   */
+  public static final class Builder {
+
+    private boolean inMemory;
+    private boolean waitWhenCache;
+    private boolean cacheCompressed;
+    private BlockCategory blockCategory;
+    private CacheWriteSource source = CacheWriteSource.READ_MISS;
+
+    private Builder() {
+    }
+
+    /**
+     * Sets in-memory treatment.
+     * @param inMemory true when in-memory treatment is requested
+     * @return this builder
+     */
+    public Builder setInMemory(boolean inMemory) {
+      this.inMemory = inMemory;
+      return this;
+    }
+
+    /**
+     * Sets wait-on-cache behavior.
+     * @param waitWhenCache true when insertion should wait
+     * @return this builder
+     */
+    public Builder setWaitWhenCache(boolean waitWhenCache) {
+      this.waitWhenCache = waitWhenCache;
+      return this;
+    }
+
+    /**
+     * Sets compressed cache preference.
+     * @param cacheCompressed true when compressed caching is requested
+     * @return this builder
+     */
+    public Builder setCacheCompressed(boolean cacheCompressed) {
+      this.cacheCompressed = cacheCompressed;
+      return this;
+    }
+
+    /**
+     * Sets the block category.
+     * @param blockCategory block category
+     * @return this builder
+     */
+    public Builder setBlockCategory(BlockCategory blockCategory) {
+      this.blockCategory = blockCategory;
+      return this;
+    }
+
+    /**
+     * Sets the cache write source.
+     * @param source cache write source
+     * @return this builder
+     */
+    public Builder setSource(CacheWriteSource source) {
+      this.source = source;
+      return this;
+    }
+
+    /**
+     * Builds the context.
+     * @return cache write context
+     */
+    public CacheWriteContext build() {
+      return new CacheWriteContext(this);
+    }
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteContext.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteContext.java
@@ -110,7 +110,7 @@ public final class CacheWriteContext {
      * @param inMemory true when in-memory treatment is requested
      * @return this builder
      */
-    public Builder setInMemory(boolean inMemory) {
+    public Builder withInMemory(boolean inMemory) {
       this.inMemory = inMemory;
       return this;
     }
@@ -120,7 +120,7 @@ public final class CacheWriteContext {
      * @param waitWhenCache true when insertion should wait
      * @return this builder
      */
-    public Builder setWaitWhenCache(boolean waitWhenCache) {
+    public Builder withWaitWhenCache(boolean waitWhenCache) {
       this.waitWhenCache = waitWhenCache;
       return this;
     }
@@ -130,7 +130,7 @@ public final class CacheWriteContext {
      * @param cacheCompressed true when compressed caching is requested
      * @return this builder
      */
-    public Builder setCacheCompressed(boolean cacheCompressed) {
+    public Builder withCacheCompressed(boolean cacheCompressed) {
       this.cacheCompressed = cacheCompressed;
       return this;
     }
@@ -140,7 +140,7 @@ public final class CacheWriteContext {
      * @param blockCategory block category
      * @return this builder
      */
-    public Builder setBlockCategory(BlockCategory blockCategory) {
+    public Builder withBlockCategory(BlockCategory blockCategory) {
       this.blockCategory = blockCategory;
       return this;
     }
@@ -150,7 +150,7 @@ public final class CacheWriteContext {
      * @param source cache write source
      * @return this builder
      */
-    public Builder setSource(CacheWriteSource source) {
+    public Builder withSource(CacheWriteSource source) {
       this.source = source;
       return this;
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteSource.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Source of a cache insertion request.
+ * <p>
+ * This value describes where a cache population request originated. It does not replace existing
+ * {@code CacheConfig} decisions. Callers should invoke cache population only after existing HBase
+ * logic has determined that the block is eligible for caching.
+ * </p>
+ */
+@InterfaceAudience.Private
+public enum CacheWriteSource {
+
+  /**
+   * Cache population after a read miss.
+   */
+  READ_MISS,
+
+  /**
+   * Cache population during flush output generation.
+   */
+  FLUSH,
+
+  /**
+   * Cache population during compaction output generation.
+   */
+  COMPACTION,
+
+  /**
+   * Cache population by prefetch.
+   */
+  PREFETCH,
+
+  /**
+   * Cache population caused by promotion from another tier.
+   */
+  PROMOTION
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteSource.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheWriteSource.java
@@ -36,6 +36,16 @@ public enum CacheWriteSource {
   READ_MISS,
 
   /**
+   * Block was inserted from the HFile write/cache-on-write path.
+   * <p>
+   * This source covers write-side population where the caller does not expose whether the HFile is
+   * being produced by flush, compaction, bulk load, or another writer. More specific write-side
+   * sources can be added later when that context is available at the call site.
+   * </p>
+   */
+  WRITE_PATH,
+
+  /**
    * Cache population during flush output generation.
    */
   FLUSH,

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/DefaultHBaseCachePlacementAdmissionPolicy.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/DefaultHBaseCachePlacementAdmissionPolicy.java
@@ -1,0 +1,124 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Objects;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Default compatibility policy that preserves current HBase block cache behavior.
+ * <p>
+ * This policy is intentionally conservative. It admits cache insertion requests by default, assumes
+ * existing {@code CacheConfig} logic has already decided whether cache population should be
+ * attempted, preserves the current HBase block representation, and maps metadata-like blocks to L1
+ * and data blocks to L2 when a tiered topology is available.
+ * </p>
+ */
+@InterfaceAudience.Private
+public class DefaultHBaseCachePlacementAdmissionPolicy implements CachePlacementAdmissionPolicy {
+
+  @Override
+  public AdmissionDecision shouldAdmit(BlockCacheKey cacheKey, Cacheable block,
+    CacheWriteContext context, AdmissionPriority priority, CacheTopologyView topologyView) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(block, "block must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(priority, "priority must not be null");
+    Objects.requireNonNull(topologyView, "topologyView must not be null");
+
+    return AdmissionDecision.admit();
+  }
+
+  @Override
+  public TierDecision selectTier(BlockCacheKey cacheKey, Cacheable block, CacheWriteContext context,
+    CacheTopologyView topologyView) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(block, "block must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(topologyView, "topologyView must not be null");
+    /*
+     * Default compatibility placement prefers metadata/index/bloom blocks in L1 and data blocks in
+     * L2 when both tiers are available, but falls back to any available tier rather than rejecting
+     * placement.
+     */
+    if (topologyView.getType() == CacheTopologyType.SINGLE) {
+      return TierDecision.single(CacheTier.SINGLE);
+    }
+
+    if (isMetaOrIndexBlock(block)) {
+      if (topologyView.getEngine(CacheTier.L1).isPresent()) {
+        return TierDecision.single(CacheTier.L1);
+      }
+      if (topologyView.getEngine(CacheTier.L2).isPresent()) {
+        return TierDecision.single(CacheTier.L2);
+      }
+      return TierDecision.none();
+    }
+
+    if (topologyView.getEngine(CacheTier.L2).isPresent()) {
+      return TierDecision.single(CacheTier.L2);
+    }
+    if (topologyView.getEngine(CacheTier.L1).isPresent()) {
+      return TierDecision.single(CacheTier.L1);
+    }
+
+    return TierDecision.none();
+  }
+
+  @Override
+  public RepresentationDecision selectRepresentation(BlockCacheKey cacheKey, Cacheable block,
+    CacheWriteContext context, CacheTopologyView topologyView) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(block, "block must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(topologyView, "topologyView must not be null");
+
+    return RepresentationDecision.CURRENT_HBASE_DEFAULT;
+  }
+
+  @Override
+  public PromotionDecision shouldPromote(BlockCacheKey cacheKey, Cacheable block,
+    CacheTier sourceTier, CacheRequestContext context, CacheTopologyView topologyView) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(block, "block must not be null");
+    Objects.requireNonNull(sourceTier, "sourceTier must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+    Objects.requireNonNull(topologyView, "topologyView must not be null");
+    /*
+     * DefaultHBaseCachePlacementAdmissionPolicy should preserve existing placement behavior. If
+     * meta/index/bloom blocks belong in L1, they should be inserted into L1 when cached. If data
+     * blocks belong in L2, promoting them to L1 on hit would change current behavior and may
+     * pollute L1. Therefore the compatibility policy should not promote by default.
+     */
+    return PromotionDecision.none();
+
+  }
+
+  private static boolean isMetaOrIndexBlock(Cacheable block) {
+    if (!(block instanceof HFileBlock)) {
+      return false;
+    }
+
+    BlockType blockType = ((HFileBlock) block).getBlockType();
+    return blockType != null && blockType.getCategory() != BlockType.BlockCategory.DATA;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
@@ -1,0 +1,286 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Disabled-cache implementation of {@link CacheAccessService}.
+ * <p>
+ * {@code NoOpCacheAccessService} is useful when block cache access is disabled but callers still
+ * want to depend on a non-null {@link CacheAccessService}. It never stores blocks, never returns
+ * cached blocks, reports zero capacity and occupancy, and treats all invalidation requests as
+ * no-ops.
+ * </p>
+ * <p>
+ * Even though this implementation does not perform cache operations, it still validates caller
+ * inputs consistently with other {@link CacheAccessService} implementations. This prevents the
+ * disabled-cache path from masking caller bugs that would fail when a real cache is configured.
+ * </p>
+ * <p>
+ * This implementation should not be used to hide configuration mistakes. It represents an explicit
+ * disabled-cache state and should be selected only when the caller has determined that no block
+ * cache is available or desired.
+ * </p>
+ */
+@InterfaceAudience.Private
+public final class NoOpCacheAccessService implements CacheAccessService {
+
+  private static final String NAME = "NoOpCacheAccessService";
+
+  private final CacheStats stats;
+
+  /**
+   * Creates a disabled cache access service with its own {@link CacheStats} instance.
+   */
+  public NoOpCacheAccessService() {
+    this(new CacheStats(NAME));
+  }
+
+  /**
+   * Creates a disabled cache access service with the supplied statistics object.
+   * <p>
+   * Allowing the statistics object to be supplied makes tests easier and allows callers to preserve
+   * existing metrics conventions if needed.
+   * </p>
+   * @param stats cache statistics object
+   */
+  public NoOpCacheAccessService(CacheStats stats) {
+    this.stats = Objects.requireNonNull(stats, "stats must not be null");
+  }
+
+  /**
+   * Returns the service name.
+   * @return service name
+   */
+  @Override
+  public String getName() {
+    return NAME;
+  }
+
+  /**
+   * Always returns {@code null} because this service does not store blocks.
+   * @param cacheKey block to fetch
+   * @param context  cache request context
+   * @return always {@code null}
+   */
+  @Override
+  public Cacheable getBlock(BlockCacheKey cacheKey, CacheRequestContext context) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+    return null;
+  }
+
+  /**
+   * Validates the request and ignores the cache insertion.
+   * @param cacheKey block cache key
+   * @param block    block contents
+   * @param context  cache write context
+   */
+  @Override
+  public void cacheBlock(BlockCacheKey cacheKey, Cacheable block, CacheWriteContext context) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(block, "block must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+  }
+
+  /**
+   * Always returns {@code false} because this service does not store blocks.
+   * @param cacheKey block to remove
+   * @return always {@code false}
+   */
+  @Override
+  public boolean evictBlock(BlockCacheKey cacheKey) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    return false;
+  }
+
+  /**
+   * Always returns {@code 0} because this service does not store blocks.
+   * @param hfileName HFile name
+   * @return always {@code 0}
+   */
+  @Override
+  public int evictBlocksByHfileName(String hfileName) {
+    Objects.requireNonNull(hfileName, "hfileName must not be null");
+    return 0;
+  }
+
+  /**
+   * Always returns {@code 0} because this service does not store blocks.
+   * @param hfileName  HFile name
+   * @param initOffset inclusive start offset
+   * @param endOffset  inclusive end offset
+   * @return always {@code 0}
+   */
+  @Override
+  public int evictBlocksRangeByHfileName(String hfileName, long initOffset, long endOffset) {
+    Objects.requireNonNull(hfileName, "hfileName must not be null");
+    return 0;
+  }
+
+  /**
+   * Always returns {@code 0} because this service does not store blocks.
+   * @param regionName region name
+   * @return always {@code 0}
+   */
+  @Override
+  public int evictBlocksByRegionName(String regionName) {
+    Objects.requireNonNull(regionName, "regionName must not be null");
+    return 0;
+  }
+
+  /**
+   * Returns this service's statistics object.
+   * @return cache statistics
+   */
+  @Override
+  public CacheStats getStats() {
+    return stats;
+  }
+
+  /**
+   * Does nothing because this service owns no resources.
+   */
+  @Override
+  public void shutdown() {
+    // noop
+  }
+
+  /**
+   * Always returns {@code 0} because this service has no capacity.
+   * @return always {@code 0}
+   */
+  @Override
+  public long getMaxSize() {
+    return 0L;
+  }
+
+  /**
+   * Always returns {@code 0} because this service has no capacity.
+   * @return always {@code 0}
+   */
+  @Override
+  public long getFreeSize() {
+    return 0L;
+  }
+
+  /**
+   * Always returns {@code 0} because this service stores no blocks.
+   * @return always {@code 0}
+   */
+  @Override
+  public long size() {
+    return 0L;
+  }
+
+  /**
+   * Always returns {@code 0} because this service stores no data blocks.
+   * @return always {@code 0}
+   */
+  @Override
+  public long getCurrentDataSize() {
+    return 0L;
+  }
+
+  /**
+   * Always returns {@code 0} because this service stores no blocks.
+   * @return always {@code 0}
+   */
+  @Override
+  public long getBlockCount() {
+    return 0L;
+  }
+
+  /**
+   * Always returns {@code 0} because this service stores no data blocks.
+   * @return always {@code 0}
+   */
+  @Override
+  public long getDataBlockCount() {
+    return 0L;
+  }
+
+  /**
+   * Always returns {@link Optional#empty()} because this service has no capacity.
+   * @param block block to check
+   * @return always {@link Optional#empty()}
+   */
+  @Override
+  public Optional<Boolean> blockFitsIntoTheCache(HFileBlock block) {
+    Objects.requireNonNull(block, "block must not be null");
+    return Optional.empty();
+  }
+
+  /**
+   * Always returns {@link Optional#empty()} because this service does not store blocks.
+   * @param key block cache key
+   * @return always {@link Optional#empty()}
+   */
+  @Override
+  public Optional<Boolean> isAlreadyCached(BlockCacheKey key) {
+    Objects.requireNonNull(key, "key must not be null");
+    return Optional.empty();
+  }
+
+  /**
+   * Always returns {@link Optional#empty()} because this service does not store blocks.
+   * @param key block cache key
+   * @return always {@link Optional#empty()}
+   */
+  @Override
+  public Optional<Integer> getBlockSize(BlockCacheKey key) {
+    Objects.requireNonNull(key, "key must not be null");
+    return Optional.empty();
+  }
+
+  /**
+   * Always returns {@code false} because cache access is disabled.
+   * @return always {@code false}
+   */
+  @Override
+  public boolean isCacheEnabled() {
+    return false;
+  }
+
+  /**
+   * Always returns {@code false} because cache access is disabled.
+   * @param timeout maximum time to wait
+   * @return always {@code false}
+   */
+  @Override
+  public boolean waitForCacheInitialization(long timeout) {
+    return false;
+  }
+
+  /**
+   * Validates the request and ignores the configuration change.
+   * @param config new configuration
+   */
+  @Override
+  public void onConfigurationChange(Configuration config) {
+    Objects.requireNonNull(config, "config must not be null");
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.io.hfile.cache;
 import java.util.Objects;
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
@@ -282,5 +283,11 @@ public final class NoOpCacheAccessService implements CacheAccessService {
   @Override
   public void onConfigurationChange(Configuration config) {
     Objects.requireNonNull(config, "config must not be null");
+  }
+
+  @Override
+  public void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
+    long size) {
+    Objects.requireNonNull(fileName, "fileName must not be null");
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
@@ -25,6 +25,7 @@ import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.CacheStats;
 import org.apache.hadoop.hbase.io.hfile.Cacheable;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.io.hfile.HFileInfo;
 import org.apache.yetus.audience.InterfaceAudience;
 
 /**
@@ -289,5 +290,20 @@ public final class NoOpCacheAccessService implements CacheAccessService {
   public void notifyFileCachingCompleted(Path fileName, int totalBlockCount, int dataBlockCount,
     long size) {
     Objects.requireNonNull(fileName, "fileName must not be null");
+  }
+
+  @Override
+  public Optional<Boolean> shouldCacheFile(HFileInfo hFileInfo, Configuration conf) {
+    Objects.requireNonNull(hFileInfo, "hFileInfo must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return Optional.empty();
+  }
+
+  @Override
+  public Optional<Boolean> shouldCacheBlock(BlockCacheKey key, long maxTimestamp,
+    Configuration conf) {
+    Objects.requireNonNull(key, "key must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return Optional.empty();
   }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/NoOpCacheAccessService.java
@@ -306,4 +306,10 @@ public final class NoOpCacheAccessService implements CacheAccessService {
     Objects.requireNonNull(conf, "conf must not be null");
     return Optional.empty();
   }
+
+  @Override
+  public long getCurrentSize() {
+    // TODO Auto-generated method stub
+    return 0;
+  }
 }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/PromotionAction.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/PromotionAction.java
@@ -1,0 +1,37 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Promotion action selected by cache placement policy.
+ */
+@InterfaceAudience.Private
+public enum PromotionAction {
+
+  /**
+   * Do not promote the block.
+   */
+  NONE,
+
+  /**
+   * Promote the block to another tier.
+   */
+  PROMOTE
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/PromotionDecision.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/PromotionDecision.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Objects;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Decision describing whether and how a cache hit should trigger promotion.
+ * <p>
+ * This decision is produced by {@link CachePlacementAdmissionPolicy} and executed by
+ * {@link CacheTopology}. The policy decides whether promotion should happen and which tier should
+ * receive the promoted block. The topology decides how promotion is performed for its semantics,
+ * for example copy for inclusive topology or move for exclusive topology.
+ * </p>
+ * <p>
+ * This class is immutable. The no-promotion decision is represented by {@link #none()}. Promotion
+ * decisions must include a non-null target tier.
+ * </p>
+ */
+@InterfaceAudience.Private
+public final class PromotionDecision {
+
+  private static final PromotionDecision NONE =
+    new PromotionDecision(PromotionAction.NONE, null, false);
+
+  private final PromotionAction action;
+  private final CacheTier targetTier;
+  private final boolean asynchronous;
+
+  private PromotionDecision(PromotionAction action, CacheTier targetTier, boolean asynchronous) {
+    this.action = Objects.requireNonNull(action, "action must not be null");
+    this.targetTier = targetTier;
+    this.asynchronous = asynchronous;
+  }
+
+  /**
+   * Returns a decision that performs no promotion.
+   * @return no-promotion decision
+   */
+  public static PromotionDecision none() {
+    return NONE;
+  }
+
+  /**
+   * Returns a decision to promote the block to the specified target tier.
+   * <p>
+   * The target tier must not be null. The actual promotion mechanics are topology-specific. For
+   * example, an inclusive topology may copy the block into the target tier while an exclusive
+   * topology may move the block.
+   * </p>
+   * @param targetTier   target tier for promotion
+   * @param asynchronous whether promotion may be performed asynchronously
+   * @return promotion decision
+   */
+  public static PromotionDecision promoteTo(CacheTier targetTier, boolean asynchronous) {
+    Objects.requireNonNull(targetTier, "targetTier must not be null");
+    return new PromotionDecision(PromotionAction.PROMOTE, targetTier, asynchronous);
+  }
+
+  /**
+   * Returns the promotion action.
+   * @return promotion action
+   */
+  public PromotionAction getAction() {
+    return action;
+  }
+
+  /**
+   * Returns whether this decision requests promotion.
+   * @return true when promotion is requested
+   */
+  public boolean shouldPromote() {
+    return action == PromotionAction.PROMOTE;
+  }
+
+  /**
+   * Returns whether this decision has a target tier.
+   * @return true when target tier is available
+   */
+  public boolean hasTargetTier() {
+    return targetTier != null;
+  }
+
+  /**
+   * Returns the target tier for promotion.
+   * <p>
+   * This method is valid only when {@link #shouldPromote()} returns true.
+   * </p>
+   * @return target tier
+   * @throws IllegalStateException if this decision does not request promotion
+   */
+  public CacheTier getTargetTier() {
+    if (targetTier == null) {
+      throw new IllegalStateException("Promotion target tier is not available");
+    }
+    return targetTier;
+  }
+
+  /**
+   * Returns whether promotion may be executed asynchronously.
+   * @return true when asynchronous promotion is allowed
+   */
+  public boolean isAsynchronous() {
+    return asynchronous;
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/RepresentationDecision.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/RepresentationDecision.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Decision describing the cached representation for an admitted block.
+ */
+@InterfaceAudience.Private
+public enum RepresentationDecision {
+
+  /**
+   * Preserve the representation already produced by current HBase code paths.
+   */
+
+  CURRENT_HBASE_DEFAULT,
+
+  /**
+   * Prefer packed or serialized representation.
+   */
+
+  PACKED,
+
+  /**
+   * Prefer unpacked or ready-to-use representation.
+   */
+
+  UNPACKED,
+
+  /**
+   * Let the target cache engine choose its preferred representation.
+   */
+
+  ENGINE_DEFAULT
+
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/SingleEngineTopology.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/SingleEngineTopology.java
@@ -1,0 +1,93 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Single-engine cache topology.
+ * <p>
+ * This topology wraps a single {@link CacheEngine}. It is primarily useful as a baseline topology
+ * and as a simple bridge for cache configurations that do not use L1/L2 tiering.
+ * </p>
+ */
+@InterfaceAudience.Private
+public class SingleEngineTopology implements CacheTopology {
+
+  private final String name;
+  private final CacheEngine engine;
+  private final CacheTopologyView view;
+
+  public SingleEngineTopology(String name, CacheEngine engine) {
+    this.name = name;
+    this.engine = engine;
+    this.view = new CacheTopologyView(this);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public CacheTopologyType getType() {
+    return CacheTopologyType.SINGLE;
+  }
+
+  @Override
+  public List<CacheEngine> getEngines() {
+    return Collections.singletonList(engine);
+  }
+
+  @Override
+  public Optional<CacheEngine> getEngine(CacheTier tier) {
+    return tier == CacheTier.SINGLE ? Optional.of(engine) : Optional.empty();
+  }
+
+  @Override
+  public CacheTopologyView getView() {
+    return view;
+  }
+
+  @Override
+  public CacheStats getStats() {
+    return engine.getStats();
+  }
+
+  @Override
+  public boolean promote(BlockCacheKey cacheKey, Cacheable block, CacheEngine sourceEngine,
+    CacheEngine targetEngine) {
+    return false;
+  }
+
+  @Override
+  public void shutdown() {
+    engine.shutdown();
+  }
+
+  @Override
+  public List<CacheTier> getTiers() {
+    return Collections.singletonList(CacheTier.SINGLE);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TierDecision.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TierDecision.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.List;
+import java.util.Objects;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Decision describing the target cache tiers for a cache insertion.
+ * <p>
+ * This decision explicitly lists the {@link CacheTier}s that should receive the block. It replaces
+ * implicit or topology-derived placement rules with a clear, ordered set of target tiers.
+ * </p>
+ * <p>
+ * The order of tiers is significant and should reflect placement priority. For example, a policy
+ * may return {@code [L1, L2]} to indicate that the block should be stored in L1 first and also
+ * written to L2 (e.g. for inclusive topologies).
+ * </p>
+ * <p>
+ * An empty decision indicates that the block should not be stored in any tier.
+ * </p>
+ * <p>
+ * This class is intentionally simple and immutable. It does not encode topology-specific behavior
+ * (e.g. inclusive vs exclusive). The {@link CacheTopology} is responsible for interpreting and
+ * executing this decision.
+ * </p>
+ */
+@InterfaceAudience.Private
+public final class TierDecision {
+
+  private static final TierDecision NONE = new TierDecision(List.of());
+
+  private final List<CacheTier> tiers;
+
+  private TierDecision(List<CacheTier> tiers) {
+    this.tiers = tiers;
+  }
+
+  /**
+   * Returns a decision that does not place the block into any cache tier.
+   * @return empty tier decision
+   */
+  public static TierDecision none() {
+    return NONE;
+  }
+
+  /**
+   * Returns a decision targeting a single cache tier.
+   * @param tier target tier
+   * @return tier decision for a single tier
+   */
+  public static TierDecision single(CacheTier tier) {
+    Objects.requireNonNull(tier, "tier must not be null");
+    return new TierDecision(List.of(tier));
+  }
+
+  /**
+   * Returns a decision targeting multiple cache tiers.
+   * <p>
+   * The provided list must not be null, must not contain null elements, and will be copied to
+   * preserve immutability.
+   * </p>
+   * @param tiers ordered list of target tiers
+   * @return tier decision for multiple tiers, or {@link #none()} if empty
+   */
+  public static TierDecision multiple(List<CacheTier> tiers) {
+    Objects.requireNonNull(tiers, "tiers must not be null");
+
+    if (tiers.isEmpty()) {
+      return NONE;
+    }
+
+    for (CacheTier tier : tiers) {
+      Objects.requireNonNull(tier, "tier in tiers must not be null");
+    }
+
+    return new TierDecision(List.copyOf(tiers));
+  }
+
+  /**
+   * Returns the ordered list of target tiers.
+   * <p>
+   * The returned list is immutable. The order reflects placement priority and may be interpreted by
+   * the topology when executing the decision.
+   * </p>
+   * @return ordered list of target tiers
+   */
+  public List<CacheTier> getTiers() {
+    return tiers;
+  }
+
+  /**
+   * Returns whether this decision contains no target tiers.
+   * @return true when no tiers are selected
+   */
+  public boolean isEmpty() {
+    return tiers.isEmpty();
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TieredExclusiveTopology.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TieredExclusiveTopology.java
@@ -1,0 +1,126 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Tiered exclusive cache topology.
+ * <p>
+ * In an exclusive topology, a block should normally reside in only one tier at a time. Promotion
+ * from L2 to L1 is therefore modeled as a move: insert into L1 and evict from L2.
+ * </p>
+ * <p>
+ * This class is introduced as a topology foundation. Production wiring and policy-driven routing
+ * are handled in later migration phases.
+ * </p>
+ */
+@InterfaceAudience.Private
+public class TieredExclusiveTopology implements CacheTopology {
+
+  private final String name;
+  private final CacheEngine l1;
+  private final CacheEngine l2;
+  private final CacheTopologyView view;
+
+  public TieredExclusiveTopology(String name, CacheEngine l1, CacheEngine l2) {
+    this.name = name;
+    this.l1 = l1;
+    this.l2 = l2;
+    this.view = new CacheTopologyView(this);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public CacheTopologyType getType() {
+    return CacheTopologyType.TIERED_EXCLUSIVE;
+  }
+
+  @Override
+  public List<CacheEngine> getEngines() {
+    return Arrays.asList(l1, l2);
+  }
+
+  @Override
+  public List<CacheTier> getTiers() {
+    return Arrays.asList(CacheTier.L1, CacheTier.L2);
+  }
+
+  @Override
+  public Optional<CacheEngine> getEngine(CacheTier tier) {
+    switch (tier) {
+      case L1:
+        return Optional.of(l1);
+      case L2:
+        return Optional.of(l2);
+      default:
+        return Optional.empty();
+    }
+  }
+
+  @Override
+  public CacheTopologyView getView() {
+    return view;
+  }
+
+  @Override
+  public CacheStats getStats() {
+    // TODO: replace with aggregate topology stats in follow-up metrics ticket.
+    return l1.getStats();
+  }
+
+  @Override
+  public boolean promote(BlockCacheKey cacheKey, Cacheable block, CacheEngine sourceEngine,
+    CacheEngine targetEngine) {
+    if (sourceEngine == null || targetEngine == null || block == null) {
+      return false;
+    }
+
+    targetEngine.cacheBlock(cacheKey, block);
+    sourceEngine.evictBlock(cacheKey);
+    return true;
+  }
+
+  @Override
+  public boolean demote(BlockCacheKey cacheKey, Cacheable block, CacheEngine sourceEngine,
+    CacheEngine targetEngine) {
+    if (sourceEngine == null || targetEngine == null || block == null) {
+      return false;
+    }
+
+    targetEngine.cacheBlock(cacheKey, block);
+    sourceEngine.evictBlock(cacheKey);
+    return true;
+  }
+
+  @Override
+  public void shutdown() {
+    l1.shutdown();
+    l2.shutdown();
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TieredInclusiveTopology.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TieredInclusiveTopology.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Arrays;
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Tiered inclusive cache topology.
+ * <p>
+ * In an inclusive topology, a block promoted from L2 to L1 may remain in L2. Promotion is therefore
+ * modeled as a copy rather than a move.
+ * </p>
+ * <p>
+ * This class is introduced as a topology foundation. Production wiring and policy-driven routing
+ * are handled in later migration phases.
+ * </p>
+ */
+@InterfaceAudience.Private
+public class TieredInclusiveTopology implements CacheTopology {
+
+  private final String name;
+  private final CacheEngine l1;
+  private final CacheEngine l2;
+  private final CacheTopologyView view;
+
+  public TieredInclusiveTopology(String name, CacheEngine l1, CacheEngine l2) {
+    this.name = name;
+    this.l1 = l1;
+    this.l2 = l2;
+    this.view = new CacheTopologyView(this);
+  }
+
+  @Override
+  public String getName() {
+    return name;
+  }
+
+  @Override
+  public CacheTopologyType getType() {
+    return CacheTopologyType.TIERED_INCLUSIVE;
+  }
+
+  @Override
+  public List<CacheEngine> getEngines() {
+    return Arrays.asList(l1, l2);
+  }
+
+  @Override
+  public List<CacheTier> getTiers() {
+    return Arrays.asList(CacheTier.L1, CacheTier.L2);
+  }
+
+  @Override
+  public Optional<CacheEngine> getEngine(CacheTier tier) {
+    switch (tier) {
+      case L1:
+        return Optional.of(l1);
+      case L2:
+        return Optional.of(l2);
+      default:
+        return Optional.empty();
+    }
+  }
+
+  @Override
+  public CacheTopologyView getView() {
+    return view;
+  }
+
+  @Override
+  public CacheStats getStats() {
+    // TODO: replace with aggregate topology stats in follow-up metrics ticket.
+    return l1.getStats();
+  }
+
+  @Override
+  public boolean promote(BlockCacheKey cacheKey, Cacheable block, CacheEngine sourceEngine,
+    CacheEngine targetEngine) {
+    if (targetEngine == null || block == null) {
+      return false;
+    }
+
+    targetEngine.cacheBlock(cacheKey, block);
+    return true;
+  }
+
+  @Override
+  public void shutdown() {
+    l1.shutdown();
+    l2.shutdown();
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TopologyBackedCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TopologyBackedCacheAccessService.java
@@ -287,8 +287,8 @@ public class TopologyBackedCacheAccessService implements CacheAccessService {
   }
 
   /**
-   * Returns aggregate occupied cache size across participating engines.
-   * @return aggregate occupied cache size
+   * Returns aggregate total cache size across participating engines.
+   * @return aggregate total cache size
    */
   @Override
   public long size() {
@@ -297,6 +297,16 @@ public class TopologyBackedCacheAccessService implements CacheAccessService {
       size += engine.size();
     }
     return size;
+  }
+
+  /**
+   * Returns aggregate occupied cache size across participating engines.
+   * @return aggregate occupied cache size
+   */
+  @Override
+  public long getCurrentSize() {
+
+    return getCurrentDataSize();
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TopologyBackedCacheAccessService.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/TopologyBackedCacheAccessService.java
@@ -1,0 +1,477 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Objects;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * {@link CacheAccessService} implementation backed by {@link CacheTopology} and {@link CacheEngine}
+ * instances.
+ * <p>
+ * This implementation connects the cache access layer to the topology, policy, and engine
+ * abstractions. {@link CachePlacementAdmissionPolicy} decides whether a block should be admitted,
+ * where it should be placed, which representation should be used, and whether a hit should trigger
+ * promotion. {@link CacheTopology} provides tier structure, engine lookup, aggregate statistics,
+ * and topology-specific promotion mechanics. {@link CacheEngine} performs the actual storage
+ * operations.
+ * </p>
+ * <p>
+ * This class is the topology-backed counterpart to {@link BlockCacheBackedCacheAccessService}. The
+ * block-cache-backed implementation is useful for incremental migration with no behavior change.
+ * This implementation is useful once callers are ready to exercise the new topology and engine
+ * abstractions directly through {@link CacheAccessService}.
+ * </p>
+ * <p>
+ * Representation selection is intentionally not invoked by this initial implementation. Until the
+ * service can actually apply representation decisions safely, especially around HFileBlock
+ * lifecycle and packed/unpacked storage, representation policy is left to a later integration step.
+ * </p>
+ */
+@InterfaceAudience.Private
+public class TopologyBackedCacheAccessService implements CacheAccessService {
+
+  private final CacheTopology topology;
+  private final CachePlacementAdmissionPolicy policy;
+  private final CacheTopologyView topologyView;
+
+  /**
+   * Creates a topology-backed cache access service.
+   * @param topology cache topology used for tier structure, engine lookup, and promotion mechanics
+   * @param policy   placement and admission policy used for cache access decisions
+   */
+  public TopologyBackedCacheAccessService(CacheTopology topology,
+    CachePlacementAdmissionPolicy policy) {
+    this.topology = Objects.requireNonNull(topology, "topology must not be null");
+    this.policy = Objects.requireNonNull(policy, "policy must not be null");
+    this.topologyView =
+      Objects.requireNonNull(topology.getView(), "topology view must not be null");
+  }
+
+  /**
+   * Returns the topology used by this service.
+   * <p>
+   * This accessor is intended for tests, diagnostics, and transitional wiring. HBase read/write
+   * path callers should use {@link CacheAccessService} methods instead of accessing topology
+   * directly.
+   * </p>
+   * @return cache topology
+   */
+  public CacheTopology getTopology() {
+    return topology;
+  }
+
+  /**
+   * Returns the placement/admission policy used by this service.
+   * @return placement/admission policy
+   */
+  public CachePlacementAdmissionPolicy getPolicy() {
+    return policy;
+  }
+
+  /**
+   * Returns the read-only topology view used by policy calls.
+   * @return read-only topology view
+   */
+  public CacheTopologyView getTopologyView() {
+    return topologyView;
+  }
+
+  /**
+   * Returns a human-readable service name.
+   * @return service name
+   */
+  @Override
+  public String getName() {
+    return topology.getName();
+  }
+
+  /**
+   * Fetches a block by checking topology tiers in lookup order.
+   * <p>
+   * The lookup order is defined by {@link CacheTopology#getTiers()}. On a cache hit, this method
+   * asks the configured {@link CachePlacementAdmissionPolicy} whether the block should be promoted.
+   * If promotion is requested and the target tier exists, promotion mechanics are delegated to
+   * {@link CacheTopology#promote(BlockCacheKey, Cacheable, CacheEngine, CacheEngine)}.
+   * </p>
+   * @param cacheKey block to fetch
+   * @param context  cache request context
+   * @return cached block, or {@code null} if not present in any tier
+   */
+  @Override
+  public Cacheable getBlock(BlockCacheKey cacheKey, CacheRequestContext context) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+
+    for (CacheTier tier : topology.getTiers()) {
+      Optional<CacheEngine> engine = topology.getEngine(tier);
+      if (engine.isEmpty()) {
+        continue;
+      }
+
+      Cacheable block = getBlockFromEngine(engine.get(), cacheKey, context);
+      if (block != null) {
+        maybePromote(cacheKey, block, tier, engine.get(), context);
+        return block;
+      }
+    }
+
+    return null;
+  }
+
+  /**
+   * Adds a block to the cache using policy-selected target tiers.
+   * <p>
+   * This method first asks the configured policy whether the block should be admitted. If admitted,
+   * the policy selects the target tier or tiers. The block is then inserted into each selected
+   * engine using {@link CacheEngine#cacheBlock(BlockCacheKey, Cacheable, boolean, boolean)}.
+   * </p>
+   * <p>
+   * The policy's representation decision is intentionally not applied in this initial
+   * implementation. The current block object is passed through unchanged.
+   * </p>
+   * @param cacheKey block cache key
+   * @param block    block contents
+   * @param context  cache write context
+   */
+  @Override
+  public void cacheBlock(BlockCacheKey cacheKey, Cacheable block, CacheWriteContext context) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+    Objects.requireNonNull(block, "block must not be null");
+    Objects.requireNonNull(context, "context must not be null");
+
+    AdmissionDecision admission =
+      policy.shouldAdmit(cacheKey, block, context, AdmissionPriority.NORMAL, topologyView);
+    if (!admission.isAdmitted()) {
+      return;
+    }
+
+    TierDecision tierDecision = policy.selectTier(cacheKey, block, context, topologyView);
+    for (CacheTier tier : tierDecision.getTiers()) {
+      Optional<CacheEngine> engine = topology.getEngine(tier);
+      if (engine.isPresent()) {
+        engine.get().cacheBlock(cacheKey, block, context.isInMemory(), context.isWaitWhenCache());
+      }
+    }
+  }
+
+  /**
+   * Evicts a single block from all engines participating in the topology.
+   * @param cacheKey block to remove
+   * @return {@code true} if at least one engine removed the block, {@code false} otherwise
+   */
+  @Override
+  public boolean evictBlock(BlockCacheKey cacheKey) {
+    Objects.requireNonNull(cacheKey, "cacheKey must not be null");
+
+    boolean evicted = false;
+    for (CacheEngine engine : topology.getEngines()) {
+      evicted |= engine.evictBlock(cacheKey);
+    }
+    return evicted;
+  }
+
+  /**
+   * Evicts all cached blocks for the given HFile from all engines participating in the topology.
+   * @param hfileName HFile name
+   * @return total number of blocks removed across all engines
+   */
+  @Override
+  public int evictBlocksByHfileName(String hfileName) {
+    Objects.requireNonNull(hfileName, "hfileName must not be null");
+
+    int evicted = 0;
+    for (CacheEngine engine : topology.getEngines()) {
+      evicted += engine.evictBlocksByHfileName(hfileName);
+    }
+    return evicted;
+  }
+
+  /**
+   * Evicts cached blocks for the given HFile range from all engines participating in the topology.
+   * @param hfileName  HFile name
+   * @param initOffset inclusive start offset
+   * @param endOffset  inclusive end offset
+   * @return total number of blocks removed across all engines
+   */
+  @Override
+  public int evictBlocksRangeByHfileName(String hfileName, long initOffset, long endOffset) {
+    Objects.requireNonNull(hfileName, "hfileName must not be null");
+
+    int evicted = 0;
+    for (CacheEngine engine : topology.getEngines()) {
+      evicted += engine.evictBlocksRangeByHfileName(hfileName, initOffset, endOffset);
+    }
+    return evicted;
+  }
+
+  /**
+   * Evicts cached blocks for the given region from all engines participating in the topology.
+   * @param regionName region name
+   * @return total number of blocks removed across all engines
+   */
+  @Override
+  public int evictBlocksByRegionName(String regionName) {
+    Objects.requireNonNull(regionName, "regionName must not be null");
+
+    int evicted = 0;
+    for (CacheEngine engine : topology.getEngines()) {
+      evicted += engine.evictBlocksByRegionName(regionName);
+    }
+    return evicted;
+  }
+
+  /**
+   * Returns aggregate topology statistics.
+   * @return aggregate cache statistics
+   */
+  @Override
+  public CacheStats getStats() {
+    return topology.getStats();
+  }
+
+  /**
+   * Shuts down the topology.
+   */
+  @Override
+  public void shutdown() {
+    topology.shutdown();
+  }
+
+  /**
+   * Returns aggregate maximum configured cache size across participating engines.
+   * @return aggregate maximum cache size
+   */
+  @Override
+  public long getMaxSize() {
+    long size = 0L;
+    for (CacheEngine engine : topology.getEngines()) {
+      size += engine.getMaxSize();
+    }
+    return size;
+  }
+
+  /**
+   * Returns aggregate free cache size across participating engines.
+   * @return aggregate free size
+   */
+  @Override
+  public long getFreeSize() {
+    long size = 0L;
+    for (CacheEngine engine : topology.getEngines()) {
+      size += engine.getFreeSize();
+    }
+    return size;
+  }
+
+  /**
+   * Returns aggregate occupied cache size across participating engines.
+   * @return aggregate occupied cache size
+   */
+  @Override
+  public long size() {
+    long size = 0L;
+    for (CacheEngine engine : topology.getEngines()) {
+      size += engine.size();
+    }
+    return size;
+  }
+
+  /**
+   * Returns aggregate occupied data-block size across participating engines.
+   * @return aggregate occupied data-block size
+   */
+  @Override
+  public long getCurrentDataSize() {
+    long size = 0L;
+    for (CacheEngine engine : topology.getEngines()) {
+      size += engine.getCurrentDataSize();
+    }
+    return size;
+  }
+
+  /**
+   * Returns aggregate cached block count across participating engines.
+   * @return aggregate cached block count
+   */
+  @Override
+  public long getBlockCount() {
+    long count = 0L;
+    for (CacheEngine engine : topology.getEngines()) {
+      count += engine.getBlockCount();
+    }
+    return count;
+  }
+
+  /**
+   * Returns aggregate cached data block count across participating engines.
+   * @return aggregate cached data block count
+   */
+  @Override
+  public long getDataBlockCount() {
+    long count = 0L;
+    for (CacheEngine engine : topology.getEngines()) {
+      count += engine.getDataBlockCount();
+    }
+    return count;
+  }
+
+  /**
+   * Checks whether the given block fits into at least one participating engine that supports this
+   * check.
+   * @param block block to check
+   * @return empty if no engine supports this check; otherwise whether at least one engine can fit
+   *         the block
+   */
+  @Override
+  public Optional<Boolean> blockFitsIntoTheCache(HFileBlock block) {
+    Objects.requireNonNull(block, "block must not be null");
+
+    boolean unsupported = true;
+    for (CacheEngine engine : topology.getEngines()) {
+      Optional<Boolean> result = engine.blockFitsIntoTheCache(block);
+      if (result.isPresent()) {
+        unsupported = false;
+        if (result.get()) {
+          return Optional.of(true);
+        }
+      }
+    }
+    return unsupported ? Optional.empty() : Optional.of(false);
+  }
+
+  /**
+   * Checks whether the block represented by the given key is present in any participating engine
+   * that supports this check.
+   * @param key block cache key
+   * @return empty if no engine supports this check; otherwise whether any engine has the block
+   */
+  @Override
+  public Optional<Boolean> isAlreadyCached(BlockCacheKey key) {
+    Objects.requireNonNull(key, "key must not be null");
+
+    boolean unsupported = true;
+    for (CacheEngine engine : topology.getEngines()) {
+      Optional<Boolean> result = engine.isAlreadyCached(key);
+      if (result.isPresent()) {
+        unsupported = false;
+        if (result.get()) {
+          return Optional.of(true);
+        }
+      }
+    }
+    return unsupported ? Optional.empty() : Optional.of(false);
+  }
+
+  /**
+   * Returns the first available cached block size reported by participating engines.
+   * <p>
+   * If the same block exists in multiple engines, this method returns the first present size in
+   * topology engine order. It does not sum duplicate copies.
+   * </p>
+   * @param key block cache key
+   * @return empty if unsupported or not present; otherwise cached block size
+   */
+  @Override
+  public Optional<Integer> getBlockSize(BlockCacheKey key) {
+    Objects.requireNonNull(key, "key must not be null");
+
+    for (CacheEngine engine : topology.getEngines()) {
+      Optional<Integer> size = engine.getBlockSize(key);
+      if (size.isPresent()) {
+        return size;
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
+   * Returns whether at least one participating engine is enabled.
+   * @return {@code true} if at least one engine is enabled, {@code false} otherwise
+   */
+  @Override
+  public boolean isCacheEnabled() {
+    for (CacheEngine engine : topology.getEngines()) {
+      if (engine.isCacheEnabled()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Waits for all participating engines to complete initialization.
+   * @param timeout maximum time to wait per engine
+   * @return {@code true} if all engines report ready/enabled, {@code false} otherwise
+   */
+  @Override
+  public boolean waitForCacheInitialization(long timeout) {
+    boolean enabled = true;
+    for (CacheEngine engine : topology.getEngines()) {
+      enabled &= engine.waitForCacheInitialization(timeout);
+    }
+    return enabled;
+  }
+
+  /**
+   * Propagates a configuration change to all participating engines.
+   * @param config new configuration
+   */
+  @Override
+  public void onConfigurationChange(Configuration config) {
+    Objects.requireNonNull(config, "config must not be null");
+    for (CacheEngine engine : topology.getEngines()) {
+      engine.onConfigurationChange(config);
+    }
+  }
+
+  private Cacheable getBlockFromEngine(CacheEngine engine, BlockCacheKey cacheKey,
+    CacheRequestContext context) {
+    Optional<BlockType> blockType = context.getBlockType();
+    if (blockType.isPresent()) {
+      return engine.getBlock(cacheKey, context.isCaching(), context.isRepeat(),
+        context.isUpdateCacheMetrics(), blockType.get());
+    }
+    return engine.getBlock(cacheKey, context.isCaching(), context.isRepeat(),
+      context.isUpdateCacheMetrics());
+  }
+
+  private void maybePromote(BlockCacheKey cacheKey, Cacheable block, CacheTier sourceTier,
+    CacheEngine sourceEngine, CacheRequestContext context) {
+    PromotionDecision decision = Objects.requireNonNull(
+      policy.shouldPromote(cacheKey, block, sourceTier, context, topologyView),
+      "policy should not return null from shouldPromote()");
+    if (!decision.shouldPromote()) {
+      return;
+    }
+
+    Optional<CacheEngine> targetEngine = topology.getEngine(decision.getTargetTier());
+    if (targetEngine.isEmpty()) {
+      return;
+    }
+
+    topology.promote(cacheKey, block, sourceEngine, targetEngine.get());
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/FromClientSideTest5.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/FromClientSideTest5.java
@@ -64,8 +64,8 @@ import org.apache.hadoop.hbase.filter.InclusiveStopFilter;
 import org.apache.hadoop.hbase.filter.RowFilter;
 import org.apache.hadoop.hbase.filter.SubstringComparator;
 import org.apache.hadoop.hbase.filter.ValueFilter;
-import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HRegionServer;
 import org.apache.hadoop.hbase.regionserver.HStore;
@@ -650,7 +650,7 @@ public class FromClientSideTest5 extends FromClientSideTestBase {
       CacheConfig cacheConf = store.getCacheConfig();
       cacheConf.setCacheDataOnWrite(true);
       cacheConf.setEvictOnClose(true);
-      BlockCache cache = cacheConf.getBlockCache().get();
+      CacheAccessService cache = cacheConf.getCacheAccessService();
 
       // establish baseline stats
       long startBlockCount = cache.getBlockCount();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAvoidCellReferencesIntoShippedBlocks.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAvoidCellReferencesIntoShippedBlocks.java
@@ -46,6 +46,9 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.CachedBlock;
 import org.apache.hadoop.hbase.io.hfile.CombinedBlockCache;
 import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
+import org.apache.hadoop.hbase.io.hfile.cache.BlockCacheBackedCacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServices;
 import org.apache.hadoop.hbase.regionserver.DelegatingInternalScanner;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.HStore;
@@ -139,7 +142,7 @@ public class TestAvoidCellReferencesIntoShippedBlocks {
       CacheConfig cacheConf = store.getCacheConfig();
       cacheConf.setCacheDataOnWrite(true);
       cacheConf.setEvictOnClose(true);
-      final BlockCache cache = cacheConf.getBlockCache().get();
+      final CacheAccessService cache = cacheConf.getCacheAccessService();
       // insert data. 5 Rows are added
       Put put = new Put(ROW);
       put.addColumn(FAMILY, QUALIFIER, data);
@@ -211,9 +214,9 @@ public class TestAvoidCellReferencesIntoShippedBlocks {
 
   private static class ScannerThread extends Thread {
     private final Table table;
-    private final BlockCache cache;
+    private final CacheAccessService cache;
 
-    public ScannerThread(Table table, BlockCache cache) {
+    public ScannerThread(Table table, CacheAccessService cache) {
       this.table = table;
       this.cache = cache;
     }
@@ -230,7 +233,9 @@ public class TestAvoidCellReferencesIntoShippedBlocks {
           }
         }
         List<BlockCacheKey> cacheList = new ArrayList<>();
-        Iterator<CachedBlock> iterator = cache.iterator();
+        @SuppressWarnings("unchecked")
+        Iterator<CachedBlock> iterator =
+          (Iterator<CachedBlock>) CacheAccessServices.asCachedBlockIterable(cache).orElseThrow();
         // evict all the blocks
         while (iterator.hasNext()) {
           CachedBlock next = iterator.next();
@@ -304,7 +309,7 @@ public class TestAvoidCellReferencesIntoShippedBlocks {
       CacheConfig cacheConf = store.getCacheConfig();
       cacheConf.setCacheDataOnWrite(true);
       cacheConf.setEvictOnClose(true);
-      final BlockCache cache = cacheConf.getBlockCache().get();
+      final CacheAccessService cache = cacheConf.getCacheAccessService();
       // insert data. 5 Rows are added
       Put put = new Put(ROW);
       put.addColumn(FAMILY, QUALIFIER, data);
@@ -364,10 +369,12 @@ public class TestAvoidCellReferencesIntoShippedBlocks {
       try (ScanPerNextResultScanner scanner =
         new ScanPerNextResultScanner(TEST_UTIL.getAsyncConnection().getTable(tableName), s)) {
         Thread evictorThread = new Thread() {
+          @SuppressWarnings("unchecked")
           @Override
           public void run() {
             List<BlockCacheKey> cacheList = new ArrayList<>();
-            Iterator<CachedBlock> iterator = cache.iterator();
+            Iterator<CachedBlock> iterator = (Iterator<CachedBlock>) CacheAccessServices
+              .asCachedBlockIterable(cache).orElseThrow();
             // evict all the blocks
             while (iterator.hasNext()) {
               CachedBlock next = iterator.next();
@@ -383,7 +390,8 @@ public class TestAvoidCellReferencesIntoShippedBlocks {
               Thread.sleep(1);
             } catch (InterruptedException e1) {
             }
-            iterator = cache.iterator();
+            iterator = (Iterator<CachedBlock>) CacheAccessServices.asCachedBlockIterable(cache)
+              .orElseThrow();
             int refBlockCount = 0;
             while (iterator.hasNext()) {
               iterator.next();
@@ -407,7 +415,8 @@ public class TestAvoidCellReferencesIntoShippedBlocks {
               while (true) {
                 newBlockRefCount = 0;
                 newCacheList.clear();
-                iterator = cache.iterator();
+                iterator = (Iterator<CachedBlock>) CacheAccessServices.asCachedBlockIterable(cache)
+                  .orElseThrow();
                 while (iterator.hasNext()) {
                   CachedBlock next = iterator.next();
                   BlockCacheKey cacheKey = new BlockCacheKey(next.getFilename(), next.getOffset());
@@ -443,7 +452,9 @@ public class TestAvoidCellReferencesIntoShippedBlocks {
   /**
    * For {@link BucketCache},we only evict Block if there is no rpc referenced.
    */
-  private void evictBlock(BlockCache blockCache, BlockCacheKey blockCacheKey) {
+  private void evictBlock(CacheAccessService cache, BlockCacheKey blockCacheKey) {
+    // TODO: will be refactored later once we get CacheEngine refactoring done
+    BlockCache blockCache = ((BlockCacheBackedCacheAccessService) cache).getBlockCache();
     assertTrue(blockCache instanceof CombinedBlockCache);
     BlockCache[] blockCaches = blockCache.getBlockCaches();
     for (BlockCache currentBlockCache : blockCaches) {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
@@ -17,8 +17,10 @@
  */
 package org.apache.hadoop.hbase.io.hfile;
 
+import static org.junit.Assert.assertSame;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
@@ -37,6 +39,9 @@ import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.io.ByteBuffAllocator;
 import org.apache.hadoop.hbase.io.hfile.BlockType.BlockCategory;
 import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
+import org.apache.hadoop.hbase.io.hfile.cache.BlockCacheBackedCacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.NoOpCacheAccessService;
 import org.apache.hadoop.hbase.io.util.MemorySizeUtil;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.testclassification.IOTests;
@@ -362,8 +367,9 @@ public class TestCacheConfig {
       }
     });
     // The eviction thread in lrublockcache needs to run.
-    while (initialL1BlockCount != lbc.getBlockCount())
+    while (initialL1BlockCount != lbc.getBlockCount()) {
       Threads.sleep(10);
+    }
     assertEquals(initialL1BlockCount, lbc.getBlockCount());
   }
 
@@ -416,5 +422,29 @@ public class TestCacheConfig {
     copyConf.setLong(HConstants.HFILE_ONHEAP_BLOCK_CACHE_FIXED_SIZE_KEY, fixedSize);
     onHeapCacheSize = MemorySizeUtil.getOnHeapCacheSize(copyConf);
     assertEquals(fixedSize, onHeapCacheSize);
+  }
+
+  @Test
+  void testCacheAccessServiceBackedByBlockCacheWhenBlockCacheIsConfigured() {
+    Configuration conf = this.conf;
+    BlockCache blockCache = BlockCacheFactory.createBlockCache(conf);
+    CacheConfig cacheConfig = new CacheConfig(conf, blockCache);
+
+    CacheAccessService service = cacheConfig.getCacheAccessService();
+
+    assertInstanceOf(BlockCacheBackedCacheAccessService.class, service);
+    assertSame(blockCache, ((BlockCacheBackedCacheAccessService) service).getBlockCache());
+  }
+
+  @Test
+  void testCacheAccessServiceIsNoOpWhenBlockCacheIsNull() {
+    Configuration conf = this.conf;
+
+    CacheConfig cacheConfig = new CacheConfig(conf, null);
+
+    CacheAccessService service = cacheConfig.getCacheAccessService();
+
+    assertInstanceOf(NoOpCacheAccessService.class, service);
+    assertFalse(service.isCacheEnabled());
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheConfig.java
@@ -41,6 +41,7 @@ import org.apache.hadoop.hbase.io.hfile.BlockType.BlockCategory;
 import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
 import org.apache.hadoop.hbase.io.hfile.cache.BlockCacheBackedCacheAccessService;
 import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServiceTestFactory;
 import org.apache.hadoop.hbase.io.hfile.cache.NoOpCacheAccessService;
 import org.apache.hadoop.hbase.io.util.MemorySizeUtil;
 import org.apache.hadoop.hbase.nio.ByteBuff;
@@ -159,31 +160,31 @@ public class TestCacheConfig {
   }
 
   /**
-   * @param bc       The block cache instance.
+   * @param service  The cache access service instance.
    * @param cc       Cache config.
    * @param doubling If true, addition of element ups counter by 2, not 1, because element added to
    *                 onheap and offheap caches.
    * @param sizing   True if we should run sizing test (doesn't always apply).
    */
-  void basicBlockCacheOps(final BlockCache bc, final CacheConfig cc, final boolean doubling,
-    final boolean sizing) {
+  void basicBlockCacheOps(final CacheAccessService service, final CacheConfig cc,
+    final boolean doubling, final boolean sizing) {
     assertTrue(CacheConfig.DEFAULT_IN_MEMORY == cc.isInMemory());
     BlockCacheKey bck = new BlockCacheKey("f", 0);
     Cacheable c = new DataCacheEntry();
     // Do asserts on block counting.
-    long initialBlockCount = bc.getBlockCount();
-    bc.cacheBlock(bck, c, cc.isInMemory());
-    assertEquals(doubling ? 2 : 1, bc.getBlockCount() - initialBlockCount);
-    bc.evictBlock(bck);
-    assertEquals(initialBlockCount, bc.getBlockCount());
+    long initialBlockCount = service.getBlockCount();
+    service.cacheBlock(bck, c, cc.isInMemory());
+    assertEquals(doubling ? 2 : 1, service.getBlockCount() - initialBlockCount);
+    service.evictBlock(bck);
+    assertEquals(initialBlockCount, service.getBlockCount());
     // Do size accounting. Do it after the above 'warm-up' because it looks like some
     // buffers do lazy allocation so sizes are off on first go around.
     if (sizing) {
-      long originalSize = bc.getCurrentSize();
-      bc.cacheBlock(bck, c, cc.isInMemory());
-      assertTrue(bc.getCurrentSize() > originalSize);
-      bc.evictBlock(bck);
-      long size = bc.getCurrentSize();
+      long originalSize = service.getCurrentDataSize();
+      service.cacheBlock(bck, c, cc.isInMemory());
+      assertTrue(service.getCurrentDataSize() > originalSize);
+      service.evictBlock(bck);
+      long size = service.getCurrentDataSize();
       assertEquals(originalSize, size);
     }
   }
@@ -254,7 +255,8 @@ public class TestCacheConfig {
     ColumnFamilyDescriptor columnFamilyDescriptor = ColumnFamilyDescriptorBuilder
       .newBuilder(Bytes.toBytes("testDisableCacheDataBlock")).setBlockCacheEnabled(false).build();
 
-    cacheConfig = new CacheConfig(conf, columnFamilyDescriptor, null, ByteBuffAllocator.HEAP);
+    cacheConfig = new CacheConfig(conf, columnFamilyDescriptor, (CacheAccessService) null,
+      ByteBuffAllocator.HEAP);
     assertFalse(cacheConfig.shouldCacheBlockOnRead(BlockCategory.DATA));
     assertFalse(cacheConfig.shouldCacheCompressed(BlockCategory.DATA));
     assertFalse(cacheConfig.shouldCacheDataCompressed());
@@ -271,9 +273,9 @@ public class TestCacheConfig {
   public void testCacheConfigDefaultLRUBlockCache() {
     CacheConfig cc = new CacheConfig(this.conf);
     assertTrue(CacheConfig.DEFAULT_IN_MEMORY == cc.isInMemory());
-    BlockCache blockCache = BlockCacheFactory.createBlockCache(this.conf);
-    basicBlockCacheOps(blockCache, cc, false, true);
-    assertTrue(blockCache instanceof LruBlockCache);
+    CacheAccessService service = CacheAccessServiceTestFactory.fromConfiguration(this.conf);
+    basicBlockCacheOps(service, cc, false, true);
+    assertTrue(CacheAccessServiceTestFactory.blockCache(service) instanceof LruBlockCache);
   }
 
   /**
@@ -303,11 +305,11 @@ public class TestCacheConfig {
     final int bcSize = 100;
     this.conf.setInt(HConstants.BUCKET_CACHE_SIZE_KEY, bcSize);
     CacheConfig cc = new CacheConfig(this.conf);
-    BlockCache blockCache = BlockCacheFactory.createBlockCache(this.conf);
-    basicBlockCacheOps(blockCache, cc, false, false);
-    assertTrue(blockCache instanceof CombinedBlockCache);
+    CacheAccessService service = CacheAccessServiceTestFactory.fromConfiguration(this.conf);
+    basicBlockCacheOps(service, cc, false, false);
+    assertTrue(CacheAccessServiceTestFactory.blockCache(service) instanceof CombinedBlockCache);
     // TODO: Assert sizes allocated are right and proportions.
-    CombinedBlockCache cbc = (CombinedBlockCache) blockCache;
+    CombinedBlockCache cbc = (CombinedBlockCache) CacheAccessServiceTestFactory.blockCache(service);
     BlockCache[] bcs = cbc.getBlockCaches();
     assertTrue(bcs[0] instanceof LruBlockCache);
     LruBlockCache lbc = (LruBlockCache) bcs[0];
@@ -335,11 +337,11 @@ public class TestCacheConfig {
     assertTrue(lruExpectedSize < bcExpectedSize);
     this.conf.setInt(HConstants.BUCKET_CACHE_SIZE_KEY, bcSize);
     CacheConfig cc = new CacheConfig(this.conf);
-    BlockCache blockCache = BlockCacheFactory.createBlockCache(this.conf);
-    basicBlockCacheOps(blockCache, cc, false, false);
-    assertTrue(blockCache instanceof CombinedBlockCache);
+    CacheAccessService service = CacheAccessServiceTestFactory.fromConfiguration(this.conf);
+    basicBlockCacheOps(service, cc, false, false);
+    assertTrue(CacheAccessServiceTestFactory.blockCache(service) instanceof CombinedBlockCache);
     // TODO: Assert sizes allocated are right and proportions.
-    CombinedBlockCache cbc = (CombinedBlockCache) blockCache;
+    CombinedBlockCache cbc = (CombinedBlockCache) CacheAccessServiceTestFactory.blockCache(service);
     FirstLevelBlockCache lbc = cbc.l1Cache;
     assertEquals(lruExpectedSize, lbc.getMaxSize());
     BlockCache bc = cbc.l2Cache;
@@ -388,19 +390,18 @@ public class TestCacheConfig {
 
   @Test
   public void testIndexOnlyLruBlockCache() {
-    CacheConfig cc = new CacheConfig(this.conf);
     conf.set(BlockCacheFactory.BLOCKCACHE_POLICY_KEY, "IndexOnlyLRU");
-    BlockCache blockCache = BlockCacheFactory.createBlockCache(this.conf);
-    assertTrue(blockCache instanceof IndexOnlyLruBlockCache);
+    CacheAccessService cache = CacheAccessServiceTestFactory.fromConfiguration(this.conf);
+    assertTrue(CacheAccessServiceTestFactory.blockCache(cache) instanceof IndexOnlyLruBlockCache);
     // reject data block
-    long initialBlockCount = blockCache.getBlockCount();
+    long initialBlockCount = cache.getBlockCount();
     BlockCacheKey bck = new BlockCacheKey("bck", 0);
     Cacheable c = new DataCacheEntry();
-    blockCache.cacheBlock(bck, c, true);
+    cache.cacheBlock(bck, c, true);
     // accept index block
     Cacheable indexCacheEntry = new IndexCacheEntry();
-    blockCache.cacheBlock(bck, indexCacheEntry, true);
-    assertEquals(initialBlockCount + 1, blockCache.getBlockCount());
+    cache.cacheBlock(bck, indexCacheEntry, true);
+    assertEquals(initialBlockCount + 1, cache.getBlockCount());
   }
 
   @Test
@@ -440,7 +441,7 @@ public class TestCacheConfig {
   void testCacheAccessServiceIsNoOpWhenBlockCacheIsNull() {
     Configuration conf = this.conf;
 
-    CacheConfig cacheConfig = new CacheConfig(conf, null);
+    CacheConfig cacheConfig = new CacheConfig(conf);
 
     CacheAccessService service = cacheConfig.getCacheAccessService();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheOnWrite.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestCacheOnWrite.java
@@ -50,6 +50,10 @@ import org.apache.hadoop.hbase.fs.HFileSystem;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
+import org.apache.hadoop.hbase.io.hfile.cache.BlockCacheBackedCacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServiceTestFactory;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServices;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.regionserver.StoreFileWriter;
@@ -88,7 +92,7 @@ public class TestCacheOnWrite {
   private FileSystem fs;
   private Random rand = new Random(12983177L);
   private Path storeFilePath;
-  private BlockCache blockCache;
+  private CacheAccessService cache;
   private String testDescription;
 
   private final CacheOnWriteType cowType;
@@ -148,46 +152,47 @@ public class TestCacheOnWrite {
   }
 
   public TestCacheOnWrite(CacheOnWriteType cowType, Compression.Algorithm compress,
-    boolean cacheCompressedData, BlockCache blockCache) {
+    boolean cacheCompressedData, CacheAccessService blockCache) {
     this.cowType = cowType;
     this.compress = compress;
     this.cacheCompressedData = cacheCompressedData;
-    this.blockCache = blockCache;
+    this.cache = blockCache;
     testDescription = "[cacheOnWrite=" + cowType + ", compress=" + compress
       + ", cacheCompressedData=" + cacheCompressedData + "]";
     LOG.info(testDescription);
   }
 
-  private static List<BlockCache> getBlockCaches() throws IOException {
+  private static List<CacheAccessService> getCacheServices() throws IOException {
     Configuration conf = TEST_UTIL.getConfiguration();
-    List<BlockCache> blockcaches = new ArrayList<>();
+    List<CacheAccessService> caches = new ArrayList<>();
     // default
-    blockcaches.add(BlockCacheFactory.createBlockCache(conf));
+    caches.add(CacheAccessServiceTestFactory.fromConfiguration(conf));
 
     // set LruBlockCache.LRU_HARD_CAPACITY_LIMIT_FACTOR_CONFIG_NAME to 2.0f due to HBASE-16287
     TEST_UTIL.getConfiguration().setFloat(LruBlockCache.LRU_HARD_CAPACITY_LIMIT_FACTOR_CONFIG_NAME,
       2.0f);
     // memory
-    BlockCache lru = new LruBlockCache(128 * 1024 * 1024, 64 * 1024, TEST_UTIL.getConfiguration());
-    blockcaches.add(lru);
+    CacheAccessService lru =
+      CacheAccessServiceTestFactory.lru(128 * 1024 * 1024, 64 * 1024, TEST_UTIL.getConfiguration());
+    caches.add(lru);
 
     // bucket cache
     FileSystem.get(conf).mkdirs(TEST_UTIL.getDataTestDir());
     int[] bucketSizes =
       { INDEX_BLOCK_SIZE, DATA_BLOCK_SIZE, BLOOM_BLOCK_SIZE, 64 * 1024, 128 * 1024 };
-    BlockCache bucketcache =
-      new BucketCache("offheap", 128 * 1024 * 1024, 64 * 1024, bucketSizes, 5, 64 * 100, null);
-    blockcaches.add(bucketcache);
-    return blockcaches;
+    CacheAccessService bucketcache = CacheAccessServiceTestFactory.bucket("offheap",
+      128 * 1024 * 1024, 64 * 1024, bucketSizes, 5, 64 * 100, null);
+    caches.add(bucketcache);
+    return caches;
   }
 
   public static Stream<Arguments> parameters() throws IOException {
     List<Arguments> params = new ArrayList<>();
-    for (BlockCache blockCache : getBlockCaches()) {
+    for (CacheAccessService cache : getCacheServices()) {
       for (CacheOnWriteType cowType : CacheOnWriteType.values()) {
         for (Compression.Algorithm compress : HBaseCommonTestingUtil.COMPRESSION_ALGORITHMS) {
           for (boolean cacheCompressedData : new boolean[] { false, true }) {
-            params.add(Arguments.of(cowType, compress, cacheCompressedData, blockCache));
+            params.add(Arguments.of(cowType, compress, cacheCompressedData, cache));
           }
         }
       }
@@ -195,23 +200,25 @@ public class TestCacheOnWrite {
     return params.stream();
   }
 
-  private void clearBlockCache(BlockCache blockCache) throws InterruptedException {
-    if (blockCache instanceof LruBlockCache) {
-      ((LruBlockCache) blockCache).clearCache();
+  private void clearBlockCache(CacheAccessService cache) throws InterruptedException {
+    // TODO: HBASE-30018 refactor later
+    BlockCache blockCache = ((BlockCacheBackedCacheAccessService) cache).getBlockCache();
+    if (cache instanceof LruBlockCache) {
+      ((LruBlockCache) cache).clearCache();
     } else {
       // BucketCache may not return all cached blocks(blocks in write queue), so check it here.
-      for (int clearCount = 0; blockCache.getBlockCount() > 0; clearCount++) {
+      for (int clearCount = 0; cache.getBlockCount() > 0; clearCount++) {
         if (clearCount > 0) {
-          LOG.warn("clear block cache " + blockCache + " " + clearCount + " times, "
-            + blockCache.getBlockCount() + " blocks remaining");
+          LOG.warn("clear block cache " + cache + " " + clearCount + " times, "
+            + cache.getBlockCount() + " blocks remaining");
           Thread.sleep(10);
         }
         for (CachedBlock block : Lists.newArrayList(blockCache)) {
           BlockCacheKey key = new BlockCacheKey(block.getFilename(), block.getOffset());
           // CombinedBucketCache may need evict two times.
-          for (int evictCount = 0; blockCache.evictBlock(key); evictCount++) {
+          for (int evictCount = 0; cache.evictBlock(key); evictCount++) {
             if (evictCount > 1) {
-              LOG.warn("evict block " + block + " in " + blockCache + " " + evictCount
+              LOG.warn("evict block " + block + " in " + cache + " " + evictCount
                 + " times, maybe a bug here");
             }
           }
@@ -233,13 +240,13 @@ public class TestCacheOnWrite {
       cowType.shouldBeCached(BlockType.LEAF_INDEX));
     conf.setBoolean(CacheConfig.CACHE_BLOOM_BLOCKS_ON_WRITE_KEY,
       cowType.shouldBeCached(BlockType.BLOOM_CHUNK));
-    cacheConf = new CacheConfig(conf, blockCache);
+    cacheConf = new CacheConfig(conf, ((BlockCacheBackedCacheAccessService) cache).getBlockCache());
     fs = HFileSystem.get(conf);
   }
 
   @AfterEach
   public void tearDown() throws IOException, InterruptedException {
-    clearBlockCache(blockCache);
+    clearBlockCache(cache);
   }
 
   @AfterAll
@@ -277,7 +284,7 @@ public class TestCacheOnWrite {
       HFileBlock block =
         reader.readBlock(offset, -1, false, true, false, true, null, encodingInCache);
       BlockCacheKey blockCacheKey = new BlockCacheKey(reader.getName(), offset);
-      HFileBlock fromCache = (HFileBlock) blockCache.getBlock(blockCacheKey, true, false, true);
+      HFileBlock fromCache = (HFileBlock) cache.getBlock(blockCacheKey, true, false, true);
       boolean isCached = fromCache != null;
       cachedBlocksOffset.add(offset);
       cachedBlocks.put(offset, fromCache == null ? null : Pair.newPair(block, fromCache));
@@ -434,7 +441,8 @@ public class TestCacheOnWrite {
       ColumnFamilyDescriptor cfd = ColumnFamilyDescriptorBuilder.newBuilder(cfBytes)
         .setCompressionType(compress).setBloomFilterType(BLOOM_TYPE).setMaxVersions(maxVersions)
         .setDataBlockEncoding(NoOpDataBlockEncoder.INSTANCE.getDataBlockEncoding()).build();
-      HRegion region = TEST_UTIL.createTestRegion(table, cfd, blockCache);
+      HRegion region = TEST_UTIL.createTestRegion(table, cfd,
+        ((BlockCacheBackedCacheAccessService) cache).getBlockCache());
       int rowIdx = 0;
       long ts = EnvironmentEdgeManager.currentTime();
       for (int iFile = 0; iFile < 5; ++iFile) {
@@ -466,8 +474,8 @@ public class TestCacheOnWrite {
         region.flush(true);
       }
 
-      clearBlockCache(blockCache);
-      assertEquals(0, blockCache.getBlockCount());
+      clearBlockCache(cache);
+      assertEquals(0, cache.getBlockCount());
 
       region.compact(false);
       LOG.debug("compactStores() returned");
@@ -475,8 +483,10 @@ public class TestCacheOnWrite {
       boolean dataBlockCached = false;
       boolean bloomBlockCached = false;
       boolean indexBlockCached = false;
+      Iterable<CachedBlock> cachedBlocks =
+        CacheAccessServices.asCachedBlockIterable(cache).orElseThrow();
 
-      for (CachedBlock block : blockCache) {
+      for (CachedBlock block : cachedBlocks) {
         if (DATA_BLOCK_TYPES.contains(block.getBlockType())) {
           dataBlockCached = true;
         } else if (BLOOM_BLOCK_TYPES.contains(block.getBlockType())) {
@@ -490,7 +500,7 @@ public class TestCacheOnWrite {
       // of testing
       // BucketCache, we cannot verify block type as it is not stored in the cache.
       boolean cacheOnCompactAndNonBucketCache =
-        cacheBlocksOnCompaction && !(blockCache instanceof BucketCache);
+        cacheBlocksOnCompaction && !(cache instanceof BucketCache);
 
       String assertErrorMessage = "\nTest description: " + testDescription
         + "\ncacheBlocksOnCompaction: " + cacheBlocksOnCompaction + "\n";

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestForceCacheImportantBlocks.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestForceCacheImportantBlocks.java
@@ -30,6 +30,8 @@ import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.compress.Compression.Algorithm;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServiceTestFactory;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.testclassification.IOTests;
@@ -96,13 +98,15 @@ public class TestForceCacheImportantBlocks {
   public void testCacheBlocks() throws IOException {
     // Set index block size to be the same as normal block size.
     TEST_UTIL.getConfiguration().setInt(HFileBlockIndex.MAX_CHUNK_SIZE_KEY, BLOCK_SIZE);
-    BlockCache blockCache = BlockCacheFactory.createBlockCache(TEST_UTIL.getConfiguration());
+    CacheAccessService cache =
+      CacheAccessServiceTestFactory.fromConfiguration(TEST_UTIL.getConfiguration());
     ColumnFamilyDescriptor cfd =
       ColumnFamilyDescriptorBuilder.newBuilder(Bytes.toBytes(CF)).setMaxVersions(MAX_VERSIONS)
         .setCompressionType(COMPRESSION_ALGORITHM).setBloomFilterType(BLOOM_TYPE)
         .setBlocksize(BLOCK_SIZE).setBlockCacheEnabled(cfCacheEnabled).build();
-    HRegion region = TEST_UTIL.createTestRegion(TABLE, cfd, blockCache);
-    CacheStats stats = blockCache.getStats();
+    HRegion region =
+      TEST_UTIL.createTestRegion(TABLE, cfd, CacheAccessServiceTestFactory.blockCache(cache));
+    CacheStats stats = cache.getStats();
     writeTestData(region);
     assertEquals(0, stats.getHitCount());
     assertEquals(0, HFile.DATABLOCK_READ_COUNT.sum());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
@@ -43,6 +43,7 @@ import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.FSDataInputStream;
 import org.apache.hadoop.fs.FSDataOutputStream;
@@ -76,6 +77,8 @@ import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.HFile.Reader;
 import org.apache.hadoop.hbase.io.hfile.HFile.Writer;
 import org.apache.hadoop.hbase.io.hfile.ReaderContext.ReaderType;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServiceTestFactory;
 import org.apache.hadoop.hbase.monitoring.ThreadLocalServerSideScanMetrics;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.RefCnt;
@@ -175,7 +178,8 @@ public class TestHFile {
     fillByteBuffAllocator(alloc, bufCount);
     Path storeFilePath = writeStoreFile();
     // Open the file reader with LRUBlockCache
-    BlockCache lru = new LruBlockCache(1024 * 1024 * 32, blockSize, true, conf);
+    CacheAccessService lru =
+      CacheAccessServiceTestFactory.lru(1024 * 1024 * 32, blockSize, true, conf);
     CacheConfig cacheConfig = new CacheConfig(conf, null, lru, alloc);
     HFile.Reader reader = HFile.createReader(fs, storeFilePath, cacheConfig, true, conf);
     long offset = 0;
@@ -216,10 +220,15 @@ public class TestHFile {
         counter.incrementAndGet();
       }
     });
-    BlockCache cache = Mockito.mock(BlockCache.class);
+    CacheAccessService cache = Mockito.mock(CacheAccessService.class);
     Mockito.when(cache.shouldCacheBlock(Mockito.any(), Mockito.anyLong(), Mockito.any()))
       .thenReturn(Optional.of(false));
     Mockito.when(cache.isCacheEnabled()).thenReturn(true);
+    Mockito.doAnswer(invocation -> {
+      Consumer<CacheAccessService> action = invocation.getArgument(0);
+      action.accept(cache);
+      return null;
+    }).when(cache).ifEnabled(Mockito.<Consumer<CacheAccessService>> any());
     Path hfilePath = new Path(TEST_UTIL.getDataTestDir(), "testWriterCacheOnWriteSkipDoesNotLeak");
     HFileContext context = new HFileContextBuilder().withBlockSize(blockSize).build();
 
@@ -263,8 +272,8 @@ public class TestHFile {
     Path storeFilePath = writeStoreFile();
 
     // Initialize the block cache and HFile reader
-    BlockCache lru = BlockCacheFactory.createBlockCache(conf);
-    assertTrue(lru instanceof LruBlockCache);
+    CacheAccessService lru = CacheAccessServiceTestFactory.fromConfiguration(conf);
+    assertTrue(CacheAccessServiceTestFactory.blockCache(lru) instanceof LruBlockCache);
     CacheConfig cacheConfig = new CacheConfig(conf, null, lru, ByteBuffAllocator.HEAP);
     HFileReaderImpl reader =
       (HFileReaderImpl) HFile.createReader(fs, storeFilePath, cacheConfig, true, conf);
@@ -337,14 +346,14 @@ public class TestHFile {
     assertBytesReadFromCache(true, DataBlockEncoding.FAST_DIFF);
   }
 
-  private BlockCache initCombinedBlockCache(final String l1CachePolicy) {
+  private CacheAccessService initCombinedBlockCacheBackedService(final String l1CachePolicy) {
     Configuration that = HBaseConfiguration.create(conf);
     that.setFloat(BUCKET_CACHE_SIZE_KEY, 32); // 32MB for bucket cache.
     that.set(BUCKET_CACHE_IOENGINE_KEY, "offheap");
     that.set(BLOCKCACHE_POLICY_KEY, l1CachePolicy);
-    BlockCache bc = BlockCacheFactory.createBlockCache(that);
+    CacheAccessService bc = CacheAccessServiceTestFactory.fromConfiguration(that);
     assertNotNull(bc);
-    assertTrue(bc instanceof CombinedBlockCache);
+    assertTrue(CacheAccessServiceTestFactory.blockCache(bc) instanceof CombinedBlockCache);
     return bc;
   }
 
@@ -358,7 +367,7 @@ public class TestHFile {
     fillByteBuffAllocator(alloc, bufCount);
     Path storeFilePath = writeStoreFile();
     // Open the file reader with CombinedBlockCache
-    BlockCache combined = initCombinedBlockCache("LRU");
+    CacheAccessService combined = initCombinedBlockCacheBackedService("LRU");
     conf.setBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, true);
     CacheConfig cacheConfig = new CacheConfig(conf, null, combined, alloc);
     HFile.Reader reader = HFile.createReader(fs, storeFilePath, cacheConfig, true, conf);
@@ -428,7 +437,8 @@ public class TestHFile {
 
     myConf.setBoolean(CacheConfig.CACHE_DATA_ON_READ_KEY, cacheConfigCacheBlockOnRead);
     // Open the file reader with LRUBlockCache
-    BlockCache lru = new LruBlockCache(1024 * 1024 * 32, blockSize, true, myConf);
+    CacheAccessService lru =
+      CacheAccessServiceTestFactory.lru(1024 * 1024 * 32, blockSize, true, myConf);
     CacheConfig cacheConfig = new CacheConfig(myConf, null, lru, alloc);
     HFile.Reader reader = HFile.createReader(fs, storeFilePath, cacheConfig, true, myConf);
     long offset = 0;
@@ -482,7 +492,7 @@ public class TestHFile {
     fillByteBuffAllocator(alloc, bufCount);
     Path storeFilePath = writeStoreFile();
     // Open the file reader with CombinedBlockCache
-    BlockCache combined = initCombinedBlockCache("LRU");
+    CacheAccessService combined = initCombinedBlockCacheBackedService("LRU");
     Configuration myConf = new Configuration(conf);
 
     myConf.setBoolean(CacheConfig.CACHE_DATA_ON_READ_KEY, cacheConfigCacheBlockOnRead);
@@ -539,7 +549,7 @@ public class TestHFile {
   private void readStoreFile(Path storeFilePath, Configuration conf, ByteBuffAllocator alloc)
     throws Exception {
     // Open the file reader with block cache disabled.
-    CacheConfig cache = new CacheConfig(conf, null, null, alloc);
+    CacheConfig cache = new CacheConfig(conf, null, (CacheAccessService) null, alloc);
     HFile.Reader reader = HFile.createReader(fs, storeFilePath, cache, true, conf);
     long offset = 0;
     while (offset < reader.getTrailer().getLoadOnOpenDataOffset()) {
@@ -1158,7 +1168,7 @@ public class TestHFile {
     fillByteBuffAllocator(alloc, bufCount);
     Path storeFilePath = writeStoreFile();
     // Open the file reader with CombinedBlockCache
-    BlockCache combined = initCombinedBlockCache(l1CachePolicy);
+    CacheAccessService combined = initCombinedBlockCacheBackedService(l1CachePolicy);
     conf.setBoolean(EVICT_BLOCKS_ON_CLOSE_KEY, true);
     CacheConfig cacheConfig = new CacheConfig(conf, null, combined, alloc);
     HFile.Reader reader = HFile.createReader(fs, storeFilePath, cacheConfig, true, conf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
@@ -219,6 +219,7 @@ public class TestHFile {
     BlockCache cache = Mockito.mock(BlockCache.class);
     Mockito.when(cache.shouldCacheBlock(Mockito.any(), Mockito.anyLong(), Mockito.any()))
       .thenReturn(Optional.of(false));
+    Mockito.when(cache.isCacheEnabled()).thenReturn(true);
     Path hfilePath = new Path(TEST_UTIL.getDataTestDir(), "testWriterCacheOnWriteSkipDoesNotLeak");
     HFileContext context = new HFileContextBuilder().withBlockSize(blockSize).build();
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlock.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlock.java
@@ -36,7 +36,6 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import java.util.Random;
 import java.util.concurrent.Callable;
 import java.util.concurrent.ExecutionException;
@@ -65,6 +64,7 @@ import org.apache.hadoop.hbase.io.FSDataInputStreamWrapper;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.io.compress.Compression.Algorithm;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.io.hfile.cache.NoOpCacheAccessService;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.MultiByteBuff;
 import org.apache.hadoop.hbase.nio.SingleByteBuff;
@@ -288,7 +288,7 @@ public class TestHFileBlock {
   @TestTemplate
   public void testNoCompression() throws IOException {
     CacheConfig cacheConf = Mockito.mock(CacheConfig.class);
-    Mockito.when(cacheConf.getBlockCache()).thenReturn(Optional.empty());
+    Mockito.when(cacheConf.getCacheAccessService()).thenReturn(new NoOpCacheAccessService());
 
     HFileBlock block =
       createTestV2Block(NONE, includesMemstoreTS, false).getBlockForCaching(cacheConf);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileBlockIndex.java
@@ -60,6 +60,7 @@ import org.apache.hadoop.hbase.io.encoding.IndexBlockEncoding;
 import org.apache.hadoop.hbase.io.hfile.HFile.Writer;
 import org.apache.hadoop.hbase.io.hfile.HFileBlockIndex.BlockIndexReader;
 import org.apache.hadoop.hbase.io.hfile.NoOpIndexBlockEncoder.NoOpEncodedSeeker;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.MultiByteBuff;
 import org.apache.hadoop.hbase.nio.RefCnt;
@@ -619,9 +620,9 @@ public class TestHFileBlockIndex {
     // should open hfile.block.index.cacheonwrite
     conf.setBoolean(CacheConfig.CACHE_INDEX_BLOCKS_ON_WRITE_KEY, true);
     CacheConfig cacheConf = new CacheConfig(conf, BlockCacheFactory.createBlockCache(conf));
-    BlockCache blockCache = cacheConf.getBlockCache().get();
+    CacheAccessService cache = cacheConf.getCacheAccessService();
     // Evict all blocks that were cached-on-write by the previous invocation.
-    blockCache.evictBlocksByHfileName(hfilePath.getName());
+    cache.evictBlocksByHfileName(hfilePath.getName());
     // Write the HFile
     HFileContext meta = new HFileContextBuilder().withBlockSize(SMALL_BLOCK_SIZE)
       .withCompression(Algorithm.NONE).withDataBlockEncoding(DataBlockEncoding.NONE).build();
@@ -671,14 +672,14 @@ public class TestHFileBlockIndex {
   public void testHFileWriterAndReader() throws IOException {
     Path hfilePath = new Path(TEST_UTIL.getDataTestDir(), "hfile_for_block_index");
     CacheConfig cacheConf = new CacheConfig(conf, BlockCacheFactory.createBlockCache(conf));
-    BlockCache blockCache = cacheConf.getBlockCache().get();
+    CacheAccessService cache = cacheConf.getCacheAccessService();
 
     for (int testI = 0; testI < INDEX_CHUNK_SIZES.length; ++testI) {
       int indexBlockSize = INDEX_CHUNK_SIZES[testI];
       int expectedNumLevels = EXPECTED_NUM_LEVELS[testI];
       LOG.info("Index block size: " + indexBlockSize + ", compression: " + compr);
       // Evict all blocks that were cached-on-write by the previous invocation.
-      blockCache.evictBlocksByHfileName(hfilePath.getName());
+      cache.evictBlocksByHfileName(hfilePath.getName());
 
       conf.setInt(HFileBlockIndex.MAX_CHUNK_SIZE_KEY, indexBlockSize);
       Set<String> keyStrSet = new HashSet<>();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileReaderImpl.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFileReaderImpl.java
@@ -35,6 +35,7 @@ import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.KeyValue;
 import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.testclassification.IOTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -118,7 +119,7 @@ public class TestHFileReaderImpl {
 
   @Test
   public void testReadWorksWhenCacheCorrupt() throws Exception {
-    BlockCache mockedCache = mock(BlockCache.class);
+    CacheAccessService mockedCache = mock(CacheAccessService.class);
     when(mockedCache.getBlock(any(), anyBoolean(), anyBoolean(), anyBoolean(), any()))
       .thenThrow(new RuntimeException("Injected error"));
     Path p = makeNewFile();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestLazyDataBlockDecompression.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestLazyDataBlockDecompression.java
@@ -132,6 +132,10 @@ public class TestLazyDataBlockDecompression {
     reader.close();
   }
 
+  /*
+   * TODO: migrate this test to use new HBASE-30018 APIs and remove the need to cast to
+   * LruBlockCache
+   */
   @TestTemplate
   public void testCompressionIncreasesEffectiveBlockCacheSize() throws Exception {
     // enough room for 2 uncompressed block

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestPrefetch.java
@@ -64,6 +64,8 @@ import org.apache.hadoop.hbase.fs.HFileSystem;
 import org.apache.hadoop.hbase.io.ByteBuffAllocator;
 import org.apache.hadoop.hbase.io.HFileLink;
 import org.apache.hadoop.hbase.io.compress.Compression;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessServiceTestFactory;
 import org.apache.hadoop.hbase.regionserver.BloomType;
 import org.apache.hadoop.hbase.regionserver.ConstantSizeRegionSplitPolicy;
 import org.apache.hadoop.hbase.regionserver.HRegionFileSystem;
@@ -102,7 +104,7 @@ public class TestPrefetch {
   private Configuration conf;
   private CacheConfig cacheConf;
   private FileSystem fs;
-  private BlockCache blockCache;
+  private CacheAccessService cache;
 
   @RegisterExtension
   private static OpenTelemetryExtension OTEL_EXT = OpenTelemetryExtension.create();
@@ -112,8 +114,8 @@ public class TestPrefetch {
     conf = TEST_UTIL.getConfiguration();
     conf.setBoolean(CacheConfig.PREFETCH_BLOCKS_ON_OPEN_KEY, true);
     fs = HFileSystem.get(conf);
-    blockCache = BlockCacheFactory.createBlockCache(conf);
-    cacheConf = new CacheConfig(conf, blockCache);
+    cache = CacheAccessServiceTestFactory.fromConfiguration(conf);
+    cacheConf = new CacheConfig(conf, cache);
   }
 
   @Test
@@ -122,7 +124,7 @@ public class TestPrefetch {
       .newBuilder(Bytes.toBytes("f")).setPrefetchBlocksOnOpen(true).build();
     Configuration c = HBaseConfiguration.create();
     assertFalse(c.getBoolean(CacheConfig.PREFETCH_BLOCKS_ON_OPEN_KEY, false));
-    CacheConfig cc = new CacheConfig(c, columnFamilyDescriptor, blockCache, ByteBuffAllocator.HEAP);
+    CacheConfig cc = new CacheConfig(c, columnFamilyDescriptor, cache, ByteBuffAllocator.HEAP);
     assertTrue(cc.shouldPrefetchOnOpen());
   }
 
@@ -137,7 +139,7 @@ public class TestPrefetch {
         .setBlockCacheEnabled(false).build();
     HFileContext meta = new HFileContextBuilder().withBlockSize(DATA_BLOCK_SIZE).build();
     CacheConfig cacheConfig =
-      new CacheConfig(conf, columnFamilyDescriptor, blockCache, ByteBuffAllocator.HEAP);
+      new CacheConfig(conf, columnFamilyDescriptor, cache, ByteBuffAllocator.HEAP);
     Path storeFile = writeStoreFile("testPrefetchBlockCacheDisabled", meta, cacheConfig);
     readStoreFile(storeFile, (r, o) -> {
       HFileBlock block = null;
@@ -148,7 +150,7 @@ public class TestPrefetch {
       }
       return block;
     }, (key, block) -> {
-      boolean isCached = blockCache.getBlock(key, true, false, true) != null;
+      boolean isCached = cache.getBlock(key, true, false, true) != null;
       if (
         block.getBlockType() == BlockType.DATA || block.getBlockType() == BlockType.ROOT_INDEX
           || block.getBlockType() == BlockType.INTERMEDIATE_INDEX
@@ -169,7 +171,7 @@ public class TestPrefetch {
     Configuration newConf = new Configuration(conf);
     newConf.setDouble(CacheConfig.PREFETCH_HEAP_USAGE_THRESHOLD, 0.1);
     CacheConfig cacheConfig =
-      new CacheConfig(newConf, columnFamilyDescriptor, blockCache, ByteBuffAllocator.HEAP);
+      new CacheConfig(newConf, columnFamilyDescriptor, cache, ByteBuffAllocator.HEAP);
     Path storeFile = writeStoreFile("testPrefetchHeapUsageAboveThreshold", meta, cacheConfig);
     MutableInt cachedCount = new MutableInt(0);
     MutableInt unCachedCount = new MutableInt(0);
@@ -182,7 +184,7 @@ public class TestPrefetch {
       }
       return block;
     }, (key, block) -> {
-      boolean isCached = blockCache.getBlock(key, true, false, true) != null;
+      boolean isCached = cache.getBlock(key, true, false, true) != null;
       if (
         block.getBlockType() == BlockType.DATA || block.getBlockType() == BlockType.ROOT_INDEX
           || block.getBlockType() == BlockType.INTERMEDIATE_INDEX
@@ -253,7 +255,7 @@ public class TestPrefetch {
       }
       return block;
     }, (key, block) -> {
-      boolean isCached = blockCache.getBlock(key, true, false, true) != null;
+      boolean isCached = cache.getBlock(key, true, false, true) != null;
       if (
         block.getBlockType() == BlockType.DATA || block.getBlockType() == BlockType.ROOT_INDEX
           || block.getBlockType() == BlockType.INTERMEDIATE_INDEX
@@ -273,7 +275,7 @@ public class TestPrefetch {
       }
       return block;
     }, (key, block) -> {
-      boolean isCached = blockCache.getBlock(key, true, false, true) != null;
+      boolean isCached = cache.getBlock(key, true, false, true) != null;
       if (block.getBlockType() == BlockType.DATA) {
         assertFalse(block.isUnpacked());
       } else if (
@@ -315,7 +317,7 @@ public class TestPrefetch {
   @Test
   public void testPrefetchCompressed() throws Exception {
     conf.setBoolean(CACHE_DATA_BLOCKS_COMPRESSED_KEY, true);
-    cacheConf = new CacheConfig(conf, blockCache);
+    cacheConf = new CacheConfig(conf, cache);
     HFileContext context = new HFileContextBuilder().withCompression(Compression.Algorithm.GZ)
       .withBlockSize(DATA_BLOCK_SIZE).build();
     Path storeFile = writeStoreFile("TestPrefetchCompressed", context);
@@ -408,7 +410,7 @@ public class TestPrefetch {
 
   private void testPrefetchWhenRefs(boolean compactionEnabled, Consumer<Cacheable> test)
     throws Exception {
-    cacheConf = new CacheConfig(conf, blockCache);
+    cacheConf = new CacheConfig(conf, cache);
     HFileContext context = new HFileContextBuilder().withBlockSize(DATA_BLOCK_SIZE).build();
     Path tableDir = new Path(TEST_UTIL.getDataTestDir(), "testPrefetchSkipRefs");
     RegionInfo region =
@@ -438,14 +440,14 @@ public class TestPrefetch {
       HFileBlock block = reader.readBlock(offset, -1, false, true, false, true, null, null, true);
       BlockCacheKey blockCacheKey = new BlockCacheKey(reader.getName(), offset);
       if (block.getBlockType() == BlockType.DATA) {
-        test.accept(blockCache.getBlock(blockCacheKey, true, false, true));
+        test.accept(cache.getBlock(blockCacheKey, true, false, true));
       }
       offset += block.getOnDiskSizeWithHeader();
     }
   }
 
   private void testPrefetchWhenHFileLink(Consumer<Cacheable> test) throws Exception {
-    cacheConf = new CacheConfig(conf, blockCache);
+    cacheConf = new CacheConfig(conf, cache);
     HFileContext context = new HFileContextBuilder().withBlockSize(DATA_BLOCK_SIZE).build();
     Path testDir = TEST_UTIL.getDataTestDir("testPrefetchWhenHFileLink");
     final RegionInfo hri =
@@ -493,7 +495,7 @@ public class TestPrefetch {
       HFileBlock block = reader.readBlock(offset, -1, false, true, false, true, null, null, true);
       BlockCacheKey blockCacheKey = new BlockCacheKey(reader.getName(), offset);
       if (block.getBlockType() == BlockType.DATA) {
-        test.accept(blockCache.getBlock(blockCacheKey, true, false, true));
+        test.accept(cache.getBlock(blockCacheKey, true, false, true));
       }
       offset += block.getOnDiskSizeWithHeader();
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestRowIndexV1RoundTrip.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestRowIndexV1RoundTrip.java
@@ -37,6 +37,7 @@ import org.apache.hadoop.hbase.SizeCachedNoTagsByteBufferKeyValue;
 import org.apache.hadoop.hbase.SizeCachedNoTagsKeyValue;
 import org.apache.hadoop.hbase.io.ByteBuffAllocator;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.testclassification.IOTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -109,7 +110,7 @@ public class TestRowIndexV1RoundTrip {
       cacheConfig = new CacheConfig(conf);
     } else {
       ByteBuffAllocator allocator = ByteBuffAllocator.create(conf, true);
-      cacheConfig = new CacheConfig(conf, null, null, allocator);
+      cacheConfig = new CacheConfig(conf, null, (CacheAccessService) null, allocator);
     }
     HFile.Reader reader = HFile.createReader(fs, hfilePath, cacheConfig, false, conf);
     HFileScanner scanner = reader.getScanner(conf, false, false);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServiceTestFactory.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServiceTestFactory.java
@@ -1,0 +1,643 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.Executor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCache;
+import org.apache.hadoop.hbase.io.hfile.LruAdaptiveBlockCache;
+import org.apache.hadoop.hbase.io.hfile.LruBlockCache;
+import org.apache.hadoop.hbase.io.hfile.TinyLfuBlockCache;
+import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
+import org.apache.hadoop.hbase.regionserver.HRegion;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Test-only factory helpers for creating {@link CacheAccessService} instances backed by legacy
+ * {@link BlockCache} implementations.
+ * <p>
+ * These helpers are intended to keep integration-style tests concise while the block cache
+ * architecture migrates toward {@link CacheAccessService}. They deliberately do not replace
+ * implementation-specific tests for {@link LruBlockCache}, {@link LruAdaptiveBlockCache},
+ * {@link TinyLfuBlockCache}, {@link BucketCache}, or other concrete cache implementations.
+ * </p>
+ * <p>
+ * Each helper mirrors a public constructor on one of the legacy cache implementations and returns
+ * either:
+ * </p>
+ * <ul>
+ * <li>a {@link CacheAccessService} facade backed by the constructed cache, or</li>
+ * <li>a {@link CacheAccessServiceTestInstance} containing both the concrete cache and the
+ * facade.</li>
+ * </ul>
+ * <p>
+ * The factory currently creates legacy {@link BlockCache} implementations and wraps them using
+ * {@link CacheAccessServices#fromBlockCache(BlockCache)}. Later, when cache engines and topologies
+ * are wired directly, the internals of this factory can change without forcing integration-style
+ * tests to be rewritten again.
+ * </p>
+ */
+@InterfaceAudience.Private
+public final class CacheAccessServiceTestFactory {
+
+  private CacheAccessServiceTestFactory() {
+  }
+
+  /**
+   * Wraps an existing {@link BlockCache} in a {@link CacheAccessService}.
+   * @param blockCache block cache to wrap
+   * @return cache access service backed by the supplied block cache
+   * @throws NullPointerException if {@code blockCache} is {@code null}
+   */
+  public static CacheAccessService fromBlockCache(BlockCache blockCache) {
+    return CacheAccessServices.fromBlockCache(blockCache);
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} from the block cache configuration.
+   * <p>
+   * This method delegates to {@link CacheAccessServices#fromConfiguration(Configuration)} and is
+   * useful for tests that want the normal legacy
+   * {@link org.apache.hadoop.hbase.io.hfile.BlockCacheFactory} construction path while receiving a
+   * {@link CacheAccessService} facade.
+   * </p>
+   * @param conf configuration used to create the legacy block cache
+   * @return cache access service created from configuration, or disabled when no cache is
+   *         configured
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessService fromConfiguration(Configuration conf) {
+    return CacheAccessServices.fromConfiguration(conf);
+  }
+
+  /**
+   * Returns a disabled/no-op cache access service.
+   * @return disabled cache access service
+   */
+  public static CacheAccessService disabled() {
+    return CacheAccessServices.disabled();
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link LruBlockCache}.
+   * @param maxSize   maximum size of cache, in bytes
+   * @param blockSize approximate size of each block, in bytes
+   * @return cache access service backed by {@link LruBlockCache}
+   */
+  public static CacheAccessService lru(long maxSize, long blockSize) {
+    return lruInstance(maxSize, blockSize).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link LruBlockCache} and its {@link CacheAccessService}
+   * facade.
+   * @param maxSize   maximum size of cache, in bytes
+   * @param blockSize approximate size of each block, in bytes
+   * @return test instance
+   */
+  public static CacheAccessServiceTestInstance<LruBlockCache> lruInstance(long maxSize,
+    long blockSize) {
+    return new CacheAccessServiceTestInstance<>(new LruBlockCache(maxSize, blockSize));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link LruBlockCache}.
+   * @param maxSize        maximum size of cache, in bytes
+   * @param blockSize      approximate size of each block, in bytes
+   * @param evictionThread whether to start the eviction thread
+   * @return cache access service backed by {@link LruBlockCache}
+   */
+  public static CacheAccessService lru(long maxSize, long blockSize, boolean evictionThread) {
+    return lruInstance(maxSize, blockSize, evictionThread).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link LruBlockCache} and its {@link CacheAccessService}
+   * facade.
+   * @param maxSize        maximum size of cache, in bytes
+   * @param blockSize      approximate size of each block, in bytes
+   * @param evictionThread whether to start the eviction thread
+   * @return test instance
+   */
+  public static CacheAccessServiceTestInstance<LruBlockCache> lruInstance(long maxSize,
+    long blockSize, boolean evictionThread) {
+    return new CacheAccessServiceTestInstance<>(
+      new LruBlockCache(maxSize, blockSize, evictionThread));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link LruBlockCache}.
+   * @param maxSize        maximum size of cache, in bytes
+   * @param blockSize      approximate size of each block, in bytes
+   * @param evictionThread whether to start the eviction thread
+   * @param conf           configuration used by the cache constructor
+   * @return cache access service backed by {@link LruBlockCache}
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessService lru(long maxSize, long blockSize, boolean evictionThread,
+    Configuration conf) {
+    return lruInstance(maxSize, blockSize, evictionThread, conf).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link LruBlockCache} and its {@link CacheAccessService}
+   * facade.
+   * @param maxSize        maximum size of cache, in bytes
+   * @param blockSize      approximate size of each block, in bytes
+   * @param evictionThread whether to start the eviction thread
+   * @param conf           configuration used by the cache constructor
+   * @return test instance
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<LruBlockCache> lruInstance(long maxSize,
+    long blockSize, boolean evictionThread, Configuration conf) {
+    Objects.requireNonNull(conf, "conf must not be null");
+    return new CacheAccessServiceTestInstance<>(
+      new LruBlockCache(maxSize, blockSize, evictionThread, conf));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link LruBlockCache}.
+   * @param maxSize   maximum size of cache, in bytes
+   * @param blockSize approximate size of each block, in bytes
+   * @param conf      configuration used by the cache constructor
+   * @return cache access service backed by {@link LruBlockCache}
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessService lru(long maxSize, long blockSize, Configuration conf) {
+    return lruInstance(maxSize, blockSize, conf).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link LruBlockCache} and its {@link CacheAccessService}
+   * facade.
+   * @param maxSize   maximum size of cache, in bytes
+   * @param blockSize approximate size of each block, in bytes
+   * @param conf      configuration used by the cache constructor
+   * @return test instance
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<LruBlockCache> lruInstance(long maxSize,
+    long blockSize, Configuration conf) {
+    Objects.requireNonNull(conf, "conf must not be null");
+    return new CacheAccessServiceTestInstance<>(new LruBlockCache(maxSize, blockSize, conf));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by a fully configured {@link LruBlockCache}.
+   * @param maxSize             maximum size of this cache, in bytes
+   * @param blockSize           expected average size of blocks, in bytes
+   * @param evictionThread      whether to run evictions in a background thread
+   * @param mapInitialSize      initial size of the backing concurrent map
+   * @param mapLoadFactor       initial load factor of the backing concurrent map
+   * @param mapConcurrencyLevel initial concurrency level of the backing concurrent map
+   * @param minFactor           percentage of total size to evict down to
+   * @param acceptableFactor    percentage of total size that triggers eviction
+   * @param singleFactor        percentage of total size for single-access blocks
+   * @param multiFactor         percentage of total size for multi-access blocks
+   * @param memoryFactor        percentage of total size for in-memory blocks
+   * @param hardLimitFactor     hard capacity limit factor
+   * @param forceInMemory       whether in-memory HFile data blocks have higher priority
+   * @param maxBlockSize        maximum block size accepted by the cache
+   * @return cache access service backed by {@link LruBlockCache}
+   */
+  public static CacheAccessService lru(long maxSize, long blockSize, boolean evictionThread,
+    int mapInitialSize, float mapLoadFactor, int mapConcurrencyLevel, float minFactor,
+    float acceptableFactor, float singleFactor, float multiFactor, float memoryFactor,
+    float hardLimitFactor, boolean forceInMemory, long maxBlockSize) {
+    return lruInstance(maxSize, blockSize, evictionThread, mapInitialSize, mapLoadFactor,
+      mapConcurrencyLevel, minFactor, acceptableFactor, singleFactor, multiFactor, memoryFactor,
+      hardLimitFactor, forceInMemory, maxBlockSize).service();
+  }
+
+  /**
+   * Creates a test instance containing a fully configured {@link LruBlockCache} and its
+   * {@link CacheAccessService} facade.
+   * @param maxSize             maximum size of this cache, in bytes
+   * @param blockSize           expected average size of blocks, in bytes
+   * @param evictionThread      whether to run evictions in a background thread
+   * @param mapInitialSize      initial size of the backing concurrent map
+   * @param mapLoadFactor       initial load factor of the backing concurrent map
+   * @param mapConcurrencyLevel initial concurrency level of the backing concurrent map
+   * @param minFactor           percentage of total size to evict down to
+   * @param acceptableFactor    percentage of total size that triggers eviction
+   * @param singleFactor        percentage of total size for single-access blocks
+   * @param multiFactor         percentage of total size for multi-access blocks
+   * @param memoryFactor        percentage of total size for in-memory blocks
+   * @param hardLimitFactor     hard capacity limit factor
+   * @param forceInMemory       whether in-memory HFile data blocks have higher priority
+   * @param maxBlockSize        maximum block size accepted by the cache
+   * @return test instance
+   */
+  public static CacheAccessServiceTestInstance<LruBlockCache> lruInstance(long maxSize,
+    long blockSize, boolean evictionThread, int mapInitialSize, float mapLoadFactor,
+    int mapConcurrencyLevel, float minFactor, float acceptableFactor, float singleFactor,
+    float multiFactor, float memoryFactor, float hardLimitFactor, boolean forceInMemory,
+    long maxBlockSize) {
+    return new CacheAccessServiceTestInstance<>(
+      new LruBlockCache(maxSize, blockSize, evictionThread, mapInitialSize, mapLoadFactor,
+        mapConcurrencyLevel, minFactor, acceptableFactor, singleFactor, multiFactor, memoryFactor,
+        hardLimitFactor, forceInMemory, maxBlockSize));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link LruAdaptiveBlockCache}.
+   * @param maxSize   maximum size of cache, in bytes
+   * @param blockSize approximate size of each block, in bytes
+   * @return cache access service backed by {@link LruAdaptiveBlockCache}
+   */
+  public static CacheAccessService lruAdaptive(long maxSize, long blockSize) {
+    return lruAdaptiveInstance(maxSize, blockSize).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link LruAdaptiveBlockCache} and its
+   * {@link CacheAccessService} facade.
+   * @param maxSize   maximum size of cache, in bytes
+   * @param blockSize approximate size of each block, in bytes
+   * @return test instance
+   */
+  public static CacheAccessServiceTestInstance<LruAdaptiveBlockCache>
+    lruAdaptiveInstance(long maxSize, long blockSize) {
+    return new CacheAccessServiceTestInstance<>(new LruAdaptiveBlockCache(maxSize, blockSize));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link LruAdaptiveBlockCache}.
+   * @param maxSize        maximum size of cache, in bytes
+   * @param blockSize      approximate size of each block, in bytes
+   * @param evictionThread whether to start the eviction thread
+   * @return cache access service backed by {@link LruAdaptiveBlockCache}
+   */
+  public static CacheAccessService lruAdaptive(long maxSize, long blockSize,
+    boolean evictionThread) {
+    return lruAdaptiveInstance(maxSize, blockSize, evictionThread).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link LruAdaptiveBlockCache} and its
+   * {@link CacheAccessService} facade.
+   * @param maxSize        maximum size of cache, in bytes
+   * @param blockSize      approximate size of each block, in bytes
+   * @param evictionThread whether to start the eviction thread
+   * @return test instance
+   */
+  public static CacheAccessServiceTestInstance<LruAdaptiveBlockCache>
+    lruAdaptiveInstance(long maxSize, long blockSize, boolean evictionThread) {
+    return new CacheAccessServiceTestInstance<>(
+      new LruAdaptiveBlockCache(maxSize, blockSize, evictionThread));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link LruAdaptiveBlockCache}.
+   * @param maxSize        maximum size of cache, in bytes
+   * @param blockSize      approximate size of each block, in bytes
+   * @param evictionThread whether to start the eviction thread
+   * @param conf           configuration used by the cache constructor
+   * @return cache access service backed by {@link LruAdaptiveBlockCache}
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessService lruAdaptive(long maxSize, long blockSize, boolean evictionThread,
+    Configuration conf) {
+    return lruAdaptiveInstance(maxSize, blockSize, evictionThread, conf).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link LruAdaptiveBlockCache} and its
+   * {@link CacheAccessService} facade.
+   * @param maxSize        maximum size of cache, in bytes
+   * @param blockSize      approximate size of each block, in bytes
+   * @param evictionThread whether to start the eviction thread
+   * @param conf           configuration used by the cache constructor
+   * @return test instance
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<LruAdaptiveBlockCache>
+    lruAdaptiveInstance(long maxSize, long blockSize, boolean evictionThread, Configuration conf) {
+    Objects.requireNonNull(conf, "conf must not be null");
+    return new CacheAccessServiceTestInstance<>(
+      new LruAdaptiveBlockCache(maxSize, blockSize, evictionThread, conf));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link LruAdaptiveBlockCache}.
+   * @param maxSize   maximum size of cache, in bytes
+   * @param blockSize approximate size of each block, in bytes
+   * @param conf      configuration used by the cache constructor
+   * @return cache access service backed by {@link LruAdaptiveBlockCache}
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessService lruAdaptive(long maxSize, long blockSize, Configuration conf) {
+    return lruAdaptiveInstance(maxSize, blockSize, conf).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link LruAdaptiveBlockCache} and its
+   * {@link CacheAccessService} facade.
+   * @param maxSize   maximum size of cache, in bytes
+   * @param blockSize approximate size of each block, in bytes
+   * @param conf      configuration used by the cache constructor
+   * @return test instance
+   * @throws NullPointerException if {@code conf} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<LruAdaptiveBlockCache>
+    lruAdaptiveInstance(long maxSize, long blockSize, Configuration conf) {
+    Objects.requireNonNull(conf, "conf must not be null");
+    return new CacheAccessServiceTestInstance<>(
+      new LruAdaptiveBlockCache(maxSize, blockSize, conf));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by a fully configured
+   * {@link LruAdaptiveBlockCache}.
+   * @param maxSize                          maximum size of this cache, in bytes
+   * @param blockSize                        expected average size of blocks, in bytes
+   * @param evictionThread                   whether to run evictions in a background thread
+   * @param mapInitialSize                   initial size of the backing concurrent map
+   * @param mapLoadFactor                    initial load factor of the backing concurrent map
+   * @param mapConcurrencyLevel              initial concurrency level of the backing concurrent map
+   * @param minFactor                        percentage of total size to evict down to
+   * @param acceptableFactor                 percentage of total size that triggers eviction
+   * @param singleFactor                     percentage of total size for single-access blocks
+   * @param multiFactor                      percentage of total size for multi-access blocks
+   * @param memoryFactor                     percentage of total size for in-memory blocks
+   * @param hardLimitFactor                  hard capacity limit factor
+   * @param forceInMemory                    whether in-memory HFile data blocks have higher
+   *                                         priority
+   * @param maxBlockSize                     maximum block size accepted by the cache
+   * @param heavyEvictionCountLimit          threshold count for heavy-eviction adaptive behavior
+   * @param heavyEvictionMbSizeLimit         threshold size for heavy-eviction adaptive behavior
+   * @param heavyEvictionOverheadCoefficient coefficient controlling adaptive reduction
+   *                                         aggressiveness
+   * @return cache access service backed by {@link LruAdaptiveBlockCache}
+   */
+  public static CacheAccessService lruAdaptive(long maxSize, long blockSize, boolean evictionThread,
+    int mapInitialSize, float mapLoadFactor, int mapConcurrencyLevel, float minFactor,
+    float acceptableFactor, float singleFactor, float multiFactor, float memoryFactor,
+    float hardLimitFactor, boolean forceInMemory, long maxBlockSize, int heavyEvictionCountLimit,
+    long heavyEvictionMbSizeLimit, float heavyEvictionOverheadCoefficient) {
+    return lruAdaptiveInstance(maxSize, blockSize, evictionThread, mapInitialSize, mapLoadFactor,
+      mapConcurrencyLevel, minFactor, acceptableFactor, singleFactor, multiFactor, memoryFactor,
+      hardLimitFactor, forceInMemory, maxBlockSize, heavyEvictionCountLimit,
+      heavyEvictionMbSizeLimit, heavyEvictionOverheadCoefficient).service();
+  }
+
+  /**
+   * Creates a test instance containing a fully configured {@link LruAdaptiveBlockCache} and its
+   * {@link CacheAccessService} facade.
+   * @param maxSize                          maximum size of this cache, in bytes
+   * @param blockSize                        expected average size of blocks, in bytes
+   * @param evictionThread                   whether to run evictions in a background thread
+   * @param mapInitialSize                   initial size of the backing concurrent map
+   * @param mapLoadFactor                    initial load factor of the backing concurrent map
+   * @param mapConcurrencyLevel              initial concurrency level of the backing concurrent map
+   * @param minFactor                        percentage of total size to evict down to
+   * @param acceptableFactor                 percentage of total size that triggers eviction
+   * @param singleFactor                     percentage of total size for single-access blocks
+   * @param multiFactor                      percentage of total size for multi-access blocks
+   * @param memoryFactor                     percentage of total size for in-memory blocks
+   * @param hardLimitFactor                  hard capacity limit factor
+   * @param forceInMemory                    whether in-memory HFile data blocks have higher
+   *                                         priority
+   * @param maxBlockSize                     maximum block size accepted by the cache
+   * @param heavyEvictionCountLimit          threshold count for heavy-eviction adaptive behavior
+   * @param heavyEvictionMbSizeLimit         threshold size for heavy-eviction adaptive behavior
+   * @param heavyEvictionOverheadCoefficient coefficient controlling adaptive reduction
+   *                                         aggressiveness
+   * @return test instance
+   */
+  public static CacheAccessServiceTestInstance<LruAdaptiveBlockCache> lruAdaptiveInstance(
+    long maxSize, long blockSize, boolean evictionThread, int mapInitialSize, float mapLoadFactor,
+    int mapConcurrencyLevel, float minFactor, float acceptableFactor, float singleFactor,
+    float multiFactor, float memoryFactor, float hardLimitFactor, boolean forceInMemory,
+    long maxBlockSize, int heavyEvictionCountLimit, long heavyEvictionMbSizeLimit,
+    float heavyEvictionOverheadCoefficient) {
+    return new CacheAccessServiceTestInstance<>(
+      new LruAdaptiveBlockCache(maxSize, blockSize, evictionThread, mapInitialSize, mapLoadFactor,
+        mapConcurrencyLevel, minFactor, acceptableFactor, singleFactor, multiFactor, memoryFactor,
+        hardLimitFactor, forceInMemory, maxBlockSize, heavyEvictionCountLimit,
+        heavyEvictionMbSizeLimit, heavyEvictionOverheadCoefficient));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link TinyLfuBlockCache}.
+   * @param maximumSizeInBytes maximum size of this cache, in bytes
+   * @param avgBlockSize       expected average size of blocks, in bytes
+   * @param executor           executor used by the underlying Caffeine cache
+   * @param conf               configuration used by the cache constructor
+   * @return cache access service backed by {@link TinyLfuBlockCache}
+   * @throws NullPointerException if {@code executor} or {@code conf} is {@code null}
+   */
+  public static CacheAccessService tinyLfu(long maximumSizeInBytes, long avgBlockSize,
+    Executor executor, Configuration conf) {
+    return tinyLfuInstance(maximumSizeInBytes, avgBlockSize, executor, conf).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link TinyLfuBlockCache} and its {@link CacheAccessService}
+   * facade.
+   * @param maximumSizeInBytes maximum size of this cache, in bytes
+   * @param avgBlockSize       expected average size of blocks, in bytes
+   * @param executor           executor used by the underlying Caffeine cache
+   * @param conf               configuration used by the cache constructor
+   * @return test instance
+   * @throws NullPointerException if {@code executor} or {@code conf} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<TinyLfuBlockCache> tinyLfuInstance(
+    long maximumSizeInBytes, long avgBlockSize, Executor executor, Configuration conf) {
+    Objects.requireNonNull(executor, "executor must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return new CacheAccessServiceTestInstance<>(
+      new TinyLfuBlockCache(maximumSizeInBytes, avgBlockSize, executor, conf));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link TinyLfuBlockCache}.
+   * @param maximumSizeInBytes maximum size of this cache, in bytes
+   * @param avgBlockSize       expected average size of blocks, in bytes
+   * @param maxBlockSize       maximum size of a block, in bytes
+   * @param executor           executor used by the underlying Caffeine cache
+   * @return cache access service backed by {@link TinyLfuBlockCache}
+   * @throws NullPointerException if {@code executor} is {@code null}
+   */
+  public static CacheAccessService tinyLfu(long maximumSizeInBytes, long avgBlockSize,
+    long maxBlockSize, Executor executor) {
+    return tinyLfuInstance(maximumSizeInBytes, avgBlockSize, maxBlockSize, executor).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link TinyLfuBlockCache} and its {@link CacheAccessService}
+   * facade.
+   * @param maximumSizeInBytes maximum size of this cache, in bytes
+   * @param avgBlockSize       expected average size of blocks, in bytes
+   * @param maxBlockSize       maximum size of a block, in bytes
+   * @param executor           executor used by the underlying Caffeine cache
+   * @return test instance
+   * @throws NullPointerException if {@code executor} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<TinyLfuBlockCache> tinyLfuInstance(
+    long maximumSizeInBytes, long avgBlockSize, long maxBlockSize, Executor executor) {
+    Objects.requireNonNull(executor, "executor must not be null");
+    return new CacheAccessServiceTestInstance<>(
+      new TinyLfuBlockCache(maximumSizeInBytes, avgBlockSize, maxBlockSize, executor));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link BucketCache}.
+   * @param ioEngineName    IO engine name
+   * @param capacity        cache capacity, in bytes
+   * @param blockSize       expected block size, in bytes
+   * @param bucketSizes     configured bucket sizes, or {@code null} to use defaults
+   * @param writerThreadNum number of writer threads
+   * @param writerQLen      writer queue length
+   * @param persistencePath persistence path, or {@code null} for non-persistent cache
+   * @return cache access service backed by {@link BucketCache}
+   * @throws IOException          if the bucket cache cannot be created
+   * @throws NullPointerException if {@code ioEngineName} is {@code null}
+   */
+  public static CacheAccessService bucket(String ioEngineName, long capacity, int blockSize,
+    int[] bucketSizes, int writerThreadNum, int writerQLen, String persistencePath)
+    throws IOException {
+    return bucketInstance(ioEngineName, capacity, blockSize, bucketSizes, writerThreadNum,
+      writerQLen, persistencePath).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link BucketCache} and its {@link CacheAccessService}
+   * facade.
+   * @param ioEngineName    IO engine name
+   * @param capacity        cache capacity, in bytes
+   * @param blockSize       expected block size, in bytes
+   * @param bucketSizes     configured bucket sizes, or {@code null} to use defaults
+   * @param writerThreadNum number of writer threads
+   * @param writerQLen      writer queue length
+   * @param persistencePath persistence path, or {@code null} for non-persistent cache
+   * @return test instance
+   * @throws IOException          if the bucket cache cannot be created
+   * @throws NullPointerException if {@code ioEngineName} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<BucketCache> bucketInstance(String ioEngineName,
+    long capacity, int blockSize, int[] bucketSizes, int writerThreadNum, int writerQLen,
+    String persistencePath) throws IOException {
+    Objects.requireNonNull(ioEngineName, "ioEngineName must not be null");
+    return new CacheAccessServiceTestInstance<>(new BucketCache(ioEngineName, capacity, blockSize,
+      bucketSizes, writerThreadNum, writerQLen, persistencePath));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link BucketCache}.
+   * @param ioEngineName               IO engine name
+   * @param capacity                   cache capacity, in bytes
+   * @param blockSize                  expected block size, in bytes
+   * @param bucketSizes                configured bucket sizes, or {@code null} to use defaults
+   * @param writerThreadNum            number of writer threads
+   * @param writerQLen                 writer queue length
+   * @param persistencePath            persistence path, or {@code null} for non-persistent cache
+   * @param ioErrorsTolerationDuration duration for tolerating IO engine errors
+   * @param conf                       configuration used by the bucket cache
+   * @return cache access service backed by {@link BucketCache}
+   * @throws IOException          if the bucket cache cannot be created
+   * @throws NullPointerException if {@code ioEngineName} or {@code conf} is {@code null}
+   */
+  public static CacheAccessService bucket(String ioEngineName, long capacity, int blockSize,
+    int[] bucketSizes, int writerThreadNum, int writerQLen, String persistencePath,
+    int ioErrorsTolerationDuration, Configuration conf) throws IOException {
+    return bucketInstance(ioEngineName, capacity, blockSize, bucketSizes, writerThreadNum,
+      writerQLen, persistencePath, ioErrorsTolerationDuration, conf).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link BucketCache} and its {@link CacheAccessService}
+   * facade.
+   * @param ioEngineName               IO engine name
+   * @param capacity                   cache capacity, in bytes
+   * @param blockSize                  expected block size, in bytes
+   * @param bucketSizes                configured bucket sizes, or {@code null} to use defaults
+   * @param writerThreadNum            number of writer threads
+   * @param writerQLen                 writer queue length
+   * @param persistencePath            persistence path, or {@code null} for non-persistent cache
+   * @param ioErrorsTolerationDuration duration for tolerating IO engine errors
+   * @param conf                       configuration used by the bucket cache
+   * @return test instance
+   * @throws IOException          if the bucket cache cannot be created
+   * @throws NullPointerException if {@code ioEngineName} or {@code conf} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<BucketCache> bucketInstance(String ioEngineName,
+    long capacity, int blockSize, int[] bucketSizes, int writerThreadNum, int writerQLen,
+    String persistencePath, int ioErrorsTolerationDuration, Configuration conf) throws IOException {
+    Objects.requireNonNull(ioEngineName, "ioEngineName must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return new CacheAccessServiceTestInstance<>(new BucketCache(ioEngineName, capacity, blockSize,
+      bucketSizes, writerThreadNum, writerQLen, persistencePath, ioErrorsTolerationDuration, conf));
+  }
+
+  /**
+   * Creates a {@link CacheAccessService} backed by {@link BucketCache}.
+   * @param ioEngineName               IO engine name
+   * @param capacity                   cache capacity, in bytes
+   * @param blockSize                  expected block size, in bytes
+   * @param bucketSizes                configured bucket sizes, or {@code null} to use defaults
+   * @param writerThreadNum            number of writer threads
+   * @param writerQLen                 writer queue length
+   * @param persistencePath            persistence path, or {@code null} for non-persistent cache
+   * @param ioErrorsTolerationDuration duration for tolerating IO engine errors
+   * @param conf                       configuration used by the bucket cache
+   * @param onlineRegions              online regions map used by the bucket cache, or {@code null}
+   * @return cache access service backed by {@link BucketCache}
+   * @throws IOException          if the bucket cache cannot be created
+   * @throws NullPointerException if {@code ioEngineName} or {@code conf} is {@code null}
+   */
+  public static CacheAccessService bucket(String ioEngineName, long capacity, int blockSize,
+    int[] bucketSizes, int writerThreadNum, int writerQLen, String persistencePath,
+    int ioErrorsTolerationDuration, Configuration conf, Map<String, HRegion> onlineRegions)
+    throws IOException {
+    return bucketInstance(ioEngineName, capacity, blockSize, bucketSizes, writerThreadNum,
+      writerQLen, persistencePath, ioErrorsTolerationDuration, conf, onlineRegions).service();
+  }
+
+  /**
+   * Creates a test instance containing {@link BucketCache} and its {@link CacheAccessService}
+   * facade.
+   * @param ioEngineName               IO engine name
+   * @param capacity                   cache capacity, in bytes
+   * @param blockSize                  expected block size, in bytes
+   * @param bucketSizes                configured bucket sizes, or {@code null} to use defaults
+   * @param writerThreadNum            number of writer threads
+   * @param writerQLen                 writer queue length
+   * @param persistencePath            persistence path, or {@code null} for non-persistent cache
+   * @param ioErrorsTolerationDuration duration for tolerating IO engine errors
+   * @param conf                       configuration used by the bucket cache
+   * @param onlineRegions              online regions map used by the bucket cache, or {@code null}
+   * @return test instance
+   * @throws IOException          if the bucket cache cannot be created
+   * @throws NullPointerException if {@code ioEngineName} or {@code conf} is {@code null}
+   */
+  public static CacheAccessServiceTestInstance<BucketCache> bucketInstance(String ioEngineName,
+    long capacity, int blockSize, int[] bucketSizes, int writerThreadNum, int writerQLen,
+    String persistencePath, int ioErrorsTolerationDuration, Configuration conf,
+    Map<String, HRegion> onlineRegions) throws IOException {
+    Objects.requireNonNull(ioEngineName, "ioEngineName must not be null");
+    Objects.requireNonNull(conf, "conf must not be null");
+    return new CacheAccessServiceTestInstance<>(
+      new BucketCache(ioEngineName, capacity, blockSize, bucketSizes, writerThreadNum, writerQLen,
+        persistencePath, ioErrorsTolerationDuration, conf, onlineRegions));
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServiceTestFactory.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServiceTestFactory.java
@@ -640,4 +640,33 @@ public final class CacheAccessServiceTestFactory {
       new BucketCache(ioEngineName, capacity, blockSize, bucketSizes, writerThreadNum, writerQLen,
         persistencePath, ioErrorsTolerationDuration, conf, onlineRegions));
   }
+
+  /**
+   * Returns the legacy {@link BlockCache} backing the supplied {@link CacheAccessService}.
+   * <p>
+   * This helper is intended for tests only. It supports transitional test migration where
+   * production code is exercised through {@link CacheAccessService}, but the test still needs
+   * direct access to the underlying legacy {@link BlockCache} for implementation-specific
+   * assertions, cached-block iteration, metrics inspection, or other diagnostic checks.
+   * </p>
+   * <p>
+   * Only {@link BlockCacheBackedCacheAccessService} is supported. Services backed by future
+   * topology/cache-engine implementations are not required to expose a legacy {@link BlockCache}.
+   * Tests that use this method should therefore be treated as compatibility tests, not as tests of
+   * the final pluggable-cache architecture.
+   * </p>
+   * @param cacheAccessService cache access service
+   * @return backing legacy block cache
+   * @throws NullPointerException     if {@code cacheAccessService} is {@code null}
+   * @throws IllegalArgumentException if {@code cacheAccessService} is not backed by a legacy
+   *                                  {@link BlockCache}
+   */
+  public static BlockCache blockCache(CacheAccessService cacheAccessService) {
+    Objects.requireNonNull(cacheAccessService, "cacheAccessService must not be null");
+    if (cacheAccessService instanceof BlockCacheBackedCacheAccessService) {
+      return ((BlockCacheBackedCacheAccessService) cacheAccessService).getBlockCache();
+    }
+    throw new IllegalArgumentException("CacheAccessService is not backed by a legacy BlockCache: "
+      + cacheAccessService.getClass().getName());
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServiceTestInstance.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServiceTestInstance.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import java.util.Objects;
+import org.apache.hadoop.hbase.io.hfile.BlockCache;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Test helper that keeps a concrete {@link BlockCache} together with the {@link CacheAccessService}
+ * facade backed by that cache.
+ * <p>
+ * This is useful for tests that need to exercise production code through
+ * {@link CacheAccessService}, while still inspecting implementation-specific state through the
+ * concrete cache instance.
+ * </p>
+ * @param <T> concrete block cache type
+ */
+@InterfaceAudience.Private
+public final class CacheAccessServiceTestInstance<T extends BlockCache> {
+
+  private final T blockCache;
+  private final CacheAccessService cacheAccessService;
+
+  CacheAccessServiceTestInstance(T blockCache) {
+    this.blockCache = Objects.requireNonNull(blockCache, "blockCache must not be null");
+    this.cacheAccessService = CacheAccessServices.fromBlockCache(blockCache);
+  }
+
+  /**
+   * Returns the concrete block cache instance.
+   * <p>
+   * Tests should use this only when they need implementation-specific inspection or assertions.
+   * Normal cache access should go through {@link #service()}.
+   * </p>
+   * @return concrete block cache
+   */
+  public T blockCache() {
+    return blockCache;
+  }
+
+  /**
+   * Returns the {@link CacheAccessService} facade backed by the concrete block cache.
+   * @return cache access service
+   */
+  public CacheAccessService service() {
+    return cacheAccessService;
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestBlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestBlockCacheBackedCacheAccessService.java
@@ -69,8 +69,8 @@ public class TestBlockCacheBackedCacheAccessService {
 
     when(blockCache.getBlock(key, true, true, false, BlockType.DATA)).thenReturn(block);
 
-    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(true).setRepeat(true)
-      .setUpdateCacheMetrics(false).setBlockType(BlockType.DATA).build();
+    CacheRequestContext context = CacheRequestContext.newBuilder().withCaching(true)
+      .withRepeat(true).withUpdateCacheMetrics(false).withBlockType(BlockType.DATA).build();
 
     assertSame(block, service.getBlock(key, context));
     verify(blockCache).getBlock(key, true, true, false, BlockType.DATA);
@@ -88,8 +88,8 @@ public class TestBlockCacheBackedCacheAccessService {
 
     when(blockCache.getBlock(key, true, false, true)).thenReturn(block);
 
-    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(true).setRepeat(false)
-      .setUpdateCacheMetrics(true).build();
+    CacheRequestContext context = CacheRequestContext.newBuilder().withCaching(true)
+      .withRepeat(false).withUpdateCacheMetrics(true).build();
 
     assertSame(block, service.getBlock(key, context));
     verify(blockCache).getBlock(key, true, false, true);
@@ -105,8 +105,8 @@ public class TestBlockCacheBackedCacheAccessService {
     BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
     Cacheable block = mock(Cacheable.class);
 
-    CacheWriteContext context = CacheWriteContext.newBuilder().setInMemory(true)
-      .setWaitWhenCache(true).setSource(CacheWriteSource.READ_MISS).build();
+    CacheWriteContext context = CacheWriteContext.newBuilder().withInMemory(true)
+      .withWaitWhenCache(true).withSource(CacheWriteSource.READ_MISS).build();
 
     service.cacheBlock(key, block, context);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestBlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestBlockCacheBackedCacheAccessService.java
@@ -1,0 +1,221 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCache;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.testclassification.IOTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link BlockCacheBackedCacheAccessService} and related service helpers.
+ */
+@Tag(IOTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestBlockCacheBackedCacheAccessService {
+
+  private static final String HFILE_NAME = "file";
+
+  private static final long BLOCK_OFFSET = 1L;
+
+  private static final long RANGE_START_OFFSET = 1L;
+
+  private static final long RANGE_END_OFFSET = 10L;
+
+  /**
+   * Verifies that context-based lookup delegates to the block-type aware legacy lookup method.
+   */
+  @Test
+  void testGetBlockWithBlockTypeDelegatesToBlockCache() {
+    BlockCache blockCache = mock(BlockCache.class);
+    CacheAccessService service = new BlockCacheBackedCacheAccessService(blockCache);
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    Cacheable block = mock(Cacheable.class);
+
+    when(blockCache.getBlock(key, true, true, false, BlockType.DATA)).thenReturn(block);
+
+    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(true).setRepeat(true)
+      .setUpdateCacheMetrics(false).setBlockType(BlockType.DATA).build();
+
+    assertSame(block, service.getBlock(key, context));
+    verify(blockCache).getBlock(key, true, true, false, BlockType.DATA);
+  }
+
+  /**
+   * Verifies that context-based lookup delegates to the legacy lookup method without block type.
+   */
+  @Test
+  void testGetBlockWithoutBlockTypeDelegatesToBlockCache() {
+    BlockCache blockCache = mock(BlockCache.class);
+    CacheAccessService service = new BlockCacheBackedCacheAccessService(blockCache);
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    Cacheable block = mock(Cacheable.class);
+
+    when(blockCache.getBlock(key, true, false, true)).thenReturn(block);
+
+    CacheRequestContext context = CacheRequestContext.newBuilder().setCaching(true).setRepeat(false)
+      .setUpdateCacheMetrics(true).build();
+
+    assertSame(block, service.getBlock(key, context));
+    verify(blockCache).getBlock(key, true, false, true);
+  }
+
+  /**
+   * Verifies that context-based insertion delegates in-memory and wait flags correctly.
+   */
+  @Test
+  void testCacheBlockDelegatesToBlockCache() {
+    BlockCache blockCache = mock(BlockCache.class);
+    CacheAccessService service = new BlockCacheBackedCacheAccessService(blockCache);
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    Cacheable block = mock(Cacheable.class);
+
+    CacheWriteContext context = CacheWriteContext.newBuilder().setInMemory(true)
+      .setWaitWhenCache(true).setSource(CacheWriteSource.READ_MISS).build();
+
+    service.cacheBlock(key, block, context);
+
+    verify(blockCache).cacheBlock(key, block, true, true);
+  }
+
+  /**
+   * Verifies that invalidation methods delegate to the wrapped block cache.
+   */
+  @Test
+  void testEvictionDelegatesToBlockCache() {
+    BlockCache blockCache = mock(BlockCache.class);
+    CacheAccessService service = new BlockCacheBackedCacheAccessService(blockCache);
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+
+    when(blockCache.evictBlock(key)).thenReturn(true);
+    when(blockCache.evictBlocksByHfileName(HFILE_NAME)).thenReturn(3);
+    when(blockCache.evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET, RANGE_END_OFFSET))
+      .thenReturn(2);
+
+    assertTrue(service.evictBlock(key));
+    assertEquals(3, service.evictBlocksByHfileName(HFILE_NAME));
+    assertEquals(2,
+      service.evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET, RANGE_END_OFFSET));
+
+    verify(blockCache).evictBlock(key);
+    verify(blockCache).evictBlocksByHfileName(HFILE_NAME);
+    verify(blockCache).evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET,
+      RANGE_END_OFFSET);
+  }
+
+  /**
+   * Verifies that stats, sizing, lifecycle, and optional helpers delegate to the wrapped cache.
+   */
+  @Test
+  void testStatsSizingLifecycleAndHelpersDelegateToBlockCache() {
+    BlockCache blockCache = mock(BlockCache.class);
+    CacheAccessService service = new BlockCacheBackedCacheAccessService(blockCache);
+    CacheStats stats = new CacheStats("test");
+    HFileBlock hfileBlock = mock(HFileBlock.class);
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    Configuration conf = new Configuration(false);
+
+    when(blockCache.getStats()).thenReturn(stats);
+    when(blockCache.getMaxSize()).thenReturn(100L);
+    when(blockCache.getFreeSize()).thenReturn(40L);
+    when(blockCache.size()).thenReturn(60L);
+    when(blockCache.getCurrentDataSize()).thenReturn(50L);
+    when(blockCache.getBlockCount()).thenReturn(10L);
+    when(blockCache.getDataBlockCount()).thenReturn(8L);
+    when(blockCache.blockFitsIntoTheCache(hfileBlock)).thenReturn(Optional.of(true));
+    when(blockCache.isAlreadyCached(key)).thenReturn(Optional.of(false));
+    when(blockCache.getBlockSize(key)).thenReturn(Optional.of(123));
+    when(blockCache.isCacheEnabled()).thenReturn(true);
+    when(blockCache.waitForCacheInitialization(500L)).thenReturn(true);
+
+    assertSame(stats, service.getStats());
+    assertEquals(100L, service.getMaxSize());
+    assertEquals(40L, service.getFreeSize());
+    assertEquals(60L, service.size());
+    assertEquals(50L, service.getCurrentDataSize());
+    assertEquals(10L, service.getBlockCount());
+    assertEquals(8L, service.getDataBlockCount());
+    assertEquals(Optional.of(true), service.blockFitsIntoTheCache(hfileBlock));
+    assertEquals(Optional.of(false), service.isAlreadyCached(key));
+    assertEquals(Optional.of(123), service.getBlockSize(key));
+    assertTrue(service.isCacheEnabled());
+    assertTrue(service.waitForCacheInitialization(500L));
+
+    service.onConfigurationChange(conf);
+    service.shutdown();
+
+    verify(blockCache).onConfigurationChange(conf);
+    verify(blockCache).shutdown();
+  }
+
+  /**
+   * Verifies factory helper methods.
+   */
+  @Test
+  void testCacheAccessServicesFactoryMethods() {
+    BlockCache blockCache = mock(BlockCache.class);
+    CacheAccessService service = CacheAccessServices.fromBlockCache(blockCache);
+
+    assertInstanceOf(BlockCacheBackedCacheAccessService.class, service);
+    assertSame(blockCache, ((BlockCacheBackedCacheAccessService) service).getBlockCache());
+    assertInstanceOf(NoOpCacheAccessService.class, CacheAccessServices.disabled());
+  }
+
+  /**
+   * Verifies disabled-cache behavior.
+   */
+  @Test
+  void testNoOpCacheAccessService() {
+    CacheAccessService service = new NoOpCacheAccessService(new CacheStats("noop"));
+
+    assertEquals("NoOpCacheAccessService", service.getName());
+    assertNull(service.getBlock(mock(BlockCacheKey.class), mock(CacheRequestContext.class)));
+    service.cacheBlock(mock(BlockCacheKey.class), mock(Cacheable.class),
+      mock(CacheWriteContext.class));
+    assertFalse(service.evictBlock(mock(BlockCacheKey.class)));
+    assertEquals(0, service.evictBlocksByHfileName(HFILE_NAME));
+    assertEquals(0L, service.getMaxSize());
+    assertEquals(0L, service.getFreeSize());
+    assertEquals(0L, service.size());
+    assertEquals(0L, service.getCurrentDataSize());
+    assertEquals(0L, service.getBlockCount());
+    assertEquals(0L, service.getDataBlockCount());
+    assertFalse(service.isCacheEnabled());
+    assertFalse(service.waitForCacheInitialization(1L));
+    service.onConfigurationChange(new Configuration(false));
+    service.shutdown();
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestBlockCacheBackedCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestBlockCacheBackedCacheAccessService.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.io.hfile.cache;
 
+import static org.junit.Assert.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertInstanceOf;
@@ -29,6 +30,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.Optional;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
@@ -217,5 +219,28 @@ public class TestBlockCacheBackedCacheAccessService {
     assertFalse(service.waitForCacheInitialization(1L));
     service.onConfigurationChange(new Configuration(false));
     service.shutdown();
+  }
+
+  @Test
+  void testNotifyFileCachingCompletedDelegatesToBlockCache() {
+    BlockCache blockCache = mock(BlockCache.class);
+    CacheAccessService service = new BlockCacheBackedCacheAccessService(blockCache);
+    Path fileName = new Path("/hbase/table/region/family/file");
+    int totalBlockCount = 10;
+    int dataBlockCount = 8;
+    long size = 1024L;
+
+    service.notifyFileCachingCompleted(fileName, totalBlockCount, dataBlockCount, size);
+
+    verify(blockCache).notifyFileCachingCompleted(fileName, totalBlockCount, dataBlockCount, size);
+  }
+
+  @Test
+  void testNotifyFileCachingCompletedRejectsNullPath() {
+    BlockCache blockCache = mock(BlockCache.class);
+    CacheAccessService service = new BlockCacheBackedCacheAccessService(blockCache);
+
+    assertThrows(NullPointerException.class,
+      () -> service.notifyFileCachingCompleted(null, 10, 8, 1024L));
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestCacheAccessServiceTestFactory.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestCacheAccessServiceTestFactory.java
@@ -1,0 +1,215 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.concurrent.Executor;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.io.hfile.LruAdaptiveBlockCache;
+import org.apache.hadoop.hbase.io.hfile.LruBlockCache;
+import org.apache.hadoop.hbase.io.hfile.TinyLfuBlockCache;
+import org.apache.hadoop.hbase.io.hfile.bucket.BucketCache;
+import org.apache.hadoop.hbase.testclassification.IOTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link CacheAccessServiceTestFactory}.
+ */
+@Tag(IOTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestCacheAccessServiceTestFactory {
+
+  private static final long MAX_SIZE = 1024L * 1024L;
+  private static final long BUCKET_CACHE_SIZE = 64L * 1024L * 1024L;
+  private static final long BLOCK_SIZE = 4096L;
+  private static final Executor DIRECT_EXECUTOR = Runnable::run;
+
+  @Test
+  void testDisabled() {
+    CacheAccessService service = CacheAccessServiceTestFactory.disabled();
+
+    assertNotNull(service);
+    assertFalse(service.isCacheEnabled());
+  }
+
+  @Test
+  void testFromBlockCacheRejectsNull() {
+    assertThrows(NullPointerException.class,
+      () -> CacheAccessServiceTestFactory.fromBlockCache(null));
+  }
+
+  @Test
+  void testFromConfigurationRejectsNull() {
+    assertThrows(NullPointerException.class,
+      () -> CacheAccessServiceTestFactory.fromConfiguration(null));
+  }
+
+  @Test
+  void testLruServiceOnlyFactory() {
+    Configuration conf = HBaseConfiguration.create();
+    CacheAccessService service =
+      CacheAccessServiceTestFactory.lru(MAX_SIZE, BLOCK_SIZE, true, conf);
+
+    try {
+      assertNotNull(service);
+      assertTrue(service.isCacheEnabled());
+    } finally {
+      service.shutdown();
+    }
+  }
+
+  @Test
+  void testLruInstanceFactory() {
+    Configuration conf = HBaseConfiguration.create();
+    CacheAccessServiceTestInstance<LruBlockCache> instance =
+      CacheAccessServiceTestFactory.lruInstance(MAX_SIZE, BLOCK_SIZE, true, conf);
+
+    try {
+      assertNotNull(instance);
+      assertNotNull(instance.blockCache());
+      assertNotNull(instance.service());
+      assertInstanceOf(LruBlockCache.class, instance.blockCache());
+      assertTrue(instance.service().isCacheEnabled());
+    } finally {
+      instance.service().shutdown();
+    }
+  }
+
+  @Test
+  void testLruAdaptiveServiceOnlyFactory() {
+    Configuration conf = HBaseConfiguration.create();
+    CacheAccessService service =
+      CacheAccessServiceTestFactory.lruAdaptive(MAX_SIZE, BLOCK_SIZE, true, conf);
+
+    try {
+      assertNotNull(service);
+      assertTrue(service.isCacheEnabled());
+    } finally {
+      service.shutdown();
+    }
+  }
+
+  @Test
+  void testLruAdaptiveInstanceFactory() {
+    Configuration conf = HBaseConfiguration.create();
+    CacheAccessServiceTestInstance<LruAdaptiveBlockCache> instance =
+      CacheAccessServiceTestFactory.lruAdaptiveInstance(MAX_SIZE, BLOCK_SIZE, true, conf);
+
+    try {
+      assertNotNull(instance);
+      assertNotNull(instance.blockCache());
+      assertNotNull(instance.service());
+      assertInstanceOf(LruAdaptiveBlockCache.class, instance.blockCache());
+      assertTrue(instance.service().isCacheEnabled());
+    } finally {
+      instance.service().shutdown();
+    }
+  }
+
+  @Test
+  void testTinyLfuServiceOnlyFactory() {
+    Configuration conf = HBaseConfiguration.create();
+    CacheAccessService service =
+      CacheAccessServiceTestFactory.tinyLfu(MAX_SIZE, BLOCK_SIZE, DIRECT_EXECUTOR, conf);
+
+    try {
+      assertNotNull(service);
+      assertTrue(service.isCacheEnabled());
+    } finally {
+      service.shutdown();
+    }
+  }
+
+  @Test
+  void testTinyLfuInstanceFactory() {
+    Configuration conf = HBaseConfiguration.create();
+    CacheAccessServiceTestInstance<TinyLfuBlockCache> instance =
+      CacheAccessServiceTestFactory.tinyLfuInstance(MAX_SIZE, BLOCK_SIZE, DIRECT_EXECUTOR, conf);
+
+    try {
+      assertNotNull(instance);
+      assertNotNull(instance.blockCache());
+      assertNotNull(instance.service());
+      assertInstanceOf(TinyLfuBlockCache.class, instance.blockCache());
+      assertTrue(instance.service().isCacheEnabled());
+    } finally {
+      instance.service().shutdown();
+    }
+  }
+
+  @Test
+  void testTinyLfuInstanceFactoryRejectsNullExecutor() {
+    assertThrows(NullPointerException.class, () -> CacheAccessServiceTestFactory
+      .tinyLfuInstance(MAX_SIZE, BLOCK_SIZE, null, HBaseConfiguration.create()));
+  }
+
+  @Test
+  void testTinyLfuInstanceFactoryRejectsNullConfiguration() {
+    assertThrows(NullPointerException.class, () -> CacheAccessServiceTestFactory
+      .tinyLfuInstance(MAX_SIZE, BLOCK_SIZE, DIRECT_EXECUTOR, null));
+  }
+
+  @Test
+  void testBucketServiceOnlyFactory() throws IOException {
+    CacheAccessService service = CacheAccessServiceTestFactory.bucket("offheap", BUCKET_CACHE_SIZE,
+      (int) BLOCK_SIZE, null, 1, 1, null);
+
+    try {
+      assertNotNull(service);
+      assertTrue(service.isCacheEnabled());
+    } finally {
+      service.shutdown();
+    }
+  }
+
+  @Test
+  void testBucketInstanceFactory() throws IOException {
+    CacheAccessServiceTestInstance<BucketCache> instance = CacheAccessServiceTestFactory
+      .bucketInstance("offheap", BUCKET_CACHE_SIZE, (int) BLOCK_SIZE, null, 1, 1, null);
+
+    try {
+      assertNotNull(instance);
+      assertNotNull(instance.blockCache());
+      assertNotNull(instance.service());
+      assertInstanceOf(BucketCache.class, instance.blockCache());
+      assertTrue(instance.service().isCacheEnabled());
+    } finally {
+      instance.service().shutdown();
+    }
+  }
+
+  @Test
+  void testBucketInstanceFactoryRejectsNullIoEngineName() {
+    assertThrows(NullPointerException.class, () -> CacheAccessServiceTestFactory
+      .bucketInstance(null, MAX_SIZE, (int) BLOCK_SIZE, null, 1, 1, null));
+  }
+
+  @Test
+  void testInstanceRejectsNullBlockCache() {
+    assertThrows(NullPointerException.class, () -> new CacheAccessServiceTestInstance<>(null));
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestNoOpCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestNoOpCacheAccessService.java
@@ -52,10 +52,10 @@ public class TestNoOpCacheAccessService {
   void testNoOpCacheAccessService() {
     CacheAccessService service = new NoOpCacheAccessService(new CacheStats("noop"));
     BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
-    CacheRequestContext requestContext = CacheRequestContext.newBuilder().setCaching(true)
-      .setRepeat(false).setUpdateCacheMetrics(true).build();
-    CacheWriteContext writeContext = CacheWriteContext.newBuilder().setInMemory(true)
-      .setWaitWhenCache(true).setSource(CacheWriteSource.READ_MISS).build();
+    CacheRequestContext requestContext = CacheRequestContext.newBuilder().withCaching(true)
+      .withRepeat(false).withUpdateCacheMetrics(true).build();
+    CacheWriteContext writeContext = CacheWriteContext.newBuilder().withInMemory(true)
+      .withWaitWhenCache(true).withSource(CacheWriteSource.READ_MISS).build();
     Cacheable block = mock(Cacheable.class);
     Configuration conf = new Configuration(false);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestNoOpCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestNoOpCacheAccessService.java
@@ -1,0 +1,117 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.testclassification.IOTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link NoOpCacheAccessService} and related service helpers.
+ */
+@Tag(IOTests.TAG)
+@Tag(SmallTests.TAG)
+
+public class TestNoOpCacheAccessService {
+
+  private static final String HFILE_NAME = "file";
+  private static final String REGION_NAME = "region";
+  private static final long BLOCK_OFFSET = 1L;
+  private static final long RANGE_START_OFFSET = 1L;
+  private static final long RANGE_END_OFFSET = 10L;
+
+  @Test
+  void testNoOpCacheAccessService() {
+    CacheAccessService service = new NoOpCacheAccessService(new CacheStats("noop"));
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    CacheRequestContext requestContext = CacheRequestContext.newBuilder().setCaching(true)
+      .setRepeat(false).setUpdateCacheMetrics(true).build();
+    CacheWriteContext writeContext = CacheWriteContext.newBuilder().setInMemory(true)
+      .setWaitWhenCache(true).setSource(CacheWriteSource.READ_MISS).build();
+    Cacheable block = mock(Cacheable.class);
+    Configuration conf = new Configuration(false);
+
+    assertEquals("NoOpCacheAccessService", service.getName());
+    assertNull(service.getBlock(key, requestContext));
+
+    service.cacheBlock(key, block, writeContext);
+
+    assertFalse(service.evictBlock(key));
+    assertEquals(0, service.evictBlocksByHfileName(HFILE_NAME));
+    assertEquals(0,
+      service.evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET, RANGE_END_OFFSET));
+    assertEquals(0, service.evictBlocksByRegionName(REGION_NAME));
+
+    assertEquals(0L, service.getMaxSize());
+    assertEquals(0L, service.getFreeSize());
+    assertEquals(0L, service.size());
+    assertEquals(0L, service.getCurrentDataSize());
+    assertEquals(0L, service.getBlockCount());
+    assertEquals(0L, service.getDataBlockCount());
+
+    assertEquals(Optional.empty(), service.blockFitsIntoTheCache(mock(HFileBlock.class)));
+    assertEquals(Optional.empty(), service.isAlreadyCached(key));
+    assertEquals(Optional.empty(), service.getBlockSize(key));
+
+    assertFalse(service.isCacheEnabled());
+    assertFalse(service.waitForCacheInitialization(1L));
+
+    service.onConfigurationChange(conf);
+    service.shutdown();
+  }
+
+  @Test
+  void testNoOpCacheAccessServiceRejectsNullInputs() {
+    CacheAccessService service = new NoOpCacheAccessService(new CacheStats("noop"));
+    Cacheable block = mock(Cacheable.class);
+    CacheRequestContext requestContext = CacheRequestContext.newBuilder().build();
+    CacheWriteContext writeContext = CacheWriteContext.newBuilder().build();
+
+    assertThrows(NullPointerException.class, () -> new NoOpCacheAccessService(null));
+    assertThrows(NullPointerException.class, () -> service.getBlock(null, requestContext));
+    assertThrows(NullPointerException.class,
+      () -> service.getBlock(new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET), null));
+    assertThrows(NullPointerException.class, () -> service.cacheBlock(null, block, writeContext));
+    assertThrows(NullPointerException.class,
+      () -> service.cacheBlock(new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET), null, writeContext));
+    assertThrows(NullPointerException.class,
+      () -> service.cacheBlock(new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET), block, null));
+    assertThrows(NullPointerException.class, () -> service.evictBlock(null));
+    assertThrows(NullPointerException.class, () -> service.evictBlocksByHfileName(null));
+    assertThrows(NullPointerException.class,
+      () -> service.evictBlocksRangeByHfileName(null, RANGE_START_OFFSET, RANGE_END_OFFSET));
+    assertThrows(NullPointerException.class, () -> service.evictBlocksByRegionName(null));
+    assertThrows(NullPointerException.class, () -> service.blockFitsIntoTheCache(null));
+    assertThrows(NullPointerException.class, () -> service.isAlreadyCached(null));
+    assertThrows(NullPointerException.class, () -> service.getBlockSize(null));
+    assertThrows(NullPointerException.class, () -> service.onConfigurationChange(null));
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestTopologyBackedCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestTopologyBackedCacheAccessService.java
@@ -1,0 +1,474 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.hfile.cache;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertInstanceOf;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import java.util.Optional;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
+import org.apache.hadoop.hbase.io.hfile.BlockType;
+import org.apache.hadoop.hbase.io.hfile.CacheStats;
+import org.apache.hadoop.hbase.io.hfile.Cacheable;
+import org.apache.hadoop.hbase.io.hfile.HFileBlock;
+import org.apache.hadoop.hbase.testclassification.IOTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for {@link TopologyBackedCacheAccessService}.
+ */
+@Tag(IOTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestTopologyBackedCacheAccessService {
+  private static final String HFILE_NAME = "file";
+
+  private static final long BLOCK_OFFSET = 1L;
+
+  private static final long RANGE_START_OFFSET = 10L;
+
+  private static final long RANGE_END_OFFSET = 100L;
+
+  /**
+   * Verifies that lookup checks topology tiers in order and returns the first cached block found.
+   */
+  @Test
+  void testGetBlockChecksTiersInOrder() {
+    BlockCacheKey key = new BlockCacheKey("file", BLOCK_OFFSET);
+    Cacheable block = mock(Cacheable.class);
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+    CacheRequestContext context = requestContext();
+
+    when(topology.getName()).thenReturn("tiered");
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getTiers()).thenReturn(List.of(CacheTier.L1, CacheTier.L2));
+    when(topology.getEngine(CacheTier.L1)).thenReturn(Optional.of(l1));
+    when(topology.getEngine(CacheTier.L2)).thenReturn(Optional.of(l2));
+    when(l1.getBlock(key, true, false, true, BlockType.DATA)).thenReturn(null);
+    when(l2.getBlock(key, true, false, true, BlockType.DATA)).thenReturn(block);
+    when(policy.shouldPromote(key, block, CacheTier.L2, context, topologyView))
+      .thenReturn(PromotionDecision.none());
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertSame(block, service.getBlock(key, context));
+
+    verify(l1).getBlock(key, true, false, true, BlockType.DATA);
+    verify(l2).getBlock(key, true, false, true, BlockType.DATA);
+    verify(policy).shouldPromote(key, block, CacheTier.L2, context, topologyView);
+  }
+
+  /**
+   * Verifies that a hit can trigger topology-level promotion when requested by policy.
+   */
+  @Test
+  void testGetBlockPromotesOnPolicyDecision() {
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    Cacheable block = mock(Cacheable.class);
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+    CacheRequestContext context = requestContext();
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getTiers()).thenReturn(List.of(CacheTier.L1, CacheTier.L2));
+    when(topology.getEngine(CacheTier.L1)).thenReturn(Optional.of(l1));
+    when(topology.getEngine(CacheTier.L2)).thenReturn(Optional.of(l2));
+    when(l1.getBlock(key, true, false, true, BlockType.DATA)).thenReturn(null);
+    when(l2.getBlock(key, true, false, true, BlockType.DATA)).thenReturn(block);
+    when(policy.shouldPromote(key, block, CacheTier.L2, context, topologyView))
+      .thenReturn(PromotionDecision.promoteTo(CacheTier.L1, false));
+    when(topology.promote(key, block, l2, l1)).thenReturn(true);
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertSame(block, service.getBlock(key, context));
+
+    verify(policy).shouldPromote(key, block, CacheTier.L2, context, topologyView);
+    verify(topology).promote(key, block, l2, l1);
+  }
+
+  /**
+   * Verifies that cache insertion is skipped when admission policy rejects the block.
+   */
+  @Test
+  void testCacheBlockSkipsInsertionWhenRejected() {
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    Cacheable block = mock(Cacheable.class);
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine engine = mock(CacheEngine.class);
+    CacheWriteContext context = writeContext();
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngine(CacheTier.SINGLE)).thenReturn(Optional.of(engine));
+    when(policy.shouldAdmit(key, block, context, AdmissionPriority.NORMAL, topologyView))
+      .thenReturn(AdmissionDecision.reject("rejected"));
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    service.cacheBlock(key, block, context);
+
+    verify(policy).shouldAdmit(key, block, context, AdmissionPriority.NORMAL, topologyView);
+    verify(policy, never()).selectTier(key, block, context, topologyView);
+    verify(engine, never()).cacheBlock(key, block, true, true);
+  }
+
+  /**
+   * Verifies that admitted blocks are inserted into policy-selected tiers.
+   */
+  @Test
+  void testCacheBlockInsertsIntoSelectedTier() {
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    Cacheable block = mock(Cacheable.class);
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine engine = mock(CacheEngine.class);
+    CacheWriteContext context = writeContext();
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngine(CacheTier.SINGLE)).thenReturn(Optional.of(engine));
+    when(policy.shouldAdmit(key, block, context, AdmissionPriority.NORMAL, topologyView))
+      .thenReturn(AdmissionDecision.admit());
+    when(policy.selectRepresentation(key, block, context, topologyView))
+      .thenReturn(RepresentationDecision.CURRENT_HBASE_DEFAULT);
+    when(policy.selectTier(key, block, context, topologyView))
+      .thenReturn(TierDecision.single(CacheTier.SINGLE));
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    service.cacheBlock(key, block, context);
+
+    verify(policy).shouldAdmit(key, block, context, AdmissionPriority.NORMAL, topologyView);
+    verify(policy, never()).selectRepresentation(key, block, context, topologyView);
+    verify(policy).selectTier(key, block, context, topologyView);
+    verify(engine).cacheBlock(key, block, true, true);
+  }
+
+  /**
+   * Verifies that insertion can target multiple tiers.
+   */
+  @Test
+  void testCacheBlockInsertsIntoMultipleSelectedTiers() {
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    Cacheable block = mock(Cacheable.class);
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+    CacheWriteContext context = writeContext();
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngine(CacheTier.L1)).thenReturn(Optional.of(l1));
+    when(topology.getEngine(CacheTier.L2)).thenReturn(Optional.of(l2));
+    when(policy.shouldAdmit(key, block, context, AdmissionPriority.NORMAL, topologyView))
+      .thenReturn(AdmissionDecision.admit());
+    when(policy.selectRepresentation(key, block, context, topologyView))
+      .thenReturn(RepresentationDecision.CURRENT_HBASE_DEFAULT);
+    when(policy.selectTier(key, block, context, topologyView))
+      .thenReturn(TierDecision.multiple(List.of(CacheTier.L1, CacheTier.L2)));
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    service.cacheBlock(key, block, context);
+
+    verify(l1).cacheBlock(key, block, true, true);
+    verify(l2).cacheBlock(key, block, true, true);
+  }
+
+  /**
+   * Verifies that eviction is propagated to all participating engines.
+   */
+  @Test
+  void testEvictBlockEvictsFromAllEngines() {
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngines()).thenReturn(List.of(l1, l2));
+    when(l1.evictBlock(key)).thenReturn(false);
+    when(l2.evictBlock(key)).thenReturn(true);
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertTrue(service.evictBlock(key));
+
+    verify(l1).evictBlock(key);
+    verify(l2).evictBlock(key);
+  }
+
+  /**
+   * Verifies that file-level eviction sums results from all engines.
+   */
+  @Test
+  void testEvictBlocksByHfileNameSumsEngineResults() {
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngines()).thenReturn(List.of(l1, l2));
+    when(l1.evictBlocksByHfileName(HFILE_NAME)).thenReturn(2);
+    when(l2.evictBlocksByHfileName(HFILE_NAME)).thenReturn(3);
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertEquals(5, service.evictBlocksByHfileName(HFILE_NAME));
+
+    verify(l1).evictBlocksByHfileName(HFILE_NAME);
+    verify(l2).evictBlocksByHfileName(HFILE_NAME);
+  }
+
+  /**
+   * Verifies that aggregate sizing methods sum engine values.
+   */
+  @Test
+  void testSizingMethodsAggregateEngines() {
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngines()).thenReturn(List.of(l1, l2));
+    when(l1.getMaxSize()).thenReturn(100L);
+    when(l2.getMaxSize()).thenReturn(200L);
+    when(l1.getFreeSize()).thenReturn(10L);
+    when(l2.getFreeSize()).thenReturn(20L);
+    when(l1.size()).thenReturn(90L);
+    when(l2.size()).thenReturn(180L);
+    when(l1.getCurrentDataSize()).thenReturn(80L);
+    when(l2.getCurrentDataSize()).thenReturn(160L);
+    when(l1.getBlockCount()).thenReturn(8L);
+    when(l2.getBlockCount()).thenReturn(16L);
+    when(l1.getDataBlockCount()).thenReturn(6L);
+    when(l2.getDataBlockCount()).thenReturn(12L);
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertEquals(300L, service.getMaxSize());
+    assertEquals(30L, service.getFreeSize());
+    assertEquals(270L, service.size());
+    assertEquals(240L, service.getCurrentDataSize());
+    assertEquals(24L, service.getBlockCount());
+    assertEquals(18L, service.getDataBlockCount());
+  }
+
+  /**
+   * Verifies that service-level stats are returned from the topology.
+   */
+  @Test
+  void testGetStatsDelegatesToTopology() {
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheStats stats = new CacheStats("topology");
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getStats()).thenReturn(stats);
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertSame(stats, service.getStats());
+  }
+
+  /**
+   * Verifies optional helper methods aggregate or search across engines.
+   */
+  @Test
+  void testOptionalHelpersUseParticipatingEngines() {
+    BlockCacheKey key = new BlockCacheKey(HFILE_NAME, BLOCK_OFFSET);
+    HFileBlock block = mock(HFileBlock.class);
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngines()).thenReturn(List.of(l1, l2));
+    when(l1.blockFitsIntoTheCache(block)).thenReturn(Optional.of(false));
+    when(l2.blockFitsIntoTheCache(block)).thenReturn(Optional.of(true));
+    when(l1.isAlreadyCached(key)).thenReturn(Optional.of(false));
+    when(l2.isAlreadyCached(key)).thenReturn(Optional.of(true));
+    when(l1.getBlockSize(key)).thenReturn(Optional.empty());
+    when(l2.getBlockSize(key)).thenReturn(Optional.of(123));
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertEquals(Optional.of(true), service.blockFitsIntoTheCache(block));
+    assertEquals(Optional.of(true), service.isAlreadyCached(key));
+    assertEquals(Optional.of(123), service.getBlockSize(key));
+  }
+
+  /**
+   * Verifies cache-enabled and initialization behavior across participating engines.
+   */
+  @Test
+  void testEnablementAndInitializationUseEngines() {
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngines()).thenReturn(List.of(l1, l2));
+    when(l1.isCacheEnabled()).thenReturn(false);
+    when(l2.isCacheEnabled()).thenReturn(true);
+    when(l1.waitForCacheInitialization(500L)).thenReturn(true);
+    when(l2.waitForCacheInitialization(500L)).thenReturn(false);
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertTrue(service.isCacheEnabled());
+    assertFalse(service.waitForCacheInitialization(500L));
+  }
+
+  /**
+   * Verifies that configuration changes are propagated to all engines and shutdown uses topology.
+   */
+  @Test
+  void testConfigurationChangeAndShutdown() {
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+    Configuration conf = new Configuration(false);
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngines()).thenReturn(List.of(l1, l2));
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    service.onConfigurationChange(conf);
+    service.shutdown();
+
+    verify(l1).onConfigurationChange(conf);
+    verify(l2).onConfigurationChange(conf);
+    verify(topology).shutdown();
+  }
+
+  /**
+   * Verifies that range-based HFile eviction is propagated to all participating engines and sums
+   * their results.
+   */
+  @Test
+  void testEvictBlocksRangeByHfileNameSumsEngineResults() {
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngines()).thenReturn(List.of(l1, l2));
+    when(l1.evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET, RANGE_END_OFFSET))
+      .thenReturn(2);
+    when(l2.evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET, RANGE_END_OFFSET))
+      .thenReturn(3);
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertEquals(5,
+      service.evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET, RANGE_END_OFFSET));
+
+    verify(l1).evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET, RANGE_END_OFFSET);
+    verify(l2).evictBlocksRangeByHfileName(HFILE_NAME, RANGE_START_OFFSET, RANGE_END_OFFSET);
+  }
+
+  /**
+   * Verifies that region-level eviction is propagated to all participating engines and sums their
+   * results.
+   */
+  @Test
+  void testEvictBlocksByRegionNameSumsEngineResults() {
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+    CacheEngine l1 = mock(CacheEngine.class);
+    CacheEngine l2 = mock(CacheEngine.class);
+
+    when(topology.getView()).thenReturn(topologyView);
+    when(topology.getEngines()).thenReturn(List.of(l1, l2));
+    when(l1.evictBlocksByRegionName("region")).thenReturn(4);
+    when(l2.evictBlocksByRegionName("region")).thenReturn(5);
+
+    CacheAccessService service = new TopologyBackedCacheAccessService(topology, policy);
+
+    assertEquals(9, service.evictBlocksByRegionName("region"));
+
+    verify(l1).evictBlocksByRegionName("region");
+    verify(l2).evictBlocksByRegionName("region");
+  }
+
+  /**
+   * Verifies that factory helper creates a topology-backed service.
+   */
+  @Test
+  void testFactoryCreatesTopologyBackedService() {
+    CacheTopology topology = mock(CacheTopology.class);
+    CacheTopologyView topologyView = mock(CacheTopologyView.class);
+    CachePlacementAdmissionPolicy policy = mock(CachePlacementAdmissionPolicy.class);
+
+    when(topology.getView()).thenReturn(topologyView);
+
+    CacheAccessService service = CacheAccessServices.fromTopology(topology, policy);
+
+    assertInstanceOf(TopologyBackedCacheAccessService.class, service);
+    assertSame(topology, ((TopologyBackedCacheAccessService) service).getTopology());
+    assertSame(policy, ((TopologyBackedCacheAccessService) service).getPolicy());
+  }
+
+  private static CacheRequestContext requestContext() {
+    return CacheRequestContext.newBuilder().setCaching(true).setRepeat(false)
+      .setUpdateCacheMetrics(true).setBlockType(BlockType.DATA).build();
+  }
+
+  private static CacheWriteContext writeContext() {
+    return CacheWriteContext.newBuilder().setInMemory(true).setWaitWhenCache(true)
+      .setSource(CacheWriteSource.READ_MISS).build();
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestTopologyBackedCacheAccessService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestTopologyBackedCacheAccessService.java
@@ -463,12 +463,12 @@ public class TestTopologyBackedCacheAccessService {
   }
 
   private static CacheRequestContext requestContext() {
-    return CacheRequestContext.newBuilder().setCaching(true).setRepeat(false)
-      .setUpdateCacheMetrics(true).setBlockType(BlockType.DATA).build();
+    return CacheRequestContext.newBuilder().withCaching(true).withRepeat(false)
+      .withUpdateCacheMetrics(true).withBlockType(BlockType.DATA).build();
   }
 
   private static CacheWriteContext writeContext() {
-    return CacheWriteContext.newBuilder().setInMemory(true).setWaitWhenCache(true)
-      .setSource(CacheWriteSource.READ_MISS).build();
+    return CacheWriteContext.newBuilder().withInMemory(true).withWaitWhenCache(true)
+      .withSource(CacheWriteSource.READ_MISS).build();
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestAtomicOperation.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestAtomicOperation.java
@@ -63,8 +63,8 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.filter.BinaryComparator;
 import org.apache.hadoop.hbase.io.HeapSize;
-import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.CacheConfig;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.VerySlowRegionServerTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -115,7 +115,7 @@ public class TestAtomicOperation {
       if (wal != null) {
         wal.close();
       }
-      cacheConfig.getBlockCache().ifPresent(BlockCache::shutdown);
+      cacheConfig.getCacheAccessService().ifEnabled(CacheAccessService::shutdown);
       region = null;
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCacheOnWriteInSchema.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCacheOnWriteInSchema.java
@@ -37,7 +37,6 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.fs.HFileSystem;
 import org.apache.hadoop.hbase.io.encoding.DataBlockEncoding;
-import org.apache.hadoop.hbase.io.hfile.BlockCache;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheFactory;
 import org.apache.hadoop.hbase.io.hfile.BlockCacheKey;
 import org.apache.hadoop.hbase.io.hfile.BlockType;
@@ -46,6 +45,7 @@ import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileBlock;
 import org.apache.hadoop.hbase.io.hfile.HFileScanner;
 import org.apache.hadoop.hbase.io.hfile.RandomKeyValueUtil;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
@@ -201,7 +201,7 @@ public class TestCacheOnWriteInSchema {
 
   private void readStoreFile(Path path) throws IOException {
     CacheConfig cacheConf = store.getCacheConfig();
-    BlockCache cache = cacheConf.getBlockCache().get();
+    CacheAccessService cache = cacheConf.getCacheAccessService();
     StoreFileInfo storeFileInfo = StoreFileInfo.createStoreFileInfoForHFile(conf, fs, path, true);
     HStoreFile sf = new HStoreFile(storeFileInfo, BloomType.ROWCOL, cacheConf);
     sf.initReader();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSecureBulkLoadManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSecureBulkLoadManager.java
@@ -50,6 +50,7 @@ import org.apache.hadoop.hbase.io.hfile.CacheConfig;
 import org.apache.hadoop.hbase.io.hfile.HFile;
 import org.apache.hadoop.hbase.io.hfile.HFileContext;
 import org.apache.hadoop.hbase.io.hfile.HFileContextBuilder;
+import org.apache.hadoop.hbase.io.hfile.cache.CacheAccessService;
 import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFactory;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
@@ -228,7 +229,8 @@ public class TestSecureBulkLoadManager {
     ColumnFamilyDescriptor family = desc.getColumnFamily(FAMILY);
     Compression.Algorithm compression = HFile.DEFAULT_COMPRESSION_ALGORITHM;
 
-    CacheConfig writerCacheConf = new CacheConfig(conf, family, null, ByteBuffAllocator.HEAP);
+    CacheConfig writerCacheConf =
+      new CacheConfig(conf, family, (CacheAccessService) null, ByteBuffAllocator.HEAP);
     writerCacheConf.setCacheDataOnWrite(false);
     HFileContext hFileContext = new HFileContextBuilder().withIncludesMvcc(false)
       .withIncludesTags(true).withCompression(compression).withCompressTags(family.isCompressTags())


### PR DESCRIPTION
### Summary

This PR adds a diagnostic/test bridge for cached-block iteration while the block cache architecture is migrating from direct BlockCache usage toward CacheAccessService.

The existing BlockCache interface extends Iterable<CachedBlock>, and a number of tests and diagnostic paths rely on that capability. CacheAccessService should remain the normal read/write-path facade and should not become a full replacement for every BlockCache method. However, tests and diagnostics still need a way to access the legacy cached-block iterator during the transition.

### Changes

* Allows BlockCacheBackedCacheAccessService to expose the cached-block iteration capability by delegating to the backing BlockCache.
* Adds helper support for discovering or unwrapping diagnostic cache views from CacheAccessService in test code.
* Adds/updates test factory support for compatibility tests that need both CacheAccessService and the underlying legacy BlockCache.
* Updates affected tests to work through CacheAccessService while preserving existing diagnostic/cache-inspection behavior.

### Compatibility notes

This is a transition/diagnostic capability. It does not change cache read/write semantics.

The main runtime path still uses CacheAccessService for cache access. Cached-block iteration remains intended for tests, diagnostics, and admin-style inspection only. Future CacheEngine/topology-backed implementations can expose equivalent diagnostic iteration when available.

### Out of scope

* No BlockCacheFactory refactoring.
* No CacheEngine runtime wiring.
* No migration of LruBlockCache, LruAdaptiveBlockCache, TinyLfuBlockCache, or BucketCache to CacheEngine.
* No broad test migration.
* No cache eviction/admission behavior changes.

### Testing

Ran:

```bash
mvn -pl hbase-server test
mvn -pl hbase-server -DskipTests compile
mvn -pl hbase-server spotless:check
mvn -pl hbase-server checkstyle:check
```

### Disclosure

Use this checklist.

Final local checks

git status
git diff --check
mvn -pl hbase-server -Dtest=TestCacheAccessServiceTestFactory test
mvn -pl hbase-server -Dtest=TestHFile#testWriterCacheOnWriteSkipDoesNotLeak test
mvn -pl hbase-server -DskipTests compile
mvn -pl hbase-server spotless:apply
mvn -pl hbase-server spotless:check
mvn -pl hbase-server checkstyle:check

Review the actual patch:

git diff --stat
git diff

Commit

Adjust file list based on git status, but likely:

git add \
  hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/BlockCacheBackedCacheAccessService.java \
  hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServices.java \
  hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/CacheAccessServiceTestFactory.java \
  hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/cache/TestCacheAccessServiceTestFactory.java \
  hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/TestHFile.java
git commit -m "HBASE-30196 Add diagnostic cache iteration support"

Push:

git push -u origin HBASE-30196-cache-diagnostic-iteration

PR title

HBASE-30196 Add diagnostic cached-block iteration support for CacheAccessService

PR description

### Summary
This PR adds a diagnostic/test bridge for cached-block iteration while the block cache architecture is migrating from direct BlockCache usage toward CacheAccessService.
The existing BlockCache interface extends Iterable<CachedBlock>, and a number of tests and diagnostic paths rely on that capability. CacheAccessService should remain the normal read/write-path facade and should not become a full replacement for every BlockCache method. However, tests and diagnostics still need a way to access the legacy cached-block iterator during the transition.
### Changes
* Allows BlockCacheBackedCacheAccessService to expose the cached-block iteration capability by delegating to the backing BlockCache.
* Adds helper support for discovering or unwrapping diagnostic cache views from CacheAccessService in test code.
* Adds/updates test factory support for compatibility tests that need both CacheAccessService and the underlying legacy BlockCache.
* Updates affected tests to work through CacheAccessService while preserving existing diagnostic/cache-inspection behavior.
### Compatibility notes
This is a transition/diagnostic capability. It does not change cache read/write semantics.
The main runtime path still uses CacheAccessService for cache access. Cached-block iteration remains intended for tests, diagnostics, and admin-style inspection only. Future CacheEngine/topology-backed implementations can expose equivalent diagnostic iteration when available.
### Out of scope
* No BlockCacheFactory refactoring.
* No CacheEngine runtime wiring.
* No migration of LruBlockCache, LruAdaptiveBlockCache, TinyLfuBlockCache, or BucketCache to CacheEngine.
* No broad test migration.
* No cache eviction/admission behavior changes.
### Testing
Ran:
```bash
mvn -pl hbase-server -Dtest=TestCacheAccessServiceTestFactory test
mvn -pl hbase-server -Dtest=TestHFile#testWriterCacheOnWriteSkipDoesNotLeak test
mvn -pl hbase-server -DskipTests compile
mvn -pl hbase-server spotless:check
mvn -pl hbase-server checkstyle:check
```

### Disclosure

Parts of this PR, including helper code structure and PR description text, were prepared with assistance from ChatGPT 5.5 and reviewed by the author.
