### PR TITLE
HBASE-29696 Fix incorrect TableInputFormat split boundaries

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableInputFormatBase.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableInputFormatBase.java
@@ -407,6 +407,9 @@ public abstract class TableInputFormatBase extends InputFormat<ImmutableBytesWri
 
     // Split Region into n chunks evenly
     byte[][] splitKeys = Bytes.split(startRow, endRow, true, n - 1);
+    // Restore the original boundaries after using synthetic ones to calculate the split keys.
+    splitKeys[0] = ts.getStartRow();
+    splitKeys[splitKeys.length - 1] = ts.getEndRow();
     for (int i = 0; i < splitKeys.length - 1; i++) {
       // In the table input format for single table we do not need to
       // store the scan object in table split because it can be memory intensive and redundant

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormatBase.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormatBase.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.mapreduce;
 
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyBoolean;
@@ -27,6 +28,7 @@ import java.io.IOException;
 import java.net.Inet6Address;
 import java.net.InetAddress;
 import java.net.UnknownHostException;
+import java.util.List;
 import java.util.Map;
 import java.util.TreeMap;
 import java.util.concurrent.ExecutorService;
@@ -52,6 +54,7 @@ import org.apache.hadoop.hbase.security.User;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.Pair;
+import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.junit.jupiter.api.Tag;
 import org.junit.jupiter.api.Test;
@@ -61,6 +64,24 @@ import org.mockito.stubbing.Answer;
 
 @Tag(SmallTests.TAG)
 public class TestTableInputFormatBase {
+
+  @Test
+  public void testCreateNInputSplitsUniformPreservesOriginalBoundaries() throws IOException {
+    TableInputFormat inputFormat = new TableInputFormat();
+    for (byte[] startRow : new byte[][] { HConstants.EMPTY_START_ROW, Bytes.toBytes("start") }) {
+      TableSplit split =
+        new TableSplit(TableName.valueOf("test"), startRow, HConstants.EMPTY_END_ROW, "localhost");
+
+      List<InputSplit> splits = inputFormat.createNInputSplitsUniform(split, 2);
+
+      assertEquals(2, splits.size());
+      TableSplit first = (TableSplit) splits.get(0);
+      TableSplit last = (TableSplit) splits.get(1);
+      assertArrayEquals(startRow, first.getStartRow());
+      assertArrayEquals(first.getEndRow(), last.getStartRow());
+      assertArrayEquals(HConstants.EMPTY_END_ROW, last.getEndRow());
+    }
+  }
 
   @Test
   public void testReuseRegionSizeCalculator() throws IOException {


### PR DESCRIPTION
### What changes were proposed in this pull request?

Restore the original start and end rows after `Bytes.split` calculates the intermediate split keys in `TableInputFormatBase#createNInputSplitsUniform`.

Synthetic finite boundaries are still used internally for calculating the split keys, but they are no longer exposed as the boundaries of the first and last generated `TableSplit`.

A regression test was added to cover both empty and non-empty start rows with an open-ended range. The test also verifies continuity between adjacent splits.

### Why are the changes needed?

An empty end row represents an unbounded scan in HBase. `createNInputSplitsUniform` temporarily replaces it with a finite all-`0xFF` key so that `Bytes.split` can calculate intermediate keys.

Previously, this temporary key was also used as the end row of the final `TableSplit`. Since scan stop rows are exclusive, rows equal to or lexicographically greater than the synthetic key, such as `0xFFFF`, could be skipped.

Restoring the original empty end row keeps the final split open-ended and preserves the complete input range.

### How was this patch tested?

Added `TestTableInputFormatBase#testCreateNInputSplitsUniformPreservesOriginalBoundaries`, covering:

- empty start and empty end rows;
- non-empty start and empty end rows;
- continuity between adjacent splits;
- preservation of the original first and last boundaries.

The regression test was run with:

mvn -pl hbase-mapreduce -am \
  -Dtest=TestTableInputFormatBase#testCreateNInputSplitsUniformPreservesOriginalBoundaries \
  -Dsurefire.failIfNoSpecifiedTests=false test