### PR TITLE
HBASE-30340: CatalogJanitor can run concurrent scans due to incorrect alreadyRunning lock handling

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/janitor/CatalogJanitor.java
@@ -164,14 +164,14 @@ public class CatalogJanitor extends ScheduledChore {
    */
   public int scan() throws IOException {
     int gcs = 0;
-    try {
-      if (!alreadyRunning.compareAndSet(false, true)) {
-        if (LOG.isDebugEnabled()) {
-          LOG.debug("CatalogJanitor already running");
-        }
-        // -1 indicates previous scan is in progress
-        return -1;
+    if (!alreadyRunning.compareAndSet(false, true)) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("CatalogJanitor already running");
       }
+      // -1 indicates previous scan is in progress
+      return -1;
+    }
+    try {
       this.lastReport = scanForReport();
       if (!this.lastReport.isEmpty()) {
         LOG.warn(this.lastReport.toString());

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/janitor/TestCatalogJanitor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/janitor/TestCatalogJanitor.java
@@ -35,6 +35,8 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.SortedMap;
 import java.util.TreeMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.hadoop.fs.FSDataOutputStream;
 import org.apache.hadoop.fs.FileStatus;
@@ -688,6 +690,52 @@ public class TestCatalogJanitor {
       threads[i].join();
     }
     assertTrue(gcValues.contains(-1), "One janitor.scan() call should have returned -1");
+  }
+
+  @Test
+  public void testAlreadyRunningStatusDoesNotClearLock() throws Exception {
+    CatalogJanitor spy = spy(this.janitor);
+
+    CountDownLatch scanStarted = new CountDownLatch(1);
+    CountDownLatch allowScanToFinish = new CountDownLatch(1);
+
+    doAnswer(invocation -> {
+      scanStarted.countDown();
+      assertTrue(allowScanToFinish.await(15, TimeUnit.SECONDS),
+        "Timed out waiting for the test to release the first catalog janitor scan.");
+      return new CatalogJanitorReport();
+    }).when(spy).scanForReport();
+
+    Thread scanThread = new Thread(() -> {
+      try {
+        spy.scan();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
+
+    scanThread.start();
+    try {
+      // First scan acquires the lock and remains running.
+      assertTrue(scanStarted.await(5, TimeUnit.SECONDS));
+      LOG.info("First catalog janitor scan started and waiting to finish.");
+
+      // Second scan detects that another scan is running.
+      assertEquals(-1, spy.scan());
+      LOG.info("Second catalog janitor scan attempt returned -1.");
+
+      // The second scan must not clear the lock.
+      // Therefore, the third scan must also report that a scan is running.
+      int result = spy.scan();
+      LOG.info("Third catalog janitor scan attempt returned {}.", result);
+      assertEquals(-1, result);
+    } finally {
+      // Let the first scan finish.
+      LOG.info("Releasing first catalog janitor scan and waiting for it to complete.");
+      allowScanToFinish.countDown();
+      scanThread.join(5000);
+      LOG.info("First catalog janitor scan thread alive after join: {}", scanThread.isAlive());
+    }
   }
 
   private FileStatus[] addMockStoreFiles(int count, MasterServices services, Path storedir)


### PR DESCRIPTION
`CatalogJanitor.scan()` can allow concurrent scans due to incorrect handling of the
`alreadyRunning` lock.

**ROOT CAUSE**
Currently, the lock acquisition is performed inside the `try` block:
```
    try {
      if (!alreadyRunning.compareAndSet(false, true)) {
        return -1;
      }
      ...
    } finally {
      alreadyRunning.set(false);
    }
```
When a scan is already running, a concurrent scan fails the `compareAndSet()` and
returns immediately. However, because the lock acquisition is inside the `try` block,
the `finally` block is still executed and resets `alreadyRunning` to false.

This allows another scan to acquire the lock while the original scan is still running.

**SOLUTION**
The lock acquisition should be moved before the `try` block:
```
    if (!alreadyRunning.compareAndSet(false, true)) {
      return -1;
    }
    try {
      ...
    } finally {
      alreadyRunning.set(false);
    }
```
This prevents another scan from starting until the current scan has completed.