### PR TITLE
HBASE-30095 Remove duplicate MiniDFSCluster startup in TestZooKeeper

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestZooKeeper.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestZooKeeper.java
@@ -75,7 +75,6 @@ public class TestZooKeeper {
     conf.setInt(HConstants.ZK_SESSION_TIMEOUT, 1000);
     conf.setClass(HConstants.HBASE_MASTER_LOADBALANCER_CLASS, MockLoadBalancer.class,
       LoadBalancer.class);
-    TEST_UTIL.startMiniDFSCluster(2);
   }
 
   @AfterAll


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30095

## What changes were proposed in this pull request?

Remove the duplicate `TEST_UTIL.startMiniDFSCluster(2)` call from `TestZooKeeper#setUpBeforeClass`.

The first MiniDFSCluster startup is retained, preserving the intended test initialization sequence: start MiniDFSCluster, start MiniZooKeeper, configure the test environment, and then start MiniHBaseCluster for each test.

## Why are the changes needed?

`HBaseTestingUtil` should manage only one MiniDFSCluster at a time. Calling `startMiniDFSCluster` twice replaces the stored `dfsCluster` and `dfsClusterFixer` references without shutting down the first cluster.

This can leave the first cluster running against the same test directories and cause HDFS namespace conflicts, including `InconsistentFSStateException`, in CI runs.

## How was this patch tested?

```bash
mvn -pl hbase-server -am -Dtest=TestZooKeeper -Dsurefire.rerunFailingTestsCount=0 test