### PR TITLE
HBASE-30299 SimpleRegionNormalizer should not attempt to merge primary and secondary replicas

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/normalizer/SimpleRegionNormalizer.java
@@ -649,6 +649,8 @@ class SimpleRegionNormalizer implements RegionNormalizer, ConfigurationObserver 
       regionStates =
         SimpleRegionNormalizer.this.masterServices.getAssignmentManager().getRegionStates();
       tableRegions = regionStates.getRegionsOfTable(tableName);
+
+      tableRegions.removeIf(r -> r.getReplicaId() != RegionInfo.DEFAULT_REPLICA_ID);
       // The list of regionInfo from getRegionsOfTable() is ordered by regionName.
       // regionName does not necessary guarantee the order by STARTKEY (let's say 'aa1', 'aa1!',
       // in order by regionName, it will be 'aa1!' followed by 'aa1').

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
@@ -750,4 +750,26 @@ public class TestSimpleRegionNormalizer {
     }
     return ret;
   }
+
+  @Test
+  public void itIgnoresSecondaryReplicasForMergeAndSplitPlanning() {
+    conf.setBoolean(SPLIT_ENABLED_KEY, true);
+    conf.setBoolean(MERGE_ENABLED_KEY, true);
+    conf.setInt(MERGE_MIN_REGION_COUNT_KEY, 1);
+    conf.setInt(MERGE_MIN_REGION_SIZE_MB_KEY, 0);
+
+    final List<RegionInfo> primaryRegions = createRegionInfos(tableName, 5);
+    final List<RegionInfo> allRegions = new ArrayList<>(primaryRegions);
+    for (RegionInfo primary : primaryRegions) {
+      allRegions.add(RegionInfoBuilder.newBuilder(tableName).setStartKey(primary.getStartKey())
+        .setEndKey(primary.getEndKey()).setRegionId(primary.getRegionId()).setReplicaId(1).build());
+    }
+
+    final Map<byte[], Integer> regionSizes = createRegionSizesMap(primaryRegions, 15, 5, 5, 15, 16);
+    setupMocksForNormalizer(regionSizes, allRegions);
+
+    assertThat(normalizer.computePlansForTable(tableDescriptor),
+      contains(new MergeNormalizationPlan.Builder().addTarget(primaryRegions.get(1), 5)
+        .addTarget(primaryRegions.get(2), 5).build()));
+  }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/normalizer/TestSimpleRegionNormalizer.java
@@ -752,7 +752,7 @@ public class TestSimpleRegionNormalizer {
   }
 
   @Test
-  public void itIgnoresSecondaryReplicasForMergeAndSplitPlanning() {
+  public void testIgnoresSecondaryReplicasForMergeAndSplitPlanning() {
     conf.setBoolean(SPLIT_ENABLED_KEY, true);
     conf.setBoolean(MERGE_ENABLED_KEY, true);
     conf.setInt(MERGE_MIN_REGION_COUNT_KEY, 1);
@@ -768,8 +768,9 @@ public class TestSimpleRegionNormalizer {
     final Map<byte[], Integer> regionSizes = createRegionSizesMap(primaryRegions, 15, 5, 5, 15, 16);
     setupMocksForNormalizer(regionSizes, allRegions);
 
-    assertThat(normalizer.computePlansForTable(tableDescriptor),
-      contains(new MergeNormalizationPlan.Builder().addTarget(primaryRegions.get(1), 5)
-        .addTarget(primaryRegions.get(2), 5).build()));
+    final List<NormalizationPlan> plans = normalizer.computePlansForTable(tableDescriptor);
+    assertThat(plans, hasSize(1));
+    assertThat(plans, contains(new MergeNormalizationPlan.Builder()
+      .addTarget(primaryRegions.get(1), 5).addTarget(primaryRegions.get(2), 5).build()));
   }
 }


### PR DESCRIPTION
SimpleRegionNormalizer currently tries to merge primary and secondary replicas, which is invalid. While these steps get rejected, it wastes time and can block normalization from completing when secondary replicas are enabled.

Fix: filter out non-primary replicas before planning merge/split operations via a single removeIf on the region list. 

Adds a test covering the case where secondary replicas are present alongside primaries.