### PR TITLE
HBASE-27691 Prevent filters from seeing synthetic scan start cells

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -279,8 +279,11 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
       // Always check bloom filter to optimize the top row seek for delete
       // family marker.
 
-      seekScanners(scanners, matcher.getStartKey(), explicitColumnQuery && lazySeekEnabledGlobally,
-        parallelSeekEnabled);
+      // Filters must only see real Cells. A lazy seek can expose a synthetic Cell
+      // for the scan start row, so disable it for non-Get filters.
+      boolean useLazySeek = explicitColumnQuery && lazySeekEnabledGlobally
+        && !(scan.hasFilter() && !scan.isGetScan());
+      seekScanners(scanners, matcher.getStartKey(), useLazySeek, parallelSeekEnabled);
 
       // set storeLimit
       this.storeLimit = scan.getMaxResultsPerColumnFamily();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/StoreScanner.java
@@ -281,8 +281,8 @@ public class StoreScanner extends NonReversedNonLazyKeyValueScanner
 
       // Filters must only see real Cells. A lazy seek can expose a synthetic Cell
       // for the scan start row, so disable it for non-Get filters.
-      boolean useLazySeek = explicitColumnQuery && lazySeekEnabledGlobally
-        && !(scan.hasFilter() && !scan.isGetScan());
+      boolean useLazySeek =
+        explicitColumnQuery && lazySeekEnabledGlobally && !(scan.hasFilter() && !scan.isGetScan());
       seekScanners(scanners, matcher.getStartKey(), useLazySeek, parallelSeekEnabled);
 
       // set storeLimit

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScanner.java
@@ -29,8 +29,11 @@ import static org.junit.jupiter.api.Assertions.fail;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.NavigableSet;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellUtil;
+import org.apache.hadoop.hbase.CompareOperator;
+import org.apache.hadoop.hbase.ExtendedCell;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.HTestConst;
@@ -48,9 +51,11 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.filter.ByteArrayComparable;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.InclusiveStopFilter;
 import org.apache.hadoop.hbase.filter.PrefixFilter;
+import org.apache.hadoop.hbase.filter.RowFilter;
 import org.apache.hadoop.hbase.filter.WhileMatchFilter;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
@@ -95,6 +100,10 @@ public class TestScanner {
 
   private static final long START_CODE = Long.MAX_VALUE;
 
+  private static final byte[] LAZY_SEEK_FAMILY = Bytes.toBytes("family");
+  private static final byte[] LAZY_SEEK_QUALIFIER = Bytes.toBytes("qualifier");
+  private static final byte[] LAZY_SEEK_ROW = Bytes.toBytes("row");
+
   private HRegion region;
 
   private byte[] firstRowBytes, secondRowBytes, thirdRowBytes;
@@ -111,6 +120,146 @@ public class TestScanner {
     thirdRowBytes[START_KEY_BYTES.length - 1] =
       (byte) (thirdRowBytes[START_KEY_BYTES.length - 1] + 2);
     col1 = Bytes.toBytes("column1");
+  }
+
+  private static final class RecordingStoreScanner extends StoreScanner {
+    private boolean initialSeekWasLazy;
+
+    RecordingStoreScanner(HStore store, Scan scan, NavigableSet<byte[]> columns)
+      throws IOException {
+      super(store, store.getScanInfo(), scan, columns, Long.MAX_VALUE);
+    }
+
+    @Override
+    protected void seekScanners(List<? extends KeyValueScanner> scanners, ExtendedCell seekKey,
+      boolean isLazy, boolean isParallelSeek) throws IOException {
+      initialSeekWasLazy = isLazy;
+      super.seekScanners(scanners, seekKey, isLazy, isParallelSeek);
+    }
+  }
+
+  private static final class TrackingRowComparator extends ByteArrayComparable {
+    private final List<byte[]> comparedRows = new ArrayList<>();
+
+    TrackingRowComparator(byte[] value) {
+      super(value);
+    }
+
+    @Override
+    public int compareTo(byte[] value, int offset, int length) {
+      comparedRows.add(Bytes.copy(value, offset, length));
+      return Bytes.compareTo(getValue(), 0, getValue().length, value, offset, length);
+    }
+
+    @Override
+    public byte[] toByteArray() {
+      return getValue();
+    }
+  }
+
+  @Test
+  public void testFilterComparatorOnlySeesActualRows() throws Exception {
+    byte[] family = Bytes.toBytes("family");
+    byte[] qualifier = Bytes.toBytes("qualifier");
+    byte[] regionStartKey = new byte[] { 1 };
+    byte[] row = new byte[] { 1, 0, 1 };
+    TableDescriptor tableDescriptor = TableDescriptorBuilder
+      .newBuilder(TableName.valueOf("testFilterComparatorOnlySeesActualRows"))
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(family)
+        .setBloomFilterType(BloomType.ROWCOL).build())
+      .build();
+    TrackingRowComparator comparator = new TrackingRowComparator(row);
+
+    StoreScanner.enableLazySeekGlobally(true);
+    try {
+      this.region = TEST_UTIL.createLocalHRegion(tableDescriptor, regionStartKey, null);
+      Put put = new Put(row);
+      put.addColumn(family, qualifier, Bytes.toBytes("value"));
+      region.put(put);
+      region.flush(true);
+
+      Scan scan = new Scan().withStartRow(regionStartKey);
+      scan.addColumn(family, qualifier);
+      scan.setFilter(new RowFilter(CompareOperator.EQUAL, comparator));
+      List<Cell> results = new ArrayList<>();
+      try (InternalScanner scanner = region.getScanner(scan)) {
+        assertFalse(scanner.next(results));
+      }
+
+      assertEquals(1, results.size());
+      assertTrue(CellUtil.matchingRows(results.get(0), row));
+      assertEquals(1, comparator.comparedRows.size());
+      assertTrue(Bytes.equals(row, comparator.comparedRows.get(0)));
+    } finally {
+      StoreScanner.enableLazySeekGlobally(StoreScanner.LAZY_SEEK_ENABLED_BY_DEFAULT);
+      HBaseTestingUtil.closeRegionAndWAL(this.region);
+    }
+  }
+
+  @Test
+  public void testInitialLazySeekForUnfilteredExplicitColumnScan() throws Exception {
+    Scan scan = new Scan().withStartRow(LAZY_SEEK_ROW);
+    scan.addColumn(LAZY_SEEK_FAMILY, LAZY_SEEK_QUALIFIER);
+    assertInitialLazySeek(scan, true, true);
+  }
+
+  @Test
+  public void testInitialLazySeekForFilteredGet() throws Exception {
+    Get get = new Get(LAZY_SEEK_ROW);
+    get.addColumn(LAZY_SEEK_FAMILY, LAZY_SEEK_QUALIFIER);
+    get.setFilter(new PrefixFilter(LAZY_SEEK_ROW));
+    assertInitialLazySeek(new Scan(get), true, true);
+  }
+
+  @Test
+  public void testInitialLazySeekForFilteredNonGetScan() throws Exception {
+    Scan scan = new Scan().withStartRow(LAZY_SEEK_ROW);
+    scan.addColumn(LAZY_SEEK_FAMILY, LAZY_SEEK_QUALIFIER);
+    scan.setFilter(new PrefixFilter(LAZY_SEEK_ROW));
+    assertInitialLazySeek(scan, true, false);
+  }
+
+  @Test
+  public void testInitialLazySeekForAllColumnScan() throws Exception {
+    assertInitialLazySeek(new Scan().withStartRow(LAZY_SEEK_ROW), true, false);
+  }
+
+  @Test
+  public void testInitialLazySeekWhenDisabledGlobally() throws Exception {
+    Scan scan = new Scan().withStartRow(LAZY_SEEK_ROW);
+    scan.addColumn(LAZY_SEEK_FAMILY, LAZY_SEEK_QUALIFIER);
+    assertInitialLazySeek(scan, false, false);
+  }
+
+  private void assertInitialLazySeek(Scan scan, boolean lazySeekEnabled, boolean expected)
+    throws IOException {
+    StoreScanner.enableLazySeekGlobally(lazySeekEnabled);
+    try {
+      HStore store = createLazySeekTestStore();
+      try (
+        RecordingStoreScanner scanner =
+          new RecordingStoreScanner(store, scan, scan.getFamilyMap().get(LAZY_SEEK_FAMILY))) {
+        assertEquals(expected, scanner.initialSeekWasLazy);
+      }
+    } finally {
+      StoreScanner.enableLazySeekGlobally(StoreScanner.LAZY_SEEK_ENABLED_BY_DEFAULT);
+      if (this.region != null) {
+        HBaseTestingUtil.closeRegionAndWAL(this.region);
+        this.region = null;
+      }
+    }
+  }
+
+  private HStore createLazySeekTestStore() throws IOException {
+    TableDescriptor tableDescriptor = TableDescriptorBuilder
+      .newBuilder(TableName.valueOf("testInitialLazySeek"))
+      .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(LAZY_SEEK_FAMILY).build()).build();
+    this.region = TEST_UTIL.createLocalHRegion(tableDescriptor, null, null);
+    Put put = new Put(LAZY_SEEK_ROW);
+    put.addColumn(LAZY_SEEK_FAMILY, LAZY_SEEK_QUALIFIER, Bytes.toBytes("value"));
+    region.put(put);
+    region.flush(true);
+    return region.getStore(LAZY_SEEK_FAMILY);
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScanner.java
@@ -163,11 +163,11 @@ public class TestScanner {
     byte[] qualifier = Bytes.toBytes("qualifier");
     byte[] regionStartKey = new byte[] { 1 };
     byte[] row = new byte[] { 1, 0, 1 };
-    TableDescriptor tableDescriptor = TableDescriptorBuilder
-      .newBuilder(TableName.valueOf("testFilterComparatorOnlySeesActualRows"))
-      .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(family)
-        .setBloomFilterType(BloomType.ROWCOL).build())
-      .build();
+    TableDescriptor tableDescriptor =
+      TableDescriptorBuilder.newBuilder(TableName.valueOf("testFilterComparatorOnlySeesActualRows"))
+        .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(family)
+          .setBloomFilterType(BloomType.ROWCOL).build())
+        .build();
     TrackingRowComparator comparator = new TrackingRowComparator(row);
 
     StoreScanner.enableLazySeekGlobally(true);
@@ -236,9 +236,8 @@ public class TestScanner {
     StoreScanner.enableLazySeekGlobally(lazySeekEnabled);
     try {
       HStore store = createLazySeekTestStore();
-      try (
-        RecordingStoreScanner scanner =
-          new RecordingStoreScanner(store, scan, scan.getFamilyMap().get(LAZY_SEEK_FAMILY))) {
+      try (RecordingStoreScanner scanner =
+        new RecordingStoreScanner(store, scan, scan.getFamilyMap().get(LAZY_SEEK_FAMILY))) {
         assertEquals(expected, scanner.initialSeekWasLazy);
       }
     } finally {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestScanner.java
@@ -51,6 +51,7 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.filter.BinaryComparator;
 import org.apache.hadoop.hbase.filter.ByteArrayComparable;
 import org.apache.hadoop.hbase.filter.Filter;
 import org.apache.hadoop.hbase.filter.InclusiveStopFilter;
@@ -190,6 +191,46 @@ public class TestScanner {
       assertTrue(CellUtil.matchingRows(results.get(0), row));
       assertEquals(1, comparator.comparedRows.size());
       assertTrue(Bytes.equals(row, comparator.comparedRows.get(0)));
+    } finally {
+      StoreScanner.enableLazySeekGlobally(StoreScanner.LAZY_SEEK_ENABLED_BY_DEFAULT);
+      HBaseTestingUtil.closeRegionAndWAL(this.region);
+    }
+  }
+
+  @Test
+  public void testWhileMatchFilterOnlySeesActualRows() throws Exception {
+    byte[] family = Bytes.toBytes("family");
+    byte[] qualifier = Bytes.toBytes("qualifier");
+    TableDescriptor tableDescriptor =
+      TableDescriptorBuilder.newBuilder(TableName.valueOf("testWhileMatchFilterOnlySeesActualRows"))
+        .setColumnFamily(ColumnFamilyDescriptorBuilder.newBuilder(family).build()).build();
+
+    StoreScanner.enableLazySeekGlobally(true);
+    try {
+      this.region = TEST_UTIL.createLocalHRegion(tableDescriptor, null, null);
+      List<String> rows = List.of("row1", "row2", "row3");
+      for (String row : rows) {
+        Put put = new Put(Bytes.toBytes(row)).addColumn(family, qualifier, Bytes.toBytes("value"));
+        region.put(put);
+      }
+      region.flush(true);
+
+      Scan scan = new Scan().addColumn(family, qualifier)
+        .setFilter(new WhileMatchFilter(new RowFilter(CompareOperator.NOT_EQUAL,
+          new BinaryComparator(HConstants.EMPTY_START_ROW))));
+      int scannedRows = 0;
+      try (InternalScanner scanner = region.getScanner(scan)) {
+        boolean hasMoreRows;
+        do {
+          List<Cell> results = new ArrayList<>();
+          hasMoreRows = scanner.next(results);
+          if (!results.isEmpty()) {
+            ++scannedRows;
+          }
+        } while (hasMoreRows);
+      }
+
+      assertEquals(rows.size(), scannedRows);
     } finally {
       StoreScanner.enableLazySeekGlobally(StoreScanner.LAZY_SEEK_ENABLED_BY_DEFAULT);
       HBaseTestingUtil.closeRegionAndWAL(this.region);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSeekOptimizations.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSeekOptimizations.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.regionserver;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -43,6 +44,7 @@ import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.Scan;
+import org.apache.hadoop.hbase.filter.PrefixFilter;
 import org.apache.hadoop.hbase.io.compress.Compression;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.testclassification.RegionServerTests;
@@ -51,6 +53,7 @@ import org.apache.hadoop.hbase.util.Bytes;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.TestInfo;
 import org.junit.jupiter.api.TestTemplate;
 import org.junit.jupiter.params.provider.Arguments;
 import org.slf4j.Logger;
@@ -120,21 +123,18 @@ public class TestSeekOptimizations {
   }
 
   @BeforeEach
-  public void setUp() {
+  public void setUp(TestInfo testInfo) throws IOException {
     RNG.setSeed(91238123L);
     expectedKVs.clear();
     TEST_UTIL.getConfiguration().setInt(BloomFilterUtil.PREFIX_LENGTH_KEY, 10);
-  }
 
-  @TestTemplate
-  public void testMultipleTimestampRanges() throws IOException {
     // enable seek counting
     StoreFileScanner.instrument();
     ColumnFamilyDescriptor columnFamilyDescriptor =
       ColumnFamilyDescriptorBuilder.newBuilder(Bytes.toBytes(FAMILY)).setCompressionType(comprAlgo)
         .setBloomFilterType(bloomType).setMaxVersions(3).build();
 
-    region = TEST_UTIL.createTestRegion("testMultipleTimestampRanges", columnFamilyDescriptor);
+    region = TEST_UTIL.createTestRegion(testInfo.getTestMethod().get().getName(), columnFamilyDescriptor);
 
     // Delete the given timestamp and everything before.
     final long latestDelTS = USE_MANY_STORE_FILES ? 1397 : -1;
@@ -150,12 +150,15 @@ public class TestSeekOptimizations {
     }
 
     prepareExpectedKVs(latestDelTS);
+  }
 
+  @TestTemplate
+  public void testMultipleTimestampRanges() throws IOException {
     for (int[] columnArr : COLUMN_SETS) {
       for (int[] rowRange : ROW_RANGES) {
         for (int maxVersions : MAX_VERSIONS_VALUES) {
           for (boolean lazySeekEnabled : new boolean[] { false, true }) {
-            testScan(columnArr, lazySeekEnabled, rowRange[0], rowRange[1], maxVersions);
+            testScan(columnArr, lazySeekEnabled, rowRange[0], rowRange[1], maxVersions, false);
           }
         }
       }
@@ -176,8 +179,8 @@ public class TestSeekOptimizations {
         + String.format("%.2f%%", expectedSeekSavings * 100));
   }
 
-  private void testScan(final int[] columnArr, final boolean lazySeekEnabled, final int startRow,
-    final int endRow, int maxVersions) throws IOException {
+  private ScanResult testScan(final int[] columnArr, final boolean lazySeekEnabled, final int startRow,
+    final int endRow, final int maxVersions, final boolean filtered) throws IOException {
     StoreScanner.enableLazySeekGlobally(lazySeekEnabled);
     final Scan scan = new Scan();
     final Set<String> qualSet = new HashSet<>();
@@ -185,6 +188,9 @@ public class TestSeekOptimizations {
       String qualStr = getQualStr(iColumn);
       scan.addColumn(FAMILY_BYTES, Bytes.toBytes(qualStr));
       qualSet.add(qualStr);
+    }
+    if (filtered) {
+      scan.setFilter(new PrefixFilter(Bytes.toBytes("row")));
     }
     scan.readVersions(maxVersions);
     scan.withStartRow(rowBytes(startRow));
@@ -198,6 +204,7 @@ public class TestSeekOptimizations {
 
     final long initialSeekCount = StoreFileScanner.getSeekCount();
     final InternalScanner scanner = region.getScanner(scan);
+    final long scannerOpenSeekCount = StoreFileScanner.getSeekCount() - initialSeekCount;
     final List<Cell> results = new ArrayList<>();
     final List<Cell> actualKVs = new ArrayList<>();
 
@@ -234,6 +241,7 @@ public class TestSeekOptimizations {
       totalSeekDiligent += seekCount;
     }
     assertKVListsEqual(testDesc, filteredKVs, actualKVs);
+    return new ScanResult(actualKVs, scannerOpenSeekCount);
   }
 
   private List<Cell> filterExpectedResults(Set<String> qualSet, byte[] startRow, byte[] endRow,
@@ -446,6 +454,26 @@ public class TestSeekOptimizations {
       throw new AssertionError("Expected and actual KV arrays differ at position " + i + ": "
         + HBaseTestingUtil.safeGetAsStr(expected, i) + " (length " + eLen + ") vs. "
         + HBaseTestingUtil.safeGetAsStr(actual, i) + " (length " + aLen + ")" + additionalMsg);
+    }
+  }
+
+  @TestTemplate
+  public void testSeeksEagerlyWhenFiltered() throws IOException {
+    ScanResult filteredLazyResults = testScan(new int[] { 0 }, true, 0, 2, 1, true);
+    ScanResult filteredEagerResults = testScan(new int[] { 0 }, false, 0, 2, 1, true);
+    assertKVListsEqual("Filtered explicit column scan results differ with lazy seeking enabled",
+      filteredEagerResults.cells, filteredLazyResults.cells);
+    assertEquals(filteredEagerResults.scannerOpenSeekCount, filteredLazyResults.scannerOpenSeekCount,
+      "Filtered explicit column scans must always eagerly seek");
+  }
+
+  private static final class ScanResult {
+    private final List<Cell> cells;
+    private final long scannerOpenSeekCount;
+
+    private ScanResult(List<Cell> cells, long scannerOpenSeekCount) {
+      this.cells = cells;
+      this.scannerOpenSeekCount = scannerOpenSeekCount;
     }
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSeekOptimizations.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSeekOptimizations.java
@@ -213,12 +213,16 @@ public class TestSeekOptimizations {
     // Such a clumsy do-while loop appears to be the official way to use an
     // internalScanner. scanner.next() return value refers to the _next_
     // result, not to the one already returned in results.
-    boolean hasNext;
-    do {
-      hasNext = scanner.next(results);
-      actualKVs.addAll(results);
-      results.clear();
-    } while (hasNext);
+    try {
+      boolean hasNext;
+      do {
+        hasNext = scanner.next(results);
+        actualKVs.addAll(results);
+        results.clear();
+      } while (hasNext);
+    } finally {
+      scanner.close();
+    }
 
     List<Cell> filteredKVs =
       filterExpectedResults(qualSet, rowBytes(startRow), rowBytes(endRow), maxVersions);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSeekOptimizations.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestSeekOptimizations.java
@@ -134,7 +134,8 @@ public class TestSeekOptimizations {
       ColumnFamilyDescriptorBuilder.newBuilder(Bytes.toBytes(FAMILY)).setCompressionType(comprAlgo)
         .setBloomFilterType(bloomType).setMaxVersions(3).build();
 
-    region = TEST_UTIL.createTestRegion(testInfo.getTestMethod().get().getName(), columnFamilyDescriptor);
+    region =
+      TEST_UTIL.createTestRegion(testInfo.getTestMethod().get().getName(), columnFamilyDescriptor);
 
     // Delete the given timestamp and everything before.
     final long latestDelTS = USE_MANY_STORE_FILES ? 1397 : -1;
@@ -179,8 +180,9 @@ public class TestSeekOptimizations {
         + String.format("%.2f%%", expectedSeekSavings * 100));
   }
 
-  private ScanResult testScan(final int[] columnArr, final boolean lazySeekEnabled, final int startRow,
-    final int endRow, final int maxVersions, final boolean filtered) throws IOException {
+  private ScanResult testScan(final int[] columnArr, final boolean lazySeekEnabled,
+    final int startRow, final int endRow, final int maxVersions, final boolean filtered)
+    throws IOException {
     StoreScanner.enableLazySeekGlobally(lazySeekEnabled);
     final Scan scan = new Scan();
     final Set<String> qualSet = new HashSet<>();
@@ -463,7 +465,8 @@ public class TestSeekOptimizations {
     ScanResult filteredEagerResults = testScan(new int[] { 0 }, false, 0, 2, 1, true);
     assertKVListsEqual("Filtered explicit column scan results differ with lazy seeking enabled",
       filteredEagerResults.cells, filteredLazyResults.cells);
-    assertEquals(filteredEagerResults.scannerOpenSeekCount, filteredLazyResults.scannerOpenSeekCount,
+    assertEquals(filteredEagerResults.scannerOpenSeekCount,
+      filteredLazyResults.scannerOpenSeekCount,
       "Filtered explicit column scans must always eagerly seek");
   }
 


### PR DESCRIPTION
# [HBASE-27691](https://issues.apache.org/jira/browse/HBASE-27691)

### What changes were proposed in this pull request?

This patch disables `StoreScanner`'s initial lazy seek for filtered non-Get scans. Doing so prevents synthetic lazy-seek Cells from being exposed to server-side Filters and Comparators, while retaining lazy seeking for unfiltered Scans and Gets.

### Why are the changes needed?

A region start boundary is not guaranteed to be a valid application row key. Passing its synthetic Cell to a `RowFilter` comparator violates the Filter contract that `filterRowKey` receives the first actual Cell of a row and can result in unexpected exceptions when Filter / Comparator code attempts to parse a seemingly truncated or otherwise malformed row key.

In our case that manifested like this:

```
Caused by: java.lang.RuntimeException: java.io.EOFException
	at com.package.MyComparator.compareTo(MyComparator.java:133)
	at org.apache.hadoop.hbase.PrivateCellUtil.compareRow(PrivateCellUtil.java:1240)
	at org.apache.hadoop.hbase.filter.CompareFilter.compareRow(CompareFilter.java:148)
	at org.apache.hadoop.hbase.filter.RowFilter.filterRowKey(RowFilter.java:90)
	at org.apache.hadoop.hbase.filter.FilterListWithOR.filterRowKey(FilterListWithOR.java:345)
	at org.apache.hadoop.hbase.filter.FilterList.filterRowKey(FilterList.java:152)
	at org.apache.hadoop.hbase.filter.FilterListWithAND.filterRowKey(FilterListWithAND.java:227)
	at org.apache.hadoop.hbase.filter.FilterList.filterRowKey(FilterList.java:152)
	at org.apache.hadoop.hbase.filter.FilterWrapper.filterRowKey(FilterWrapper.java:108)
	at org.apache.hadoop.hbase.regionserver.HRegion$RegionScannerImpl.filterRowKey(HRegion.java:7545)
	at org.apache.hadoop.hbase.regionserver.HRegion$RegionScannerImpl.nextInternal(HRegion.java:7361)
	at org.apache.hadoop.hbase.regionserver.HRegion$RegionScannerImpl.nextRaw(HRegion.java:7153)
	at org.apache.hadoop.hbase.regionserver.RSRpcServices.scan(RSRpcServices.java:3330)
	...
```

This change reinstates the protection intended by [HBASE-6562](https://issues.apache.org/jira/browse/HBASE-6562), using its later proposed (unmerged) [eager initial seek patch](https://issues.apache.org/jira/secure/attachment/12563194/6562-0.96-v1.txt). 

### Are there any concerns?

First let's provide some background context.

#### How does lazy seeking work, and why is its design problematic?

Lazy seeking uses synthetic Cells as part of the scanner's control flow. They are essentially placeholders indicating "start looking from here." A problem with this design is that before a real Cell has been read from a StoreFile, this placeholder is made visible to a filter with no supplemental context to be able to differentiate it as such. A filter has no definitive means to distinguish a synthetic Cell from a real one, so it may attempt to unsafely process the row key (decoding it, comparing it, using the value to decide to end the scan, etc). Filter or comparator code therefore can be required to have overly broad exception handling.

#### What is the proposal for fixing this design problem?

To elaborate on what was stated above, this patch ensures a filtered non-Get scan reads a real first Cell before invoking the filter. The correction is limited to this specific case where correctness requires that filters see a real Cell. Scans without explicit columns already do an eager initial seek. Unfiltered scans, Gets, and subsequent post-initialization repositioning still retain the existing lazy seek behavior.

#### What are the risks of making this correction?

A known risk of making this correction is potentially unnecessary work done at the beginning of the scan. A StoreScanner is the scanner for one column family in one region scan. On opening it, HBase may have multiple underlying scanners, one for each StoreFile plus one for the Region Server MemStore. Previously with an explicit-column scan, HBase could tell each underlying scanner "don't seek yet - wait until I know you are needed." The patch instead says that filtered non-Get scans must "seek now, so the first Cell I present to the filter is real." If a column family has many StoreFiles, each selected StoreFile scanner may do an HFile index lookup and potentially read blocks to position itself. The MemStore scanner is also positioned. The cost is proportional to the number of underlying scanners opened, not the number of rows returned. That overhead can materially matter for short filtered scans over stores with many files if the scan would otherwise have avoided touching some of them.

#### Is there a better way to fix this?

I have been unable to determine a more appropriate way to address this and am open to ideas. Deeper API design changes could involve enhancing the Filter abstract class or Cell interface and do not appear advisable for such a narrow problem surface area, as that would introduce major risks.

### How was this patch tested?

A ROWCOL Bloom regression test verifies that a Comparator sees only the persisted row, not a synthetic region-boundary Cell. Focused tests also cover each lazy-seek decision branch.

```bash
mvn -ntp -pl hbase-server -am \
  -Dtest=TestScanner \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```