### PR TITLE
HBASE-29640 Add metric for oldest procedure age

### DIFF
--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterProcSource.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterProcSource.java
@@ -51,4 +51,9 @@ public interface MetricsMasterProcSource extends BaseSource {
 
   String NUM_MASTER_WALS_DESC = "Number of master WAL files";
 
+  String OLDEST_PROCEDURE_AGE_NAME = "oldestProcedureAge";
+
+  String OLDEST_PROCEDURE_AGE_DESC =
+    "Age in milliseconds of the oldest active master procedure (Gauge).";
+
 }

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterProcSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterProcSourceImpl.java
@@ -56,6 +56,9 @@ public class MetricsMasterProcSourceImpl extends BaseSourceImpl implements Metri
     if (masterWrapper != null) {
       metricsRecordBuilder.addGauge(Interns.info(NUM_MASTER_WALS_NAME, NUM_MASTER_WALS_DESC),
         masterWrapper.getNumWALFiles());
+      metricsRecordBuilder.addGauge(
+        Interns.info(OLDEST_PROCEDURE_AGE_NAME, OLDEST_PROCEDURE_AGE_DESC),
+        masterWrapper.getOldestProcedureAge());
     }
 
     metricsRegistry.snapshot(metricsRecordBuilder, all);

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterProcSourceImpl.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterProcSourceImpl.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.master;
 
+import java.util.Map;
 import org.apache.hadoop.hbase.metrics.BaseSourceImpl;
 import org.apache.hadoop.hbase.metrics.Interns;
 import org.apache.hadoop.metrics2.MetricsCollector;
@@ -56,9 +57,13 @@ public class MetricsMasterProcSourceImpl extends BaseSourceImpl implements Metri
     if (masterWrapper != null) {
       metricsRecordBuilder.addGauge(Interns.info(NUM_MASTER_WALS_NAME, NUM_MASTER_WALS_DESC),
         masterWrapper.getNumWALFiles());
+      Map<String, Long> oldestProcedureAgeByType = masterWrapper.getOldestProcedureAgeByType();
       metricsRecordBuilder.addGauge(
         Interns.info(OLDEST_PROCEDURE_AGE_NAME, OLDEST_PROCEDURE_AGE_DESC),
-        masterWrapper.getOldestProcedureAge());
+        oldestProcedureAgeByType.values().stream().mapToLong(Long::longValue).max().orElse(0L));
+      oldestProcedureAgeByType.forEach((procedureType, age) -> metricsRecordBuilder.addGauge(
+        Interns.info(OLDEST_PROCEDURE_AGE_NAME + "_" + procedureType, OLDEST_PROCEDURE_AGE_DESC),
+        age));
     }
 
     metricsRegistry.snapshot(metricsRecordBuilder, all);

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapper.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapper.java
@@ -124,9 +124,10 @@ public interface MetricsMasterWrapper {
   long getNumWALFiles();
 
   /**
-   * Get the age in milliseconds of the oldest active master procedure.
+   * Get the age in milliseconds of the oldest active master procedure for each procedure type,
+   * keyed by the procedure's simple class name.
    */
-  long getOldestProcedureAge();
+  Map<String, Long> getOldestProcedureAgeByType();
 
   /**
    * Get the number of region split plans executed.

--- a/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapper.java
+++ b/hbase-hadoop-compat/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapper.java
@@ -124,6 +124,11 @@ public interface MetricsMasterWrapper {
   long getNumWALFiles();
 
   /**
+   * Get the age in milliseconds of the oldest active master procedure.
+   */
+  long getOldestProcedureAge();
+
+  /**
    * Get the number of region split plans executed.
    */
   long getSplitPlanCount();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
@@ -29,8 +29,11 @@ import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.TableDescriptor;
+import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
 import org.apache.hadoop.hbase.quotas.QuotaObserverChore;
 import org.apache.hadoop.hbase.quotas.SpaceQuotaSnapshot;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
 import org.apache.hadoop.hbase.util.PairOfSameType;
 import org.apache.hadoop.hbase.zookeeper.ZKWatcher;
 import org.apache.yetus.audience.InterfaceAudience;
@@ -178,6 +181,18 @@ public class MetricsMasterWrapperImpl implements MetricsMasterWrapper {
   @Override
   public long getNumWALFiles() {
     return master.getNumWALFiles();
+  }
+
+  @Override
+  public long getOldestProcedureAge() {
+    ProcedureExecutor<MasterProcedureEnv> procedureExecutor = master.getMasterProcedureExecutor();
+    if (procedureExecutor == null) {
+      return 0L;
+    }
+    long now = EnvironmentEdgeManager.currentTime();
+    return procedureExecutor.getActiveProceduresNoCopy().stream()
+      .filter(procedure -> !procedure.isFinished())
+      .mapToLong(procedure -> Math.max(0L, now - procedure.getSubmittedTime())).max().orElse(0L);
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
@@ -30,6 +30,7 @@ import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.procedure2.Procedure;
 import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
 import org.apache.hadoop.hbase.quotas.QuotaObserverChore;
 import org.apache.hadoop.hbase.quotas.SpaceQuotaSnapshot;
@@ -184,15 +185,20 @@ public class MetricsMasterWrapperImpl implements MetricsMasterWrapper {
   }
 
   @Override
-  public long getOldestProcedureAge() {
+  public Map<String, Long> getOldestProcedureAgeByType() {
     ProcedureExecutor<MasterProcedureEnv> procedureExecutor = master.getMasterProcedureExecutor();
     if (procedureExecutor == null) {
-      return 0L;
+      return Collections.emptyMap();
     }
     long now = EnvironmentEdgeManager.currentTime();
-    return procedureExecutor.getActiveProceduresNoCopy().stream()
-      .filter(procedure -> !procedure.isFinished())
-      .mapToLong(procedure -> Math.max(0L, now - procedure.getSubmittedTime())).max().orElse(0L);
+    Map<String, Long> oldestProcedureAgeByType = new HashMap<>();
+    for (Procedure<MasterProcedureEnv> procedure : procedureExecutor.getActiveProceduresNoCopy()) {
+      if (!procedure.isFinished()) {
+        long age = Math.max(0L, now - procedure.getSubmittedTime());
+        oldestProcedureAgeByType.merge(procedure.getClass().getSimpleName(), age, Math::max);
+      }
+    }
+    return oldestProcedureAgeByType;
   }
 
   @Override

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/MetricsMasterWrapperImpl.java
@@ -192,7 +192,7 @@ public class MetricsMasterWrapperImpl implements MetricsMasterWrapper {
     }
     long now = EnvironmentEdgeManager.currentTime();
     Map<String, Long> oldestProcedureAgeByType = new HashMap<>();
-    for (Procedure<MasterProcedureEnv> procedure : procedureExecutor.getActiveProceduresNoCopy()) {
+    for (Procedure<MasterProcedureEnv> procedure : procedureExecutor.getProcedures()) {
       if (!procedure.isFinished()) {
         long age = Math.max(0L, now - procedure.getSubmittedTime());
         oldestProcedureAgeByType.merge(procedure.getClass().getSimpleName(), age, Math::max);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestOldestProcedureMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestOldestProcedureMetrics.java
@@ -22,9 +22,11 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 import java.util.List;
+import java.util.Map;
 import org.apache.hadoop.hbase.CompatibilityFactory;
+import org.apache.hadoop.hbase.master.locking.LockProcedure;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
-import org.apache.hadoop.hbase.procedure2.Procedure;
+import org.apache.hadoop.hbase.master.procedure.ServerCrashProcedure;
 import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
 import org.apache.hadoop.hbase.test.MetricsAssertHelper;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
@@ -56,32 +58,39 @@ public class TestOldestProcedureMetrics {
 
     HMaster master = mock(HMaster.class);
     ProcedureExecutor<MasterProcedureEnv> procedureExecutor = mock(ProcedureExecutor.class);
-    Procedure<MasterProcedureEnv> oldest = mock(Procedure.class);
-    Procedure<MasterProcedureEnv> newer = mock(Procedure.class);
-    Procedure<MasterProcedureEnv> finished = mock(Procedure.class);
+    LockProcedure oldestLock = mock(LockProcedure.class);
+    LockProcedure newerLock = mock(LockProcedure.class);
+    ServerCrashProcedure serverCrash = mock(ServerCrashProcedure.class);
+    ServerCrashProcedure finished = mock(ServerCrashProcedure.class);
 
     when(master.getMasterProcedureExecutor()).thenReturn(procedureExecutor);
     when(procedureExecutor.getActiveProceduresNoCopy())
-      .thenReturn(List.of(oldest, newer, finished));
-    when(oldest.getSubmittedTime()).thenReturn(1_000L);
-    when(newer.getSubmittedTime()).thenReturn(4_000L);
+      .thenReturn(List.of(oldestLock, newerLock, serverCrash, finished));
+    when(oldestLock.getSubmittedTime()).thenReturn(1_000L);
+    when(newerLock.getSubmittedTime()).thenReturn(4_000L);
+    when(serverCrash.getSubmittedTime()).thenReturn(2_000L);
     when(finished.isFinished()).thenReturn(true);
     when(finished.getSubmittedTime()).thenReturn(100L);
 
     MetricsMasterWrapperImpl wrapper = new MetricsMasterWrapperImpl(master);
-    assertEquals(9_000L, wrapper.getOldestProcedureAge());
+    assertEquals(Map.of("LockProcedure", 9_000L, "ServerCrashProcedure", 8_000L),
+      wrapper.getOldestProcedureAgeByType());
 
     MetricsMasterProcSource source = new MetricsMasterProcSourceImpl(wrapper);
     METRICS_HELPER.assertGauge(MetricsMasterProcSource.OLDEST_PROCEDURE_AGE_NAME, 9_000L, source);
+    METRICS_HELPER.assertGauge(MetricsMasterProcSource.OLDEST_PROCEDURE_AGE_NAME + "_LockProcedure",
+      9_000L, source);
+    METRICS_HELPER.assertGauge(
+      MetricsMasterProcSource.OLDEST_PROCEDURE_AGE_NAME + "_ServerCrashProcedure", 8_000L, source);
 
     when(procedureExecutor.getActiveProceduresNoCopy()).thenReturn(List.of());
-    assertEquals(0L, wrapper.getOldestProcedureAge());
+    assertEquals(Map.of(), wrapper.getOldestProcedureAgeByType());
 
-    when(procedureExecutor.getActiveProceduresNoCopy()).thenReturn(List.of(newer));
-    when(newer.getSubmittedTime()).thenReturn(11_000L);
-    assertEquals(0L, wrapper.getOldestProcedureAge());
+    when(procedureExecutor.getActiveProceduresNoCopy()).thenReturn(List.of(newerLock));
+    when(newerLock.getSubmittedTime()).thenReturn(11_000L);
+    assertEquals(Map.of("LockProcedure", 0L), wrapper.getOldestProcedureAgeByType());
 
     when(master.getMasterProcedureExecutor()).thenReturn(null);
-    assertEquals(0L, wrapper.getOldestProcedureAge());
+    assertEquals(Map.of(), wrapper.getOldestProcedureAgeByType());
   }
 }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestOldestProcedureMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestOldestProcedureMetrics.java
@@ -1,0 +1,87 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.List;
+import org.apache.hadoop.hbase.CompatibilityFactory;
+import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.procedure2.Procedure;
+import org.apache.hadoop.hbase.procedure2.ProcedureExecutor;
+import org.apache.hadoop.hbase.test.MetricsAssertHelper;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hbase.util.ManualEnvironmentEdge;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(MasterTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestOldestProcedureMetrics {
+
+  private static final MetricsAssertHelper METRICS_HELPER =
+    CompatibilityFactory.getInstance(MetricsAssertHelper.class);
+
+  @AfterEach
+  public void resetEnvironmentEdge() {
+    EnvironmentEdgeManager.reset();
+  }
+
+  @Test
+  @SuppressWarnings("unchecked")
+  public void testOldestProcedureAge() {
+    ManualEnvironmentEdge edge = new ManualEnvironmentEdge();
+    edge.setValue(10_000L);
+    EnvironmentEdgeManager.injectEdge(edge);
+
+    HMaster master = mock(HMaster.class);
+    ProcedureExecutor<MasterProcedureEnv> procedureExecutor = mock(ProcedureExecutor.class);
+    Procedure<MasterProcedureEnv> oldest = mock(Procedure.class);
+    Procedure<MasterProcedureEnv> newer = mock(Procedure.class);
+    Procedure<MasterProcedureEnv> finished = mock(Procedure.class);
+
+    when(master.getMasterProcedureExecutor()).thenReturn(procedureExecutor);
+    when(procedureExecutor.getActiveProceduresNoCopy())
+      .thenReturn(List.of(oldest, newer, finished));
+    when(oldest.getSubmittedTime()).thenReturn(1_000L);
+    when(newer.getSubmittedTime()).thenReturn(4_000L);
+    when(finished.isFinished()).thenReturn(true);
+    when(finished.getSubmittedTime()).thenReturn(100L);
+
+    MetricsMasterWrapperImpl wrapper = new MetricsMasterWrapperImpl(master);
+    assertEquals(9_000L, wrapper.getOldestProcedureAge());
+
+    MetricsMasterProcSource source = new MetricsMasterProcSourceImpl(wrapper);
+    METRICS_HELPER.assertGauge(MetricsMasterProcSource.OLDEST_PROCEDURE_AGE_NAME, 9_000L, source);
+
+    when(procedureExecutor.getActiveProceduresNoCopy()).thenReturn(List.of());
+    assertEquals(0L, wrapper.getOldestProcedureAge());
+
+    when(procedureExecutor.getActiveProceduresNoCopy()).thenReturn(List.of(newer));
+    when(newer.getSubmittedTime()).thenReturn(11_000L);
+    assertEquals(0L, wrapper.getOldestProcedureAge());
+
+    when(master.getMasterProcedureExecutor()).thenReturn(null);
+    assertEquals(0L, wrapper.getOldestProcedureAge());
+  }
+}

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestOldestProcedureMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/TestOldestProcedureMetrics.java
@@ -64,7 +64,7 @@ public class TestOldestProcedureMetrics {
     ServerCrashProcedure finished = mock(ServerCrashProcedure.class);
 
     when(master.getMasterProcedureExecutor()).thenReturn(procedureExecutor);
-    when(procedureExecutor.getActiveProceduresNoCopy())
+    when(procedureExecutor.getProcedures())
       .thenReturn(List.of(oldestLock, newerLock, serverCrash, finished));
     when(oldestLock.getSubmittedTime()).thenReturn(1_000L);
     when(newerLock.getSubmittedTime()).thenReturn(4_000L);
@@ -83,10 +83,10 @@ public class TestOldestProcedureMetrics {
     METRICS_HELPER.assertGauge(
       MetricsMasterProcSource.OLDEST_PROCEDURE_AGE_NAME + "_ServerCrashProcedure", 8_000L, source);
 
-    when(procedureExecutor.getActiveProceduresNoCopy()).thenReturn(List.of());
+    when(procedureExecutor.getProcedures()).thenReturn(List.of());
     assertEquals(Map.of(), wrapper.getOldestProcedureAgeByType());
 
-    when(procedureExecutor.getActiveProceduresNoCopy()).thenReturn(List.of(newerLock));
+    when(procedureExecutor.getProcedures()).thenReturn(List.of(newerLock));
     when(newerLock.getSubmittedTime()).thenReturn(11_000L);
     assertEquals(Map.of("LockProcedure", 0L), wrapper.getOldestProcedureAgeByType());
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-29640

**What changes were proposed in this pull request?**

This pull request adds an `oldestProcedureAge` gauge to the existing `Master,sub=Procedure` metrics source. The gauge reports the age in milliseconds of the oldest unfinished master procedure, calculated from its submitted time.

The metric returns zero when there are no active procedures or when the master procedure executor is not yet available. Finished procedures are ignored, and negative values caused by clock adjustments are clamped to zero.

**Why are the changes needed?**

Operators currently have no direct metric for identifying how long the oldest master procedure has been active. Exposing this value makes it easier to detect stuck or unexpectedly long-running procedures and to configure monitoring and alerting around procedure execution.

**How was this patch tested?**

A new `TestOldestProcedureMetrics` test verifies:

- Selection of the oldest unfinished procedure.
- Exclusion of finished procedures.
- Export of the `oldestProcedureAge` gauge.
- The zero value when there are no active procedures.
- The zero value when the procedure executor is unavailable.
- Protection against negative values after clock adjustments.

```bash
mvn -pl hbase-server -am \
  -Dtest=TestOldestProcedureMetrics \
  -Dsurefire.failIfNoSpecifiedTests=false test