### PR TITLE
HBASE-30165 Preserve sibling replicas in location cache

### DIFF
--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncNonMetaRegionLocator.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncNonMetaRegionLocator.java
@@ -23,7 +23,6 @@ import static org.apache.hadoop.hbase.HConstants.NINES;
 import static org.apache.hadoop.hbase.HConstants.USE_META_REPLICAS;
 import static org.apache.hadoop.hbase.HConstants.ZEROES;
 import static org.apache.hadoop.hbase.TableName.META_TABLE_NAME;
-import static org.apache.hadoop.hbase.client.AsyncRegionLocatorHelper.createRegionLocations;
 import static org.apache.hadoop.hbase.client.AsyncRegionLocatorHelper.isGood;
 import static org.apache.hadoop.hbase.client.ConnectionConfiguration.HBASE_CLIENT_META_CACHE_INVALIDATE_INTERVAL;
 import static org.apache.hadoop.hbase.client.ConnectionUtils.createClosestRowAfter;
@@ -575,7 +574,7 @@ class AsyncNonMetaRegionLocator {
   }
 
   void addLocationToCache(HRegionLocation loc) {
-    getTableCache(loc.getRegion().getTable()).regionLocationCache.add(createRegionLocations(loc));
+    getTableCache(loc.getRegion().getTable()).regionLocationCache.add(loc);
   }
 
   RegionLocations getCachedLocation(TableName tableName, byte[] startKey) {

--- a/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocationCache.java
+++ b/hbase-client/src/main/java/org/apache/hadoop/hbase/client/AsyncRegionLocationCache.java
@@ -18,7 +18,9 @@
 package org.apache.hadoop.hbase.client;
 
 import static org.apache.hadoop.hbase.client.AsyncRegionLocatorHelper.canUpdateOnError;
+import static org.apache.hadoop.hbase.client.AsyncRegionLocatorHelper.createRegionLocations;
 import static org.apache.hadoop.hbase.client.AsyncRegionLocatorHelper.removeRegionLocation;
+import static org.apache.hadoop.hbase.client.AsyncRegionLocatorHelper.replaceRegionLocation;
 import static org.apache.hadoop.hbase.client.ConnectionUtils.isEmptyStopRow;
 import static org.apache.hadoop.hbase.util.Bytes.BYTES_COMPARATOR;
 
@@ -95,6 +97,24 @@ final class AsyncRegionLocationCache {
     cache.put(startKey, locs);
     cleanProblematicOverlappedRegions(locs);
     return locs;
+  }
+
+  public synchronized RegionLocations add(HRegionLocation loc) {
+    byte[] startKey = loc.getRegion().getStartKey();
+    RegionLocations oldLocs = cache.get(startKey);
+    if (
+      oldLocs == null || !RegionReplicaUtil
+        .isReplicasForSameRegion(oldLocs.getRegionLocation().getRegion(), loc.getRegion())
+    ) {
+      return add(createRegionLocations(loc));
+    }
+
+    RegionLocations newLocs = replaceRegionLocation(oldLocs, loc);
+    if (isEqual(newLocs, oldLocs)) {
+      return oldLocs;
+    }
+    cache.put(startKey, newLocs);
+    return newLocs;
   }
 
   /**

--- a/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocationCache.java
+++ b/hbase-client/src/test/java/org/apache/hadoop/hbase/client/TestAsyncRegionLocationCache.java
@@ -1,0 +1,85 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.client;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.Arrays;
+import org.apache.hadoop.hbase.HBaseConfiguration;
+import org.apache.hadoop.hbase.HRegionLocation;
+import org.apache.hadoop.hbase.RegionLocations;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.testclassification.ClientTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hbase.thirdparty.io.netty.util.HashedWheelTimer;
+
+@Tag(SmallTests.TAG)
+@Tag(ClientTests.TAG)
+public class TestAsyncRegionLocationCache {
+
+  @Test
+  public void testAddingIndividualReplicasPreservesSiblings() {
+    RegionInfo primary =
+      RegionInfoBuilder.newBuilder(TableName.valueOf("test")).setRegionId(1).build();
+
+    for (int[] order : new int[][] { { 0, 1, 2 }, { 2, 1, 0 } }) {
+      AsyncNonMetaRegionLocator locator = createLocator();
+      for (int replicaId : order) {
+        locator.addLocationToCache(location(primary, replicaId));
+      }
+
+      RegionLocations locations =
+        locator.getCachedLocation(primary.getTable(), primary.getStartKey());
+      assertEquals(3, locations.numNonNullElements(), Arrays.toString(order));
+    }
+  }
+
+  @Test
+  public void testAddingDifferentRegionReplacesReplicas() {
+    TableName tableName = TableName.valueOf("test");
+    RegionInfo oldPrimary = RegionInfoBuilder.newBuilder(tableName).setRegionId(1).build();
+    RegionInfo newPrimary = RegionInfoBuilder.newBuilder(tableName).setRegionId(2).build();
+    AsyncNonMetaRegionLocator locator = createLocator();
+
+    locator.addLocationToCache(location(oldPrimary, 0));
+    locator.addLocationToCache(location(oldPrimary, 1));
+    locator.addLocationToCache(location(newPrimary, 0));
+
+    RegionLocations locations = locator.getCachedLocation(tableName, newPrimary.getStartKey());
+    assertEquals(newPrimary, locations.getRegionLocation(0).getRegion());
+    assertNull(locations.getRegionLocation(1));
+  }
+
+  private static AsyncNonMetaRegionLocator createLocator() {
+    AsyncConnectionImpl connection = mock(AsyncConnectionImpl.class);
+    when(connection.getConfiguration()).thenReturn(HBaseConfiguration.create());
+    return new AsyncNonMetaRegionLocator(connection, mock(HashedWheelTimer.class));
+  }
+
+  private static HRegionLocation location(RegionInfo primary, int replicaId) {
+    RegionInfo region = RegionReplicaUtil.getRegionInfoForReplica(primary, replicaId);
+    return new HRegionLocation(region, ServerName.valueOf("server", 16000 + replicaId, 1));
+  }
+}


### PR DESCRIPTION
The async client can update region replica locations one at a time after a move. Before this change, caching replicas 0, 1, and 2 separately left only one replica in the cache, so later lookups for the sibling replicas missed.

Single-location updates now use a synchronized path that replaces only the matching replica. Different primary regions still use the existing replacement path, and complete metadata responses still control the replica-list length.

Jira: https://issues.apache.org/jira/browse/HBASE-30165

## Verification

The regression exercises `AsyncNonMetaRegionLocator.addLocationToCache` in ascending and descending replica order. It also checks that a different primary region with the same start key replaces stale siblings.

<details>
<summary>Commands and raw output</summary>

Before, on `d11cafefbcbe8b356aaede41fcf9b153dbf2c2bc` with only the regression test applied:

```console
$ JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl hbase-client -Dtest=TestAsyncRegionLocationCache test
[ERROR] Tests run: 2, Failures: 1, Errors: 0, Skipped: 0
[ERROR] TestAsyncRegionLocationCache.testAddingIndividualReplicasPreservesSiblings:55 [0, 1, 2] ==> expected: <3> but was: <1>
[INFO] BUILD FAILURE
```

After:

```console
$ JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl hbase-client -Dtest=TestAsyncRegionLocationCache test
[INFO] Tests run: 2, Failures: 0, Errors: 0, Skipped: 0
[INFO] BUILD SUCCESS
```

The only full-module failure is also present on unmodified master:

```console
$ JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl hbase-client test
[ERROR] TestRegistryEndpointsRefresher.testDurationBetweenRefreshes:121 40 ==> expected: <true> but was: <false>
[ERROR] Tests run: 309, Failures: 1, Errors: 0, Skipped: 0

$ git checkout d11cafefbcbe8b356aaede41fcf9b153dbf2c2bc
$ JAVA_HOME=$(/usr/libexec/java_home -v 17) mvn -pl hbase-client -Dtest=TestRegistryEndpointsRefresher#testDurationBetweenRefreshes test
[ERROR] TestRegistryEndpointsRefresher.testDurationBetweenRefreshes:121 36 ==> expected: <true> but was: <false>
[INFO] BUILD FAILURE
```

</details>
