### PR TITLE
HBASE-29984 Support separate old WAL directories in backup

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalBackupManager.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/IncrementalBackupManager.java
@@ -184,10 +184,10 @@ public class IncrementalBackupManager extends BackupManager {
     }
 
     // Include the .oldlogs files too.
-    FileStatus[] oldlogs = fs.listStatus(oldLogDir);
-    for (FileStatus oldlog : oldlogs) {
-      p = oldlog.getPath();
-      currentLogFile = p.toString();
+    List<String> oldlogs = BackupUtils.getFiles(fs, oldLogDir, new ArrayList<>(), path -> true);
+    for (String oldlog : oldlogs) {
+      p = new Path(oldlog);
+      currentLogFile = oldlog;
       if (AbstractFSWALProvider.isMetaFile(p)) {
         if (LOG.isDebugEnabled()) {
           LOG.debug("Skip .meta log file: " + currentLogFile);

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/util/BackupUtils.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/util/BackupUtils.java
@@ -332,6 +332,10 @@ public final class BackupUtils {
     if (p.getName().endsWith(MasterRegionFactory.ARCHIVED_WAL_SUFFIX)) {
       return null;
     }
+    Path parent = p.getParent();
+    if (parent != null && ServerName.isFullServerName(parent.getName())) {
+      return ServerName.valueOf(parent.getName()).getAddress().toString();
+    }
     try {
       String urlDecodedName = URLDecoder.decode(p.getName(), "UTF8");
       Iterable<String> nameSplitsOnComma = Splitter.on(",").split(urlDecodedName);

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupUtils.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupUtils.java
@@ -111,6 +111,11 @@ public class TestBackupUtils {
           + "regiongroup-0" + BackupUtils.LOGNAME_SEPARATOR + EnvironmentEdgeManager.currentTime());
       assertEquals(host + Addressing.HOSTNAME_PORT_SEPARATOR + port,
         BackupUtils.parseHostFromOldLog(testOldWalWithRegionGroupingPath));
+
+      Path testOldWalInServerDirPath = new Path(new Path(oldLogDir, serverName.toString()),
+        "wal" + BackupUtils.LOGNAME_SEPARATOR + EnvironmentEdgeManager.currentTime());
+      assertEquals(host + Addressing.HOSTNAME_PORT_SEPARATOR + port,
+        BackupUtils.parseHostFromOldLog(testOldWalInServerDirPath));
     }
 
   }

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupManager.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupManager.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup;
+
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtil;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.backup.impl.BackupAdminImpl;
+import org.apache.hadoop.hbase.backup.impl.IncrementalBackupManager;
+import org.apache.hadoop.hbase.backup.util.BackupUtils;
+import org.apache.hadoop.hbase.client.Connection;
+import org.apache.hadoop.hbase.client.ConnectionFactory;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(LargeTests.TAG)
+public class TestIncrementalBackupManager extends TestBackupBase {
+
+  @BeforeAll
+  public static void setUp() throws Exception {
+    TEST_UTIL = new HBaseTestingUtil();
+    conf1 = TEST_UTIL.getConfiguration();
+    conf1.setBoolean(AbstractFSWALProvider.SEPARATE_OLDLOGDIR, true);
+    autoRestoreOnFailure = true;
+    useSecondCluster = false;
+    setUpHelper();
+  }
+
+  @Test
+  public void testCollectWALFilesFromRegionServerDirectories() throws Exception {
+    testCollectWALFiles(true);
+  }
+
+  @Test
+  public void testCollectWALFilesFromFlatOldWALDirectory() throws Exception {
+    testCollectWALFiles(false);
+  }
+
+  private void testCollectWALFiles(boolean separateOldLogDir) throws Exception {
+    Configuration testConf = new Configuration(conf1);
+    testConf.setBoolean(AbstractFSWALProvider.SEPARATE_OLDLOGDIR, separateOldLogDir);
+    List<TableName> tables = List.of(table1);
+    try (Connection conn = ConnectionFactory.createConnection(testConf);
+      BackupAdminImpl backupAdmin = new BackupAdminImpl(conn)) {
+      String fullBackupId =
+        backupAdmin.backupTables(createBackupRequest(BackupType.FULL, tables, BACKUP_ROOT_DIR));
+      assertTrue(checkSucceeded(fullBackupId));
+
+      try (IncrementalBackupManager manager = new IncrementalBackupManager(conn, testConf)) {
+        BackupInfo backupInfo = manager.createBackupInfo("backup_test", BackupType.INCREMENTAL,
+          tables, BACKUP_ROOT_DIR, -1, -1, false);
+        Map<String, Long> previousTimestamps =
+          BackupUtils.getRSLogTimestampMins(manager.readLogTimestampMap());
+        ServerName serverName = TEST_UTIL.getMiniHBaseCluster().getRegionServer(0).getServerName();
+        Long previousTimestamp = previousTimestamps.get(serverName.getAddress().toString());
+        assertNotNull(previousTimestamp);
+
+        TEST_UTIL.waitFor(30_000,
+          () -> EnvironmentEdgeManager.currentTime() > previousTimestamp + 1);
+        Path walRootDir = CommonFSUtils.getWALRootDir(conf1);
+        Path archiveDir = new Path(walRootDir,
+          AbstractFSWALProvider.getWALArchiveDirectoryName(testConf, serverName.toString()));
+        String walName = (separateOldLogDir ? "wal" : serverName.toString())
+          + BackupUtils.LOGNAME_SEPARATOR + (previousTimestamp + 1);
+        Path archivedWAL = new Path(archiveDir, walName);
+        FileSystem fs = walRootDir.getFileSystem(conf1);
+        fs.mkdirs(archiveDir);
+        fs.create(archivedWAL).close();
+
+        manager.getIncrBackupLogFileMap();
+
+        assertTrue(backupInfo.getIncrBackupFileList().contains(archivedWAL.toString()));
+      }
+    }
+  }
+}


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-29984

### What changes were proposed in this pull request?

This change updates `IncrementalBackupManager` to recursively collect archived WAL files under the old WAL directory instead of assuming that every direct child is a WAL file.

It reuses `BackupUtils.getFiles` so that both the existing flat layout and the per-RegionServer directory layout enabled by `hbase.separate.oldlogdir.by.regionserver` are supported.

A regression test is added to verify that an archived WAL stored under a RegionServer-specific directory is included in the incremental backup file list.

`BackupUtils.parseHostFromOldLog` now derives the host and port from the parent directory when it is a full `ServerName`. It falls back to the existing WAL filename parsing for the flat old WAL layout.

### Why are the changes needed?

When `hbase.separate.oldlogdir.by.regionserver` is enabled, archived WALs are stored in RegionServer-specific subdirectories under the old WAL directory.

The existing backup code uses `FileSystem.listStatus` and treats every direct child as a WAL file. It can therefore attempt to parse a directory as a WAL and fail during incremental backup log collection.

Recursively collecting files supports both directory layouts without changing the existing WAL filtering behavior.

Without this handling, a path such as `oldWALs/<serverName>/wal.<timestamp>` cannot be associated with its RegionServer because the WAL basename does not contain the host and port. `IncrementalBackupManager` would consequently skip the archived WAL.

### How was this patch tested?

Updated `TestIncrementalBackupManager` to create an archived WAL using the following layout: 

```bash
oldWALs/<serverName>/wal.<timestamp>
```

The test verifies that the host is obtained from the parent directory and that the archived WAL is included in the incremental backup file list.

Also ran `TestBackupUtils` to verify that the existing flat WAL filename parsing continues to work.

```bash
mvn -pl hbase-backup -am \
  -DskipITs \
  -Dtest=TestBackupUtils \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test

mvn -pl hbase-backup -am \
  -DskipITs \
  -Dtest=TestIncrementalBackupManager \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

Addressed both review comments:

- Added direct unit coverage for the parent-directory fallback in `BackupUtils.parseHostFromOldLog`.
- Added incremental backup coverage for `SEPARATE_OLDLOGDIR=false`, while retaining the existing `SEPARATE_OLDLOGDIR=true` coverage.