### PR TITLE
HBASE-30235 Fix Javadoc syntax errors

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RoundRobinTableInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/RoundRobinTableInputFormat.java
@@ -43,7 +43,9 @@ import org.apache.yetus.audience.InterfaceAudience;
  * host few or none. This class does a pass over the return from the super-class to better spread
  * the load. See the below helpful Flipkart blog post for a description and from where the base of
  * this code comes from (with permission).
- * @see https://tech.flipkart.com/is-data-locality-always-out-of-the-box-in-hadoop-not-really-2ae9c95163cb
+ * @see <a href=
+ *      "https://tech.flipkart.com/is-data-locality-always-out-of-the-box-in-hadoop-not-really-2ae9c95163cb">
+ *      Is data locality always out of the box in Hadoop? Not really</a>
  */
 @InterfaceAudience.Public
 public class RoundRobinTableInputFormat extends TableInputFormat {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruAdaptiveBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruAdaptiveBlockCache.java
@@ -147,7 +147,7 @@ public class LruAdaptiveBlockCache implements FirstLevelBlockCache {
   private static final String LRU_MIN_FACTOR_CONFIG_NAME = "hbase.lru.blockcache.min.factor";
 
   /**
-   * Acceptable size of cache (no evictions if size < acceptable)
+   * Acceptable size of cache (no evictions if {@code size < acceptable})
    */
   private static final String LRU_ACCEPTABLE_FACTOR_CONFIG_NAME =
     "hbase.lru.blockcache.acceptable.factor";
@@ -264,10 +264,10 @@ public class LruAdaptiveBlockCache implements FirstLevelBlockCache {
   /** Approximate block size */
   private final long blockSize;
 
-  /** Acceptable size of cache (no evictions if size < acceptable) */
+  /** Acceptable size of cache (no evictions if {@code size < acceptable}) */
   private final float acceptableFactor;
 
-  /** Minimum threshold of cache (when evicting, evict until size < min) */
+  /** Minimum threshold of cache (when evicting, evict until {@code size < min}) */
   private final float minFactor;
 
   /** Single access bucket size */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/LruBlockCache.java
@@ -98,7 +98,7 @@ public class LruBlockCache implements FirstLevelBlockCache {
   private static final String LRU_MIN_FACTOR_CONFIG_NAME = "hbase.lru.blockcache.min.factor";
 
   /**
-   * Acceptable size of cache (no evictions if size < acceptable)
+   * Acceptable size of cache (no evictions if {@code size < acceptable})
    */
   private static final String LRU_ACCEPTABLE_FACTOR_CONFIG_NAME =
     "hbase.lru.blockcache.acceptable.factor";
@@ -213,10 +213,10 @@ public class LruBlockCache implements FirstLevelBlockCache {
   /** Approximate block size */
   private long blockSize;
 
-  /** Acceptable size of cache (no evictions if size < acceptable) */
+  /** Acceptable size of cache (no evictions if {@code size < acceptable}) */
   private float acceptableFactor;
 
-  /** Minimum threshold of cache (when evicting, evict until size < min) */
+  /** Minimum threshold of cache (when evicting, evict until {@code size < min}) */
   private float minFactor;
 
   /** Single access bucket size */

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreSizing.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/MemStoreSizing.java
@@ -32,17 +32,17 @@ import org.apache.yetus.audience.InterfaceAudience;
  * 3 examples to illustrate their usage:
  * <p>
  * Consider a store with 100MB of key-values allocated on-heap and 20MB of metadata allocated
- * on-heap. The counters are <100MB, 120MB, 0>, respectively.
+ * on-heap. The counters are {@code <100MB, 120MB, 0>}, respectively.
  * </p>
  * <p>
  * Consider a store with 100MB of key-values allocated off-heap and 20MB of metadata allocated
- * on-heap (e.g, CAM index). The counters are <100MB, 20MB, 100MB>, respectively.
+ * on-heap (e.g, CAM index). The counters are {@code <100MB, 20MB, 100MB>}, respectively.
  * </p>
  * <p>
  * Consider a store with 100MB of key-values from which 95MB are allocated off-heap and 5MB are
  * allocated on-heap (e.g., due to upserts) and 20MB of metadata from which 15MB allocated off-heap
- * (e.g, CCM index) and 5MB allocated on-heap (e.g, CSLM index in active). The counters are <100MB,
- * 10MB, 110MB>, respectively.
+ * (e.g, CCM index) and 5MB allocated on-heap (e.g, CSLM index in active). The counters are
+ * {@code <100MB, 10MB, 110MB>}, respectively.
  * </p>
  * Like {@link TimeRangeTracker}, it has thread-safe and non-thread-safe implementations.
  */


### PR DESCRIPTION
This applies the same Javadoc syntax fixes as #8376.