### PR TITLE
HBASE-30332 Preserve QueryMetrics for empty results

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -1428,7 +1428,10 @@ public final class ProtobufUtil {
 
     ExtendedCell[] cells = ClientInternalHelper.getExtendedRawCells(result);
     if (cells == null || cells.length == 0) {
-      return result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
+      ClientProtos.Result emptyResult = result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
+      return result.getMetrics() == null
+        ? emptyResult
+        : emptyResult.toBuilder().setMetrics(toQueryMetrics(result.getMetrics())).build();
     }
 
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
@@ -1468,7 +1471,12 @@ public final class ProtobufUtil {
   public static ClientProtos.Result toResultNoData(final Result result) {
     if (result.getExists() != null) return toResult(result.getExists(), result.isStale());
     int size = result.size();
-    if (size == 0) return result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
+    if (size == 0) {
+      ClientProtos.Result emptyResult = result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
+      return result.getMetrics() == null
+        ? emptyResult
+        : emptyResult.toBuilder().setMetrics(toQueryMetrics(result.getMetrics())).build();
+    }
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
     builder.setAssociatedCellCount(size);
     builder.setStale(result.isStale());
@@ -1506,7 +1514,7 @@ public final class ProtobufUtil {
     }
 
     List<CellProtos.Cell> values = proto.getCellList();
-    if (values.isEmpty()) {
+    if (values.isEmpty() && !proto.hasMetrics()) {
       return proto.getStale() ? EMPTY_RESULT_STALE : EMPTY_RESULT;
     }
 
@@ -1564,9 +1572,14 @@ public final class ProtobufUtil {
       }
     }
 
-    Result r = (cells == null || cells.isEmpty())
-      ? (proto.getStale() ? EMPTY_RESULT_STALE : EMPTY_RESULT)
-      : Result.create(cells, null, proto.getStale());
+    Result r;
+    if (cells == null || cells.isEmpty()) {
+      r = proto.hasMetrics()
+        ? Result.create(EMPTY_CELL_ARRAY, null, proto.getStale())
+        : (proto.getStale() ? EMPTY_RESULT_STALE : EMPTY_RESULT);
+    } else {
+      r = Result.create(cells, null, proto.getStale());
+    }
 
     if (proto.hasMetrics()) {
       r.setMetrics(toQueryMetrics(proto.getMetrics()));

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -1423,15 +1423,13 @@ public final class ProtobufUtil {
    */
   public static ClientProtos.Result toResult(final Result result, boolean encodeTags) {
     if (result.getExists() != null) {
-      return toResult(result.getExists(), result.isStale());
+      return toResult(result.getExists(), result.isStale(), result.getMetrics());
     }
 
     ExtendedCell[] cells = ClientInternalHelper.getExtendedRawCells(result);
     if (cells == null || cells.length == 0) {
-      ClientProtos.Result emptyResult = result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
-      return result.getMetrics() == null
-        ? emptyResult
-        : emptyResult.toBuilder().setMetrics(toQueryMetrics(result.getMetrics())).build();
+      return withMetrics(result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB,
+        result.getMetrics());
     }
 
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
@@ -1463,19 +1461,37 @@ public final class ProtobufUtil {
   }
 
   /**
+   * Convert a client Result to a protocol buffer Result
+   * @param existence the client existence to send
+   * @param stale     whether the result is stale
+   * @param metrics   query metrics associated with the result
+   * @return the converted protocol buffer Result
+   */
+  public static ClientProtos.Result toResult(final boolean existence, boolean stale,
+    QueryMetrics metrics) {
+    return withMetrics(toResult(existence, stale), metrics);
+  }
+
+  private static ClientProtos.Result withMetrics(ClientProtos.Result result, QueryMetrics metrics) {
+    return metrics == null
+      ? result
+      : result.toBuilder().setMetrics(toQueryMetrics(metrics)).build();
+  }
+
+  /**
    * Convert a client Result to a protocol buffer Result. The pb Result does not include the Cell
    * data. That is for transport otherwise.
    * @param result the client Result to convert
    * @return the converted protocol buffer Result
    */
   public static ClientProtos.Result toResultNoData(final Result result) {
-    if (result.getExists() != null) return toResult(result.getExists(), result.isStale());
+    if (result.getExists() != null) {
+      return toResult(result.getExists(), result.isStale(), result.getMetrics());
+    }
     int size = result.size();
     if (size == 0) {
-      ClientProtos.Result emptyResult = result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
-      return result.getMetrics() == null
-        ? emptyResult
-        : emptyResult.toBuilder().setMetrics(toQueryMetrics(result.getMetrics())).build();
+      return withMetrics(result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB,
+        result.getMetrics());
     }
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
     builder.setAssociatedCellCount(size);
@@ -1507,6 +1523,11 @@ public final class ProtobufUtil {
    */
   public static Result toResult(final ClientProtos.Result proto, boolean decodeTags) {
     if (proto.hasExists()) {
+      if (proto.hasMetrics()) {
+        Result result = Result.create((Cell[]) null, proto.getExists(), proto.getStale());
+        result.setMetrics(toQueryMetrics(proto.getMetrics()));
+        return result;
+      }
       if (proto.getStale()) {
         return proto.getExists() ? EMPTY_RESULT_EXISTS_TRUE_STALE : EMPTY_RESULT_EXISTS_FALSE_STALE;
       }
@@ -1547,10 +1568,7 @@ public final class ProtobufUtil {
       ) {
         throw new IllegalArgumentException("bad proto: exists with cells is no allowed " + proto);
       }
-      if (proto.getStale()) {
-        return proto.getExists() ? EMPTY_RESULT_EXISTS_TRUE_STALE : EMPTY_RESULT_EXISTS_FALSE_STALE;
-      }
-      return proto.getExists() ? EMPTY_RESULT_EXISTS_TRUE : EMPTY_RESULT_EXISTS_FALSE;
+      return toResult(proto);
     }
 
     // TODO: Unit test that has some Cells in scanner and some in the proto.

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hbase.ArrayBackedTag;
@@ -138,22 +139,27 @@ public class TestProtobufUtil {
   @Test
   public void testEmptyResultWithQueryMetrics() throws IOException {
     long blockBytesScanned = 123L;
-    Result result = Result.create(Collections.emptyList());
-    result.setMetrics(new QueryMetrics(blockBytesScanned));
+    for (Boolean exists : Arrays.asList(null, false, true)) {
+      Result result = Result.create(Collections.emptyList(), exists);
+      result.setMetrics(new QueryMetrics(blockBytesScanned));
 
-    for (ClientProtos.Result proto : List.of(ProtobufUtil.toResult(result),
-      ProtobufUtil.toResultNoData(result))) {
-      assertTrue(proto.hasMetrics());
-      assertEquals(blockBytesScanned, proto.getMetrics().getBlockBytesScanned());
+      for (ClientProtos.Result proto : List.of(ProtobufUtil.toResult(result),
+        ProtobufUtil.toResultNoData(result))) {
+        assertEquals(exists, proto.hasExists() ? proto.getExists() : null);
+        assertTrue(proto.hasMetrics());
+        assertEquals(blockBytesScanned, proto.getMetrics().getBlockBytesScanned());
 
-      Result roundTrip = ProtobufUtil.toResult(proto);
-      assertNotNull(roundTrip.getMetrics());
-      assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+        Result roundTrip = ProtobufUtil.toResult(proto);
+        assertEquals(exists, roundTrip.getExists());
+        assertNotNull(roundTrip.getMetrics());
+        assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
 
-      roundTrip = ProtobufUtil.toResult(proto,
-        PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()));
-      assertNotNull(roundTrip.getMetrics());
-      assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+        roundTrip = ProtobufUtil.toResult(proto,
+          PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()));
+        assertEquals(exists, roundTrip.getExists());
+        assertNotNull(roundTrip.getMetrics());
+        assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+      }
     }
 
     ClientProtos.Result emptyProto = ClientProtos.Result.getDefaultInstance();

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.shaded.protobuf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -43,6 +44,8 @@ import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.QueryMetrics;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.SlowLogParams;
 import org.apache.hadoop.hbase.io.TimeRange;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
@@ -130,6 +133,35 @@ public class TestProtobufUtil {
     getBuilder.setQueryMetricsEnabled(false);
     Get get = ProtobufUtil.toGet(proto);
     assertEquals(getBuilder.build(), ProtobufUtil.toGet(get));
+  }
+
+  @Test
+  public void testEmptyResultWithQueryMetrics() throws IOException {
+    long blockBytesScanned = 123L;
+    Result result = Result.create(Collections.emptyList());
+    result.setMetrics(new QueryMetrics(blockBytesScanned));
+
+    for (ClientProtos.Result proto : List.of(ProtobufUtil.toResult(result),
+      ProtobufUtil.toResultNoData(result))) {
+      assertTrue(proto.hasMetrics());
+      assertEquals(blockBytesScanned, proto.getMetrics().getBlockBytesScanned());
+
+      Result roundTrip = ProtobufUtil.toResult(proto);
+      assertNotNull(roundTrip.getMetrics());
+      assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+
+      roundTrip = ProtobufUtil.toResult(proto,
+        PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()));
+      assertNotNull(roundTrip.getMetrics());
+      assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+    }
+
+    ClientProtos.Result emptyProto = ClientProtos.Result.getDefaultInstance();
+    assertNull(ProtobufUtil.toResult(emptyProto).getMetrics());
+    assertNull(ProtobufUtil
+      .toResult(emptyProto,
+        PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()))
+      .getMetrics());
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -2535,8 +2535,8 @@ public class RSRpcServices extends HBaseRpcServicesBase<HRegionServer>
         }
       }
       if (existence != null) {
-        ClientProtos.Result pbr =
-          ProtobufUtil.toResult(existence, region.getRegionInfo().getReplicaId() != 0);
+        ClientProtos.Result pbr = ProtobufUtil.toResult(existence,
+          region.getRegionInfo().getReplicaId() != 0, r != null ? r.getMetrics() : null);
         builder.setResult(pbr);
       } else if (r != null) {
         ClientProtos.Result pbr;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableQueryMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableQueryMetrics.java
@@ -108,6 +108,25 @@ public class TestAsyncTableQueryMetrics {
     }
 
     assertEquals(getClusterBlockBytesScanned(), bbs);
+
+    g1.setCheckExistenceOnly(true);
+    g2.setCheckExistenceOnly(true);
+    g3.setCheckExistenceOnly(true);
+
+    result = CONN.getTable(TABLE_NAME).get(g1).get();
+    assertEquals(Boolean.TRUE, result.getExists());
+    assertNotNull(result.getMetrics());
+    bbs += result.getMetrics().getBlockBytesScanned();
+    assertEquals(getClusterBlockBytesScanned(), bbs);
+
+    futures = CONN.getTable(TABLE_NAME).get(List.of(g1, g2, g3));
+    for (CompletableFuture<Result> future : futures) {
+      result = future.join();
+      assertEquals(Boolean.TRUE, result.getExists());
+      assertNotNull(result.getMetrics());
+      bbs += result.getMetrics().getBlockBytesScanned();
+    }
+    assertEquals(getClusterBlockBytesScanned(), bbs);
   }
 
   @Test


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30332

### What changes were proposed in this pull request?

This pull request preserves `QueryMetrics` when an empty `Result` is converted to and from protobuf.

The changes:

- Preserve metrics in both `ProtobufUtil.toResult` and `ProtobufUtil.toResultNoData` when the result contains no cells.
- Continue reusing the cached empty protobuf instances when metrics are not present.
- Create a per-response empty `Result` when deserializing a protobuf containing metrics, instead of attaching metrics to the shared cached `EMPTY_RESULT`.
- Add a focused regression test covering both serialization and both deserialization paths.

No protobuf schema change is required.

### Why are the changes needed?

When a `Get` with query metrics enabled requests a row that does not exist, the RegionServer still computes and attaches `QueryMetrics`, including `blockBytesScanned`, to the empty `Result`.

However, the protobuf conversion methods returned cached empty protobuf instances before copying the metrics. As a result, the client received `result.getMetrics() == null`.

Simply preserving the metrics during serialization would also expose a second problem: the deserialization path could attach metrics to a shared cached empty `Result`, potentially leaking those metrics into later requests where metrics were not enabled.

These changes preserve the metrics while ensuring that metrics-bearing empty results are not shared between requests.

### How was this patch tested?

The following focused test was run:

```bash
mvn -pl hbase-client -am \
  -Dtest=TestProtobufUtil \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test