### PR TITLE
HBASE-30352: Tolerate stale recovered.edits below durable seqid in split/merge

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManagerUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManagerUtil.java
@@ -24,10 +24,14 @@ import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
 import java.util.ListIterator;
+import java.util.NavigableSet;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
 import org.apache.commons.lang3.ArrayUtils;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.HConstants;
 import org.apache.hadoop.hbase.ServerName;
@@ -37,9 +41,13 @@ import org.apache.hadoop.hbase.client.RegionReplicaUtil;
 import org.apache.hadoop.hbase.favored.FavoredNodesManager;
 import org.apache.hadoop.hbase.master.RegionState;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.util.FSUtils;
 import org.apache.hadoop.hbase.util.FutureUtils;
 import org.apache.hadoop.hbase.wal.WALSplitUtil;
 import org.apache.yetus.audience.InterfaceAudience;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 import org.apache.hadoop.hbase.shaded.protobuf.RequestConverter;
 import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.GetRegionInfoRequest;
@@ -50,6 +58,7 @@ import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.GetRegionIn
  */
 @InterfaceAudience.Private
 final class AssignmentManagerUtil {
+  private static final Logger LOG = LoggerFactory.getLogger(AssignmentManagerUtil.class);
   private static final int DEFAULT_REGION_REPLICA = 1;
 
   private AssignmentManagerUtil() {
@@ -294,10 +303,79 @@ final class AssignmentManagerUtil {
   }
 
   static void checkClosedRegion(MasterProcedureEnv env, RegionInfo regionInfo) throws IOException {
-    if (WALSplitUtil.hasRecoveredEdits(env.getMasterConfiguration(), regionInfo)) {
-      throw new IOException("Recovered.edits are found in Region: " + regionInfo
-        + ", abort split/merge to prevent data loss");
+    if (!WALSplitUtil.hasRecoveredEdits(env.getMasterConfiguration(), regionInfo)) {
+      return;
     }
+    // A recovered.edits file whose max seqid is <= the region's last flushed seqid is stale:
+    // its edits are already durable in HFiles. This happens e.g. when a graceful region move
+    // is followed by a WAL split of the source RS - the split creates recovered.edits for a
+    // region that has already been reopened elsewhere and flushed. Cleaning up such files here
+    // (rather than aborting split/merge) matches the tolerance HRegion itself applies at open.
+    if (tryDropStaleRecoveredEdits(env, regionInfo)) {
+      return;
+    }
+    throw new IOException("Recovered.edits are found in Region: " + regionInfo
+      + ", abort split/merge to prevent data loss");
+  }
+
+  /**
+   * Try to remove recovered.edits files that are provably below the region's last flushed seqid.
+   * @return true if, after cleanup, no recovered.edits remain for the region
+   */
+  private static boolean tryDropStaleRecoveredEdits(MasterProcedureEnv env, RegionInfo regionInfo) {
+    long durableSeqId = env.getMasterServices().getServerManager()
+      .getLastFlushedSequenceId(regionInfo.getEncodedNameAsBytes()).getLastFlushedSequenceId();
+    if (durableSeqId <= 0L) {
+      // No authoritative durability info at the master; play safe and let the caller abort.
+      return false;
+    }
+    try {
+      Configuration conf = env.getMasterConfiguration();
+      Path regionWALDir =
+        CommonFSUtils.getWALRegionDir(conf, regionInfo.getTable(), regionInfo.getEncodedName());
+      Path regionDir = FSUtils.getRegionDirFromRootDir(CommonFSUtils.getRootDir(conf), regionInfo);
+      Path wrongRegionWALDir = CommonFSUtils.getWrongWALRegionDir(conf, regionInfo.getTable(),
+        regionInfo.getEncodedName());
+      FileSystem walFs = CommonFSUtils.getWALFileSystem(conf);
+      FileSystem rootFs = CommonFSUtils.getRootDirFileSystem(conf);
+      return dropStaleEditsUnder(walFs, regionWALDir, durableSeqId, regionInfo)
+        && dropStaleEditsUnder(rootFs, regionDir, durableSeqId, regionInfo)
+        && dropStaleEditsUnder(walFs, wrongRegionWALDir, durableSeqId, regionInfo);
+    } catch (IOException e) {
+      LOG.warn("Failed to inspect recovered.edits for {}; falling back to abort", regionInfo, e);
+      return false;
+    }
+  }
+
+  private static boolean dropStaleEditsUnder(FileSystem fs, Path regionDir, long durableSeqId,
+    RegionInfo regionInfo) throws IOException {
+    NavigableSet<Path> files = WALSplitUtil.getSplitEditFilesSorted(fs, regionDir);
+    if (files.isEmpty()) {
+      return true;
+    }
+    for (Path p : files) {
+      long fileMaxSeqId;
+      try {
+        fileMaxSeqId = Long.parseLong(p.getName());
+      } catch (NumberFormatException e) {
+        LOG.warn("Non-numeric recovered.edits filename {} for {}; not dropping", p, regionInfo);
+        return false;
+      }
+      if (fileMaxSeqId > durableSeqId) {
+        LOG.info("Recovered.edits {} for {} has maxSeqId={} > durableSeqId={}; needs replay", p,
+          regionInfo, fileMaxSeqId, durableSeqId);
+        return false;
+      }
+    }
+    for (Path p : files) {
+      LOG.info("Removing stale recovered.edits {} for {} (durableSeqId={})", p, regionInfo,
+        durableSeqId);
+      if (!fs.delete(p, false)) {
+        LOG.warn("Failed to delete stale recovered.edits {} for {}", p, regionInfo);
+        return false;
+      }
+    }
+    return true;
   }
 
   /**

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestAssignmentManagerUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestAssignmentManagerUtil.java
@@ -18,6 +18,7 @@
 package org.apache.hadoop.hbase.master.assignment;
 
 import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.IOException;
@@ -25,18 +26,25 @@ import java.util.List;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import java.util.stream.Stream;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.fs.FileSystem;
+import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.hbase.HBaseIOException;
 import org.apache.hadoop.hbase.HBaseTestingUtil;
 import org.apache.hadoop.hbase.TableName;
 import org.apache.hadoop.hbase.client.ColumnFamilyDescriptorBuilder;
+import org.apache.hadoop.hbase.client.Put;
 import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionReplicaUtil;
+import org.apache.hadoop.hbase.client.Table;
 import org.apache.hadoop.hbase.client.TableDescriptorBuilder;
 import org.apache.hadoop.hbase.master.HMaster;
 import org.apache.hadoop.hbase.master.procedure.MasterProcedureEnv;
 import org.apache.hadoop.hbase.testclassification.MasterTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.CommonFSUtils;
+import org.apache.hadoop.hbase.wal.WALSplitUtil;
 import org.junit.jupiter.api.AfterAll;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeAll;
@@ -125,5 +133,51 @@ public class TestAssignmentManagerUtil {
       .mapToObj(i -> RegionReplicaUtil.getRegionInfoForReplica(regionA, i))
       .map(AM.getRegionStates()::getRegionStateNode).forEachOrdered(
         rn -> assertFalse(rn.isTransitionScheduled(), "Should have unset the proc for " + rn));
+  }
+
+  @Test
+  public void testCheckClosedRegionDropsStaleRecoveredEdits() throws Exception {
+    try (Table t = UTIL.getConnection().getTable(TABLE_NAME)) {
+      for (int i = 0; i < 10; i++) {
+        t.put(new Put(Bytes.toBytes(i)).addColumn(Bytes.toBytes("cf"), Bytes.toBytes("q"),
+          Bytes.toBytes(i)));
+      }
+    }
+    UTIL.getAdmin().flush(TABLE_NAME);
+    UTIL.waitFor(30_000,
+      () -> getPrimaryRegions().stream().anyMatch(r -> ENV.getMasterServices().getServerManager()
+        .getLastFlushedSequenceId(r.getEncodedNameAsBytes()).getLastFlushedSequenceId() > 0L));
+
+    RegionInfo region = getPrimaryRegions().stream()
+      .filter(r -> ENV.getMasterServices().getServerManager()
+        .getLastFlushedSequenceId(r.getEncodedNameAsBytes()).getLastFlushedSequenceId() > 0L)
+      .findFirst().orElseThrow(() -> new AssertionError("no region has a durable seqid yet"));
+    long durable = ENV.getMasterServices().getServerManager()
+      .getLastFlushedSequenceId(region.getEncodedNameAsBytes()).getLastFlushedSequenceId();
+
+    Configuration conf = ENV.getMasterConfiguration();
+    Path walRegionDir =
+      CommonFSUtils.getWALRegionDir(conf, region.getTable(), region.getEncodedName());
+    Path editsDir = WALSplitUtil.getRegionDirRecoveredEditsDir(walRegionDir);
+    FileSystem fs = CommonFSUtils.getWALFileSystem(conf);
+    fs.mkdirs(editsDir);
+
+    Path staleFile = new Path(editsDir, String.format("%019d", 1L));
+    fs.create(staleFile).close();
+    assertTrue(fs.exists(staleFile));
+
+    AssignmentManagerUtil.checkClosedRegion(ENV, region);
+    assertFalse(fs.exists(staleFile), "stale recovered.edits should have been removed");
+
+    Path freshFile = new Path(editsDir, String.format("%019d", durable + 1000L));
+    fs.create(freshFile).close();
+    try {
+      AssignmentManagerUtil.checkClosedRegion(ENV, region);
+      fail("checkClosedRegion should have thrown for a fresh recovered.edits file");
+    } catch (IOException expected) {
+      // expected
+    } finally {
+      fs.delete(freshFile, false);
+    }
   }
 }


### PR DESCRIPTION
## Context

Follow-up to the discussion on #8584 (HBASE-30335). @Apache9 suggested in https://github.com/apache/hbase/pull/8584#issuecomment-5487364435:

> In `MergeTableRegionsProcedure`, when we have a `recovered.edits` file, we should check if the edits are all below the persistent seqNum, if so we are OK to remove the directory and go on.

This PR implements that check for both `MergeTableRegionsProcedure` and `SplitTableRegionProcedure` (both call `AssignmentManagerUtil.checkClosedRegion`).

JIRA: https://issues.apache.org/jira/browse/HBASE-30352

## The incident this addresses

1. Region `112d9f08` was gracefully moved from RS-A → RS-B.
2. RS-B opened the region with `openSeqNum=4997750282`; all prior edits were durable in HFiles.
3. ~25 s later, RS-A was declared dead and its WAL was split.
4. The split worker produced a `recovered.edits` file for this region containing `seqId=4997750280` — an edit already flushed on HFile before RS-A closed.
5. `MergeTableRegionsProcedure` later hit `MERGE_TABLE_REGIONS_CHECK_CLOSED_REGIONS`, saw the `recovered.edits` file, and threw. The region sat in CLOSED/RIT for ~49 min until master failover cleared it.

## Change

`AssignmentManagerUtil.checkClosedRegion` now, when `hasRecoveredEdits` is true:

1. Reads the region's `lastFlushedSequenceId` from `ServerManager`.
2. For each recovered.edits file in every candidate location (WAL region dir, root region dir, legacy "wrong" WAL region dir), parses the filename — which is `formatRecoveredEditsFileName(maxEditWALSeqNum)` — to get the file's max seqid.
3. If every file's max seqid ≤ `lastFlushedSequenceId`, deletes those specific files and returns.
4. Otherwise the pre-existing abort behavior is preserved as a safe fallback (unknown/no durable info, or a file that could contain non-durable edits).

Filename parsing avoids opening/reading the WAL edits; the writer contract already encodes the max seqid in the file name via `WALSplitUtil.getCompletedRecoveredEditsFilePath`.

## Files

- `hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManagerUtil.java` — the tolerance logic.
- `hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestAssignmentManagerUtil.java` — new test `testCheckClosedRegionDropsStaleRecoveredEdits` verifies (a) a stale file is dropped and the check passes, (b) a file with a fresh seqid still causes the abort.

## Local run

```
TestAssignmentManagerUtil - 3 tests / 0 failures / 0 errors / 0 skipped - 15.14 s
```

## Notes / open questions

- The improvement only takes effect when `ServerManager` has an authoritative `lastFlushedSequenceId` for the region. With HBASE-30335 landing, this will be the case immediately after region OPEN. Without HBASE-30335 it kicks in after the first flush heartbeat. In either case, the fallback matches today's behavior.
- Not implemented here (Apache9's other suggested item): proactively removing stale `recovered.edits` on region OPEN. Happy to file/pick that up separately if reviewers agree it should be in scope.
