### PR TITLE
HBASE-30304 Prevent Bytes.toBytesBinary from throwing on truncated \x escape

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/util/Bytes.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/util/Bytes.java
@@ -610,7 +610,7 @@ public class Bytes implements Comparable<Bytes> {
     int size = 0;
     for (int i = 0; i < in.length(); ++i) {
       char ch = in.charAt(i);
-      if (ch == '\\' && in.length() > i + 1 && in.charAt(i + 1) == 'x') {
+      if (ch == '\\' && in.length() > i + 3 && in.charAt(i + 1) == 'x') {
         // ok, take next 2 hex digits.
         char hd1 = in.charAt(i + 2);
         char hd2 = in.charAt(i + 3);

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/util/BytesTestBase.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/util/BytesTestBase.java
@@ -423,9 +423,11 @@ public class BytesTestBase {
   }
 
   @Test
-  public void testToBytesBinaryTrailingBackslashes() {
+  public void testToBytesBinaryTruncatedHexDigit() {
     try {
       Bytes.toBytesBinary("abc\\x00\\x01\\");
+      Bytes.toBytesBinary("abc\\x00\\x01\\x");
+      Bytes.toBytesBinary("abc\\x00\\x01\\x0");
     } catch (StringIndexOutOfBoundsException ex) {
       fail("Illegal string access: " + ex.getMessage());
     }


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-30304