### PR TITLE
HBASE-30099 Avoid NPE when GetBootstrapNodes RPC arrives during startup

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -473,7 +473,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
 
   private FileSystemUtilizationChore fsUtilizationChore;
 
-  private BootstrapNodeManager bootstrapNodeManager;
+  private volatile BootstrapNodeManager bootstrapNodeManager;
 
   /**
    * True if this RegionServer is coming up in a cluster where there is no Master; means it needs to
@@ -3729,7 +3729,10 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
 
   @Override
   public Iterator<ServerName> getBootstrapNodes() {
-    return bootstrapNodeManager.getBootstrapNodes().iterator();
+    BootstrapNodeManager manager = bootstrapNodeManager;
+    return manager != null
+      ? manager.getBootstrapNodes().iterator()
+      : Collections.<ServerName> emptyList().iterator();
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HRegionServer.java
@@ -473,7 +473,7 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
 
   private FileSystemUtilizationChore fsUtilizationChore;
 
-  private BootstrapNodeManager bootstrapNodeManager;
+  private volatile BootstrapNodeManager bootstrapNodeManager;
 
   /**
    * True if this RegionServer is coming up in a cluster where there is no Master; means it needs to
@@ -3729,7 +3729,8 @@ public class HRegionServer extends HBaseServerBase<RSRpcServices>
 
   @Override
   public Iterator<ServerName> getBootstrapNodes() {
-    return bootstrapNodeManager.getBootstrapNodes().iterator();
+    BootstrapNodeManager manager = bootstrapNodeManager;
+    return manager != null ? manager.getBootstrapNodes().iterator() : Collections.emptyIterator();
   }
 
   @Override

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestBootstrapNodeManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestBootstrapNodeManager.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.regionserver;
 import static org.hamcrest.CoreMatchers.hasItems;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyInt;
 import static org.mockito.Mockito.atLeast;
@@ -85,6 +86,13 @@ public class TestBootstrapNodeManager {
   private void assertListEquals(List<ServerName> expected, List<ServerName> actual) {
     assertEquals(expected.size(), expected.size());
     assertThat(actual, hasItems(expected.toArray(new ServerName[0])));
+  }
+
+  @Test
+  public void testGetBootstrapNodesBeforeInitialization() {
+    HRegionServer regionServer = mock(HRegionServer.class);
+    when(regionServer.getBootstrapNodes()).thenCallRealMethod();
+    assertFalse(regionServer.getBootstrapNodes().hasNext());
   }
 
   @Test


### PR DESCRIPTION
### What changes were proposed in this pull request?

Make `HRegionServer#getBootstrapNodes` return an empty iterator when `bootstrapNodeManager` has not been initialized yet.

Declare `bootstrapNodeManager` as volatile to ensure safe publication between the RegionServer startup thread and RPC handler threads.

Add a regression test covering calls to `getBootstrapNodes` before `bootstrapNodeManager` initialization.


### Why are the changes needed?

The RPC server can start accepting connections before `preRegistrationInitialization()` assigns `bootstrapNodeManager`.

If a `GetBootstrapNodes` RPC arrives during this startup window, `HRegionServer#getBootstrapNodes` dereferences a null `bootstrapNodeManager` and throws a `NullPointerException`.

Returning an empty iterator during this window avoids the startup race and allows callers to continue bootstrap-node discovery normally.


### How was this patch tested?

```bash
mvn -pl hbase-server -am \
  -Dtest=TestBootstrapNodeManager \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -DskipITs \
  test