### PR TITLE
HBASE-30354 Add JDK 21 nightly checks

### DIFF
--- a/dev-support/Jenkinsfile
+++ b/dev-support/Jenkinsfile
@@ -38,6 +38,7 @@ pipeline {
     OUTPUT_DIR_RELATIVE_JDK8_HADOOP3 = 'output-jdk8-hadoop3'
     OUTPUT_DIR_RELATIVE_JDK11_HADOOP3 = 'output-jdk11-hadoop3'
     OUTPUT_DIR_RELATIVE_JDK17_HADOOP3 = 'output-jdk17-hadoop3'
+    OUTPUT_DIR_RELATIVE_JDK21_HADOOP3 = 'output-jdk21-hadoop3'
 
     PROJECT = 'hbase'
     PROJECT_PERSONALITY = 'https://raw.githubusercontent.com/apache/hbase/master/dev-support/hbase-personality.sh'
@@ -135,6 +136,7 @@ pipeline {
         stash name: 'jdk8-hadoop3-result', allowEmpty: true, includes: "${OUTPUT_DIR_RELATIVE_JDK8_HADOOP3}/doesn't-match"
         stash name: 'jdk11-hadoop3-result', allowEmpty: true, includes: "${OUTPUT_DIR_RELATIVE_JDK11_HADOOP3}/doesn't-match"
         stash name: 'jdk17-hadoop3-result', allowEmpty: true, includes: "${OUTPUT_DIR_RELATIVE_JDK17_HADOOP3}/doesn't-match"
+        stash name: 'jdk21-hadoop3-result', allowEmpty: true, includes: "${OUTPUT_DIR_RELATIVE_JDK21_HADOOP3}/doesn't-match"
       }
     }
     stage ('health checks') {
@@ -691,6 +693,116 @@ pipeline {
             }
           }
         }
+        stage ('yetus jdk21 hadoop3 checks') {
+          agent {
+            node {
+              label 'hbase'
+            }
+          }
+          environment {
+            BASEDIR = "${env.WORKSPACE}/component"
+            TESTS = "${env.DEEP_CHECKS}"
+            OUTPUT_DIR_RELATIVE = "${env.OUTPUT_DIR_RELATIVE_JDK21_HADOOP3}"
+            OUTPUT_DIR = "${env.WORKSPACE}/${env.OUTPUT_DIR_RELATIVE_JDK21_HADOOP3}"
+            SET_JAVA_HOME = "/usr/lib/jvm/java-21"
+            // Activates hadoop 3.0 profile in maven runs.
+            HADOOP_PROFILE = '3.0'
+            SKIP_ERRORPRONE = true
+          }
+          steps {
+            // Must do prior to anything else, since if one of them timesout we'll stash the commentfile
+            sh '''#!/usr/bin/env bash
+              set -e
+              rm -rf "${OUTPUT_DIR}" && mkdir "${OUTPUT_DIR}"
+              echo '(x) {color:red}-1 jdk21 hadoop3 checks{color}' >"${OUTPUT_DIR}/commentfile"
+              echo "-- Something went wrong running this stage, please [check relevant console output|${BUILD_URL}/console]." >> "${OUTPUT_DIR}/commentfile"
+            '''
+            unstash 'yetus'
+            dir('component') {
+              checkout scm
+            }
+            sh '''#!/usr/bin/env bash
+              set -e
+              rm -rf "${OUTPUT_DIR}/machine" && mkdir "${OUTPUT_DIR}/machine"
+              "${BASEDIR}/dev-support/gather_machine_environment.sh" "${OUTPUT_DIR_RELATIVE}/machine"
+              echo "got the following saved stats in '${OUTPUT_DIR_RELATIVE}/machine'"
+              ls -lh "${OUTPUT_DIR_RELATIVE}/machine"
+            '''
+            script {
+              def ret = sh(
+                returnStatus: true,
+                script: '''#!/usr/bin/env bash
+                  set -e
+                  declare -i status=0
+                  if "${BASEDIR}/dev-support/hbase_nightly_yetus.sh" ; then
+                    echo '(/) {color:green}+1 jdk21 hadoop3 checks{color}' > "${OUTPUT_DIR}/commentfile"
+                  else
+                    echo '(x) {color:red}-1 jdk21 hadoop3 checks{color}' > "${OUTPUT_DIR}/commentfile"
+                    status=1
+                  fi
+                  echo "-- For more information [see jdk21 report|${BUILD_URL}JDK21_20Nightly_20Build_20Report_20_28Hadoop3_29/]" >> "${OUTPUT_DIR}/commentfile"
+                  exit "${status}"
+                '''
+              )
+              if (ret != 0) {
+                // mark the build as UNSTABLE instead of FAILURE, to avoid skipping the later publish of
+                // test output. See HBASE-26339 for more details.
+                currentBuild.result = 'UNSTABLE'
+              }
+            }
+          }
+          post {
+            always {
+              stash name: 'jdk21-hadoop3-result', includes: "${OUTPUT_DIR_RELATIVE}/commentfile"
+              junit testResults: "${env.OUTPUT_DIR_RELATIVE}/**/target/**/TEST-*.xml", allowEmptyResults: true
+              // zip surefire reports.
+              sh '''#!/bin/bash -e
+                if [ -d "${OUTPUT_DIR}/archiver" ]; then
+                  count=$(find "${OUTPUT_DIR}/archiver" -type f | wc -l)
+                  if [[ 0 -ne ${count} ]]; then
+                    echo "zipping ${count} archived files"
+                    zip -q -m -r "${OUTPUT_DIR}/test_logs.zip" "${OUTPUT_DIR}/archiver"
+                  else
+                    echo "No archived files, skipping compressing."
+                  fi
+                else
+                  echo "No archiver directory, skipping compressing."
+                fi
+              '''
+              sshPublisher(publishers: [
+                sshPublisherDesc(configName: 'Nightlies',
+                  transfers: [
+                    sshTransfer(remoteDirectory: "hbase/${JOB_NAME}/${BUILD_NUMBER}",
+                      sourceFiles: "${env.OUTPUT_DIR_RELATIVE}/test_logs.zip"
+                    )
+                  ]
+                )
+              ])
+              // remove the big test logs zip file, store the nightlies url in test_logs.html
+              sh '''#!/bin/bash -e
+                if [ -f "${OUTPUT_DIR}/test_logs.zip" ]; then
+                  echo "Remove ${OUTPUT_DIR}/test_logs.zip for saving space"
+                  rm -rf "${OUTPUT_DIR}/test_logs.zip"
+                  python3 ${BASEDIR}/dev-support/gen_redirect_html.py "${ASF_NIGHTLIES_BASE}/${OUTPUT_DIR_RELATIVE}" > "${OUTPUT_DIR}/test_logs.html"
+                else
+                  echo "No test_logs.zip, skipping"
+                fi
+              '''
+              // Has to be relative to WORKSPACE.
+              archiveArtifacts artifacts: "${env.OUTPUT_DIR_RELATIVE}/*"
+              archiveArtifacts artifacts: "${env.OUTPUT_DIR_RELATIVE}/**/*"
+              publishHTML target: [
+                allowMissing         : true,
+                keepAll              : true,
+                alwaysLinkToLastBuild: true,
+                // Has to be relative to WORKSPACE.
+                reportDir            : "${env.OUTPUT_DIR_RELATIVE}",
+                reportFiles          : 'console-report.html',
+                reportName           : 'JDK21 Nightly Build Report (Hadoop3)'
+              ]
+            }
+          }
+        }
       } // parallel
     } //stage:_health checks
   } //stages
@@ -707,18 +819,21 @@ pipeline {
              rm -rf ${OUTPUT_DIR_RELATIVE_JDK8_HADOOP3}
              rm -rf ${OUTPUT_DIR_RELATIVE_JDK11_HADOOP3}
              rm -rf ${OUTPUT_DIR_RELATIVE_JDK17_HADOOP3}
+             rm -rf ${OUTPUT_DIR_RELATIVE_JDK21_HADOOP3}
            '''
            unstash 'general-result'
            unstash 'jdk8-hadoop2-result'
            unstash 'jdk8-hadoop3-result'
            unstash 'jdk11-hadoop3-result'
            unstash 'jdk17-hadoop3-result'
+           unstash 'jdk21-hadoop3-result'
 
            def results = ["${env.OUTPUT_DIR_RELATIVE_GENERAL}/commentfile",
                           "${env.OUTPUT_DIR_RELATIVE_JDK8_HADOOP2}/commentfile",
                           "${env.OUTPUT_DIR_RELATIVE_JDK8_HADOOP3}/commentfile",
                           "${env.OUTPUT_DIR_RELATIVE_JDK11_HADOOP3}/commentfile",
-                          "${env.OUTPUT_DIR_RELATIVE_JDK17_HADOOP3}/commentfile"]
+                          "${env.OUTPUT_DIR_RELATIVE_JDK17_HADOOP3}/commentfile",
+                          "${env.OUTPUT_DIR_RELATIVE_JDK21_HADOOP3}/commentfile"]
            echo env.BRANCH_NAME
            echo env.BUILD_URL
            echo currentBuild.result

--- a/dev-support/docker/Dockerfile
+++ b/dev-support/docker/Dockerfile
@@ -132,6 +132,13 @@ SHELL ["/bin/bash", "-o", "pipefail", "-c"]
 RUN curl --location --fail --silent --show-error --output /tmp/adoptopenjdk17.tar.gz "${OPENJDK17_URL}" && \
   echo "${OPENJDK17_SHA256} */tmp/adoptopenjdk17.tar.gz" | sha256sum -c -
 
+FROM base_image AS openjdk21_download_image
+ENV OPENJDK21_URL='https://github.com/adoptium/temurin21-binaries/releases/download/jdk-21.0.12.1%2B1/OpenJDK21U-jdk_x64_linux_hotspot_21.0.12.1_1.tar.gz'
+ENV OPENJDK21_SHA256='ce79869e1307ed8ee1e2baa86a412b1eb5b75d10a01006d788a6f968bcfaee94'
+SHELL ["/bin/bash", "-o", "pipefail", "-c"]
+RUN curl --location --fail --silent --show-error --output /tmp/adoptopenjdk21.tar.gz "${OPENJDK21_URL}" && \
+  echo "${OPENJDK21_SHA256} */tmp/adoptopenjdk21.tar.gz" | sha256sum -c -
+
 ##
 # build the final image
 #
@@ -187,6 +194,14 @@ RUN mkdir -p /usr/lib/jvm && \
   ln -s "/usr/lib/jvm/$(basename "$(tar -tf /tmp/adoptopenjdk17.tar.gz | head -n1)")" /usr/lib/jvm/java-17-adoptopenjdk && \
   ln -s /usr/lib/jvm/java-17-adoptopenjdk /usr/lib/jvm/java-17 && \
   rm /tmp/adoptopenjdk17.tar.gz
+
+# hadolint ignore=DL3010
+COPY --from=openjdk21_download_image /tmp/adoptopenjdk21.tar.gz /tmp/adoptopenjdk21.tar.gz
+RUN mkdir -p /usr/lib/jvm && \
+  tar xzf /tmp/adoptopenjdk21.tar.gz -C /usr/lib/jvm && \
+  ln -s "/usr/lib/jvm/$(basename "$(tar -tf /tmp/adoptopenjdk21.tar.gz | head -n1)")" /usr/lib/jvm/java-21-adoptopenjdk && \
+  ln -s /usr/lib/jvm/java-21-adoptopenjdk /usr/lib/jvm/java-21 && \
+  rm /tmp/adoptopenjdk21.tar.gz
 
 # configure default environment for Yetus. Yetus in dockermode seems to require
 # these values to be specified here; the various --foo-path flags do not


### PR DESCRIPTION
Jira: HBASE-30354

---

Nightly runs jdk8-hadoop2, jdk8-hadoop3, jdk11-hadoop3 and jdk17-hadoop3. Nothing exercises Java 21, so the work under HBASE-29546 has no CI signal and the support matrix cannot move past JDK 17.

- Add Temurin 21.0.12.1+1 to the CI image, pinned by URL and sha256, linked at /usr/lib/jvm/java-21 alongside the existing 8, 11 and 17
- Clone the jdk17 hadoop3 stage as jdk21 hadoop3, with its stash, cleanup, unstash, comment entry and HTML report

Nightly only for now. Precommit can follow once the axis has been green.

---

Worth noting for reviewers: precommit does not run the nightly pipeline, so green checks here say nothing about whether the new stage works. **The first real test is the next nightly run on master after this merges.**

What I could verify is that it parses against the plugin versions our own Jenkins runs, using the declarative linter it exposes:

```sh
curl -X POST -F "jenkinsfile=<dev-support/Jenkinsfile" \
  https://ci-hbase.apache.org/pipeline-model-converter/validate
```

`Jenkinsfile successfully validated.` for this patch. That is syntax only though.
