### PR TITLE
HBASE-30345: Ensure FileIOEngine.shutdown() closes every backing file

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/FileIOEngine.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/io/hfile/bucket/FileIOEngine.java
@@ -17,6 +17,7 @@
  */
 package org.apache.hadoop.hbase.io.hfile.bucket;
 
+import java.io.Closeable;
 import java.io.File;
 import java.io.IOException;
 import java.io.RandomAccessFile;
@@ -225,15 +226,23 @@ public class FileIOEngine extends PersistentIOEngine {
   @Override
   public void shutdown() {
     for (int i = 0; i < filePaths.length; i++) {
+      closeAll(filePaths[i], fileChannels[i], rafs[i]);
+    }
+  }
+
+  /**
+   * Close each non-null closeable, logging failures without throwing, so one failure cannot skip
+   * the rest.
+   */
+  private static void closeAll(String filePath, Closeable... closeables) {
+    for (Closeable c : closeables) {
+      if (c == null) {
+        continue;
+      }
       try {
-        if (fileChannels[i] != null) {
-          fileChannels[i].close();
-        }
-        if (rafs[i] != null) {
-          rafs[i].close();
-        }
-      } catch (IOException ex) {
-        LOG.error("Failed closing " + filePaths[i] + " when shudown the IOEngine", ex);
+        c.close();
+      } catch (IOException e) {
+        LOG.error("Failed closing {} when shutting down the IOEngine", filePath, e);
       }
     }
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestFileIOEngine.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/io/hfile/bucket/TestFileIOEngine.java
@@ -27,6 +27,8 @@ import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
+import java.io.RandomAccessFile;
+import java.lang.reflect.Field;
 import java.nio.ByteBuffer;
 import java.nio.channels.FileChannel;
 import java.util.ArrayList;
@@ -191,5 +193,25 @@ public class TestFileIOEngine {
     for (int i = 1; i < fileChannels.length; i++) {
       assertEquals(fileChannels[i], reopenedFileChannels[i]);
     }
+  }
+
+  @Test
+  public void testShutdownClosesRandomAccessFileWhenChannelCloseFails() throws Exception {
+    FileChannel[] channels = fileIOEngine.getFileChannels();
+
+    // rafs is private
+    Field rafsField = FileIOEngine.class.getDeclaredField("rafs");
+    rafsField.setAccessible(true);
+    RandomAccessFile[] rafs = (RandomAccessFile[]) rafsField.get(fileIOEngine);
+
+    FileChannel failingChannel = Mockito.mock(FileChannel.class);
+    Mockito.doThrow(new IOException("channel close failed")).when(failingChannel).close();
+    RandomAccessFile raf = Mockito.mock(RandomAccessFile.class);
+    channels[0] = failingChannel;
+    rafs[0] = raf;
+
+    fileIOEngine.shutdown();
+
+    Mockito.verify(raf).close();
   }
 }


### PR DESCRIPTION
### Problem

`org.apache.hadoop.hbase.io.hfile.bucket.FileIOEngine.shutdown()` closed the `java.nio.channels.FileChannel` and the `java.io.RandomAccessFile` for each backing file inside a single `try` block. If `java.nio.channels.FileChannel.close()` threw `java.io.IOException`, the matching `java.io.RandomAccessFile.close()` was skipped and that file handle was leaked. `shutdown()` also runs from the `FileIOEngine` constructor's failure path, so a partially initialized engine leaked the same way.

### Change

* Close the `FileChannel` and the `RandomAccessFile` for each backing file independently.
* A failure closing one no longer prevents the attempt to close the other.
* `shutdown()` keeps logging the `java.io.IOException` at `ERROR` rather than throwing it.

### Testing

* `mvn -pl hbase-server -am -Dtest=TestFileIOEngine test`
* `mvn -pl hbase-server -am spotless:check`