### PR TITLE
HBASE-30350 Fix stale Region-In-Transition tracker entries on region deletion

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -1212,7 +1212,7 @@ public class AssignmentManager {
     regionStateStore.deleteRegions(regions);
     for (int i = 0; i < regions.size(); ++i) {
       final RegionInfo regionInfo = regions.get(i);
-      regionStates.deleteRegion(regionInfo);
+      deleteRegion(regionInfo);
     }
   }
 
@@ -2409,8 +2409,7 @@ public class AssignmentManager {
     RegionInfo[] mergeParents) throws IOException {
     final RegionStateNode node = regionStates.getOrCreateRegionStateNode(child);
     for (RegionInfo ri : mergeParents) {
-      regionStates.deleteRegion(ri);
-      regionInTransitionTracker.handleRegionDelete(ri);
+      deleteRegion(ri);
     }
 
     TableDescriptor td = master.getTableDescriptors().get(child.getTable());
@@ -2419,6 +2418,27 @@ public class AssignmentManager {
     if (shouldAssignFavoredNodes(child)) {
       getFavoredNodePromoter().generateFavoredNodesForMergedRegion(child, mergeParents);
     }
+  }
+
+  /**
+   * Remove a region that is no longer needed (split/merged parent GC'd, etc) from all in-memory
+   * assignment tracking. Must remove from both {@link #regionStates} and
+   * {@link #regionInTransitionTracker} -- they are separate maps and are not kept in sync with each
+   * other automatically. A caller that only calls {@code regionStates.deleteRegion(...)} can leave
+   * a stale entry behind in the RIT tracker (visible via the periodic "STUCK Region-In-Transition"
+   * warning) for as long as the master runs, since nothing else removes it short of a full
+   * re-derive of state from hbase:meta on master failover.
+   */
+  public void deleteRegion(final RegionInfo regionInfo) {
+    regionStates.deleteRegion(regionInfo);
+    regionInTransitionTracker.handleRegionDelete(regionInfo);
+  }
+
+  /**
+   * Plural form of {@link #deleteRegion(RegionInfo)}.
+   */
+  public void deleteRegions(final List<RegionInfo> regionInfos) {
+    regionInfos.forEach(this::deleteRegion);
   }
 
   /*

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManagerUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManagerUtil.java
@@ -284,7 +284,7 @@ final class AssignmentManagerUtil {
     // Remove from in-memory states
     regions.flatMap(hri -> IntStream.range(1, regionReplication)
       .mapToObj(i -> RegionReplicaUtil.getRegionInfoForReplica(hri, i))).forEach(hri -> {
-        env.getAssignmentManager().getRegionStates().deleteRegion(hri);
+        env.getAssignmentManager().deleteRegion(hri);
         env.getMasterServices().getServerManager().removeRegion(hri);
         FavoredNodesManager fnm = env.getMasterServices().getFavoredNodesManager();
         if (fnm != null) {

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/GCRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/GCRegionProcedure.java
@@ -111,9 +111,7 @@ public class GCRegionProcedure extends AbstractStateMachineRegionProcedure<GCReg
           // from CatalogJanitor.
           AssignmentManager am = masterServices.getAssignmentManager();
           if (am != null) {
-            if (am.getRegionStates() != null) {
-              am.getRegionStates().deleteRegion(getRegion());
-            }
+            am.deleteRegion(getRegion());
           }
           env.getAssignmentManager().getRegionStateStore().deleteRegion(getRegion());
           masterServices.getServerManager().removeRegion(getRegion());

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/EnableTableProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/EnableTableProcedure.java
@@ -118,7 +118,7 @@ public class EnableTableProcedure extends AbstractStateMachineTableProcedure<Ena
             for (RegionInfo regionInfo : copyOfRegions) {
               if (regionInfo.getReplicaId() > (configuredReplicaCount - 1)) {
                 // delete the region from the regionStates
-                env.getAssignmentManager().getRegionStates().deleteRegion(regionInfo);
+                env.getAssignmentManager().deleteRegion(regionInfo);
                 // remove it from the list of regions of the table
                 LOG.info("Removed replica={} of {}", regionInfo.getRegionId(), regionInfo);
                 regionsOfTable.remove(regionInfo);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RestoreSnapshotProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/procedure/RestoreSnapshotProcedure.java
@@ -506,7 +506,7 @@ public class RestoreSnapshotProcedure
     int regionReplication) {
     FavoredNodesManager fnm = env.getMasterServices().getFavoredNodesManager();
 
-    env.getAssignmentManager().getRegionStates().deleteRegions(regionInfos);
+    env.getAssignmentManager().deleteRegions(regionInfos);
     env.getMasterServices().getServerManager().removeRegions(regionInfos);
     if (fnm != null) {
       fnm.deleteFavoredNodesForRegions(regionInfos);
@@ -518,7 +518,7 @@ public class RestoreSnapshotProcedure
         for (int i = 1; i < regionReplication; i++) {
           RegionInfo regionInfoForReplica =
             RegionReplicaUtil.getRegionInfoForReplica(regionInfo, i);
-          env.getAssignmentManager().getRegionStates().deleteRegion(regionInfoForReplica);
+          env.getAssignmentManager().deleteRegion(regionInfoForReplica);
           env.getMasterServices().getServerManager().removeRegion(regionInfoForReplica);
           if (fnm != null) {
             fnm.deleteFavoredNodesForRegion(regionInfoForReplica);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestAssignmentManager.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestAssignmentManager.java
@@ -18,10 +18,12 @@
 package org.apache.hadoop.hbase.master.assignment;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotNull;
 import static org.junit.jupiter.api.Assertions.assertNull;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
+import java.util.Arrays;
 import java.util.Collections;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
@@ -130,6 +132,72 @@ public class TestAssignmentManager extends TestAssignmentManagerBase {
     assertEquals(assignFailedCount, assignProcMetrics.getFailedCounter().getCount());
     assertEquals(unassignSubmittedCount + 1, unassignProcMetrics.getSubmittedCounter().getCount());
     assertEquals(unassignFailedCount, unassignProcMetrics.getFailedCounter().getCount());
+  }
+
+  @Test
+  public void testDeleteRegionRemovesStaleRegionInTransitionEntry() throws Exception {
+    TableName tableName = TableName.valueOf(testMethodName);
+    RegionInfo hri = createRegionInfo(tableName, 1);
+
+    rsDispatcher.setMockRsExecutor(new GoodRsExecutor());
+    waitOnFuture(submitProcedure(createAssignProcedure(hri)));
+    // This test table is never registered as ENABLED with the TableStateManager, so the tracker
+    // treats OPEN as a non-terminal state here and keeps the region tracked as in-transition --
+    // mirroring a split/merge parent that is left registered in the tracker (in whatever state it
+    // was last in) but never reaches a state the tracker treats as terminal-and-removable before
+    // being deleted from regionStates.
+    assertEquals(State.OPEN, am.getRegionStates().getRegionState(hri).getState());
+    assertTrue(isTracked(hri));
+
+    // Simulate GCRegionProcedure's cleanup of a no-longer-needed region: it must remove the region
+    // from both regionStates and the RegionInTransitionTracker, not just the former, or the "STUCK
+    // Region-In-Transition" chore will keep reporting an already-deleted region indefinitely.
+    am.deleteRegion(hri);
+    assertNull(am.getRegionStates().getRegionStateNode(hri));
+    assertFalse(isTracked(hri));
+  }
+
+  @Test
+  public void testGCRegionProcedureRemovesStaleRegionInTransitionEntry() throws Exception {
+    TableName tableName = TableName.valueOf(testMethodName);
+    RegionInfo hri = createRegionInfo(tableName, 1);
+
+    rsDispatcher.setMockRsExecutor(new GoodRsExecutor());
+    waitOnFuture(submitProcedure(createAssignProcedure(hri)));
+    // Same non-terminal-state setup as testDeleteRegionRemovesStaleRegionInTransitionEntry, but
+    // here we run the actual GCRegionProcedure end-to-end instead of calling
+    // AssignmentManager#deleteRegion directly, to prove the real procedure used to GC a
+    // no-longer-needed region (e.g. by CatalogJanitor) also clears the tracker.
+    assertEquals(State.OPEN, am.getRegionStates().getRegionState(hri).getState());
+    assertTrue(isTracked(hri));
+
+    waitOnFuture(submitProcedure(
+      new GCRegionProcedure(master.getMasterProcedureExecutor().getEnvironment(), hri)));
+    assertNull(am.getRegionStates().getRegionStateNode(hri));
+    assertFalse(isTracked(hri));
+  }
+
+  @Test
+  public void testDeleteRegionsRemovesStaleRegionInTransitionEntries() throws Exception {
+    TableName tableName = TableName.valueOf(testMethodName);
+    RegionInfo hri1 = createRegionInfo(tableName, 1);
+    RegionInfo hri2 = createRegionInfo(tableName, 2);
+
+    rsDispatcher.setMockRsExecutor(new GoodRsExecutor());
+    waitOnFuture(submitProcedure(createAssignProcedure(hri1)));
+    waitOnFuture(submitProcedure(createAssignProcedure(hri2)));
+    assertTrue(isTracked(hri1));
+    assertTrue(isTracked(hri2));
+
+    am.deleteRegions(Arrays.asList(hri1, hri2));
+    assertNull(am.getRegionStates().getRegionStateNode(hri1));
+    assertNull(am.getRegionStates().getRegionStateNode(hri2));
+    assertFalse(isTracked(hri1));
+    assertFalse(isTracked(hri2));
+  }
+
+  private boolean isTracked(RegionInfo hri) {
+    return am.getRegionsInTransition().stream().anyMatch(node -> node.getRegionInfo().equals(hri));
   }
 
   private void testAssign(final MockRSExecutor executor) throws Exception {


### PR DESCRIPTION
## Summary

`RegionInTransitionTracker` and `RegionStates` are two separate in-memory maps on the master that are not kept in sync automatically. Several code paths deleted a region from `RegionStates` directly without notifying the tracker, so a deleted region could be left behind in the tracker forever — surfacing as a permanently stuck "STUCK Region-In-Transition" warning that only clears on a full master restart (`loadMeta()` rebuilds the tracker from `hbase:meta` from scratch; a GC'd region isn't in meta, so no stale entry survives that path).

This was the root cause of a 9.8h stuck RIT incident: `GCRegionProcedure` deleted a no-longer-needed region from `RegionStates` but never told the tracker, leaving a stale entry that nothing but a restart could clear.

**Fix:** add `AssignmentManager#deleteRegion(RegionInfo)` and its plural form `#deleteRegions(List<RegionInfo>)` as the single sync point that updates both maps together, and route every region-deletion call site through it instead of calling `RegionStates#deleteRegion(s)` directly.

**Confirmed live bug, reproduced end-to-end:** `GCRegionProcedure`. Temporarily reverting its call site back to a direct `RegionStates#deleteRegion()` call reproduces the original incident symptom in `testGCRegionProcedureRemovesStaleRegionInTransitionEntry` (the tracker entry survives GC); restoring the fix makes the same test pass again.

**Plausible but unconfirmed live bug:** `AssignmentManager#deleteTable`. `DeleteTableProcedure` waits for `RegionStates` to clear RIT before calling it, but that wait only checks `RegionStates`, not the tracker — so it doesn't rule out a stale tracker entry, though it isn't proven reachable either.

**Defensive hardening, not confirmed reachable today** (the region being deleted at these sites is already untracked — either terminal/OFFLINE on a disabled table, or a non-default replica, which the tracker never tracks in the first place):
- `AssignmentManagerUtil#removeNonDefaultReplicas` (split/merge)
- `EnableTableProcedure` (replica-count-decrease cleanup)
- `RestoreSnapshotProcedure#deleteRegionsFromInMemoryStates`

## Test plan

- `testDeleteRegionRemovesStaleRegionInTransitionEntry` / `testDeleteRegionsRemovesStaleRegionInTransitionEntries` — cover the singular/plural `AssignmentManager#deleteRegion(s)` sync point directly.
- `testGCRegionProcedureRemovesStaleRegionInTransitionEntry` — runs the real `GCRegionProcedure` end-to-end through the procedure executor. Verified this test fails against the pre-fix code path and passes against the fix.
- Ran `TestAssignmentManager`, `TestAssignmentManagerUtil`, `TestEnableTableProcedure`, `TestRestoreSnapshotProcedure`, and related suites — all green, no regressions.
