### PR TITLE
HBASE-30093 Start stochastic search timeout after initialization

### DIFF
--- a/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
+++ b/hbase-balancer/src/main/java/org/apache/hadoop/hbase/master/balancer/StochasticLoadBalancer.java
@@ -585,7 +585,6 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
     BalancerClusterState cluster = createState(loadOfOneTable, loads, finder, rackManager);
 
     long startTime = EnvironmentEdgeManager.currentTime();
-    cluster.setStopRequestedAt(startTime + maxRunningTime);
 
     initCosts(cluster);
     balancerConditionals.loadClusterState(cluster);
@@ -636,6 +635,7 @@ public class StochasticLoadBalancer extends BaseLoadBalancer {
       currentCost / sumMultiplier, functionCost(), computedMaxSteps);
 
     final String initFunctionTotalCosts = totalCostsPerFunc();
+    cluster.setStopRequestedAt(EnvironmentEdgeManager.currentTime() + maxRunningTime);
     // Perform a stochastic walk to see if we can get a good fit.
     long step;
     boolean planImprovedConditionals = false;

--- a/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancer.java
+++ b/hbase-balancer/src/test/java/org/apache/hadoop/hbase/master/balancer/TestStochasticLoadBalancer.java
@@ -27,6 +27,7 @@ import static org.mockito.Mockito.when;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Deque;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -44,6 +45,7 @@ import org.apache.hadoop.hbase.ServerName;
 import org.apache.hadoop.hbase.Size;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.master.RackManager;
 import org.apache.hadoop.hbase.master.RegionPlan;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
@@ -494,6 +496,42 @@ public class TestStochasticLoadBalancer extends StochasticBalancerTestBase {
         assertEquals(expectedCost, actualCost, 0);
       }
     }
+  }
+
+  @Test
+  public void testSearchDeadlineIsSetAfterInitialization() throws Exception {
+    Configuration testConf = new Configuration(conf);
+    testConf.setInt(StochasticLoadBalancer.MAX_STEPS_KEY, 0);
+    boolean[] needsBalanceCalled = { false };
+    boolean[] deadlineSet = { false };
+    StochasticLoadBalancer balancer =
+      new StochasticLoadBalancer(new DummyMetricsStochasticBalancer()) {
+        @Override
+        protected BalancerClusterState createState(Map<ServerName, List<RegionInfo>> clusterState,
+          Map<String, Deque<BalancerRegionLoad>> loads, RegionHDFSBlockLocationFinder finder,
+          RackManager rackManager) {
+          return new BalancerClusterState(clusterState, loads, finder, rackManager) {
+            @Override
+            void setStopRequestedAt(long stopRequestedAt) {
+              deadlineSet[0] = true;
+              assertTrue(needsBalanceCalled[0]);
+              super.setStopRequestedAt(stopRequestedAt);
+            }
+          };
+        }
+
+        @Override
+        boolean needsBalance(TableName tableName, BalancerClusterState cluster) {
+          needsBalanceCalled[0] = true;
+          return true;
+        }
+      };
+    balancer.setClusterInfoProvider(new DummyClusterInfoProvider(testConf));
+    balancer.initialize();
+
+    balancer.balanceTable(HConstants.ENSEMBLE_TABLE_NAME, createServerMap(2, 2, 1, 1, 1));
+
+    assertTrue(deadlineSet[0]);
   }
 
   @Test


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30093

## What changes were proposed in this pull request?

Start the maxRunningTime deadline immediately before the stochastic walk. Keep the original start time for total-duration metrics and logging. Add a regression test for the deadline ordering.

## Why are the changes needed?

Balancer initialization currently consumes part of the stochastic search time budget. On a busy host, this can leave too little time to find a better balance plan and cause load balancer tests to fail intermittently.

## How was this patch tested?

```bash
mvn -pl hbase-balancer -am -Dtest=TestStochasticLoadBalancer#testSearchDeadlineIsSetAfterInitialization -Dsurefire.failIfNoSpecifiedTests=false test

mvn -pl hbase-balancer -am -Dtest=TestStochasticLoadBalancerRegionReplicaSameHosts -Dsurefire.failIfNoSpecifiedTests=false test

mvn -pl hbase-balancer -am -Dtest=TestStochasticLoadBalancer -Dsurefire.failIfNoSpecifiedTests=false test

mvn -pl hbase-balancer spotless:check
```