### PR TITLE
HBASE-30317 Fix synchronization race in TestExecutorService

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/executor/TestExecutorService.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/executor/TestExecutorService.java
@@ -98,7 +98,8 @@ public class TestExecutorService {
     ExecutorStatus status = executor.getStatus();
     assertTrue(status.queuedEvents.isEmpty());
     assertEquals(5, status.running.size());
-    checkStatusDump(status);
+    Waiter.waitFor(mockedServer.getConfiguration(), 10000,
+      () -> checkStatusDump(executor.getStatus()));
 
     // Now interrupt the running Executor
     synchronized (lock) {
@@ -141,13 +142,13 @@ public class TestExecutorService {
       .submit(new TestEventHandler(mockedServer, EventType.M_SERVER_SHUTDOWN, lock, counter));
   }
 
-  private void checkStatusDump(ExecutorStatus status) throws IOException {
+  private boolean checkStatusDump(ExecutorStatus status) throws IOException {
     StringWriter sw = new StringWriter();
     status.dumpTo(sw, "");
     String dump = sw.toString();
     LOG.info("Got status dump:\n" + dump);
 
-    assertTrue(dump.contains("Waiting on java.util.concurrent.atomic.AtomicBoolean"));
+    return dump.contains("Waiting on java.util.concurrent.atomic.AtomicBoolean");
   }
 
   public static class TestEventHandler extends EventHandler {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30317

## What changes were proposed in this pull request?

Update `TestExecutorService.testExecutorService` to poll fresh `ExecutorStatus` snapshots with `Waiter.waitFor` until the status dump shows a handler waiting on the `AtomicBoolean` monitor.

The existing dump check now returns a boolean used as the wait predicate. No fixed sleep is introduced.

## Why are the changes needed?

The test previously waited only for the shared counter to reach five. However, each handler increments the counter before performing its initial logging and entering `lock.wait()`.

Therefore, `counter == 5` proves only that all handlers have started. Under resource pressure, the status dump can be captured while all handlers are still RUNNABLE in `StringConcatFactory.makeConcatWithConstants`, causing the expected waiting-state assertion to fail.

Waiting for the expected state in the actual executor status dump removes this synchronization race.

## How was this patch tested?

```bash
mvn \
  -pl hbase-server -am \
  -Dtest=org.apache.hadoop.hbase.executor.TestExecutorService \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test
```

The resulting executor status dump showed all five handlers in the `WAITING` state on the `AtomicBoolean` monitor.