### PR TITLE
HBASE-30094 Reset TestRollbackSCP state before reruns

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRollbackSCP.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestRollbackSCP.java
@@ -133,6 +133,11 @@ public class TestRollbackSCP {
   @BeforeEach
   public void setUp() throws IOException {
     UTIL.ensureSomeNonStoppedRegionServersAvailable(2);
+    // Surefire reruns failed tests in the same JVM without rerunning @BeforeAll, so reset the
+    // fault injection state before each attempt.
+    INJECTED.set(false);
+    ProcedureTestingUtility.setKillAndToggleBeforeStoreUpdateInRollback(
+      UTIL.getMiniHBaseCluster().getMaster().getMasterProcedureExecutor(), false);
   }
 
   private ServerCrashProcedure getSCPForServer(ServerName serverName) throws IOException {


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30094

**What changes were proposed in this pull request?**

Reset the static fault-injection guard and the procedure executor's rollback kill/toggle flags in `TestRollbackSCP#setUp` before every test attempt.

**Why are the changes needed?**

Surefire reruns failed test methods in the same JVM without invoking `@BeforeAll` again. State left by the first attempt can therefore prevent fault injection on the retry and cause the test to time out while waiting for the procedure executor to stop.

Resetting both states in `@BeforeEach` makes every attempt independent.

**How was this patch tested?**

```bash
mvn -pl hbase-server -am -PrunLargeTests \
  -Dtest=TestRollbackSCP \
  -Dsurefire.rerunFailingTestsCount=2 \
  -Dwarbucks.skip=true \
  clean test