### PR TITLE
HBASE-30322: Persist all fields of BackupInfo

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
@@ -435,6 +435,18 @@ public class BackupInfo implements Comparable<BackupInfo> {
     builder.setBackupType(BackupProtos.BackupType.valueOf(getType().name()));
     builder.setWorkersNumber(workers);
     builder.setBandwidth(bandwidth);
+    builder.setTotalBytesCopied(totalBytesCopied);
+    builder.setNoChecksumVerify(noChecksumVerify);
+    if (incrBackupFileList != null) {
+      builder.addAllIncrBackupFileList(incrBackupFileList);
+    }
+    if (incrTimestampMap != null) {
+      for (Entry<TableName, Map<String, Long>> entry : incrTimestampMap.entrySet()) {
+        builder.putIncrTimestampMap(entry.getKey().getNameAsString(),
+          BackupProtos.BackupInfo.RSTimestampMap.newBuilder().putAllRsTimestamp(entry.getValue())
+            .build());
+      }
+    }
     return builder.build();
   }
 
@@ -507,7 +519,7 @@ public class BackupInfo implements Comparable<BackupInfo> {
     BackupInfo context = new BackupInfo();
     context.setBackupId(proto.getBackupId());
     context.setBackupTableInfoMap(toMap(proto.getBackupTableInfoList()));
-    context.setTableSetTimestampMap(getTableSetTimestampMap(proto.getTableSetTimestampMap()));
+    context.setTableSetTimestampMap(toTableTimestampMap(proto.getTableSetTimestampMap()));
     context.setCompleteTs(proto.getCompleteTs());
     if (proto.hasFailedMessage()) {
       context.setFailedMsg(proto.getFailedMessage());
@@ -516,8 +528,13 @@ public class BackupInfo implements Comparable<BackupInfo> {
       context.setState(BackupInfo.BackupState.valueOf(proto.getBackupState().name()));
     }
 
-    context
-      .setHLogTargetDir(BackupUtils.getLogBackupDir(proto.getBackupRootDir(), proto.getBackupId()));
+    // Only incremental backups have a WAL target directory. Setting this unconditionally would
+    // hand FULL backups a non-null path that never existed, which cleanupHLogDir() would then
+    // try to delete.
+    if (BackupType.valueOf(proto.getBackupType().name()) == BackupType.INCREMENTAL) {
+      context.setHLogTargetDir(
+        BackupUtils.getLogBackupDir(proto.getBackupRootDir(), proto.getBackupId()));
+    }
 
     if (proto.hasBackupPhase()) {
       context.setPhase(BackupPhase.valueOf(proto.getBackupPhase().name()));
@@ -530,6 +547,14 @@ public class BackupInfo implements Comparable<BackupInfo> {
     context.setType(BackupType.valueOf(proto.getBackupType().name()));
     context.setWorkers(proto.getWorkersNumber());
     context.setBandwidth(proto.getBandwidth());
+    context.setTotalBytesCopied(proto.getTotalBytesCopied());
+    context.setNoChecksumVerify(proto.getNoChecksumVerify());
+    if (proto.getIncrBackupFileListCount() > 0) {
+      context.setIncrBackupFileList(new ArrayList<>(proto.getIncrBackupFileListList()));
+    }
+    if (proto.getIncrTimestampMapCount() > 0) {
+      context.setIncrTimestampMap(toTableTimestampMap(proto.getIncrTimestampMapMap()));
+    }
     return context;
   }
 
@@ -542,14 +567,13 @@ public class BackupInfo implements Comparable<BackupInfo> {
   }
 
   private static Map<TableName, Map<String, Long>>
-    getTableSetTimestampMap(Map<String, BackupProtos.BackupInfo.RSTimestampMap> map) {
-    Map<TableName, Map<String, Long>> tableSetTimestampMap = new HashMap<>();
+    toTableTimestampMap(Map<String, BackupProtos.BackupInfo.RSTimestampMap> map) {
+    Map<TableName, Map<String, Long>> result = new HashMap<>();
     for (Entry<String, BackupProtos.BackupInfo.RSTimestampMap> entry : map.entrySet()) {
-      tableSetTimestampMap.put(TableName.valueOf(entry.getKey()),
-        entry.getValue().getRsTimestampMap());
+      result.put(TableName.valueOf(entry.getKey()), entry.getValue().getRsTimestampMap());
     }
 
-    return tableSetTimestampMap;
+    return result;
   }
 
   public String getShortDescription() {

--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/BackupInfo.java
@@ -519,7 +519,7 @@ public class BackupInfo implements Comparable<BackupInfo> {
     BackupInfo context = new BackupInfo();
     context.setBackupId(proto.getBackupId());
     context.setBackupTableInfoMap(toMap(proto.getBackupTableInfoList()));
-    context.setTableSetTimestampMap(toTableTimestampMap(proto.getTableSetTimestampMap()));
+    context.setTableSetTimestampMap(getTableSetTimestampMap(proto.getTableSetTimestampMap()));
     context.setCompleteTs(proto.getCompleteTs());
     if (proto.hasFailedMessage()) {
       context.setFailedMsg(proto.getFailedMessage());
@@ -528,13 +528,8 @@ public class BackupInfo implements Comparable<BackupInfo> {
       context.setState(BackupInfo.BackupState.valueOf(proto.getBackupState().name()));
     }
 
-    // Only incremental backups have a WAL target directory. Setting this unconditionally would
-    // hand FULL backups a non-null path that never existed, which cleanupHLogDir() would then
-    // try to delete.
-    if (BackupType.valueOf(proto.getBackupType().name()) == BackupType.INCREMENTAL) {
-      context.setHLogTargetDir(
-        BackupUtils.getLogBackupDir(proto.getBackupRootDir(), proto.getBackupId()));
-    }
+    context
+      .setHLogTargetDir(BackupUtils.getLogBackupDir(proto.getBackupRootDir(), proto.getBackupId()));
 
     if (proto.hasBackupPhase()) {
       context.setPhase(BackupPhase.valueOf(proto.getBackupPhase().name()));
@@ -553,7 +548,7 @@ public class BackupInfo implements Comparable<BackupInfo> {
       context.setIncrBackupFileList(new ArrayList<>(proto.getIncrBackupFileListList()));
     }
     if (proto.getIncrTimestampMapCount() > 0) {
-      context.setIncrTimestampMap(toTableTimestampMap(proto.getIncrTimestampMapMap()));
+      context.setIncrTimestampMap(getTableSetTimestampMap(proto.getIncrTimestampMapMap()));
     }
     return context;
   }
@@ -567,13 +562,14 @@ public class BackupInfo implements Comparable<BackupInfo> {
   }
 
   private static Map<TableName, Map<String, Long>>
-    toTableTimestampMap(Map<String, BackupProtos.BackupInfo.RSTimestampMap> map) {
-    Map<TableName, Map<String, Long>> result = new HashMap<>();
+    getTableSetTimestampMap(Map<String, BackupProtos.BackupInfo.RSTimestampMap> map) {
+    Map<TableName, Map<String, Long>> tableSetTimestampMap = new HashMap<>();
     for (Entry<String, BackupProtos.BackupInfo.RSTimestampMap> entry : map.entrySet()) {
-      result.put(TableName.valueOf(entry.getKey()), entry.getValue().getRsTimestampMap());
+      tableSetTimestampMap.put(TableName.valueOf(entry.getKey()),
+        entry.getValue().getRsTimestampMap());
     }
 
-    return result;
+    return tableSetTimestampMap;
   }
 
   public String getShortDescription() {

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupInfoSerialization.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupInfoSerialization.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.backup;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import java.io.IOException;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(SmallTests.TAG)
+public class TestBackupInfoSerialization {
+
+  private static BackupInfo newIncrementalBackupInfo() {
+    return new BackupInfo("backup_1234567890", BackupType.INCREMENTAL,
+      new TableName[] { TableName.valueOf("t1") }, "/hbase/backup");
+  }
+
+  private static BackupInfo newFullBackupInfo() {
+    return new BackupInfo("backup_1234567890", BackupType.FULL,
+      new TableName[] { TableName.valueOf("t1") }, "/hbase/backup");
+  }
+
+  @Test
+  public void testIncrBackupFileListSurvivesRoundTrip() throws IOException {
+    List<String> walFiles = Arrays.asList("/hbase/oldWALs/host1.example.com,16020,1234567890.100",
+      "/hbase/oldWALs/host2.example.com,16020,1234567890.200");
+
+    BackupInfo original = newIncrementalBackupInfo();
+    original.setIncrBackupFileList(walFiles);
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertEquals(walFiles, roundTripped.getIncrBackupFileList());
+  }
+
+  @Test
+  public void testIncrBackupFileListOrderIsPreserved() throws IOException {
+    List<String> walFiles = Arrays.asList("/hbase/oldWALs/c.example.com,16020,1.300",
+      "/hbase/oldWALs/a.example.com,16020,1.100", "/hbase/oldWALs/b.example.com,16020,1.200");
+
+    BackupInfo original = newIncrementalBackupInfo();
+    original.setIncrBackupFileList(walFiles);
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertEquals(walFiles, roundTripped.getIncrBackupFileList());
+  }
+
+  @Test
+  public void testUnsetIncrBackupFileListRemainsNull() throws IOException {
+    BackupInfo original = newIncrementalBackupInfo();
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertNull(roundTripped.getIncrBackupFileList());
+  }
+
+  @Test
+  public void testEmptyIncrBackupFileListRemainsNull() throws IOException {
+    BackupInfo original = newIncrementalBackupInfo();
+    original.setIncrBackupFileList(Arrays.asList());
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertNull(roundTripped.getIncrBackupFileList());
+  }
+
+  @Test
+  public void testEqualsDistinguishesIncrBackupFileList() throws IOException {
+    BackupInfo withFiles = newIncrementalBackupInfo();
+    withFiles.setIncrBackupFileList(Arrays.asList("/hbase/oldWALs/host1,16020,1.100"));
+
+    BackupInfo withoutFiles = newIncrementalBackupInfo();
+
+    assertTrue(!withFiles.equals(withoutFiles));
+  }
+
+  @Test
+  public void testTotalBytesCopiedSurvivesRoundTrip() throws IOException {
+    BackupInfo original = newIncrementalBackupInfo();
+    original.setTotalBytesCopied(9876543210L);
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertEquals(9876543210L, roundTripped.getTotalBytesCopied());
+  }
+
+  @Test
+  public void testNoChecksumVerifySurvivesRoundTripWhenTrue() throws IOException {
+    BackupInfo original = newIncrementalBackupInfo();
+    original.setNoChecksumVerify(true);
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertTrue(roundTripped.getNoChecksumVerify());
+  }
+
+  @Test
+  public void testNoChecksumVerifySurvivesRoundTripWhenFalse() throws IOException {
+    BackupInfo original = newIncrementalBackupInfo();
+    original.setNoChecksumVerify(false);
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertFalse(roundTripped.getNoChecksumVerify());
+  }
+
+  @Test
+  public void testIncrTimestampMapSurvivesRoundTrip() throws IOException {
+    Map<String, Long> t1Timestamps = new HashMap<>();
+    t1Timestamps.put("host1.example.com:16020", 100L);
+    t1Timestamps.put("host2.example.com:16020", 200L);
+    Map<String, Long> t2Timestamps = new HashMap<>();
+    t2Timestamps.put("host1.example.com:16020", 300L);
+
+    Map<TableName, Map<String, Long>> incrTimestampMap = new HashMap<>();
+    incrTimestampMap.put(TableName.valueOf("t1"), t1Timestamps);
+    incrTimestampMap.put(TableName.valueOf("t2"), t2Timestamps);
+
+    BackupInfo original = newIncrementalBackupInfo();
+    original.setIncrTimestampMap(incrTimestampMap);
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertEquals(incrTimestampMap, roundTripped.getIncrTimestampMap());
+  }
+
+  @Test
+  public void testUnsetIncrTimestampMapRemainsNull() throws IOException {
+    BackupInfo original = newIncrementalBackupInfo();
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertNull(roundTripped.getIncrTimestampMap());
+  }
+
+  @Test
+  public void testIncrementalBackupRetainsHLogTargetDir() throws IOException {
+    BackupInfo original = newIncrementalBackupInfo();
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertEquals(original.getHLogTargetDir(), roundTripped.getHLogTargetDir());
+  }
+
+  @Test
+  public void testFullBackupHasNoHLogTargetDir() throws IOException {
+    BackupInfo original = newFullBackupInfo();
+    assertNull(original.getHLogTargetDir());
+
+    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
+
+    assertNull(roundTripped.getHLogTargetDir());
+  }
+}

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupInfoSerialization.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestBackupInfoSerialization.java
@@ -40,11 +40,6 @@ public class TestBackupInfoSerialization {
       new TableName[] { TableName.valueOf("t1") }, "/hbase/backup");
   }
 
-  private static BackupInfo newFullBackupInfo() {
-    return new BackupInfo("backup_1234567890", BackupType.FULL,
-      new TableName[] { TableName.valueOf("t1") }, "/hbase/backup");
-  }
-
   @Test
   public void testIncrBackupFileListSurvivesRoundTrip() throws IOException {
     List<String> walFiles = Arrays.asList("/hbase/oldWALs/host1.example.com,16020,1234567890.100",
@@ -168,13 +163,4 @@ public class TestBackupInfoSerialization {
     assertEquals(original.getHLogTargetDir(), roundTripped.getHLogTargetDir());
   }
 
-  @Test
-  public void testFullBackupHasNoHLogTargetDir() throws IOException {
-    BackupInfo original = newFullBackupInfo();
-    assertNull(original.getHLogTargetDir());
-
-    BackupInfo roundTripped = BackupInfo.fromByteArray(original.toByteArray());
-
-    assertNull(roundTripped.getHLogTargetDir());
-  }
 }

--- a/hbase-protocol-shaded/src/main/protobuf/Backup.proto
+++ b/hbase-protocol-shaded/src/main/protobuf/Backup.proto
@@ -93,6 +93,10 @@ message BackupInfo {
   optional uint32 workers_number = 11;
   optional uint64 bandwidth = 12;
   map<string, RSTimestampMap> table_set_timestamp = 13;
+  repeated string incr_backup_file_list = 14;
+  optional uint64 total_bytes_copied = 15;
+  optional bool no_checksum_verify = 16;
+  map<string, RSTimestampMap> incr_timestamp_map = 17;
 
   message RSTimestampMap {
     map<string, uint64> rs_timestamp = 1;


### PR DESCRIPTION
The class BackupInfo has a pair of methods, `toProtosBackupInfo()` and `fromProto()`, so you can convert the POJO BackupInfo to and from the protobuf version. These methods do not handle all fields, so some information is lost. They do not handle:
- `totalBytesCopied`
- `noChecksumVerify`
- `incrBackupFileList`
- `incrTimestampMap`

In particular I ran into a problem when `incrBackupFileList` was missing after getting a BackupInfo from BackupAdmin.