### PR TITLE
HBASE-30319  Remove unused private fields flagged by new UnusedPrivateFie…

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupSystemTable.java
@@ -167,7 +167,6 @@ public final class BackupSystemTable implements Closeable {
   private final Connection connection;
 
   private final static String BACKUP_INFO_PREFIX = "session:";
-  private final static String START_CODE_ROW = "startcode:";
   private final static byte[] ACTIVE_SESSION_ROW = Bytes.toBytes("activesession:");
   private final static byte[] ACTIVE_SESSION_COL = Bytes.toBytes("c");
 

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormat.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestTableInputFormat.java
@@ -79,8 +79,6 @@ public class TestTableInputFormat {
   private static MiniMRCluster mrCluster;
   static final byte[] FAMILY = Bytes.toBytes("family");
 
-  private static final byte[][] columns = new byte[][] { FAMILY };
-
   @BeforeAll
   public static void beforeClass() throws Exception {
     UTIL.startMiniCluster();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/MasterQuotasObserver.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/MasterQuotasObserver.java
@@ -45,7 +45,6 @@ public class MasterQuotasObserver implements MasterCoprocessor, MasterObserver {
   public static final String REMOVE_QUOTA_ON_TABLE_DELETE = "hbase.quota.remove.on.table.delete";
   public static final boolean REMOVE_QUOTA_ON_TABLE_DELETE_DEFAULT = true;
 
-  private CoprocessorEnvironment cpEnv;
   private Configuration conf;
   private boolean quotasEnabled = false;
   private MasterServices masterServices;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HMobStore.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/HMobStore.java
@@ -102,7 +102,6 @@ public class HMobStore extends HStore {
   // table, we need to find the original mob files by this table name. For details please see
   // cloning snapshot for mob files.
   private final byte[] refCellTags;
-  private StoreFileTracker mobStoreSFT = null;
 
   public HMobStore(final HRegion region, final ColumnFamilyDescriptor family,
     final Configuration confParam, boolean warmup) throws IOException {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/metrics/MetricsThrottleExceptions.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/metrics/MetricsThrottleExceptions.java
@@ -29,15 +29,6 @@ public class MetricsThrottleExceptions {
    */
   private static final String METRICS_NAME = "ThrottleExceptions";
 
-  /**
-   * The name of the metrics context that metrics will be under.
-   */
-  private static final String METRICS_CONTEXT = "regionserver";
-
-  /**
-   * Description
-   */
-  private static final String METRICS_DESCRIPTION = "Metrics about RPC throttling exceptions";
 
   /**
    * The name of the metrics context that metrics will be under in jmx

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompactionArchiveConcurrentClose.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestCompactionArchiveConcurrentClose.java
@@ -64,7 +64,6 @@ public class TestCompactionArchiveConcurrentClose {
   private HBaseTestingUtil testUtil;
 
   private Path testDir;
-  private AtomicBoolean archived = new AtomicBoolean();
 
   // Static field to track archived state for the static inner class
   private static final AtomicBoolean STATIC_ARCHIVED = new AtomicBoolean();

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsUserAggregate.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMetricsUserAggregate.java
@@ -47,7 +47,6 @@ public class TestMetricsUserAggregate {
   private MetricsRegionServerWrapperStub wrapper;
   private MetricsRegionServer rsm;
   private MetricsUserAggregate userAgg;
-  private TableName tableName = TableName.valueOf("testUserAggregateMetrics");
 
   @BeforeAll
   public static void classSetUp() {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestStoreScanner.java
@@ -98,7 +98,6 @@ public class TestStoreScanner {
   private static final String CF_STR = "cf";
   private static final byte[] CF = Bytes.toBytes(CF_STR);
   static Configuration CONF = HBaseConfiguration.create();
-  private static final HBaseTestingUtil TEST_UTIL = new HBaseTestingUtil();
   private ScanInfo scanInfo = new ScanInfo(CONF, CF, 0, Integer.MAX_VALUE, Long.MAX_VALUE,
     KeepDeletedCells.FALSE, HConstants.DEFAULT_BLOCKSIZE, 0, CellComparator.getInstance(), false);
 


### PR DESCRIPTION
**Description:**

Removes a couple of unused private fields identified while testing a new checkstyle check `UnusedPrivateFieldCheck`, currently in review upstream in the (https://github.com/checkstyle/checkstyle/pull/19816) project.

**Diff report of hbase :** Found  violations in diff report : https://checkstyle-diff-reports.s3.us-east-2.amazonaws.com/31a666b_2026091037/reports/diff/Hbase/index.html

**What the check does:**
 it flags private fields that are declared but never referenced anywhere in the file  a common source of dead code in large, long-lived codebases. It's aware of common false-positive sources (reflection-based frameworks, Lombok, DI annotations, etc. via a configurable `ignoreAnnotationCanonicalNames` property) and ignores well-known name-based conventions like serialVersionUID by default via `ignoredFieldNames` or user can customize for their own use case .

Each was manually verified as genuinely unused before removal  not referenced via reflection, annotations, or any other indirect means.

This is primarily meant as real-world signal for the check development feedback on false positives, edge cases, or naming conventions this project relies on is very welcome, and will help shape the check before it's finalized upstream.

Issue: [HBASE-30319](https://issues.apache.org/jira/browse/HBASE-30319)