### PR TITLE
HBASE-30160: Prevent region creation if the encoded region names are …

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionStates.java
@@ -331,6 +331,14 @@ public class RegionStates {
   }
 
   /**
+   * Returns all regions of the table, irrespective of assignment or split/offline state.
+   */
+  public List<RegionInfo> getAllRegionsOfTable(TableName table) {
+    return getTableRegionStateNodes(table).stream().map(RegionStateNode::getRegionInfo)
+      .collect(Collectors.toList());
+  }
+
+  /**
    * Get the regions for deleting a table.
    * <p/>
    * Here we need to return all the regions irrespective of the states in order to archive them all.
@@ -338,8 +346,7 @@ public class RegionStates {
    * references to the regions, we will lose the data of the regions.
    */
   public List<RegionInfo> getRegionsOfTableForDeleting(TableName table) {
-    return getTableRegionStateNodes(table).stream().map(RegionStateNode::getRegionInfo)
-      .collect(Collectors.toList());
+    return getAllRegionsOfTable(table);
   }
 
   /** Returns Return the regions of the table and filter them. */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
@@ -71,6 +71,7 @@ import org.apache.hadoop.hbase.regionserver.storefiletracker.StoreFileTrackerFac
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hbase.util.ModifyRegionUtils;
 import org.apache.hadoop.hbase.util.Pair;
 import org.apache.hadoop.hbase.util.Threads;
 import org.apache.hadoop.hbase.wal.WALSplitUtil;
@@ -141,6 +142,8 @@ public class SplitTableRegionProcedure
         .setEndKey(bestSplitRow).setSplit(false).setRegionId(rid).build();
     this.daughterTwoRI = RegionInfoBuilder.newBuilder(table).setStartKey(bestSplitRow)
       .setEndKey(regionToSplit.getEndKey()).setSplit(false).setRegionId(rid).build();
+    ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(daughterOneRI, daughterTwoRI),
+      env.getAssignmentManager().getRegionStates().getAllRegionsOfTable(getTableName()));
 
     if (tableDescriptor.getRegionSplitPolicyClassName() != null) {
       // Since we don't have region reference here, creating the split policy instance without it.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/SplitTableRegionProcedure.java
@@ -143,7 +143,7 @@ public class SplitTableRegionProcedure
     this.daughterTwoRI = RegionInfoBuilder.newBuilder(table).setStartKey(bestSplitRow)
       .setEndKey(regionToSplit.getEndKey()).setSplit(false).setRegionId(rid).build();
     ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(daughterOneRI, daughterTwoRI),
-      env.getAssignmentManager().getRegionStates().getAllRegionsOfTable(getTableName()));
+      env.getAssignmentManager().getRegionStates());
 
     if (tableDescriptor.getRegionSplitPolicyClassName() != null) {
       // Since we don't have region reference here, creating the split policy instance without it.

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/CreateTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/CreateTableProcedure.java
@@ -298,7 +298,7 @@ public class CreateTableProcedure extends AbstractStateMachineTableProcedure<Cre
 
     try {
       ModifyRegionUtils.checkForEncodedNameCollisions(newRegions,
-        env.getAssignmentManager().getRegionStates().getAllRegionsOfTable(getTableName()));
+        env.getAssignmentManager().getRegionStates());
     } catch (DoNotRetryIOException e) {
       setFailure("master-create-table", e);
       return false;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/CreateTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/CreateTableProcedure.java
@@ -296,6 +296,14 @@ public class CreateTableProcedure extends AbstractStateMachineTableProcedure<Cre
       return false;
     }
 
+    try {
+      ModifyRegionUtils.checkForEncodedNameCollisions(newRegions,
+        env.getAssignmentManager().getRegionStates().getAllRegionsOfTable(getTableName()));
+    } catch (DoNotRetryIOException e) {
+      setFailure("master-create-table", e);
+      return false;
+    }
+
     if (!tableName.isSystemTable()) {
       // do not check rs group for system tables as we may block the bootstrap.
       Supplier<String> forWhom = () -> "table " + tableName;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ModifyRegionUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ModifyRegionUtils.java
@@ -21,7 +21,11 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
 import java.util.concurrent.ExecutionException;
@@ -30,6 +34,7 @@ import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
@@ -80,6 +85,33 @@ public abstract class ModifyRegionUtils {
       }
     }
     return hRegionInfos;
+  }
+
+  /**
+   * Checks a set of candidate regions against each other and against a set of already-existing
+   * regions for encoded-name collisions.
+   */
+  public static void checkForEncodedNameCollisions(final Collection<RegionInfo> candidates,
+    final Collection<RegionInfo> existing) throws IOException {
+    if (candidates == null || candidates.isEmpty()) {
+      return;
+    }
+    Map<String, RegionInfo> seen = new HashMap<>();
+    if (existing != null) {
+      for (RegionInfo ri : existing) {
+        seen.putIfAbsent(ri.getEncodedName(), ri);
+      }
+    }
+    Set<String> candidateNames = new HashSet<>();
+    for (RegionInfo ri : candidates) {
+      String encoded = ri.getEncodedName();
+      RegionInfo conflict = seen.get(encoded);
+      if (conflict != null || !candidateNames.add(encoded)) {
+        throw new DoNotRetryIOException("Encoded region name collision detected: '" + encoded
+          + "' for table " + ri.getTable() + ". Refusing to proceed.");
+      }
+      seen.put(encoded, ri);
+    }
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ModifyRegionUtils.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/util/ModifyRegionUtils.java
@@ -21,10 +21,9 @@ import java.io.IOException;
 import java.io.InterruptedIOException;
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
-import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.concurrent.Callable;
 import java.util.concurrent.CompletionService;
@@ -39,6 +38,7 @@ import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.master.assignment.RegionStates;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -88,29 +88,25 @@ public abstract class ModifyRegionUtils {
   }
 
   /**
-   * Checks a set of candidate regions against each other and against a set of already-existing
-   * regions for encoded-name collisions.
+   * Checks candidate regions for encoded\-name collisions. Ensures there are no duplicates in the
+   * input and no conflicts with existing region states.
    */
   public static void checkForEncodedNameCollisions(final Collection<RegionInfo> candidates,
-    final Collection<RegionInfo> existing) throws IOException {
+    final RegionStates regionStates) throws IOException {
     if (candidates == null || candidates.isEmpty()) {
       return;
     }
-    Map<String, RegionInfo> seen = new HashMap<>();
-    if (existing != null) {
-      for (RegionInfo ri : existing) {
-        seen.putIfAbsent(ri.getEncodedName(), ri);
-      }
-    }
+    Objects.requireNonNull(regionStates, "regionStates is null");
     Set<String> candidateNames = new HashSet<>();
     for (RegionInfo ri : candidates) {
       String encoded = ri.getEncodedName();
-      RegionInfo conflict = seen.get(encoded);
-      if (conflict != null || !candidateNames.add(encoded)) {
+      if (
+        !candidateNames.add(encoded)
+          || regionStates.getRegionStateNodeFromEncodedRegionName(encoded) != null
+      ) {
         throw new DoNotRetryIOException("Encoded region name collision detected: '" + encoded
           + "' for table " + ri.getTable() + ". Refusing to proceed.");
       }
-      seen.put(encoded, ri);
     }
   }
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestEncodedNameCollisionDetection.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestEncodedNameCollisionDetection.java
@@ -65,7 +65,7 @@ public class TestEncodedNameCollisionDetection {
   }
 
   /**
-   *  Verifies that duplicate encoded region names within candidate regions are rejected.
+   * Verifies that duplicate encoded region names within candidate regions are rejected.
    */
   @Test
   public void testDetectsDuplicatesInCandidates() {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestEncodedNameCollisionDetection.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestEncodedNameCollisionDetection.java
@@ -1,0 +1,108 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.procedure;
+
+import static org.junit.jupiter.api.Assertions.assertDoesNotThrow;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.Collections;
+import org.apache.hadoop.hbase.DoNotRetryIOException;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.ModifyRegionUtils;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests for encoded region-name collision detection (HBASE-30160). If two regions end up with the
+ * same encoded name, we should fail fast instead of allowing subtle metadata corruption later.
+ */
+
+@Tag(SmallTests.TAG)
+public class TestEncodedNameCollisionDetection {
+
+  /**
+   * Happy-path check: distinct candidate regions should pass without throwing.
+   */
+  @Test
+  public void testAcceptsDistinctCandidates() {
+    TableName tableName = TableName.valueOf("test_table");
+    long regionId = System.currentTimeMillis();
+
+    RegionInfo ri1 = RegionInfoBuilder.newBuilder(tableName).setStartKey(new byte[] { 0, 0 })
+      .setEndKey(new byte[] { 1, 0 }).setSplit(false).setRegionId(regionId).build();
+
+    RegionInfo ri2 = RegionInfoBuilder.newBuilder(tableName).setStartKey(new byte[] { 1, 0 })
+      .setEndKey(new byte[] { 2, 0 }).setSplit(false).setRegionId(regionId + 1).build();
+
+    assertDoesNotThrow(
+      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(ri1, ri2), null));
+  }
+
+  @Test
+  public void testDetectsDuplicatesInCandidates() {
+    TableName tableName = TableName.valueOf("test_table");
+    RegionInfo ri1 = mockRegionInfo(tableName, "same-encoded-name");
+    RegionInfo ri2 = mockRegionInfo(tableName, "same-encoded-name");
+
+    DoNotRetryIOException exception = assertThrows(DoNotRetryIOException.class,
+      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(ri1, ri2), null));
+    assertTrue(exception.getMessage().contains("Encoded region name collision detected"));
+  }
+
+  /**
+   * A candidate region should be rejected if its encoded name already exists.
+   */
+  @Test
+  public void testDetectsCollisionWithExistingRegions() {
+    TableName tableName = TableName.valueOf("test_table");
+    RegionInfo existingRegion = mockRegionInfo(tableName, "same-encoded-name");
+    RegionInfo candidateRegion = mockRegionInfo(tableName, "same-encoded-name");
+
+    DoNotRetryIOException exception = assertThrows(DoNotRetryIOException.class,
+      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(candidateRegion),
+        Arrays.asList(existingRegion)));
+    assertTrue(exception.getMessage().contains("Encoded region name collision detected"));
+  }
+
+  /**
+   * Test that checkForEncodedNameCollisions properly handles empty/null inputs.
+   */
+  @Test
+  public void testHandlesEmptyInputs() throws IOException {
+    ModifyRegionUtils.checkForEncodedNameCollisions(null, null);
+    ModifyRegionUtils.checkForEncodedNameCollisions(Collections.emptyList(), null);
+    ModifyRegionUtils.checkForEncodedNameCollisions(null, Collections.emptyList());
+    ModifyRegionUtils.checkForEncodedNameCollisions(Collections.emptyList(),
+      Collections.emptyList());
+  }
+
+  private RegionInfo mockRegionInfo(TableName tableName, String encodedName) {
+    RegionInfo regionInfo = mock(RegionInfo.class);
+    when(regionInfo.getEncodedName()).thenReturn(encodedName);
+    when(regionInfo.getTable()).thenReturn(tableName);
+    return regionInfo;
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestEncodedNameCollisionDetection.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/procedure/TestEncodedNameCollisionDetection.java
@@ -23,13 +23,14 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
-import java.io.IOException;
 import java.util.Arrays;
 import java.util.Collections;
 import org.apache.hadoop.hbase.DoNotRetryIOException;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
+import org.apache.hadoop.hbase.master.assignment.RegionStateNode;
+import org.apache.hadoop.hbase.master.assignment.RegionStates;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.ModifyRegionUtils;
 import org.junit.jupiter.api.Tag;
@@ -57,18 +58,25 @@ public class TestEncodedNameCollisionDetection {
     RegionInfo ri2 = RegionInfoBuilder.newBuilder(tableName).setStartKey(new byte[] { 1, 0 })
       .setEndKey(new byte[] { 2, 0 }).setSplit(false).setRegionId(regionId + 1).build();
 
+    RegionStates regionStates = mock(RegionStates.class);
+
     assertDoesNotThrow(
-      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(ri1, ri2), null));
+      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(ri1, ri2), regionStates));
   }
 
+  /**
+   *  Verifies that duplicate encoded region names within candidate regions are rejected.
+   */
   @Test
   public void testDetectsDuplicatesInCandidates() {
     TableName tableName = TableName.valueOf("test_table");
     RegionInfo ri1 = mockRegionInfo(tableName, "same-encoded-name");
     RegionInfo ri2 = mockRegionInfo(tableName, "same-encoded-name");
 
+    RegionStates regionStates = mock(RegionStates.class);
+
     DoNotRetryIOException exception = assertThrows(DoNotRetryIOException.class,
-      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(ri1, ri2), null));
+      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(ri1, ri2), regionStates));
     assertTrue(exception.getMessage().contains("Encoded region name collision detected"));
   }
 
@@ -78,25 +86,34 @@ public class TestEncodedNameCollisionDetection {
   @Test
   public void testDetectsCollisionWithExistingRegions() {
     TableName tableName = TableName.valueOf("test_table");
-    RegionInfo existingRegion = mockRegionInfo(tableName, "same-encoded-name");
     RegionInfo candidateRegion = mockRegionInfo(tableName, "same-encoded-name");
+    RegionStates regionStates = mock(RegionStates.class);
+    when(regionStates.getRegionStateNodeFromEncodedRegionName("same-encoded-name"))
+      .thenReturn(mock(RegionStateNode.class));
 
-    DoNotRetryIOException exception = assertThrows(DoNotRetryIOException.class,
-      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(candidateRegion),
-        Arrays.asList(existingRegion)));
+    DoNotRetryIOException exception =
+      assertThrows(DoNotRetryIOException.class, () -> ModifyRegionUtils
+        .checkForEncodedNameCollisions(Arrays.asList(candidateRegion), regionStates));
     assertTrue(exception.getMessage().contains("Encoded region name collision detected"));
   }
 
   /**
-   * Test that checkForEncodedNameCollisions properly handles empty/null inputs.
+   * Test that checkForEncodedNameCollisions handles empty/null inputs and rejects null RegionStates
+   * when candidates are present.
    */
   @Test
-  public void testHandlesEmptyInputs() throws IOException {
-    ModifyRegionUtils.checkForEncodedNameCollisions(null, null);
-    ModifyRegionUtils.checkForEncodedNameCollisions(Collections.emptyList(), null);
-    ModifyRegionUtils.checkForEncodedNameCollisions(null, Collections.emptyList());
-    ModifyRegionUtils.checkForEncodedNameCollisions(Collections.emptyList(),
-      Collections.emptyList());
+  public void testInputValidationAndNullRegionStatesBehavior() {
+    assertDoesNotThrow(() -> ModifyRegionUtils.checkForEncodedNameCollisions(null, null));
+    assertDoesNotThrow(
+      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Collections.emptyList(), null));
+    assertDoesNotThrow(
+      () -> ModifyRegionUtils.checkForEncodedNameCollisions(null, mock(RegionStates.class)));
+    assertDoesNotThrow(() -> ModifyRegionUtils
+      .checkForEncodedNameCollisions(Collections.emptyList(), mock(RegionStates.class)));
+
+    RegionInfo candidateRegion = mockRegionInfo(TableName.valueOf("test_table"), "candidate");
+    assertThrows(NullPointerException.class,
+      () -> ModifyRegionUtils.checkForEncodedNameCollisions(Arrays.asList(candidateRegion), null));
   }
 
   private RegionInfo mockRegionInfo(TableName tableName, String encodedName) {


### PR DESCRIPTION
…the same

**AI Usage**

Used github copilot to implement the changes and then hand reviewed all the changes.

**Testing**

1. Reproduced the error for CreateTableProcedure and SplitTableRegionProcedure as mentioned in the ticket. 
2. Applied the fix.
3. Tested the same scenario manually for CreateTableProcedure and SplitTableRegionProcedure.
4. Got the DoNotRetryException instead of hanging procedure for long time.
ex.

```
key1 = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,94,66,185,153,219,183,152,87,250,161,224,241,188,9,104,93,49,83,91,38,117,42,147,161,38,82,122,70,135,158,151,48,132,229,185,227,108,110,42,108,7,12,239,3,150,81,189,67,33,177,222,99,45,251,43,17,131,104,193,190,36,31,174,149,175,211,87,7,138,1,250,241,186,131,140,125,165,65,49,131,174,174,248,230,249,229,70,167,201,26,254,77,236,7,222,109,14,109,158,151,244,22,8,148,168,138,56,55,7,181,118,172,231,7,16,34,252,185,31,109,189,19,86,169,237,88,240,177].pack("C*")
key2 = [0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,0,94,66,185,153,219,183,152,87,250,161,224,241,188,9,104,93,49,83,91,166,117,42,147,161,38,82,122,70,135,158,151,48,132,229,185,227,108,110,42,108,7,12,239,3,150,209,188,67,33,177,222,99,45,251,43,17,131,104,193,62,36,31,174,149,175,211,87,7,138,1,250,241,186,131,140,125,165,65,49,131,174,174,248,102,249,229,70,167,201,26,254,77,236,7,222,109,14,109,158,151,244,22,8,148,168,138,56,55,7,53,119,172,231,7,16,34,252,185,31,109,189,19,86,41,237,88,240,177].pack("C*")

hbase:037:0> create 'table1','f',SPLITS => [key1, key2]

ERROR: org.apache.hadoop.hbase.DoNotRetryIOException: Encoded region name collision detected: '495efdcd24c0fa172bef0c39ec4c9ab4' for table table1. Refusing to proceed.
	at org.apache.hadoop.hbase.util.ModifyRegionUtils.checkForEncodedNameCollisions(ModifyRegionUtils.java:110)
	at org.apache.hadoop.hbase.master.procedure.CreateTableProcedure.prepareCreate(CreateTableProcedure.java:297)
	at org.apache.hadoop.hbase.master.procedure.CreateTableProcedure.executeFromState(CreateTableProcedure.java:95)
	at org.apache.hadoop.hbase.master.procedure.CreateTableProcedure.executeFromState(CreateTableProcedure.java:60)
	at org.apache.hadoop.hbase.procedure2.StateMachineProcedure.execute(StateMachineProcedure.java:188)
	at org.apache.hadoop.hbase.procedure2.Procedure.doExecute(Procedure.java:963)
	at org.apache.hadoop.hbase.procedure2.ProcedureExecutor.execProcedure(ProcedureExecutor.java:1785)
	at org.apache.hadoop.hbase.procedure2.ProcedureExecutor.executeProcedure(ProcedureExecutor.java:1462)
	at org.apache.hadoop.hbase.procedure2.ProcedureExecutor$WorkerThread.runProcedure(ProcedureExecutor.java:2110)
	at org.apache.hadoop.hbase.trace.TraceUtil.trace(TraceUtil.java:216)
	at org.apache.hadoop.hbase.procedure2.ProcedureExecutor$WorkerThread.run(ProcedureExecutor.java:2137)

For usage try 'help "create"'

Took 0.5583 seconds
```
