### PR TITLE
HBASE-30054 Avoid cascading delete for failed backups

### DIFF
--- a/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
+++ b/hbase-backup/src/main/java/org/apache/hadoop/hbase/backup/impl/BackupAdminImpl.java
@@ -306,6 +306,9 @@ public class BackupAdminImpl implements BackupAdmin {
   private List<BackupInfo> getAffectedBackupSessions(BackupInfo backupInfo, TableName tn,
     BackupSystemTable table) throws IOException {
     LOG.debug("GetAffectedBackupInfos for: " + backupInfo.getBackupId() + " table=" + tn);
+    if (backupInfo.getState() != BackupState.COMPLETE) {
+      return Collections.emptyList();
+    }
     long ts = backupInfo.getStartTs();
     List<BackupInfo> list = new ArrayList<>();
     List<BackupInfo> history = table.getBackupHistory(withRoot(backupInfo.getBackupRootDir()));

--- a/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupWithFailures.java
+++ b/hbase-backup/src/test/java/org/apache/hadoop/hbase/backup/TestIncrementalBackupWithFailures.java
@@ -19,9 +19,11 @@ package org.apache.hadoop.hbase.backup;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.util.List;
+import java.util.Set;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.backup.BackupInfo.BackupState;
 import org.apache.hadoop.hbase.backup.impl.BackupAdminImpl;
@@ -103,6 +105,25 @@ public class TestIncrementalBackupWithFailures extends TestBackupBase {
 
     // #3 - incremental backup for multiple tables
     incrementalBackupWithFailures();
+
+    String failedBackupId;
+    try (BackupSystemTable table = new BackupSystemTable(conn)) {
+      failedBackupId =
+        table.getBackupHistory(BackupInfo.withState(BackupState.FAILED)).get(0).getBackupId();
+    }
+
+    conf1.unset(TableBackupClient.BACKUP_CLIENT_IMPL_CLASS);
+    String backupIdIncremental = client.backupTables(createBackupRequest(BackupType.INCREMENTAL,
+      Lists.newArrayList(table1, table2), BACKUP_ROOT_DIR));
+    assertTrue(checkSucceeded(backupIdIncremental));
+
+    assertEquals(1, client.deleteBackups(new String[] { failedBackupId }));
+    assertTrue(checkSucceeded(backupIdIncremental));
+    try (BackupSystemTable table = new BackupSystemTable(conn)) {
+      assertNull(table.readBackupInfo(failedBackupId));
+      assertEquals(Set.of(table1, table2),
+        Set.copyOf(table.readBackupInfo(backupIdIncremental).getTableNames()));
+    }
 
     admin.close();
     conn.close();


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30054

## What changes were proposed in this pull request?

This patch prevents non-complete backup sessions from participating in cascading backup deletion. `BackupAdminImpl#getAffectedBackupSessions` now returns no affected sessions unless the backup being deleted is in the `COMPLETE` state.

`TestIncrementalBackupWithFailures` was extended to create a successful incremental backup after failed incremental backup attempts, delete one of the failed backups, and verify that the successful backup remains complete with its table list intact.

## Why are the changes needed?

A failed backup is not part of the committed backup chain because the backup system table is restored before the `FAILED` backup record is written.

However, deleting a failed backup currently runs the same affected-session calculation used for completed backups. As a result, newer successful incremental backups can be treated as dependent backups and have their metadata or backup image removed.

Only completed backups can have later backups depending on them. Skipping the cascading calculation for non-complete backups allows the failed backup itself to be cleaned up without affecting later valid backups.

## How was this patch tested?

```bash

mvn -pl hbase-backup -am \
  -Dtest=TestIncrementalBackupWithFailures \
  -Dsurefire.failIfNoSpecifiedTests=false \
  test

```

The test covers a completed full backup, failed incremental backup attempts, a later completed incremental backup, and deletion of a failed backup. It verifies that the failed backup record is removed and that the later completed backup remains available with both tables.