### PR TITLE
HBASE-30288 Fix WALPlayer bulk output table mappings

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALPlayer.java
@@ -21,11 +21,8 @@ import java.io.IOException;
 import java.text.ParseException;
 import java.text.SimpleDateFormat;
 import java.util.ArrayList;
-import java.util.Collections;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
-import java.util.Set;
 import java.util.TreeMap;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.conf.Configured;
@@ -99,7 +96,7 @@ public class WALPlayer extends Configured implements Tool {
    * {@link CellSortReducer}
    */
   static class WALKeyValueMapper extends Mapper<WALKey, WALEdit, WritableComparable<?>, Cell> {
-    private Set<String> tableSet = new HashSet<String>();
+    private final Map<TableName, TableName> tables = new TreeMap<>();
     private boolean multiTableSupport = false;
     private boolean diskBasedSortingEnabled = false;
 
@@ -107,8 +104,8 @@ public class WALPlayer extends Configured implements Tool {
     public void map(WALKey key, WALEdit value, Context context) throws IOException {
       try {
         // skip all other tables
-        TableName table = key.getTableName();
-        if (tableSet.contains(table.getNameAsString())) {
+        TableName targetTable = tables.get(key.getTableName());
+        if (targetTable != null) {
           for (Cell cell : value.getCells()) {
             if (WALEdit.isMetaEditFamily(cell)) {
               continue;
@@ -121,7 +118,8 @@ public class WALPlayer extends Configured implements Tool {
             PrivateCellUtil.setSequenceId(cell, key.getSequenceId());
 
             byte[] outKey = multiTableSupport
-              ? Bytes.add(table.getName(), Bytes.toBytes(tableSeparator), CellUtil.cloneRow(cell))
+              ? Bytes.add(targetTable.getName(), Bytes.toBytes(tableSeparator),
+                CellUtil.cloneRow(cell))
               : CellUtil.cloneRow(cell);
             ExtendedCell extendedCell = PrivateCellUtil.ensureExtendedCell(cell);
             context.write(wrapKey(outKey, extendedCell), new MapReduceExtendedCell(extendedCell));
@@ -136,10 +134,19 @@ public class WALPlayer extends Configured implements Tool {
     @Override
     public void setup(Context context) throws IOException {
       Configuration conf = context.getConfiguration();
-      String[] tables = conf.getStrings(TABLES_KEY);
+      String[] tableMap = conf.getStrings(TABLE_MAP_KEY);
+      String[] tablesToUse = conf.getStrings(TABLES_KEY);
+      if (tableMap == null) {
+        tableMap = tablesToUse;
+      }
+      if (tablesToUse.length != tableMap.length) {
+        throw new IOException("Incorrect table mapping specified.");
+      }
+      for (int i = 0; i < tablesToUse.length; i++) {
+        tables.put(TableName.valueOf(tablesToUse[i]), TableName.valueOf(tableMap[i]));
+      }
       this.multiTableSupport = conf.getBoolean(MULTI_TABLES_SUPPORT, false);
       this.diskBasedSortingEnabled = HFileOutputFormat2.diskBasedSortingEnabled(conf);
-      Collections.addAll(tableSet, tables);
     }
 
     private WritableComparable<?> wrapKey(byte[] key, ExtendedCell cell) {
@@ -349,7 +356,7 @@ public class WALPlayer extends Configured implements Tool {
         true);
 
       // the bulk HFile case
-      List<TableName> tableNames = getTableNameList(tables);
+      List<TableName> tableNames = getTableNameList(tableMap);
 
       job.setMapperClass(WALKeyValueMapper.class);
       if (diskBasedSortingEnabled) {

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALPlayer.java
@@ -137,16 +137,23 @@ public class TestWALPlayer {
   /**
    * Tests that when you write multiple cells with the same timestamp they are properly sorted by
    * their sequenceId in WALPlayer/CellSortReducer so that the correct one wins when querying from
-   * the resulting bulkloaded HFiles. See HBASE-27649
+   * the resulting bulkloaded HFiles. Also verifies that bulk output honors source-to-target table
+   * mappings. See HBASE-27649 and HBASE-30288.
    */
   @Test
-  public void testWALPlayerBulkLoadWithOverriddenTimestamps(TestInfo testInfo) throws Exception {
-    final TableName tableName = TableName.valueOf(testInfo.getTestMethod().get().getName() + "1");
+  public void testWALPlayerBulkLoadWithTableMappingAndOverriddenTimestamps(TestInfo testInfo)
+    throws Exception {
+    final TableName sourceTableName =
+      TableName.valueOf(testInfo.getTestMethod().get().getName() + "Source");
+    final TableName targetTableName =
+      TableName.valueOf(testInfo.getTestMethod().get().getName() + "Target");
     final byte[] family = Bytes.toBytes("family");
     final byte[] column1 = Bytes.toBytes("c1");
     final byte[] column2 = Bytes.toBytes("c2");
     final byte[] row = Bytes.toBytes("row");
-    final Table table = TEST_UTIL.createTable(tableName, family);
+    final Table sourceTable = TEST_UTIL.createTable(sourceTableName, family);
+    final Table targetTable =
+      TEST_UTIL.createTable(targetTableName, family, new byte[][] { Bytes.toBytes("row0") });
 
     long now = EnvironmentEdgeManager.currentTime();
     // put a row into the first table
@@ -154,7 +161,7 @@ public class TestWALPlayer {
     p.addColumn(family, column1, now, column1);
     p.addColumn(family, column2, now, column2);
 
-    table.put(p);
+    sourceTable.put(p);
 
     byte[] lastVal = null;
 
@@ -163,7 +170,7 @@ public class TestWALPlayer {
       p = new Put(row);
       p.addColumn(family, column1, now, lastVal);
 
-      table.put(p);
+      sourceTable.put(p);
 
       // wal rolling is necessary to trigger the bug. otherwise no sorting
       // needs to occur in the reducer because it's all sorted and coming from a single file.
@@ -187,24 +194,24 @@ public class TestWALPlayer {
     final byte[] finalLastVal = lastVal;
 
     runWithDiskBasedSortingDisabledAndEnabled(() -> {
-      assertEquals(0, ToolRunner.run(configuration, player,
-        new String[] { walInputDir, tableName.getNameAsString() }));
+      assertEquals(0, ToolRunner.run(configuration, player, new String[] { walInputDir,
+        sourceTableName.getNameAsString(), targetTableName.getNameAsString() }));
 
       Get g = new Get(row);
-      Result result = table.get(g);
+      Result result = sourceTable.get(g);
       byte[] value = CellUtil.cloneValue(result.getColumnLatestCell(family, column1));
       assertThat(Bytes.toStringBinary(value), equalTo(Bytes.toStringBinary(finalLastVal)));
 
-      TEST_UTIL.truncateTable(tableName);
+      TEST_UTIL.truncateTable(targetTableName);
       g = new Get(row);
-      result = table.get(g);
+      result = targetTable.get(g);
       assertThat(result.listCells(), nullValue());
 
-      BulkLoadHFiles.create(configuration).bulkLoad(tableName,
-        new Path(outPath, tableName.getNamespaceAsString() + "/" + tableName.getNameAsString()));
+      BulkLoadHFiles.create(configuration).bulkLoad(targetTableName, new Path(outPath,
+        targetTableName.getNamespaceAsString() + "/" + targetTableName.getNameAsString()));
 
       g = new Get(row);
-      result = table.get(g);
+      result = targetTable.get(g);
       value = CellUtil.cloneValue(result.getColumnLatestCell(family, column1));
 
       assertThat(result.listCells(), notNullValue());


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30288

### What changes were proposed in this pull request?

This PR makes WALPlayer honor source-to-target table mappings when generating bulk-output HFiles.

The bulk mapper now builds the mapping from `TABLES_KEY` and `TABLE_MAP_KEY`, keeps source table names for WAL filtering, and emits mapped target table names in multi-table composite keys. The bulk job is also configured with target table descriptors and region locators.

The existing bulk-load test now uses distinct source and target tables, with the target table pre-split using a different region layout, and verifies that the generated HFiles can be loaded into the mapped target table.

### Why are the changes needed?

Before this change, the bulk-output path ignored the target table mappings. `WALKeyValueMapper` emitted source table names, and `createSubmittableJob` configured `HFileOutputFormat` with source table metadata.

As a result, HFiles could be generated under the wrong table path and with region boundaries or table descriptors belonging to the source table, preventing them from being correctly bulk-loaded into the intended target table.

### How was this patch tested?

```bash
mvn -pl hbase-mapreduce -am \
  '-Dtest=TestWALPlayer#testWALPlayerBulkLoadWithTableMappingAndOverriddenTimestamps' \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test

mvn -pl hbase-mapreduce -am -Dtest=TestWALPlayer -Dsurefire.failIfNoSpecifiedTests=false test