### PR TITLE
HBASE-30092 Avoid stringifying protobuf RPC parameters in task snapshots

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredRPCHandlerImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/monitoring/MonitoredRPCHandlerImpl.java
@@ -249,6 +249,9 @@ public class MonitoredRPCHandlerImpl extends MonitoredTaskImpl implements Monito
         paramList.add(Bytes.toStringBinary((byte[]) param));
       } else if (param instanceof Operation) {
         paramList.add(((Operation) param).toMap());
+      } else if (param instanceof Message) {
+        // Do not stringify protobufs, as large requests can OOM the monitoring path.
+        paramList.add(param.getClass().getSimpleName());
       } else {
         paramList.add(param.toString());
       }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/monitoring/TestTaskMonitor.java
@@ -42,6 +42,11 @@ import org.skyscreamer.jsonassert.JSONAssert;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
+import org.apache.hbase.thirdparty.com.google.protobuf.ByteString;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.ClientProtos;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.FilterProtos;
+
 @Tag(MiscTests.TAG)
 @Tag(SmallTests.TAG)
 public class TestTaskMonitor {
@@ -287,6 +292,21 @@ public class TestTaskMonitor {
     assertNotEquals(clone.getRPCQueueTime(), monitor.getRPCQueueTime());
     assertNotEquals(clone.toMap(), monitor.toMap());
     assertNotEquals(clone.toJSON(), monitor.toJSON());
+  }
+
+  @Test
+  public void testCloneDoesNotStringifyProtobufParams() {
+    ClientProtos.ScanRequest request = ClientProtos.ScanRequest.newBuilder()
+      .setScan(ClientProtos.Scan.newBuilder().setFilter(FilterProtos.Filter.newBuilder()
+        .setName("large-filter").setSerializedFilter(ByteString.copyFrom(new byte[64 * 1024]))))
+      .build();
+    MonitoredRPCHandlerImpl monitor = new MonitoredRPCHandlerImpl("test");
+    monitor.setRPC("Scan", new Object[] { request }, 0);
+    monitor.setRPCPacket(request);
+
+    Map<String, Object> rpcCall = (Map<String, Object>) monitor.clone().toMap().get("rpcCall");
+    assertEquals(List.of("ScanRequest"), rpcCall.get("params"));
+    assertEquals((long) request.getSerializedSize(), rpcCall.get("packetlength"));
   }
 
   private class TestParam {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30092

### What changes were proposed in this pull request?

This change avoids calling `Message.toString()` when `MonitoredRPCHandlerImpl` generates RPC monitoring information.

For protobuf parameters, HBase now records only the protobuf message type, such as `ScanRequest`. The existing `packetlength` field continues to report the serialized request size.

### Why are the changes needed?

HBASE-30092 reports that `MonitoredRPCHandlerImpl.generateCallInfoMap()` can cause an out-of-memory error while generating RegionServer heartbeat information for a large in-flight RPC request.

Calling `toString()` on a protobuf recursively materializes the complete TextFormat representation. For large RPC requests, this creates a significant additional allocation in the monitoring path and can exhaust the RegionServer heap.

Recording only the protobuf message type keeps monitoring allocation independent of the request payload size while preserving the RPC method and serialized packet length.

### How was this patch tested?

Added a regression test to `TestTaskMonitor`, covering:

- Cloning a monitored RPC containing a large protobuf `ScanRequest`.
- The RPC parameters contain only the protobuf message type.
- The serialized packet length is preserved.

The focused unit test can be run with:

```bash
mvn -pl hbase-server -am \
  -DskipITs \
  '-Dtest=TestTaskMonitor#testCloneDoesNotStringifyProtobufParams' \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test