### PR TITLE
Implement GzipByteBuffDecompressor and GzipHFileDecompressionContext …

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
@@ -66,7 +66,7 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
     if (inputDirect && outputDirect) {
       return decompressor != null;
     }
-    return true;
+    return !inputDirect && !outputDirect;
   }
 
   @Override

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
@@ -1,0 +1,129 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress;
+
+import edu.umd.cs.findbugs.annotations.Nullable;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.hadoop.hbase.nio.SingleByteBuff;
+import org.apache.hadoop.io.compress.zlib.ZlibDecompressor;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Glue for ByteBuffDecompressor on top of Hadoop's native
+ * {@link ZlibDecompressor.ZlibDirectDecompressor}.
+ */
+@InterfaceAudience.Private
+public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
+
+  private static final int GZIP_HEADER_LENGTH = 10;
+  private static final int GZIP_TRAILER_LENGTH = 8;
+
+  @Nullable
+  private final ZlibDecompressor.ZlibDirectDecompressor decompressor;
+
+  private boolean allowByteBuffDecompression;
+
+  GzipByteBuffDecompressor(boolean nativeZlibLoaded) {
+    decompressor = nativeZlibLoaded
+      ? new ZlibDecompressor.ZlibDirectDecompressor(ZlibDecompressor.CompressionHeader.GZIP_FORMAT,
+        0)
+      : null;
+    allowByteBuffDecompression = true;
+  }
+
+  @Override
+  public boolean canDecompress(ByteBuff output, ByteBuff input) {
+    return decompressor != null && allowByteBuffDecompression && output instanceof SingleByteBuff
+      && input instanceof SingleByteBuff && output.nioByteBuffers()[0].isDirect()
+      && input.nioByteBuffers()[0].isDirect();
+  }
+
+  @Override
+  public int decompress(ByteBuff output, ByteBuff input, int inputLen) throws IOException {
+    if (decompressor == null) {
+      throw new IllegalStateException(
+        "GzipByteBuffDecompressor#decompress() was called but Hadoop's native zlib library is "
+          + "not loaded, this should never happen since canDecompress() would have returned false");
+    }
+    if (!(output instanceof SingleByteBuff) || !(input instanceof SingleByteBuff)) {
+      throw new IllegalStateException(
+        "At least one buffer is not a SingleByteBuff, this is not supported");
+    }
+
+    ByteBuffer nioInput = input.nioByteBuffers()[0];
+    ByteBuffer nioOutput = output.nioByteBuffers()[0];
+    if (!nioInput.isDirect() || !nioOutput.isDirect()) {
+      throw new IllegalStateException(
+        "At least one buffer is not direct, this is not supported by the native zlib decompressor");
+    }
+
+    int inputStart = nioInput.position();
+    int outputStart = nioOutput.position();
+    ByteBuffer gzipMember = nioInput.duplicate();
+    gzipMember.limit(inputStart + inputLen);
+
+    decompressor.reset();
+    while (!decompressor.finished()) {
+      int outputRemainingBefore = nioOutput.remaining();
+      try {
+        decompressor.decompress(gzipMember, nioOutput);
+      } catch (IOException e) {
+        throw new IOException("Invalid gzip stream: " + e.getMessage(), e);
+      }
+      // No progress means either the output buffer is full or the gzip member is truncated.
+      if (nioOutput.remaining() == outputRemainingBefore && !decompressor.finished()) {
+        if (!nioOutput.hasRemaining()) {
+          throw new IOException("Output buffer is too small for the decompressed gzip stream");
+        }
+        throw new IOException("Unexpected end of gzip stream");
+      }
+    }
+
+    if (gzipMember.hasRemaining()) {
+      throw new IOException("Unexpected trailing bytes after decompressing gzip stream");
+    }
+
+    nioInput.position(inputStart + inputLen);
+    return nioOutput.position() - outputStart;
+  }
+
+  @Override
+  public void reinit(@Nullable Compression.HFileDecompressionContext newHFileDecompressionContext) {
+    if (newHFileDecompressionContext == null) {
+      return;
+    }
+    if (!(newHFileDecompressionContext instanceof GzipHFileDecompressionContext)) {
+      throw new IllegalArgumentException(
+        "GzipByteBuffDecompressor#reinit() was given an HFileDecompressionContext that was not "
+          + "a GzipHFileDecompressionContext, this should never happen");
+    }
+    GzipHFileDecompressionContext gzipContext =
+      (GzipHFileDecompressionContext) newHFileDecompressionContext;
+    allowByteBuffDecompression = gzipContext.isAllowByteBuffDecompression();
+  }
+
+  @Override
+  public void close() {
+    if (decompressor != null) {
+      decompressor.end();
+    }
+  }
+
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
@@ -66,6 +66,9 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
       throw new IllegalStateException(
         "At least one buffer is not a SingleByteBuff, this is not supported");
     }
+    if (inputLen < GZIP_HEADER_LENGTH + GZIP_TRAILER_LENGTH) {
+      throw new IOException("Input of length " + inputLen + " is too short to be a gzip member");
+    }
 
     ByteBuffer nioInput = input.nioByteBuffers()[0];
     ByteBuffer nioOutput = output.nioByteBuffers()[0];
@@ -76,6 +79,8 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
 
     int inputStart = nioInput.position();
     int outputStart = nioOutput.position();
+
+
     ByteBuffer gzipMember = nioInput.duplicate();
     gzipMember.limit(inputStart + inputLen);
 

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
@@ -20,6 +20,9 @@ package org.apache.hadoop.hbase.io.compress;
 import edu.umd.cs.findbugs.annotations.Nullable;
 import java.io.IOException;
 import java.nio.ByteBuffer;
+import java.util.zip.CRC32;
+import java.util.zip.DataFormatException;
+import java.util.zip.Inflater;
 import org.apache.hadoop.hbase.nio.ByteBuff;
 import org.apache.hadoop.hbase.nio.SingleByteBuff;
 import org.apache.hadoop.io.compress.zlib.ZlibDecompressor;
@@ -38,6 +41,8 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
   @Nullable
   private final ZlibDecompressor.ZlibDirectDecompressor decompressor;
 
+  private final Inflater inflater = new Inflater(true);
+
   private boolean allowByteBuffDecompression;
 
   GzipByteBuffDecompressor(boolean nativeZlibLoaded) {
@@ -50,18 +55,22 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
 
   @Override
   public boolean canDecompress(ByteBuff output, ByteBuff input) {
-    return decompressor != null && allowByteBuffDecompression && output instanceof SingleByteBuff
-      && input instanceof SingleByteBuff && output.nioByteBuffers()[0].isDirect()
-      && input.nioByteBuffers()[0].isDirect();
+    if (!allowByteBuffDecompression) {
+      return false;
+    }
+    if (!(output instanceof SingleByteBuff) || !(input instanceof SingleByteBuff)) {
+      return false;
+    }
+    boolean inputDirect = input.nioByteBuffers()[0].isDirect();
+    boolean outputDirect = output.nioByteBuffers()[0].isDirect();
+    if (inputDirect && outputDirect) {
+      return decompressor != null;
+    }
+    return true;
   }
 
   @Override
   public int decompress(ByteBuff output, ByteBuff input, int inputLen) throws IOException {
-    if (decompressor == null) {
-      throw new IllegalStateException(
-        "GzipByteBuffDecompressor#decompress() was called but Hadoop's native zlib library is "
-          + "not loaded, this should never happen since canDecompress() would have returned false");
-    }
     if (!(output instanceof SingleByteBuff) || !(input instanceof SingleByteBuff)) {
       throw new IllegalStateException(
         "At least one buffer is not a SingleByteBuff, this is not supported");
@@ -72,14 +81,25 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
 
     ByteBuffer nioInput = input.nioByteBuffers()[0];
     ByteBuffer nioOutput = output.nioByteBuffers()[0];
-    if (!nioInput.isDirect() || !nioOutput.isDirect()) {
-      throw new IllegalStateException(
-        "At least one buffer is not direct, this is not supported by the native zlib decompressor");
-    }
+    boolean inputDirect = nioInput.isDirect();
+    boolean outputDirect = nioOutput.isDirect();
 
+    if (inputDirect && outputDirect) {
+      if (decompressor == null) {
+        throw new IllegalStateException(
+          "GzipByteBuffDecompressor#decompress() was called with direct buffers but Hadoop's "
+            + "native zlib library is not loaded, this should never happen since "
+            + "canDecompress() would have returned false");
+      }
+      return decompressOffHeap(nioInput, nioOutput, inputLen);
+    }
+    return decompressOnHeap(nioInput, nioOutput, inputLen);
+  }
+
+  private int decompressOffHeap(ByteBuffer nioInput, ByteBuffer nioOutput, int inputLen)
+    throws IOException {
     int inputStart = nioInput.position();
     int outputStart = nioOutput.position();
-
 
     ByteBuffer gzipMember = nioInput.duplicate();
     gzipMember.limit(inputStart + inputLen);
@@ -92,7 +112,6 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
       } catch (IOException e) {
         throw new IOException("Invalid gzip stream: " + e.getMessage(), e);
       }
-      // No progress means either the output buffer is full or the gzip member is truncated.
       if (nioOutput.remaining() == outputRemainingBefore && !decompressor.finished()) {
         if (!nioOutput.hasRemaining()) {
           throw new IOException("Output buffer is too small for the decompressed gzip stream");
@@ -107,6 +126,70 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
 
     nioInput.position(inputStart + inputLen);
     return nioOutput.position() - outputStart;
+  }
+
+  // ZlibDirectDecompressor requires direct buffers — heap ByteBuffers have no stable native
+  // address, so we fall back to Java's Inflater for the heap case.
+  private int decompressOnHeap(ByteBuffer nioInput, ByteBuffer nioOutput, int inputLen)
+    throws IOException {
+    if (!nioInput.hasArray() || !nioOutput.hasArray()) {
+      throw new IllegalStateException(
+        "decompressOnHeap() requires heap ByteBuffers with backing arrays");
+    }
+    int inputStart = nioInput.position();
+    int outputStart = nioOutput.position();
+
+    inflater.reset();
+    inflater.setInput(nioInput.array(), nioInput.arrayOffset() + inputStart + GZIP_HEADER_LENGTH,
+      inputLen - GZIP_HEADER_LENGTH - GZIP_TRAILER_LENGTH);
+    int totalDecompressed = 0;
+    while (!inflater.finished()) {
+      int remaining = nioOutput.remaining() - totalDecompressed;
+      if (remaining == 0) {
+        throw new IOException("Output buffer is too small for the decompressed gzip stream");
+      }
+      int n;
+      try {
+        n = inflater.inflate(nioOutput.array(), nioOutput.arrayOffset() + outputStart + totalDecompressed,
+          remaining);
+      } catch (DataFormatException e) {
+        throw new IOException("Invalid gzip stream: " + e.getMessage(), e);
+      }
+      if (n == 0 && !inflater.finished()) {
+        if (inflater.needsInput()) {
+          throw new IOException("Unexpected end of gzip stream");
+        }
+        throw new IOException("Unexpected state in gzip stream");
+      }
+      totalDecompressed += n;
+    }
+    verifyGzipTrailer(nioInput.array(), nioInput.arrayOffset() + inputStart, inputLen,
+      nioOutput.array(), nioOutput.arrayOffset() + outputStart, totalDecompressed);
+    nioOutput.position(outputStart + totalDecompressed);
+    nioInput.position(inputStart + inputLen);
+    return totalDecompressed;
+  }
+
+  // Inflater runs in nowrap (raw DEFLATE) mode and is unaware of the gzip envelope, so it never
+  // checks the trailer. ZlibDirectDecompressor handles this automatically via GZIP_FORMAT, but
+  // for heap buffers we must verify the CRC32 and ISIZE fields ourselves.
+  private static void verifyGzipTrailer(byte[] inputData, int inputDataOffset, int inputLen,
+    byte[] outputData, int outputDataOffset, int decompressedLen) throws IOException {
+    long expectedCrc = readLittleEndianUInt32(inputData, inputDataOffset + inputLen - 8);
+    long expectedSize = readLittleEndianUInt32(inputData, inputDataOffset + inputLen - 4);
+    CRC32 crc32 = new CRC32();
+    crc32.update(outputData, outputDataOffset, decompressedLen);
+    if (crc32.getValue() != expectedCrc) {
+      throw new IOException("Gzip CRC32 mismatch");
+    }
+    if ((decompressedLen & 0xFFFFFFFFL) != expectedSize) {
+      throw new IOException("Gzip size mismatch");
+    }
+  }
+
+  private static long readLittleEndianUInt32(byte[] data, int offset) {
+    return (data[offset] & 0xFFL) | ((data[offset + 1] & 0xFFL) << 8)
+      | ((data[offset + 2] & 0xFFL) << 16) | ((data[offset + 3] & 0xFFL) << 24);
   }
 
   @Override
@@ -126,6 +209,7 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
 
   @Override
   public void close() {
+    inflater.end();
     if (decompressor != null) {
       decompressor.end();
     }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipByteBuffDecompressor.java
@@ -150,8 +150,8 @@ public class GzipByteBuffDecompressor implements ByteBuffDecompressor {
       }
       int n;
       try {
-        n = inflater.inflate(nioOutput.array(), nioOutput.arrayOffset() + outputStart + totalDecompressed,
-          remaining);
+        n = inflater.inflate(nioOutput.array(),
+          nioOutput.arrayOffset() + outputStart + totalDecompressed, remaining);
       } catch (DataFormatException e) {
         throw new IOException("Invalid gzip stream: " + e.getMessage(), e);
       }

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipHFileDecompressionContext.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/GzipHFileDecompressionContext.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress;
+
+import java.io.IOException;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.util.ClassSize;
+import org.apache.yetus.audience.InterfaceAudience;
+
+/**
+ * Holds HFile-level settings used by GzipByteBuffDecompressor. It's expensive to pull these from a
+ * Configuration object every time we decompress a block, so pull them upon opening an HFile, and
+ * reuse them in every block that gets decompressed.
+ */
+@InterfaceAudience.Private
+public final class GzipHFileDecompressionContext extends Compression.HFileDecompressionContext {
+
+  public static final long FIXED_OVERHEAD =
+    ClassSize.estimateBase(GzipHFileDecompressionContext.class, false);
+
+  private final boolean allowByteBuffDecompression;
+
+  private GzipHFileDecompressionContext(boolean allowByteBuffDecompression) {
+    this.allowByteBuffDecompression = allowByteBuffDecompression;
+  }
+
+  public boolean isAllowByteBuffDecompression() {
+    return allowByteBuffDecompression;
+  }
+
+  public static GzipHFileDecompressionContext fromConfiguration(Configuration conf) {
+    return new GzipHFileDecompressionContext(
+      conf.getBoolean("hbase.io.compress.gz.allowByteBuffDecompression", true));
+  }
+
+  @Override
+  public void close() throws IOException {
+  }
+
+  @Override
+  public long heapSize() {
+    return FIXED_OVERHEAD;
+  }
+
+  @Override
+  public String toString() {
+    return "GzipHFileDecompressionContext{allowByteBuffDecompression=" + allowByteBuffDecompression
+      + '}';
+  }
+}

--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ReusableStreamGzipCodec.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/io/compress/ReusableStreamGzipCodec.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import java.io.OutputStream;
 import java.util.Arrays;
 import java.util.zip.GZIPOutputStream;
+import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.util.JVM;
 import org.apache.hadoop.io.compress.CompressionOutputStream;
 import org.apache.hadoop.io.compress.CompressorStream;
@@ -35,9 +36,9 @@ import org.slf4j.LoggerFactory;
  * Fixes an inefficiency in Hadoop's Gzip codec, allowing to reuse compression streams.
  */
 @InterfaceAudience.Private
-public class ReusableStreamGzipCodec extends GzipCodec {
+public class ReusableStreamGzipCodec extends GzipCodec implements ByteBuffDecompressionCodec {
 
-  private static final Logger LOG = LoggerFactory.getLogger(ReusableStreamGzipCodec.class);
+  private static final Logger LOG = LoggerFactory.getLogger(Compression.class);
 
   /**
    * A bridge that wraps around a DeflaterOutputStream to make it a CompressionOutputStream.
@@ -183,6 +184,22 @@ public class ReusableStreamGzipCodec extends GzipCodec {
       return super.createOutputStream(out);
     }
     return new ReusableGzipOutputStream(out);
+  }
+
+  @Override
+  public ByteBuffDecompressor createByteBuffDecompressor() {
+    return new GzipByteBuffDecompressor(ZlibFactory.isNativeZlibLoaded(getConf()));
+  }
+
+  @Override
+  public Class<? extends ByteBuffDecompressor> getByteBuffDecompressorType() {
+    return GzipByteBuffDecompressor.class;
+  }
+
+  @Override
+  public Compression.HFileDecompressionContext
+    getDecompressionContextFromConfiguration(Configuration conf) {
+    return GzipHFileDecompressionContext.fromConfiguration(conf);
   }
 
 }

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/compress/TestGzipByteBuffDecompressor.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/compress/TestGzipByteBuffDecompressor.java
@@ -60,9 +60,12 @@ public class TestGzipByteBuffDecompressor {
     // Deliberately constructed as if native zlib is unavailable, regardless of this JVM's actual
     // environment, so this test is deterministic everywhere.
     ByteBuff emptySingleDirectBuff = new SingleByteBuff(ByteBuffer.allocateDirect(0));
+    ByteBuff emptySingleHeapBuff = new SingleByteBuff(ByteBuffer.allocate(0));
     try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
       assertFalse(decompressor.canDecompress(emptySingleDirectBuff, emptySingleDirectBuff),
-        "Without native zlib there is no way to decompress via ByteBuffs");
+        "Without native zlib, direct-to-direct decompression is not available");
+      assertTrue(decompressor.canDecompress(emptySingleHeapBuff, emptySingleHeapBuff),
+        "On-heap decompression uses Java Inflater and works without native zlib");
     }
   }
 
@@ -77,9 +80,10 @@ public class TestGzipByteBuffDecompressor {
 
     try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
       assertTrue(decompressor.canDecompress(emptySingleDirectBuff, emptySingleDirectBuff));
-      // The native zlib binding reads/writes buffer memory directly, so only direct buffers are
-      // supported; heap buffers must fall back to stream-based decompression instead.
-      assertFalse(decompressor.canDecompress(emptySingleHeapBuff, emptySingleHeapBuff));
+      assertTrue(decompressor.canDecompress(emptySingleHeapBuff, emptySingleHeapBuff),
+        "On-heap decompression is supported when both buffers are heap SingleByteBuffs");
+      // Mixed (one direct, one heap) is not supported: decompressOnHeap() requires both to have
+      // backing arrays, and decompressOffHeap() requires both to be direct.
       assertFalse(decompressor.canDecompress(emptySingleHeapBuff, emptySingleDirectBuff));
       assertFalse(decompressor.canDecompress(emptySingleDirectBuff, emptySingleHeapBuff));
       assertFalse(decompressor.canDecompress(emptyMultiHeapBuff, emptyMultiHeapBuff));
@@ -90,6 +94,13 @@ public class TestGzipByteBuffDecompressor {
 
   private static ByteBuff directBuffWith(byte[] data) {
     ByteBuffer buffer = ByteBuffer.allocateDirect(data.length);
+    buffer.put(data);
+    buffer.rewind();
+    return new SingleByteBuff(buffer);
+  }
+
+  private static ByteBuff heapBuffWith(byte[] data) {
+    ByteBuffer buffer = ByteBuffer.allocate(data.length);
     buffer.put(data);
     buffer.rewind();
     return new SingleByteBuff(buffer);
@@ -290,6 +301,153 @@ public class TestGzipByteBuffDecompressor {
         + "GzipHFileDecompressionContext");
     } catch (IllegalArgumentException e) {
       assertTrue(e.getMessage().contains("GzipHFileDecompressionContext"));
+    }
+  }
+
+  // ---------------------------------------------------------------------------
+  // On-heap (heap→heap) decompression tests
+  //
+  // On-heap decompression uses Java's Inflater (raw DEFLATE) and does not rely on the native zlib
+  // library, so these tests use GzipByteBuffDecompressor(false) and are deterministic everywhere.
+  // ---------------------------------------------------------------------------
+
+  @Test
+  public void itDecompressesHeapToHeapSuccessfully() throws IOException {
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = heapBuffWith(COMPRESSED_PAYLOAD);
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
+    }
+  }
+
+  @Test
+  public void itDecompressesHeapToHeapSuccessfullyWhenNativeZlibIsAlsoAvailable()
+    throws IOException {
+    assumeNativeZlibLoaded();
+    // The on-heap path always uses Java Inflater regardless of native availability; this confirms
+    // that routing to on-heap doesn't accidentally use the native decompressor.
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = heapBuffWith(COMPRESSED_PAYLOAD);
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
+    }
+  }
+
+  @Test
+  public void itDecompressesHeapToHeapFailsWhenOutputBufferTooSmall() throws IOException {
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(10));
+      ByteBuff input = heapBuffWith(COMPRESSED_PAYLOAD);
+      decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      fail("Expected an IOException because the output buffer is too small");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Output buffer is too small"));
+    }
+  }
+
+  @Test
+  public void itDecompressesHeapToHeapFailsOnTooShortInput() throws IOException {
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = new SingleByteBuff(ByteBuffer.allocate(10));
+      decompressor.decompress(output, input, 10);
+      fail("Expected an IOException because the input is too short to be a gzip member");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("too short to be a gzip member"));
+    }
+  }
+
+  @Test
+  public void itDecompressesHeapToHeapFailsOnCorruptedDeflateBody() throws IOException {
+    // Corrupt a byte inside the DEFLATE payload (bytes 10 through len-9). Depending on where the
+    // bit-flip lands, the Java Inflater either throws DataFormatException immediately ("Invalid
+    // gzip stream") or produces wrong output that the subsequent CRC32 check catches ("Gzip CRC32
+    // mismatch"). Either way the corruption must not silently pass.
+    byte[] corrupted = Arrays.copyOf(COMPRESSED_PAYLOAD, COMPRESSED_PAYLOAD.length);
+    corrupted[15] ^= (byte) 0xff;
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = heapBuffWith(corrupted);
+      decompressor.decompress(output, input, corrupted.length);
+      fail("Expected an IOException because the DEFLATE payload is corrupted");
+    } catch (IOException e) {
+      assertTrue(
+        e.getMessage().contains("Invalid gzip stream") || e.getMessage().contains("Gzip CRC32 mismatch"),
+        "Expected an IOException about corrupted gzip data, got: " + e.getMessage());
+    }
+  }
+
+  @Test
+  public void itDecompressesHeapToHeapFailsOnCrc32Mismatch() throws IOException {
+    // The on-heap path verifies the CRC32 field in the trailer itself (the Java Inflater only
+    // handles raw DEFLATE and never inspects the gzip envelope). Corrupt the first 4 bytes of the
+    // 8-byte trailer (CRC32), leaving ISIZE intact, to trigger exactly the CRC32 check.
+    byte[] corrupted = Arrays.copyOf(COMPRESSED_PAYLOAD, COMPRESSED_PAYLOAD.length);
+    corrupted[corrupted.length - 8] ^= (byte) 0xff;
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = heapBuffWith(corrupted);
+      decompressor.decompress(output, input, corrupted.length);
+      fail("Expected an IOException due to a CRC32 mismatch in the gzip trailer");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Gzip CRC32 mismatch"));
+    }
+  }
+
+  @Test
+  public void itDecompressesHeapToHeapFailsOnIsizeMismatch() throws IOException {
+    // Corrupt the last 4 bytes of the 8-byte trailer (ISIZE), leaving CRC32 intact, to trigger
+    // exactly the size check. This catches truncated or padded output that slipped past CRC.
+    byte[] corrupted = Arrays.copyOf(COMPRESSED_PAYLOAD, COMPRESSED_PAYLOAD.length);
+    corrupted[corrupted.length - 4] ^= (byte) 0xff;
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = heapBuffWith(corrupted);
+      decompressor.decompress(output, input, corrupted.length);
+      fail("Expected an IOException due to an ISIZE mismatch in the gzip trailer");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Gzip size mismatch"));
+    }
+  }
+
+  @Test
+  public void itDecompressesHeapToHeapSucceedsRepeatedly() throws IOException {
+    // The Java Inflater must be reset between calls; verify multiple sequential decompressions on
+    // the same instance all produce correct output.
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      for (int i = 0; i < 3; i++) {
+        ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+        ByteBuff input = heapBuffWith(COMPRESSED_PAYLOAD);
+        int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+        assertEquals("HBase is fun to use and very fast",
+          Bytes.toString(output.toBytes(0, decompressedSize)));
+      }
+    }
+  }
+
+  @Test
+  public void itDecompressesHeapToHeapIsStillUsableAfterAPreviousCallThrows() throws IOException {
+    byte[] corrupted = Arrays.copyOf(COMPRESSED_PAYLOAD, COMPRESSED_PAYLOAD.length);
+    corrupted[corrupted.length - 8] ^= (byte) 0xff;
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      ByteBuff badOutput = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff badInput = heapBuffWith(corrupted);
+      try {
+        decompressor.decompress(badOutput, badInput, corrupted.length);
+        fail("Expected an IOException because the CRC32 is corrupted");
+      } catch (IOException e) {
+        assertTrue(e.getMessage().contains("Gzip CRC32 mismatch"));
+      }
+
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocate(64));
+      ByteBuff input = heapBuffWith(COMPRESSED_PAYLOAD);
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
     }
   }
 

--- a/hbase-common/src/test/java/org/apache/hadoop/hbase/io/compress/TestGzipByteBuffDecompressor.java
+++ b/hbase-common/src/test/java/org/apache/hadoop/hbase/io/compress/TestGzipByteBuffDecompressor.java
@@ -1,0 +1,296 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.junit.jupiter.api.Assertions.fail;
+import static org.junit.jupiter.api.Assumptions.assumeTrue;
+
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.util.Arrays;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.hbase.nio.ByteBuff;
+import org.apache.hadoop.hbase.nio.MultiByteBuff;
+import org.apache.hadoop.hbase.nio.SingleByteBuff;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.util.NativeCodeLoader;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(SmallTests.TAG)
+public class TestGzipByteBuffDecompressor {
+
+  /*
+   * "HBase is fun to use and very fast" compressed as a single gzip member via GZIPOutputStream,
+   * matching the framing that ReusableStreamGzipCodec produces on the compression side.
+   */
+  private static final byte[] COMPRESSED_PAYLOAD = Bytes.fromHex(
+    "1f8b08000000000000fff3704a2c4e55c82c56482bcd5328c9572805f212f35214ca528b2a15d2128b4b006edf170321000000");
+
+  /**
+   * GzipByteBuffDecompressor is backed by Hadoop's native zlib binding, so actually decompressing
+   * anything requires that native library to be loaded on this JVM.
+   */
+  private static void assumeNativeZlibLoaded() {
+    assumeTrue(NativeCodeLoader.isNativeCodeLoaded(),
+      "Hadoop's native code is not loaded on this JVM, skipping");
+  }
+
+  @Test
+  public void testCapabilitiesWithoutNativeZlibLoaded() {
+    // Deliberately constructed as if native zlib is unavailable, regardless of this JVM's actual
+    // environment, so this test is deterministic everywhere.
+    ByteBuff emptySingleDirectBuff = new SingleByteBuff(ByteBuffer.allocateDirect(0));
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      assertFalse(decompressor.canDecompress(emptySingleDirectBuff, emptySingleDirectBuff),
+        "Without native zlib there is no way to decompress via ByteBuffs");
+    }
+  }
+
+  @Test
+  public void testCapabilitiesWithNativeZlibLoaded() {
+    assumeNativeZlibLoaded();
+    ByteBuff emptySingleHeapBuff = new SingleByteBuff(ByteBuffer.allocate(0));
+    ByteBuff emptyMultiHeapBuff = new MultiByteBuff(ByteBuffer.allocate(0), ByteBuffer.allocate(0));
+    ByteBuff emptySingleDirectBuff = new SingleByteBuff(ByteBuffer.allocateDirect(0));
+    ByteBuff emptyMultiDirectBuff =
+      new MultiByteBuff(ByteBuffer.allocateDirect(0), ByteBuffer.allocateDirect(0));
+
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      assertTrue(decompressor.canDecompress(emptySingleDirectBuff, emptySingleDirectBuff));
+      // The native zlib binding reads/writes buffer memory directly, so only direct buffers are
+      // supported; heap buffers must fall back to stream-based decompression instead.
+      assertFalse(decompressor.canDecompress(emptySingleHeapBuff, emptySingleHeapBuff));
+      assertFalse(decompressor.canDecompress(emptySingleHeapBuff, emptySingleDirectBuff));
+      assertFalse(decompressor.canDecompress(emptySingleDirectBuff, emptySingleHeapBuff));
+      assertFalse(decompressor.canDecompress(emptyMultiHeapBuff, emptyMultiHeapBuff));
+      assertFalse(decompressor.canDecompress(emptyMultiDirectBuff, emptyMultiDirectBuff));
+      assertFalse(decompressor.canDecompress(emptySingleDirectBuff, emptyMultiDirectBuff));
+    }
+  }
+
+  private static ByteBuff directBuffWith(byte[] data) {
+    ByteBuffer buffer = ByteBuffer.allocateDirect(data.length);
+    buffer.put(data);
+    buffer.rewind();
+    return new SingleByteBuff(buffer);
+  }
+
+  @Test
+  public void testDecompressDirectToDirect() throws IOException {
+    assumeNativeZlibLoaded();
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = directBuffWith(COMPRESSED_PAYLOAD);
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
+    }
+  }
+
+  @Test
+  public void testDecompressFailsOnTooShortInput() throws IOException {
+    assumeNativeZlibLoaded();
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = new SingleByteBuff(ByteBuffer.allocateDirect(10));
+      decompressor.decompress(output, input, 10);
+      fail("Expected an IOException because the input is too short to be a gzip member");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("too short to be a gzip member"));
+    }
+  }
+
+  @Test
+  public void testDecompressFailsOnBadMagicBytes() throws IOException {
+    assumeNativeZlibLoaded();
+    byte[] corrupted = Arrays.copyOf(COMPRESSED_PAYLOAD, COMPRESSED_PAYLOAD.length);
+    corrupted[0] ^= (byte) 0xff;
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = directBuffWith(corrupted);
+      decompressor.decompress(output, input, corrupted.length);
+      fail("Expected an IOException because the magic bytes are wrong");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Invalid gzip stream"));
+    }
+  }
+
+  @Test
+  public void testDecompressFailsWhenOutputBufferTooSmall() throws IOException {
+    assumeNativeZlibLoaded();
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(10));
+      ByteBuff input = directBuffWith(COMPRESSED_PAYLOAD);
+      decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      fail("Expected an IOException because the output buffer is too small");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Output buffer is too small"));
+    }
+  }
+
+  @Test
+  public void testDecompressFailsOnCorruptedCrc32() throws IOException {
+    assumeNativeZlibLoaded();
+    byte[] corrupted = Arrays.copyOf(COMPRESSED_PAYLOAD, COMPRESSED_PAYLOAD.length);
+    // First 4 bytes of the 8-byte trailer are the CRC32, leave ISIZE (the last 4 bytes) alone.
+    corrupted[corrupted.length - 8] ^= (byte) 0xff;
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = directBuffWith(corrupted);
+      decompressor.decompress(output, input, corrupted.length);
+      fail("Expected an IOException because the trailer's CRC32 no longer matches");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Invalid gzip stream"));
+    }
+  }
+
+  @Test
+  public void testDecompressFailsOnCorruptedIsize() throws IOException {
+    assumeNativeZlibLoaded();
+    byte[] corrupted = Arrays.copyOf(COMPRESSED_PAYLOAD, COMPRESSED_PAYLOAD.length);
+    // Last 4 bytes of the 8-byte trailer are the ISIZE.
+    corrupted[corrupted.length - 4] ^= (byte) 0xff;
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = directBuffWith(corrupted);
+      decompressor.decompress(output, input, corrupted.length);
+      fail("Expected an IOException because the trailer's ISIZE no longer matches");
+    } catch (IOException e) {
+      assertTrue(e.getMessage().contains("Invalid gzip stream"));
+    }
+  }
+
+  @Test
+  public void testDecompressSucceedsRepeatedlyOnTheSameDecompressor() throws IOException {
+    assumeNativeZlibLoaded();
+    // Mirrors how CodecPool actually uses these: one instance is reused across many blocks, so the
+    // native decompressor must produce a correct result on every call, not just the first.
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      for (int i = 0; i < 3; i++) {
+        ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+        ByteBuff input = directBuffWith(COMPRESSED_PAYLOAD);
+        int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+        assertEquals("HBase is fun to use and very fast",
+          Bytes.toString(output.toBytes(0, decompressedSize)));
+      }
+    }
+  }
+
+  @Test
+  public void testDecompressorIsStillUsableAfterAPreviousCallThrows() throws IOException {
+    assumeNativeZlibLoaded();
+    byte[] corrupted = Arrays.copyOf(COMPRESSED_PAYLOAD, COMPRESSED_PAYLOAD.length);
+    // First 4 bytes of the 8-byte trailer are the CRC32.
+    corrupted[corrupted.length - 8] ^= (byte) 0xff;
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff badOutput = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff badInput = directBuffWith(corrupted);
+      try {
+        decompressor.decompress(badOutput, badInput, corrupted.length);
+        fail("Expected an IOException because the trailer's CRC32 no longer matches");
+      } catch (IOException e) {
+        assertTrue(e.getMessage().contains("Invalid gzip stream"));
+      }
+
+      // A prior failure must not leave the shared native decompressor state corrupted for the
+      // next, valid call.
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = directBuffWith(COMPRESSED_PAYLOAD);
+      int decompressedSize = decompressor.decompress(output, input, COMPRESSED_PAYLOAD.length);
+      assertEquals("HBase is fun to use and very fast",
+        Bytes.toString(output.toBytes(0, decompressedSize)));
+    }
+  }
+
+  /**
+   * This is the exact gate {@code HFileBlockDefaultDecodingContext#canDecompressViaByteBuff} relies
+   * on to decide between ByteBuff decompression and the stream path, driven end-to-end from the
+   * {@code hbase.io.compress.gz.allowByteBuffDecompression} config flag.
+   */
+  @Test
+  public void testReinitControlsByteBuffDecompressionViaConfigFlag() {
+    assumeNativeZlibLoaded();
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = directBuffWith(COMPRESSED_PAYLOAD);
+
+      Configuration conf = new Configuration(false);
+      conf.setBoolean("hbase.io.compress.gz.allowByteBuffDecompression", false);
+      decompressor.reinit(GzipHFileDecompressionContext.fromConfiguration(conf));
+      assertFalse(decompressor.canDecompress(output, input),
+        "Block reader must fall back to stream decompression when the config flag "
+          + "disables ByteBuff decompression");
+
+      conf.setBoolean("hbase.io.compress.gz.allowByteBuffDecompression", true);
+      decompressor.reinit(GzipHFileDecompressionContext.fromConfiguration(conf));
+      assertTrue(decompressor.canDecompress(output, input),
+        "Block reader must use ByteBuff decompression when the config flag is enabled");
+
+      // The default, with no config value set, must also allow ByteBuff decompression.
+      decompressor
+        .reinit(GzipHFileDecompressionContext.fromConfiguration(new Configuration(false)));
+      assertTrue(decompressor.canDecompress(output, input));
+    }
+  }
+
+  @Test
+  public void testReinitWithNullContextIsNoOp() {
+    assumeNativeZlibLoaded();
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(true)) {
+      ByteBuff output = new SingleByteBuff(ByteBuffer.allocateDirect(64));
+      ByteBuff input = directBuffWith(COMPRESSED_PAYLOAD);
+
+      Configuration conf = new Configuration(false);
+      conf.setBoolean("hbase.io.compress.gz.allowByteBuffDecompression", false);
+      decompressor.reinit(GzipHFileDecompressionContext.fromConfiguration(conf));
+      assertFalse(decompressor.canDecompress(output, input));
+
+      decompressor.reinit(null);
+      assertFalse(decompressor.canDecompress(output, input),
+        "reinit(null) must not reset allowByteBuffDecompression back to the default");
+    }
+  }
+
+  @Test
+  public void testReinitFailsOnWrongContextType() {
+    Compression.HFileDecompressionContext wrongContext =
+      new Compression.HFileDecompressionContext() {
+        @Override
+        public void close() {
+        }
+
+        @Override
+        public long heapSize() {
+          return 0;
+        }
+      };
+    try (GzipByteBuffDecompressor decompressor = new GzipByteBuffDecompressor(false)) {
+      decompressor.reinit(wrongContext);
+      fail("Expected an IllegalArgumentException because the context was not a "
+        + "GzipHFileDecompressionContext");
+    } catch (IllegalArgumentException e) {
+      assertTrue(e.getMessage().contains("GzipHFileDecompressionContext"));
+    }
+  }
+
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/compress/TestHFileCompressionGzip.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/compress/TestHFileCompressionGzip.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.io.compress;
+
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.Path;
+import org.apache.hadoop.hbase.HBaseTestingUtility;
+import org.apache.hadoop.hbase.testclassification.IOTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(IOTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestHFileCompressionGzip extends HFileTestBase {
+
+  private static Configuration conf;
+
+  @BeforeAll
+  public static void setUpBeforeClass() throws Exception {
+    HFileTestBase.setUpBeforeClass();
+  }
+
+  @BeforeEach
+  public void setUp() throws Exception {
+    conf = TEST_UTIL.getConfiguration();
+    HFileTestBase.setUpBeforeClass();
+  }
+
+  @Test
+  public void testWithStreamDecompression() throws Exception {
+    conf.setBoolean("hbase.io.compress.gz.allowByteBuffDecompression", false);
+    Compression.Algorithm.GZ.reload(conf);
+
+    Path path = new Path(TEST_UTIL.getDataTestDir(),
+      HBaseTestingUtility.getRandomUUID().toString() + ".hfile");
+    doTest(conf, path, Compression.Algorithm.GZ);
+  }
+
+  @Test
+  public void testWithByteBuffDecompression() throws Exception {
+    conf.setBoolean("hbase.io.compress.gz.allowByteBuffDecompression", true);
+    Compression.Algorithm.GZ.reload(conf);
+
+    Path path = new Path(TEST_UTIL.getDataTestDir(),
+      HBaseTestingUtility.getRandomUUID().toString() + ".hfile");
+    doTest(conf, path, Compression.Algorithm.GZ);
+  }
+
+}


### PR DESCRIPTION
## Why

HBase's `ByteBuffDecompressor` interface enables block decompression directly from/to
`ByteBuffer` objects, avoiding intermediate byte array copies. GZIP had no implementation
of this interface — all GZIP decompression went through a byte array round-trip regardless
of whether the underlying buffers were on-heap or off-heap.

## What

Adds `GzipByteBuffDecompressor`, a `ByteBuffDecompressor` for GZIP that handles two cases:

- **Off-heap (direct ByteBuffers):** delegates to Hadoop's native `ZlibDirectDecompressor`
  with `GZIP_FORMAT`. Requires native zlib to be loaded; `canDecompress()` returns false
  if it isn't.
- **On-heap (heap ByteBuffers):** uses Java's `Inflater` in raw DEFLATE (`nowrap`) mode,
  skipping the 10-byte GZIP header manually and verifying the CRC32 and ISIZE trailer
  fields after inflation. The native `ZlibDirectDecompressor` requires a stable native
  memory address, which heap `ByteBuffer`s do not provide, making this fallback necessary.

Also adds:

- `GzipHFileDecompressionContext` — carries per-context configuration (e.g. whether
  ByteBuff decompression is allowed), wired in via `reinit()`
- Input-length validation — rejects inputs shorter than the minimum valid GZIP member
  (header + trailer = 18 bytes)

## Testing

- Off-heap → off-heap decompression
- On-heap → on-heap decompression
- CRC32 mismatch detection
- ISIZE mismatch detection
- Input too short
- Output buffer too small
- `canDecompress()` guard logic
