### PR TITLE
HBASE-30332 Preserve QueryMetrics for empty results (#8555)

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -1387,7 +1387,10 @@ public final class ProtobufUtil {
 
     Cell[] cells = result.rawCells();
     if (cells == null || cells.length == 0) {
-      return result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
+      ClientProtos.Result emptyResult = result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
+      return result.getMetrics() == null
+        ? emptyResult
+        : emptyResult.toBuilder().setMetrics(toQueryMetrics(result.getMetrics())).build();
     }
 
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
@@ -1427,7 +1430,12 @@ public final class ProtobufUtil {
   public static ClientProtos.Result toResultNoData(final Result result) {
     if (result.getExists() != null) return toResult(result.getExists(), result.isStale());
     int size = result.size();
-    if (size == 0) return result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
+    if (size == 0) {
+      ClientProtos.Result emptyResult = result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
+      return result.getMetrics() == null
+        ? emptyResult
+        : emptyResult.toBuilder().setMetrics(toQueryMetrics(result.getMetrics())).build();
+    }
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
     builder.setAssociatedCellCount(size);
     builder.setStale(result.isStale());
@@ -1465,7 +1473,7 @@ public final class ProtobufUtil {
     }
 
     List<CellProtos.Cell> values = proto.getCellList();
-    if (values.isEmpty()) {
+    if (values.isEmpty() && !proto.hasMetrics()) {
       return proto.getStale() ? EMPTY_RESULT_STALE : EMPTY_RESULT;
     }
 
@@ -1523,9 +1531,14 @@ public final class ProtobufUtil {
       }
     }
 
-    Result r = (cells == null || cells.isEmpty())
-      ? (proto.getStale() ? EMPTY_RESULT_STALE : EMPTY_RESULT)
-      : Result.create(cells, null, proto.getStale());
+    Result r;
+    if (cells == null || cells.isEmpty()) {
+      r = proto.hasMetrics()
+        ? Result.create(EMPTY_CELL_ARRAY, null, proto.getStale())
+        : (proto.getStale() ? EMPTY_RESULT_STALE : EMPTY_RESULT);
+    } else {
+      r = Result.create(cells, null, proto.getStale());
+    }
 
     if (proto.hasMetrics()) {
       r.setMetrics(toQueryMetrics(proto.getMetrics()));

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/shaded/protobuf/ProtobufUtil.java
@@ -1382,15 +1382,13 @@ public final class ProtobufUtil {
    */
   public static ClientProtos.Result toResult(final Result result, boolean encodeTags) {
     if (result.getExists() != null) {
-      return toResult(result.getExists(), result.isStale());
+      return toResult(result.getExists(), result.isStale(), result.getMetrics());
     }
 
     Cell[] cells = result.rawCells();
     if (cells == null || cells.length == 0) {
-      ClientProtos.Result emptyResult = result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
-      return result.getMetrics() == null
-        ? emptyResult
-        : emptyResult.toBuilder().setMetrics(toQueryMetrics(result.getMetrics())).build();
+      return withMetrics(result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB,
+        result.getMetrics());
     }
 
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
@@ -1422,19 +1420,37 @@ public final class ProtobufUtil {
   }
 
   /**
+   * Convert a client Result to a protocol buffer Result
+   * @param existence the client existence to send
+   * @param stale     whether the result is stale
+   * @param metrics   query metrics associated with the result
+   * @return the converted protocol buffer Result
+   */
+  public static ClientProtos.Result toResult(final boolean existence, boolean stale,
+    QueryMetrics metrics) {
+    return withMetrics(toResult(existence, stale), metrics);
+  }
+
+  private static ClientProtos.Result withMetrics(ClientProtos.Result result, QueryMetrics metrics) {
+    return metrics == null
+      ? result
+      : result.toBuilder().setMetrics(toQueryMetrics(metrics)).build();
+  }
+
+  /**
    * Convert a client Result to a protocol buffer Result. The pb Result does not include the Cell
    * data. That is for transport otherwise.
    * @param result the client Result to convert
    * @return the converted protocol buffer Result
    */
   public static ClientProtos.Result toResultNoData(final Result result) {
-    if (result.getExists() != null) return toResult(result.getExists(), result.isStale());
+    if (result.getExists() != null) {
+      return toResult(result.getExists(), result.isStale(), result.getMetrics());
+    }
     int size = result.size();
     if (size == 0) {
-      ClientProtos.Result emptyResult = result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB;
-      return result.getMetrics() == null
-        ? emptyResult
-        : emptyResult.toBuilder().setMetrics(toQueryMetrics(result.getMetrics())).build();
+      return withMetrics(result.isStale() ? EMPTY_RESULT_PB_STALE : EMPTY_RESULT_PB,
+        result.getMetrics());
     }
     ClientProtos.Result.Builder builder = ClientProtos.Result.newBuilder();
     builder.setAssociatedCellCount(size);
@@ -1466,6 +1482,11 @@ public final class ProtobufUtil {
    */
   public static Result toResult(final ClientProtos.Result proto, boolean decodeTags) {
     if (proto.hasExists()) {
+      if (proto.hasMetrics()) {
+        Result result = Result.create((Cell[]) null, proto.getExists(), proto.getStale());
+        result.setMetrics(toQueryMetrics(proto.getMetrics()));
+        return result;
+      }
       if (proto.getStale()) {
         return proto.getExists() ? EMPTY_RESULT_EXISTS_TRUE_STALE : EMPTY_RESULT_EXISTS_FALSE_STALE;
       }
@@ -1506,10 +1527,7 @@ public final class ProtobufUtil {
       ) {
         throw new IllegalArgumentException("bad proto: exists with cells is no allowed " + proto);
       }
-      if (proto.getStale()) {
-        return proto.getExists() ? EMPTY_RESULT_EXISTS_TRUE_STALE : EMPTY_RESULT_EXISTS_FALSE_STALE;
-      }
-      return proto.getExists() ? EMPTY_RESULT_EXISTS_TRUE : EMPTY_RESULT_EXISTS_FALSE;
+      return toResult(proto);
     }
 
     // TODO: Unit test that has some Cells in scanner and some in the proto.

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
@@ -25,6 +25,7 @@ import static org.junit.jupiter.api.Assertions.assertTrue;
 import java.io.IOException;
 import java.lang.reflect.Method;
 import java.nio.ByteBuffer;
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import org.apache.hadoop.hbase.ArrayBackedTag;
@@ -137,22 +138,27 @@ public class TestProtobufUtil {
   @Test
   public void testEmptyResultWithQueryMetrics() throws IOException {
     long blockBytesScanned = 123L;
-    Result result = Result.create(Collections.emptyList());
-    result.setMetrics(new QueryMetrics(blockBytesScanned));
+    for (Boolean exists : Arrays.asList(null, false, true)) {
+      Result result = Result.create(Collections.emptyList(), exists);
+      result.setMetrics(new QueryMetrics(blockBytesScanned));
 
-    for (ClientProtos.Result proto : List.of(ProtobufUtil.toResult(result),
-      ProtobufUtil.toResultNoData(result))) {
-      assertTrue(proto.hasMetrics());
-      assertEquals(blockBytesScanned, proto.getMetrics().getBlockBytesScanned());
+      for (ClientProtos.Result proto : List.of(ProtobufUtil.toResult(result),
+        ProtobufUtil.toResultNoData(result))) {
+        assertEquals(exists, proto.hasExists() ? proto.getExists() : null);
+        assertTrue(proto.hasMetrics());
+        assertEquals(blockBytesScanned, proto.getMetrics().getBlockBytesScanned());
 
-      Result roundTrip = ProtobufUtil.toResult(proto);
-      assertNotNull(roundTrip.getMetrics());
-      assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+        Result roundTrip = ProtobufUtil.toResult(proto);
+        assertEquals(exists, roundTrip.getExists());
+        assertNotNull(roundTrip.getMetrics());
+        assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
 
-      roundTrip = ProtobufUtil.toResult(proto,
-        PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()));
-      assertNotNull(roundTrip.getMetrics());
-      assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+        roundTrip = ProtobufUtil.toResult(proto,
+          PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()));
+        assertEquals(exists, roundTrip.getExists());
+        assertNotNull(roundTrip.getMetrics());
+        assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+      }
     }
 
     ClientProtos.Result emptyProto = ClientProtos.Result.getDefaultInstance();

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
@@ -19,6 +19,7 @@ package org.apache.hadoop.hbase.shaded.protobuf;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import java.io.IOException;
@@ -42,6 +43,8 @@ import org.apache.hadoop.hbase.client.Delete;
 import org.apache.hadoop.hbase.client.Get;
 import org.apache.hadoop.hbase.client.Increment;
 import org.apache.hadoop.hbase.client.Put;
+import org.apache.hadoop.hbase.client.QueryMetrics;
+import org.apache.hadoop.hbase.client.Result;
 import org.apache.hadoop.hbase.client.SlowLogParams;
 import org.apache.hadoop.hbase.io.TimeRange;
 import org.apache.hadoop.hbase.testclassification.SmallTests;
@@ -129,6 +132,35 @@ public class TestProtobufUtil {
     getBuilder.setQueryMetricsEnabled(false);
     Get get = ProtobufUtil.toGet(proto);
     assertEquals(getBuilder.build(), ProtobufUtil.toGet(get));
+  }
+
+  @Test
+  public void testEmptyResultWithQueryMetrics() throws IOException {
+    long blockBytesScanned = 123L;
+    Result result = Result.create(Collections.emptyList());
+    result.setMetrics(new QueryMetrics(blockBytesScanned));
+
+    for (ClientProtos.Result proto : List.of(ProtobufUtil.toResult(result),
+      ProtobufUtil.toResultNoData(result))) {
+      assertTrue(proto.hasMetrics());
+      assertEquals(blockBytesScanned, proto.getMetrics().getBlockBytesScanned());
+
+      Result roundTrip = ProtobufUtil.toResult(proto);
+      assertNotNull(roundTrip.getMetrics());
+      assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+
+      roundTrip = ProtobufUtil.toResult(proto,
+        PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()));
+      assertNotNull(roundTrip.getMetrics());
+      assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
+    }
+
+    ClientProtos.Result emptyProto = ClientProtos.Result.getDefaultInstance();
+    assertNull(ProtobufUtil.toResult(emptyProto).getMetrics());
+    assertNull(ProtobufUtil
+      .toResult(emptyProto,
+        PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()))
+      .getMetrics());
   }
 
   /**

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/shaded/protobuf/TestProtobufUtil.java
@@ -33,6 +33,7 @@ import org.apache.hadoop.hbase.ByteBufferKeyValue;
 import org.apache.hadoop.hbase.Cell;
 import org.apache.hadoop.hbase.CellBuilderType;
 import org.apache.hadoop.hbase.CellComparatorImpl;
+import org.apache.hadoop.hbase.CellUtil;
 import org.apache.hadoop.hbase.ExtendedCellBuilder;
 import org.apache.hadoop.hbase.ExtendedCellBuilderFactory;
 import org.apache.hadoop.hbase.HConstants;
@@ -142,7 +143,7 @@ public class TestProtobufUtil {
       Result result = Result.create(Collections.emptyList(), exists);
       result.setMetrics(new QueryMetrics(blockBytesScanned));
 
-      for (ClientProtos.Result proto : List.of(ProtobufUtil.toResult(result),
+      for (ClientProtos.Result proto : Arrays.asList(ProtobufUtil.toResult(result),
         ProtobufUtil.toResultNoData(result))) {
         assertEquals(exists, proto.hasExists() ? proto.getExists() : null);
         assertTrue(proto.hasMetrics());
@@ -153,8 +154,8 @@ public class TestProtobufUtil {
         assertNotNull(roundTrip.getMetrics());
         assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
 
-        roundTrip = ProtobufUtil.toResult(proto,
-          PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()));
+        roundTrip =
+          ProtobufUtil.toResult(proto, CellUtil.createCellScanner(Collections.<Cell> emptyList()));
         assertEquals(exists, roundTrip.getExists());
         assertNotNull(roundTrip.getMetrics());
         assertEquals(blockBytesScanned, roundTrip.getMetrics().getBlockBytesScanned());
@@ -163,10 +164,9 @@ public class TestProtobufUtil {
 
     ClientProtos.Result emptyProto = ClientProtos.Result.getDefaultInstance();
     assertNull(ProtobufUtil.toResult(emptyProto).getMetrics());
-    assertNull(ProtobufUtil
-      .toResult(emptyProto,
-        PrivateCellUtil.createExtendedCellScanner(Collections.<ExtendedCell> emptyList()))
-      .getMetrics());
+    assertNull(
+      ProtobufUtil.toResult(emptyProto, CellUtil.createCellScanner(Collections.<Cell> emptyList()))
+        .getMetrics());
   }
 
   /**

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/regionserver/RSRpcServices.java
@@ -2617,8 +2617,8 @@ public class RSRpcServices implements HBaseRPCErrorHandler, AdminService.Blockin
         }
       }
       if (existence != null) {
-        ClientProtos.Result pbr =
-          ProtobufUtil.toResult(existence, region.getRegionInfo().getReplicaId() != 0);
+        ClientProtos.Result pbr = ProtobufUtil.toResult(existence,
+          region.getRegionInfo().getReplicaId() != 0, r != null ? r.getMetrics() : null);
         builder.setResult(pbr);
       } else if (r != null) {
         ClientProtos.Result pbr;

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableQueryMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableQueryMetrics.java
@@ -110,6 +110,25 @@ public class TestAsyncTableQueryMetrics {
     }
 
     assertEquals(getClusterBlockBytesScanned(), bbs);
+
+    g1.setCheckExistenceOnly(true);
+    g2.setCheckExistenceOnly(true);
+    g3.setCheckExistenceOnly(true);
+
+    result = CONN.getTable(TABLE_NAME).get(g1).get();
+    assertEquals(Boolean.TRUE, result.getExists());
+    assertNotNull(result.getMetrics());
+    bbs += result.getMetrics().getBlockBytesScanned();
+    assertEquals(getClusterBlockBytesScanned(), bbs);
+
+    futures = CONN.getTable(TABLE_NAME).get(List.of(g1, g2, g3));
+    for (CompletableFuture<Result> future : futures) {
+      result = future.join();
+      assertEquals(Boolean.TRUE, result.getExists());
+      assertNotNull(result.getMetrics());
+      bbs += result.getMetrics().getBlockBytesScanned();
+    }
+    assertEquals(getClusterBlockBytesScanned(), bbs);
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableQueryMetrics.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/client/TestAsyncTableQueryMetrics.java
@@ -121,7 +121,7 @@ public class TestAsyncTableQueryMetrics {
     bbs += result.getMetrics().getBlockBytesScanned();
     assertEquals(getClusterBlockBytesScanned(), bbs);
 
-    futures = CONN.getTable(TABLE_NAME).get(List.of(g1, g2, g3));
+    futures = CONN.getTable(TABLE_NAME).get(ImmutableList.of(g1, g2, g3));
     for (CompletableFuture<Result> future : futures) {
       result = future.join();
       assertEquals(Boolean.TRUE, result.getExists());


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30332

Original PR: #8555

### What changes were proposed in this pull request?

Backport #8555 to branch-2.

This change preserves `QueryMetrics` when empty and existence-only `Result` instances are converted to and from protobuf. It also avoids attaching metrics to shared cached `Result` instances.

The tests were adapted for branch-2 compatibility:

- Replaced `List.of` with `Arrays.asList` and `ImmutableList.of`
- Replaced `PrivateCellUtil.createExtendedCellScanner` with `CellUtil.createCellScanner`

### Why are the changes needed?

`QueryMetrics` can be lost when an empty or existence-only `Result` is returned because the conversion paths return cached protobuf or `Result` instances before copying the metrics.

The additional test changes are required because branch-2 uses the Java 8 source level and does not contain the newer `createExtendedCellScanner` API.

### How was this patch tested?

The following tests and formatting checks were run:

```bash
mvn -Dhadoop.profile=3.0 \
  -pl hbase-client -am \
  -Dtest=TestProtobufUtil \
  test

mvn -Dhadoop.profile=3.0 \
  -pl hbase-server -am \
  -Dtest=TestAsyncTableQueryMetrics \
  test

mvn -Dhadoop.profile=3.0 \
  -pl hbase-client,hbase-server \
  spotless:check