### PR TITLE
HBASE-30344 Wait for RegionServer sync replication state

### DIFF
--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSyncReplicationStandbyKillMaster.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/replication/TestSyncReplicationStandbyKillMaster.java
@@ -108,6 +108,10 @@ public class TestSyncReplicationStandbyKillMaster extends SyncReplicationTestBas
     await().atMost(Duration.ofMinutes(3))
       .untilAsserted(() -> assertEquals(SyncReplicationState.DOWNGRADE_ACTIVE,
         UTIL2.getAdmin().getReplicationPeerSyncReplicationState(PEER_ID)));
+    await().atMost(Duration.ofMinutes(3))
+      .untilAsserted(() -> assertEquals(SyncReplicationState.DOWNGRADE_ACTIVE,
+        UTIL2.getRSForFirstRegionInTable(TABLE_NAME).getReplicationSourceService()
+          .getReplicationPeers().getPeer(PEER_ID).getSyncReplicationState()));
 
     verify(UTIL2, 0, COUNT);
   }


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30344

### What changes were proposed in this pull request?

Wait for the RegionServer serving the test table to observe the DOWNGRADE_ACTIVE sync replication state before verifying the replicated data in TestSyncReplicationStandbyKillMaster.

### Why are the changes needed?

After Master recovery, the peer state returned by Admin can become DOWNGRADE_ACTIVE before the RegionServer refreshes its local peer state. The test may start reading while the RegionServer still treats the peer as STANDBY, causing DoNotRetryIOException.
The production-side STANDBY protection remains unchanged.

### How was this patch tested?

Ran TestSyncReplicationStandbyKillMaster five consecutive times with Surefire retries disabled. 

```bash
for run in 1 2 3 4 5; do
  mvn -pl hbase-server -am \
    -Dtest=TestSyncReplicationStandbyKillMaster \
    -Dsurefire.failIfNoSpecifiedTests=false \
    -Dsurefire.rerunFailingTestsCount=0 \
    -DskipITs \
    test || exit 1
done