### PR TITLE
HBASE-30275 TestRecoveryPersistentBucketCache#testBucketCacheRecovery…

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestRecoveryPersistentBucketCache.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestRecoveryPersistentBucketCache.java
@@ -22,10 +22,12 @@ import static org.apache.hadoop.hbase.io.hfile.bucket.BucketCache.ACCEPT_FACTOR_
 import static org.apache.hadoop.hbase.io.hfile.bucket.BucketCache.DEFAULT_ERROR_TOLERATION_DURATION;
 import static org.apache.hadoop.hbase.io.hfile.bucket.BucketCache.EXTRA_FREE_FACTOR_CONFIG_NAME;
 import static org.apache.hadoop.hbase.io.hfile.bucket.BucketCache.MIN_FACTOR_CONFIG_NAME;
+import static org.awaitility.Awaitility.await;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.time.Duration;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseConfiguration;
@@ -251,9 +253,11 @@ public class TestRecoveryPersistentBucketCache {
     BucketCache newBucketCache = new BucketCache("file:" + testDir + "/bucket.cache", 36 * 1024,
       8192, bucketSizes, writeThreads, writerQLen, testDir + "/bucket.persistence",
       DEFAULT_ERROR_TOLERATION_DURATION, conf);
-    while (!newBucketCache.getBackingMapValidated().get()) {
-      Thread.sleep(10);
-    }
+    // backingMapValidated is set inside retrieveFromFile(), but isCacheEnabled() (which
+    // getBlock() checks) is set to true only in the finally block that follows. Waiting on
+    // backingMapValidated alone leaves a race window; await both conditions together.
+    await().atMost(Duration.ofSeconds(30)).pollInterval(Duration.ofMillis(10)).until(
+      () -> newBucketCache.getBackingMapValidated().get() && newBucketCache.isCacheEnabled());
 
     BlockCacheKey[] newKeys = CacheTestUtils.regenerateKeys(blocks, names);
 


### PR DESCRIPTION
…WithAllocationInconsistencies has a race condition between backingMapValidated and cacheState=ENABLED (#8456)

Reviewed-by: Umesh Kumar <9414umeshkumar@gmail.com>