### PR TITLE
HBASE-30320 TestMemStoreLAB#testLABChunkQueue OOM on fast hardware due to unbounded off-pool chunk allocation (#8533)

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMemStoreLAB.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/regionserver/TestMemStoreLAB.java
@@ -328,12 +328,19 @@ public class TestMemStoreLAB {
 
   private Thread getChunkQueueTestThread(final MemStoreLABImpl mslab, String threadName,
     Cell cellToCopyInto) {
+    // Reserve 20% of max heap as safety margin to prevent OOM on fast hardware where threads can
+    // allocate many GB of chunks within the 1-second test window.
+    final long maxMemory = ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getMax();
+    final long memoryLimit = (long) (maxMemory * 0.8);
     Thread thread = new Thread() {
       volatile boolean stopped = false;
 
       @Override
       public void run() {
         while (!stopped) {
+          if (ManagementFactory.getMemoryMXBean().getHeapMemoryUsage().getUsed() > memoryLimit) {
+            break;
+          }
           // keep triggering chunk retirement
           mslab.copyCellInto(cellToCopyInto);
         }


### PR DESCRIPTION
back port for https://github.com/apache/hbase/pull/8533