### PR TITLE
HBASE-30320 TestMemStoreLAB#testLABChunkQueue OOM on fast hardware due to unbounded off-pool chunk allocation

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMemStoreLAB.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMemStoreLAB.java
@@ -329,12 +329,19 @@ public class TestMemStoreLAB {
 
   private Thread getChunkQueueTestThread(final MemStoreLABImpl mslab, String threadName,
     ExtendedCell cellToCopyInto) {
+    // Reserve 20% of max heap as safety margin to prevent OOM on fast hardware where threads can
+    // allocate many GB of chunks within the 1-second test window.
+    final long maxMemory = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
+    final long memoryLimit = (long) (maxMemory * 0.8);
     Thread thread = new Thread() {
       volatile boolean stopped = false;
 
       @Override
       public void run() {
         while (!stopped) {
+          if (ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() > memoryLimit) {
+            break;
+          }
           // keep triggering chunk retirement
           mslab.copyCellInto(cellToCopyInto);
         }


### PR DESCRIPTION
## Summary

`TestMemStoreLAB#testLABChunkQueue` OOMs on machines with fast memory subsystems (e.g. Apple Silicon) even with large heap sizes (12GB+).

**Root Cause:** The test spawns 10 threads allocating 256KB chunks in a tight loop for a fixed 1-second window. Once the ChunkCreator pool reaches `maxCount`, subsequent allocations use unbounded off-pool chunk creation. All chunks remain live until `mslab.close()` is called after the threads stop. On fast hardware (~5,000 iterations/thread/sec), this creates ~12.5GB in 1 second, exceeding heap. On slower x86 CI machines (~700 iter/thread/sec), only ~1.7GB is created, fitting within the default 2.2GB surefire heap.

**Fix:** Add a memory guard — before each `copyCellInto`, check heap usage via `ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed()` and stop allocating if used memory exceeds 80% of max heap. The 1-second time window is preserved; threads exit early only on memory-constrained JVMs.

- **Before:** OOM with any heap < 13GB on Apple Silicon
- **After:** Passes with 4GB heap on all hardware

## Test plan

- [x] Verified `TestMemStoreLAB` (all 5 tests) passes with `-Dsurefire.Xmx=4g` on Apple Silicon
- [x] Verified at heap sizes 4g, 6g, 8g, 10g, 12g — all pass after fix (all failed before)
- [x] Verified chunk-recycling assertion still validates correctly (test semantics unchanged)
- [x] Same vulnerable code exists in branch-2, branch-2.5, branch-2.6, and master