### PR TITLE
HBASE-30348 Throttles should work for system tables (excluding quotas, meta)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
@@ -155,7 +155,7 @@ public class QuotaCache implements Stoppable {
    * @return the limiter associated to the specified user/table
    */
   public QuotaLimiter getUserLimiter(final UserGroupInformation ugi, final TableName table) {
-    if (table.isSystemTable()) {
+    if (QuotaUtil.isThrottleExempt(table)) {
       return NoopQuotaLimiter.get();
     }
     return getUserQuotaState(ugi).getTableLimiter(table);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
@@ -648,6 +648,20 @@ public class QuotaUtil extends QuotaTableUtil {
    * @param conn      connection to re-use
    * @param tableName table name which has moved into space quota violation
    */
+  /**
+   * Returns true if the given table must never be subject to RPC throttling.
+   * <p>
+   * Only {@code hbase:meta} and {@code hbase:quota} are exempt. Throttling either of those risks
+   * deadlock, because the throttling machinery itself depends on them: quotas are loaded from
+   * {@code hbase:quota}, and clients resolve region locations through {@code hbase:meta}, so
+   * delaying those requests could prevent a throttle from ever being lifted. Every other table may
+   * be throttled, including the remaining tables in the {@code hbase} namespace and the backup
+   * tables.
+   */
+  public static boolean isThrottleExempt(final TableName tableName) {
+    return TableName.META_TABLE_NAME.equals(tableName) || QUOTA_TABLE_NAME.equals(tableName);
+  }
+
   public static void disableTableIfNotDisabled(Connection conn, TableName tableName)
     throws IOException {
     try {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
@@ -137,7 +137,7 @@ public class RegionServerRpcQuotaManager implements RpcQuotaManager, Configurati
    */
   public OperationQuota getQuota(final UserGroupInformation ugi, final TableName table,
     final int blockSizeBytes) {
-    if (isQuotaEnabled() && !table.isSystemTable() && isRpcThrottleEnabled()) {
+    if (isQuotaEnabled() && !QuotaUtil.isThrottleExempt(table) && isRpcThrottleEnabled()) {
       UserQuotaState userQuotaState = quotaCache.getUserQuotaState(ugi);
       QuotaLimiter userLimiter = userQuotaState.getTableLimiter(table);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaUtil.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.quotas;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(RegionServerTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestQuotaUtil {
+
+  @Test
+  public void testMetaTableIsThrottleExempt() {
+    assertTrue(QuotaUtil.isThrottleExempt(TableName.META_TABLE_NAME));
+  }
+
+  @Test
+  public void testQuotaTableIsThrottleExempt() {
+    assertTrue(QuotaUtil.isThrottleExempt(QuotaTableUtil.QUOTA_TABLE_NAME));
+  }
+
+  @Test
+  public void testBackupTablesAreNotThrottleExempt() {
+    // Backup tables live in a system namespace, so they were previously exempt. They can
+    // accumulate very large cells, which makes them a meaningful source of IO pressure, so
+    // operators need to be able to throttle them.
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("backup:system")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("backup:system_bulk")));
+  }
+
+  @Test
+  public void testOtherSystemTablesAreNotThrottleExempt() {
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:namespace")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:acl")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:labels")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:rsgroup")));
+  }
+
+  @Test
+  public void testUserTablesAreNotThrottleExempt() {
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("my_table")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("my_ns:my_table")));
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-30348

### Problem

Throttles are silently unenforceable on any system table.

`RegionServerRpcQuotaManager#getQuota` short-circuits to `NoopOperationQuota` when `TableName#isSystemTable()` is true, and `QuotaCache#getUserLimiter` returns `NoopQuotaLimiter` under the same condition. Because `isSystemTable()` is set for every table in the `hbase` namespace *and* every table in the `backup` namespace, no quota of any kind — user, table, or namespace — can throttle those tables. The quota is accepted, stored, and displayed by `list_quotas`, but the request path never consults a limiter, so nothing is ever enforced and nothing warns the operator.

We hit this in production. Reads against `backup:system` were saturating a RegionServer's disk IO. A namespace `READ_SIZE` throttle on `backup`, then a table-level `READ_SIZE` throttle, then a table-level `REQUEST_NUMBER` throttle of 20 req/s were applied in sequence, and all three had exactly zero measurable effect — no change in throttling exceptions, no change in IO. There was no signal anywhere that the quotas could not apply.

### Why the exemption exists, and why it is too broad

The exemption guards against a deadlock in the throttling machinery itself: quotas are loaded from `hbase:quota`, and clients resolve region locations through `hbase:meta`. Throttling either table can prevent a throttle from ever being lifted.

That reasoning covers those two tables and does not extend to the rest of the `hbase` namespace, and certainly not to the `backup` tables, whose traffic is ordinary read/write load that operators have a legitimate need to bound.

### Change

- Add `QuotaUtil#isThrottleExempt(TableName)`, which returns true only for `hbase:meta` and `hbase:quota`.
- Use it in place of `TableName#isSystemTable()` in `RegionServerRpcQuotaManager#getQuota` and `QuotaCache#getUserLimiter`.

Every other table becomes throttleable, including the remaining `hbase` namespace tables and the backup tables.

### Compatibility

This is a behavior change, but only for operators who have already configured a quota that matches a system table. Nothing is throttled by default; a quota must be explicitly set. Two cases are worth calling out:

- A namespace throttle on `hbase` or `backup` now takes effect where it previously did not.
- A user throttle with no table/namespace filter now also covers that user's requests to system tables (other than meta and quota).

Both were arguably the operator's intent when the quota was set, but anyone relying on the old silent no-op should review their existing quotas before upgrading.

### Testing

Adds `TestQuotaUtil`, covering that meta and quota are exempt and that the backup tables, the other `hbase` namespace tables, and user tables are not.
