### PR TITLE
HBASE-30303: Fix balancing for regions assigned through RSGroup fallback

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupBasedLoadBalancer.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/rsgroup/RSGroupBasedLoadBalancer.java
@@ -322,12 +322,18 @@ public class RSGroupBasedLoadBalancer implements LoadBalancer {
       } catch (IOException exp) {
         LOG.debug("RSGroup information null for region of table " + tableName, exp);
       }
+      List<ServerName> candidateServers = Collections.emptyList();
+      if (targetRSGInfo != null) {
+        List<ServerName> onlineServers = Lists.newArrayList(clusterLoad.keySet());
+        candidateServers = filterOfflineServers(targetRSGInfo, onlineServers);
+        if (isFallbackEnabled() && candidateServers.isEmpty()) {
+          candidateServers = getFallBackCandidates(onlineServers);
+        }
+      }
       for (Map.Entry<ServerName, List<RegionInfo>> serverRegionMap : clusterLoad.entrySet()) {
         ServerName currentHostServer = serverRegionMap.getKey();
         List<RegionInfo> regionInfoList = serverRegionMap.getValue();
-        if (
-          targetRSGInfo == null || !targetRSGInfo.containsServer(currentHostServer.getAddress())
-        ) {
+        if (!candidateServers.contains(currentHostServer)) {
           regionInfoList.forEach(regionInfo -> {
             regionPlansForMisplacedRegions.add(new RegionPlan(regionInfo, currentHostServer, null));
           });

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupsFallback.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/rsgroup/TestRSGroupsFallback.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.rsgroup;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -25,6 +26,7 @@ import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.BalanceResponse;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
@@ -93,10 +95,20 @@ public class TestRSGroupsFallback extends TestRSGroupsBase {
     // server of test group crash, regions move to default group
     crashRsInGroup(groupName);
     assertRegionsInGroup(tableName, RSGroupInfo.DEFAULT_GROUP);
+    assertTrue(MASTER.balance().isBalancerRan());
+    assertRegionsInGroup(tableName, RSGroupInfo.DEFAULT_GROUP);
+    BalanceResponse response = MASTER.balance();
+    assertTrue(response.isBalancerRan());
+    assertEquals(0, response.getMovesCalculated());
 
     // server of default group crash, regions move to any other group
     crashRsInGroup(RSGroupInfo.DEFAULT_GROUP);
     assertRegionsInGroup(tableName, FALLBACK_GROUP);
+    assertTrue(MASTER.balance().isBalancerRan());
+    assertRegionsInGroup(tableName, FALLBACK_GROUP);
+    response = MASTER.balance();
+    assertTrue(response.isBalancerRan());
+    assertEquals(0, response.getMovesCalculated());
 
     // add a new server to default group, regions move to default group
     TEST_UTIL.getMiniHBaseCluster().startRegionServerAndWait(60000);


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30303

### What changes were proposed in this pull request?

This pull request updates `RSGroupBasedLoadBalancer#correctAssignments` to use the same candidate-server selection logic as region assignment when RSGroup fallback is enabled.

When the target RSGroup has no online RegionServers, `correctAssignments` now validates region locations against the effective fallback candidates.

The existing `TestRSGroupsFallback` test is also extended to verify that no region moves are calculated when regions are correctly hosted on fallback servers.


### Why are the changes needed?

When RSGroup fallback is enabled and a table's target RSGroup has no online RegionServers, its regions are assigned to the default RSGroup, or to any available RegionServer if the default group is also unavailable.

Previously, `correctAssignments` only validated these regions against the table's original RSGroup. Therefore, regions already hosted on valid fallback servers were incorrectly classified as misplaced during every balance run, resulting in continuous and unnecessary region movement.


### How was this patch tested?

The following tests were executed:

```bash
mvn -pl hbase-server \
  -am \
  -Dtest=org.apache.hadoop.hbase.rsgroup.TestRSGroupsFallback \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test

mvn -pl hbase-server \
  -am \
  -Dtest=org.apache.hadoop.hbase.master.balancer.TestRSGroupBasedLoadBalancer \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test

```

`TestRSGroupsFallback` verifies that balancing calculates no moves after regions fall back to the default RSGroup and after they fall back to another available RSGroup.