### PR TITLE
HBASE-30334: Reopen parent regions on rollback of MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
@@ -287,9 +287,9 @@ public class MergeTableRegionsProcedure
           rollbackCloseRegionsForMerge(env);
           break;
         case MERGE_TABLE_REGIONS_CLOSE_REGIONS:
-          // If it rolls back with state MERGE_TABLE_REGIONS_CLOSE_REGIONS, no need to call
-          // rollbackCloseRegionsForMerge(), otherwise, it will result in duplicate
-          // TransitRegionStateProcedures for parents that are already OPENING. Mirrors
+          // No-op. The reopen TransitRegionStateProcedures for the two parents were already
+          // submitted by the rollback of MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS above;
+          // submitting a second batch here would race the first. Mirrors
           // SplitTableRegionProcedure's rollback of SPLIT_TABLE_REGION_CLOSE_PARENT_REGION.
           break;
         case MERGE_TABLE_REGIONS_PRE_MERGE_OPERATION:

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/MergeTableRegionsProcedure.java
@@ -284,9 +284,13 @@ public class MergeTableRegionsProcedure
           cleanupMergedRegion(env);
           break;
         case MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS:
+          rollbackCloseRegionsForMerge(env);
           break;
         case MERGE_TABLE_REGIONS_CLOSE_REGIONS:
-          rollbackCloseRegionsForMerge(env);
+          // If it rolls back with state MERGE_TABLE_REGIONS_CLOSE_REGIONS, no need to call
+          // rollbackCloseRegionsForMerge(), otherwise, it will result in duplicate
+          // TransitRegionStateProcedures for parents that are already OPENING. Mirrors
+          // SplitTableRegionProcedure's rollback of SPLIT_TABLE_REGION_CLOSE_PARENT_REGION.
           break;
         case MERGE_TABLE_REGIONS_PRE_MERGE_OPERATION:
           postRollBackMergeRegions(env);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestMergeTableRegionsProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestMergeTableRegionsProcedure.java
@@ -335,10 +335,9 @@ public class TestMergeTableRegionsProcedure {
 
   /**
    * HBASE-30334 repro. Plant a stale recovered.edits file on a parent region so that
-   * MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS throws (the exact failure from the 49-min
-   * stuck-RIT incident). After rollback the parents MUST be OPEN. If they stay stuck
-   * (e.g. CLOSED / MERGING), we've reproduced the incident locally and the rollback path
-   * as-is is broken.
+   * MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS throws (the exact failure from the 49-min stuck-RIT
+   * incident). After rollback the parents MUST be OPEN. If they stay stuck (e.g. CLOSED / MERGING),
+   * we've reproduced the incident locally and the rollback path as-is is broken.
    */
   @Test
   public void testRollbackReopensParentsAfterCheckClosedRegionsFailure() throws Exception {
@@ -380,18 +379,15 @@ public class TestMergeTableRegionsProcedure {
     RegionState.State s1Post =
       am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState();
     LOG.info("HBASE-30334-DEBUG post-rollback: {} state={} / {} state={}",
-      regionsToMerge[0].getEncodedName(), s0Post,
-      regionsToMerge[1].getEncodedName(), s1Post);
+      regionsToMerge[0].getEncodedName(), s0Post, regionsToMerge[1].getEncodedName(), s1Post);
 
     ProcedureTestingUtility.assertProcFailed(procExec, procId);
 
     fs.delete(staleFile, false);
 
     UTIL.waitFor(30_000, 500, () -> {
-      RegionState.State a =
-        am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState();
-      RegionState.State b =
-        am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState();
+      RegionState.State a = am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState();
+      RegionState.State b = am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState();
       return a == RegionState.State.OPEN && b == RegionState.State.OPEN;
     });
   }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestMergeTableRegionsProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestMergeTableRegionsProcedure.java
@@ -387,24 +387,13 @@ public class TestMergeTableRegionsProcedure {
 
     fs.delete(staleFile, false);
 
-    long elapsed = org.apache.hadoop.hbase.Waiter.waitFor(conf, 30_000, 500, false,
-      new org.apache.hadoop.hbase.Waiter.Predicate<Exception>() {
-        @Override
-        public boolean evaluate() {
-          RegionState.State a =
-            am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState();
-          RegionState.State b =
-            am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState();
-          return a == RegionState.State.OPEN && b == RegionState.State.OPEN;
-        }
-      });
-
-    assertTrue(elapsed > 0,
-      "Parents must be OPEN after merge rollback (HBASE-30334). Final states: "
-      + regionsToMerge[0].getEncodedName() + "="
-      + am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState() + ", "
-      + regionsToMerge[1].getEncodedName() + "="
-      + am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState());
+    UTIL.waitFor(30_000, 500, () -> {
+      RegionState.State a =
+        am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState();
+      RegionState.State b =
+        am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState();
+      return a == RegionState.State.OPEN && b == RegionState.State.OPEN;
+    });
   }
 
   @Test

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestMergeTableRegionsProcedure.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestMergeTableRegionsProcedure.java
@@ -25,6 +25,8 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.MetaTableAccessor;
@@ -38,6 +40,7 @@ import org.apache.hadoop.hbase.client.SnapshotType;
 import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
+import org.apache.hadoop.hbase.master.RegionState;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureConstants;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureTestingUtility;
@@ -51,7 +54,10 @@ import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
 import org.apache.hadoop.hbase.testclassification.LargeTests;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.util.Threads;
+import org.apache.hadoop.hbase.wal.WALSplitUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -325,6 +331,80 @@ public class TestMergeTableRegionsProcedure {
     UTIL.waitUntilAllRegionsAssigned(tableName);
     List<HRegion> regions = UTIL.getMiniHBaseCluster().getRegions(tableName);
     assertEquals(initialRegionCount, regions.size());
+  }
+
+  /**
+   * HBASE-30334 repro. Plant a stale recovered.edits file on a parent region so that
+   * MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS throws (the exact failure from the 49-min
+   * stuck-RIT incident). After rollback the parents MUST be OPEN. If they stay stuck
+   * (e.g. CLOSED / MERGING), we've reproduced the incident locally and the rollback path
+   * as-is is broken.
+   */
+  @Test
+  public void testRollbackReopensParentsAfterCheckClosedRegionsFailure() throws Exception {
+    final TableName tableName = TableName.valueOf(testMethodName);
+    UTIL.createTable(tableName, new byte[][] { HConstants.CATALOG_FAMILY },
+      new byte[][] { new byte[] { 'b' } });
+    UTIL.waitUntilAllRegionsAssigned(tableName);
+
+    List<RegionInfo> ris = MetaTableAccessor.getTableRegions(UTIL.getConnection(), tableName);
+    assertEquals(2, ris.size());
+    RegionInfo[] regionsToMerge = new RegionInfo[] { ris.get(0), ris.get(1) };
+
+    Configuration conf = UTIL.getConfiguration();
+    Path regionDir =
+      FSUtils.getRegionDirFromRootDir(CommonFSUtils.getRootDir(conf), regionsToMerge[0]);
+    Path recoveredEditsDir = WALSplitUtil.getRegionDirRecoveredEditsDir(regionDir);
+    FileSystem fs = CommonFSUtils.getRootDirFileSystem(conf);
+    fs.mkdirs(recoveredEditsDir);
+    Path staleFile = new Path(recoveredEditsDir, "0000000000000000001");
+    fs.createNewFile(staleFile);
+    assertTrue(WALSplitUtil.hasRecoveredEdits(conf, regionsToMerge[0]),
+      "stale recovered.edits file must be visible");
+
+    AssignmentManager am = UTIL.getHBaseCluster().getMaster().getAssignmentManager();
+    LOG.info("HBASE-30334-DEBUG pre-merge: {} state={} / {} state={}",
+      regionsToMerge[0].getEncodedName(),
+      am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState(),
+      regionsToMerge[1].getEncodedName(),
+      am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState());
+
+    final ProcedureExecutor<MasterProcedureEnv> procExec = getMasterProcedureExecutor();
+    MergeTableRegionsProcedure proc =
+      new MergeTableRegionsProcedure(procExec.getEnvironment(), regionsToMerge, true);
+    long procId = procExec.submitProcedure(proc);
+    ProcedureTestingUtility.waitProcedure(procExec, procId);
+
+    RegionState.State s0Post =
+      am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState();
+    RegionState.State s1Post =
+      am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState();
+    LOG.info("HBASE-30334-DEBUG post-rollback: {} state={} / {} state={}",
+      regionsToMerge[0].getEncodedName(), s0Post,
+      regionsToMerge[1].getEncodedName(), s1Post);
+
+    ProcedureTestingUtility.assertProcFailed(procExec, procId);
+
+    fs.delete(staleFile, false);
+
+    long elapsed = org.apache.hadoop.hbase.Waiter.waitFor(conf, 30_000, 500, false,
+      new org.apache.hadoop.hbase.Waiter.Predicate<Exception>() {
+        @Override
+        public boolean evaluate() {
+          RegionState.State a =
+            am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState();
+          RegionState.State b =
+            am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState();
+          return a == RegionState.State.OPEN && b == RegionState.State.OPEN;
+        }
+      });
+
+    assertTrue(elapsed > 0,
+      "Parents must be OPEN after merge rollback (HBASE-30334). Final states: "
+      + regionsToMerge[0].getEncodedName() + "="
+      + am.getRegionStates().getRegionStateNode(regionsToMerge[0]).getState() + ", "
+      + regionsToMerge[1].getEncodedName() + "="
+      + am.getRegionStates().getRegionStateNode(regionsToMerge[1]).getState());
   }
 
   @Test


### PR DESCRIPTION
## Summary

Fix indefinite stuck RIT when `MergeTableRegionsProcedure` fails at `MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS`.

`rollbackState()` for `CHECK_CLOSED_REGIONS` was a bare `break;`. When `checkClosedRegions()` throws — e.g. a stale `recovered.edits` file survives from a prior WAL split — the procedure enters rollback but never re-opens the parents. Both parents stay CLOSED behind the merge's exclusive locks with no automatic recovery. Observed in production as a ~48-minute stuck RIT that only cleared after operator-driven HMaster failover.

## Fix

Mirror `SplitTableRegionProcedure`'s inversion pattern — move the reopen into the `CHECK_CLOSED_REGIONS` rollback body, and turn the `CLOSE_REGIONS` rollback body into an explicit no-op:

| State | Before | After |
|---|---|---|
| `MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS` | `break;` (no-op) | `rollbackCloseRegionsForMerge(env);` — submits TRSPs to reopen both parents |
| `MERGE_TABLE_REGIONS_CLOSE_REGIONS` | `rollbackCloseRegionsForMerge(env);` | `break;` (no-op) — reopen already dispatched by the state above; a second call would race the first |

This ensures the reopen fires on the first rollback tick, regardless of whether the framework subsequently decrements to `CLOSE_REGIONS`.

The shape matches `SplitTableRegionProcedure.rollbackState()`:
- `SPLIT_TABLE_REGIONS_CHECK_CLOSED_REGIONS` → calls `openParentRegion(env)`.
- `SPLIT_TABLE_REGION_CLOSE_PARENT_REGION` → explicit no-op with an equivalent comment.

`rollbackCloseRegionsForMerge` is unchanged and retains its HBASE-28405 `state != MERGING` guard, so it is a safe idempotent target for the rollback path.

JIRA: https://issues.apache.org/jira/browse/HBASE-30334

## Test plan
- [x] New regression test `TestMergeTableRegionsProcedure#testRollbackReopensParentsAfterCheckClosedRegionsFailure` plants a `recovered.edits/<seqid>` file on a parent, submits a merge, and asserts both parents transition back to `OPEN` after the procedure rolls back. Fails on the pre-fix code (parents stay `CLOSED`), passes on this change.
- [x] Existing rollback tests in `TestMergeTableRegionsProcedure` still pass.
- [x] Compile clean: `mvn -pl hbase-server -am -DskipTests compile test-compile` → BUILD SUCCESS.