### PR TITLE
HBASE-29272 Fix TableSnapshotInputFormatImpl returning 0 for InputSplit length (branch-3.0)

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/TableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/TableSnapshotInputFormat.java
@@ -56,10 +56,33 @@ public class TableSnapshotInputFormat implements InputFormat<ImmutableBytesWrita
       this.delegate = delegate;
     }
 
+    /**
+     * @deprecated since 3.0.0 and will be removed in 4.0.0.
+     * Use {@link #TableSnapshotRegionSplit(TableSnapshotInputFormatImpl.InputSplit)} instead.
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
+    @Deprecated
     public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
       List<String> locations, Scan scan, Path restoreDir) {
+      this(htd, regionInfo, locations, scan, restoreDir, 1);
+    }
+
+    /**
+     * Creates a TableSnapshotRegionSplit with the given region information and the estimated length
+     * of the region in bytes. The length is used by the MapReduce framework to balance the
+     * distribution of splits; a value of 0 may cause the framework to skip the split.
+     * @param htd the table descriptor
+     * @param regionInfo the region info
+     * @param locations the locations of the region
+     * @param scan the scan to use
+     * @param restoreDir the directory to restore the snapshot to
+     * @param length the estimated size of the region in bytes
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
+    public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
+      List<String> locations, Scan scan, Path restoreDir, long length) {
       this.delegate =
-        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir);
+        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir, length);
     }
 
     @Override

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/TableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapred/TableSnapshotInputFormat.java
@@ -56,10 +56,33 @@ public class TableSnapshotInputFormat implements InputFormat<ImmutableBytesWrita
       this.delegate = delegate;
     }
 
+    /**
+   * @deprecated since 3.0.1 and will be removed in 4.0.0.
+     * Use {@link #TableSnapshotRegionSplit(TableSnapshotInputFormatImpl.InputSplit)} instead.
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
+    @Deprecated
     public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
       List<String> locations, Scan scan, Path restoreDir) {
+      this(htd, regionInfo, locations, scan, restoreDir, 1);
+    }
+
+    /**
+     * Creates a TableSnapshotRegionSplit with the given region information and the estimated length
+     * of the region in bytes. The length is used by the MapReduce framework to balance the
+     * distribution of splits; a value of 0 may cause the framework to skip the split.
+     * @param htd the table descriptor
+     * @param regionInfo the region info
+     * @param locations the locations of the region
+     * @param scan the scan to use
+     * @param restoreDir the directory to restore the snapshot to
+     * @param length the estimated size of the region in bytes
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
+    public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
+      List<String> locations, Scan scan, Path restoreDir, long length) {
       this.delegate =
-        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir);
+        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir, length);
     }
 
     @Override

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormat.java
@@ -95,10 +95,33 @@ public class TableSnapshotInputFormat extends InputFormat<ImmutableBytesWritable
       this.delegate = delegate;
     }
 
+    /**
+     * @deprecated since 3.0.0 and will be removed in 4.0.0.
+     * Use {@link #TableSnapshotRegionSplit(TableSnapshotInputFormatImpl.InputSplit)} instead.
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
+    @Deprecated
     public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
       List<String> locations, Scan scan, Path restoreDir) {
+      this(htd, regionInfo, locations, scan, restoreDir, 1);
+    }
+
+    /**
+     * Creates a TableSnapshotRegionSplit with the given region information and the estimated length
+     * of the region in bytes. The length is used by the MapReduce framework to balance the
+     * distribution of splits; a value of 0 may cause the framework to skip the split.
+     * @param htd the table descriptor
+     * @param regionInfo the region info
+     * @param locations the locations of the region
+     * @param scan the scan to use
+     * @param restoreDir the directory to restore the snapshot to
+     * @param length the estimated size of the region in bytes
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
+    public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
+      List<String> locations, Scan scan, Path restoreDir, long length) {
       this.delegate =
-        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir);
+        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir, length);
     }
 
     @Override

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormat.java
@@ -95,10 +95,33 @@ public class TableSnapshotInputFormat extends InputFormat<ImmutableBytesWritable
       this.delegate = delegate;
     }
 
+    /**
+   * @deprecated since 3.0.1 and will be removed in 4.0.0.
+     * Use {@link #TableSnapshotRegionSplit(TableSnapshotInputFormatImpl.InputSplit)} instead.
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
+    @Deprecated
     public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
       List<String> locations, Scan scan, Path restoreDir) {
+      this(htd, regionInfo, locations, scan, restoreDir, 1);
+    }
+
+    /**
+     * Creates a TableSnapshotRegionSplit with the given region information and the estimated length
+     * of the region in bytes. The length is used by the MapReduce framework to balance the
+     * distribution of splits; a value of 0 may cause the framework to skip the split.
+     * @param htd the table descriptor
+     * @param regionInfo the region info
+     * @param locations the locations of the region
+     * @param scan the scan to use
+     * @param restoreDir the directory to restore the snapshot to
+     * @param length the estimated size of the region in bytes
+     * @see <a href="https://issues.apache.org/jira/browse/HBASE-29272">HBASE-29272</a>
+     */
+    public TableSnapshotRegionSplit(TableDescriptor htd, RegionInfo regionInfo,
+      List<String> locations, Scan scan, Path restoreDir, long length) {
       this.delegate =
-        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir);
+        new TableSnapshotInputFormatImpl.InputSplit(htd, regionInfo, locations, scan, restoreDir, length);
     }
 
     @Override

--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
@@ -20,6 +20,7 @@ package org.apache.hadoop.hbase.mapreduce;
 import java.io.ByteArrayOutputStream;
 import java.io.DataInput;
 import java.io.DataOutput;
+import java.io.EOFException;
 import java.io.IOException;
 import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
@@ -45,8 +46,10 @@ import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotHelper;
+import org.apache.hadoop.hbase.snapshot.RegionSizes;
 import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.snapshot.SnapshotManifest;
+import org.apache.hadoop.hbase.snapshot.SnapshotRegionSizeCalculator;
 import org.apache.hadoop.hbase.util.Bytes;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.RegionSplitter;
@@ -145,13 +148,14 @@ public class TableSnapshotInputFormatImpl {
     private String[] locations;
     private String scan;
     private String restoreDir;
+    private long length;
 
     // constructor for mapreduce framework / Writable
     public InputSplit() {
     }
 
     public InputSplit(TableDescriptor htd, RegionInfo regionInfo, List<String> locations, Scan scan,
-      Path restoreDir) {
+      Path restoreDir, long length) {
       this.htd = htd;
       this.regionInfo = regionInfo;
       if (locations == null || locations.isEmpty()) {
@@ -166,6 +170,7 @@ public class TableSnapshotInputFormatImpl {
       }
 
       this.restoreDir = restoreDir.toString();
+      this.length = length;
     }
 
     public TableDescriptor getHtd() {
@@ -181,8 +186,7 @@ public class TableSnapshotInputFormatImpl {
     }
 
     public long getLength() {
-      // TODO: We can obtain the file sizes of the snapshot here.
-      return 0;
+      return length;
     }
 
     public String[] getLocations() {
@@ -219,6 +223,7 @@ public class TableSnapshotInputFormatImpl {
 
       Bytes.writeByteArray(out, Bytes.toBytes(scan));
       Bytes.writeByteArray(out, Bytes.toBytes(restoreDir));
+      out.writeLong(length);
 
     }
 
@@ -235,6 +240,12 @@ public class TableSnapshotInputFormatImpl {
 
       this.scan = Bytes.toString(Bytes.readByteArray(in));
       this.restoreDir = Bytes.toString(Bytes.readByteArray(in));
+      try {
+        this.length = in.readLong();
+      } catch (EOFException e) {
+        // Older serialized splits do not carry length and keep the previous behavior
+        this.length = 0L;
+      }
     }
   }
 
@@ -441,6 +452,8 @@ public class TableSnapshotInputFormatImpl {
     }
 
     List<InputSplit> splits = new ArrayList<>();
+    RegionSizes regionSizes =
+      SnapshotRegionSizeCalculator.calculateRegionSizes(conf, manifest);
     for (RegionInfo hri : regionManifests) {
       // load region descriptor
       List<String> hosts = null;
@@ -455,6 +468,8 @@ public class TableSnapshotInputFormatImpl {
           hosts = calculateLocationsForInputSplit(conf, htd, hri, tableDir);
         }
       }
+
+      long snapshotRegionSize = regionSizes.getRegionSize(hri.getEncodedName());
 
       if (numSplits > 1) {
         byte[][] sp = sa.split(hri.getStartKey(), hri.getEndKey(), numSplits, true);
@@ -478,7 +493,8 @@ public class TableSnapshotInputFormatImpl {
                 Bytes.compareTo(scan.getStopRow(), sp[i + 1]) < 0 ? scan.getStopRow() : sp[i + 1]);
             }
 
-            splits.add(new InputSplit(htd, hri, hosts, boundedScan, restoreDir));
+            splits.add(new InputSplit(htd, hri, hosts, boundedScan, restoreDir,
+              snapshotRegionSize / numSplits));
           }
         }
       } else {
@@ -487,7 +503,7 @@ public class TableSnapshotInputFormatImpl {
             hri.getEndKey())
         ) {
 
-          splits.add(new InputSplit(htd, hri, hosts, scan, restoreDir));
+          splits.add(new InputSplit(htd, hri, hosts, scan, restoreDir, snapshotRegionSize));
         }
       }
     }

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/RegionSizes.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/RegionSizes.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.snapshot;
+
+import java.util.Collections;
+import java.util.Map;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Holds the size of each region in a snapshot.
+ */
+@InterfaceAudience.Private
+public class RegionSizes {
+
+  private final Map<String, Long> regionSizeMap;
+
+  RegionSizes(Map<String, Long> regionSizeMap) {
+    this.regionSizeMap = regionSizeMap;
+  }
+
+  /**
+   * Returns the total size of the given region in bytes.
+   * @param encodedRegionName the encoded region name
+   * @return the size of the region, or 0 if the region is not present in the snapshot
+   */
+  public long getRegionSize(String encodedRegionName) {
+    return regionSizeMap.getOrDefault(encodedRegionName, 0L);
+  }
+
+  /**
+   * Returns an unmodifiable view of the region size map.
+   * @return a map of region encoded names to their total size in bytes
+   */
+  public Map<String, Long> getRegionSizeMap() {
+    return Collections.unmodifiableMap(regionSizeMap);
+  }
+}

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotInfo.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotInfo.java
@@ -160,6 +160,7 @@ public final class SnapshotInfo extends AbstractHBaseTool {
     private AtomicLong hfilesMobSize = new AtomicLong();
     private AtomicLong nonSharedHfilesArchiveSize = new AtomicLong();
     private AtomicLong logSize = new AtomicLong();
+    private Map<String, Long> regionSizeMap = new ConcurrentHashMap<>();
 
     private final SnapshotProtos.SnapshotDescription snapshot;
     private final TableName snapshotTable;
@@ -180,6 +181,14 @@ public final class SnapshotInfo extends AbstractHBaseTool {
       this.snapshotTable = TableName.valueOf(snapshot.getTable());
       this.conf = conf;
       this.fs = fs;
+    }
+
+    /**
+     * Returns the map containing region sizes.
+     * @return A map where keys are region names and values are their corresponding sizes.
+     */
+    public Map<String, Long> getRegionSizeMap() {
+      return regionSizeMap;
     }
 
     /** Returns the snapshot descriptor */
@@ -351,6 +360,12 @@ public final class SnapshotInfo extends AbstractHBaseTool {
         hfilesMissing.incrementAndGet();
       }
       return new FileInfo(inArchive, size, isCorrupted);
+    }
+
+    void updateRegionSizeMap(final RegionInfo region,
+      final SnapshotRegionManifest.StoreFile storeFile) {
+      long currentSize = regionSizeMap.getOrDefault(region.getEncodedName(), 0L);
+      regionSizeMap.put(region.getEncodedName(), currentSize + storeFile.getFileSize());
     }
 
     /**
@@ -633,6 +648,7 @@ public final class SnapshotInfo extends AbstractHBaseTool {
           final SnapshotRegionManifest.StoreFile storeFile) throws IOException {
           if (!storeFile.hasReference()) {
             stats.addStoreFile(regionInfo, family, storeFile, filesMap);
+            stats.updateRegionSizeMap(regionInfo, storeFile);
           }
         }
       });

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionSizeCalculator.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/snapshot/SnapshotRegionSizeCalculator.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.snapshot;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.hbase.snapshot.SnapshotInfo.SnapshotStats;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.yetus.audience.InterfaceAudience;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos;
+
+/**
+ * Utility class to calculate the size of each region in a snapshot.
+ */
+@InterfaceAudience.Private
+public class SnapshotRegionSizeCalculator {
+
+  /**
+   * Calculate the size of each region in the snapshot.
+   * @return A map of region encoded names to their total size in bytes.
+   * @throws IOException If an error occurs during calculation.
+   */
+  public static RegionSizes calculateRegionSizes(Configuration conf,
+    SnapshotManifest manifest) throws IOException {
+    FileSystem fs = FileSystem.get(CommonFSUtils.getRootDir(conf).toUri(), conf);
+    SnapshotProtos.SnapshotDescription snapshot =
+      SnapshotDescriptionUtils.readSnapshotInfo(fs, manifest.getSnapshotDir());
+    SnapshotStats stats = SnapshotInfo.getSnapshotStats(conf, snapshot, null);
+    return new RegionSizes(stats.getRegionSizeMap());
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/snapshot/TestSnapshotRegionSizeCalculator.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/snapshot/TestSnapshotRegionSizeCalculator.java
@@ -1,0 +1,112 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.snapshot;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.Admin;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.junit.jupiter.api.AfterAll;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.hbase.shaded.protobuf.generated.SnapshotProtos;
+
+@Tag(SmallTests.TAG)
+public class TestSnapshotRegionSizeCalculator {
+
+  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
+  private static FileSystem fs;
+  private static Path rootDir;
+  private static Path snapshotDir;
+  private static SnapshotProtos.SnapshotDescription snapshotDesc;
+  private static SnapshotManifest manifest;
+  private static Admin admin;
+  private static Configuration conf;
+
+  @BeforeAll
+  public static void setupCluster() throws Exception {
+    TEST_UTIL.startMiniCluster(3);
+    conf = TEST_UTIL.getConfiguration();
+    fs = TEST_UTIL.getTestFileSystem();
+    rootDir = TEST_UTIL.getDataTestDir("TestSnapshotRegionSizeCalculator");
+    CommonFSUtils.setRootDir(conf, rootDir);
+    admin = TEST_UTIL.getAdmin();
+  }
+
+  @AfterAll
+  public static void tearDown() throws Exception {
+    fs.delete(rootDir, true);
+    TEST_UTIL.shutdownMiniCluster();
+  }
+
+  @Test
+  public void testCalculateRegionSize() throws IOException {
+    TableName tableName = TableName.valueOf("test_table");
+    String snapshotName = "test_snapshot";
+
+    // table has no data
+    TEST_UTIL.createTable(tableName, Bytes.toBytes("info"));
+    admin = TEST_UTIL.getConnection().getAdmin();
+    admin.snapshot(snapshotName, tableName);
+    Path snapshotDir = SnapshotDescriptionUtils.getCompletedSnapshotDir(snapshotName,
+      TEST_UTIL.getDefaultRootDirPath());
+    SnapshotProtos.SnapshotDescription snapshotDesc =
+      SnapshotDescriptionUtils.readSnapshotInfo(TEST_UTIL.getTestFileSystem(), snapshotDir);
+    SnapshotManifest manifest = SnapshotManifest.open(TEST_UTIL.getConfiguration(),
+      TEST_UTIL.getTestFileSystem(), snapshotDir, snapshotDesc);
+
+    RegionSizes regionSizes =
+      SnapshotRegionSizeCalculator.calculateRegionSizes(TEST_UTIL.getConfiguration(), manifest);
+
+    for (Map.Entry<String, Long> entry : regionSizes.getRegionSizeMap().entrySet()) {
+      assertEquals(0, (long) entry.getValue(), "Region size should be 0.");
+    }
+
+    admin.deleteSnapshot(snapshotName);
+
+    // table has some data
+    TEST_UTIL.loadTable(admin.getConnection().getTable(tableName), Bytes.toBytes("info"));
+    admin.snapshot(snapshotName, tableName);
+    snapshotDir = SnapshotDescriptionUtils.getCompletedSnapshotDir(snapshotName,
+      TEST_UTIL.getDefaultRootDirPath());
+    snapshotDesc =
+      SnapshotDescriptionUtils.readSnapshotInfo(TEST_UTIL.getTestFileSystem(), snapshotDir);
+    manifest = SnapshotManifest.open(TEST_UTIL.getConfiguration(), TEST_UTIL.getTestFileSystem(),
+      snapshotDir, snapshotDesc);
+    regionSizes =
+      SnapshotRegionSizeCalculator.calculateRegionSizes(TEST_UTIL.getConfiguration(), manifest);
+    for (Map.Entry<String, Long> entry : regionSizes.getRegionSizeMap().entrySet()) {
+      assertTrue(entry.getValue() > 0, "Region size should be greater than 0.");
+    }
+
+    TEST_UTIL.deleteTable(tableName);
+    admin.deleteSnapshot(snapshotName);
+  }
+}


### PR DESCRIPTION
## Summary
Backport of #6947 to branch-3.0.

When Spark reads an HBase snapshot via `TableSnapshotInputFormat`, `InputSplit.getLength()` always returned 0. This caused the distributed computation framework (e.g. Spark) to treat all splits as empty and skip processing, resulting in no data or bogus data being read.

This change calculates the per-region size via the new `SnapshotRegionSizeCalculator` and sets the `InputSplit` length accordingly, so the framework can correctly schedule and process the splits.

## Changes
- Added `RegionSizes` and `SnapshotRegionSizeCalculator` classes.
- `SnapshotInfo` now accumulates per-region sizes during manifest scanning.
- `TableSnapshotInputFormatImpl.InputSplit` carries a `length` field, serialized in `write`/`readFields`.
- Added `TestSnapshotRegionSizeCalculator`.

## Branch-specific note
On this stable branch the `@Deprecated` `TableSnapshotRegionSplit` constructors (using `TableDescriptor`/`RegionInfo`) are **retained** for API compatibility. They are only removed on master (4.0.0).

## Tests
- `mvn test -pl hbase-server -Dtest=TestSnapshotRegionSizeCalculator`
