### PR TITLE
HBASE-30355 setupMiniKdc port-conflict retry never triggers because Kerby throws KrbException, not BindException

### DIFF
--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
@@ -21,16 +21,12 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
-import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.BindException;
-import java.net.DatagramSocket;
-import java.net.InetAddress;
-import java.net.ServerSocket;
 import java.net.SocketException;
 import java.net.URI;
 import java.security.PrivilegedExceptionAction;
@@ -200,36 +196,6 @@ public class TestLogLevel {
       }
     }
     return false;
-  }
-
-  /**
-   * Reproduces the port-conflict flake deterministically: occupy the KDC port on both TCP and UDP,
-   * pin MiniKdc to it, and show the resulting failure is a Kerby {@code KrbException}, not a
-   * {@link BindException}. This is why the {@code catch (BindException)} retry in
-   * {@link #setupMiniKdc()} never fired for the reported failure.
-   */
-  @Test
-  public void testKdcBindConflictSurfacesAsKrbException() throws Exception {
-    int port;
-    try (ServerSocket probe = new ServerSocket(0, 1, InetAddress.getByName(LOCALHOST))) {
-      port = probe.getLocalPort();
-    }
-    try (ServerSocket tcp = new ServerSocket(port, 1, InetAddress.getByName(LOCALHOST));
-      DatagramSocket udp = new DatagramSocket(port, InetAddress.getByName(LOCALHOST))) {
-      Properties conf = MiniKdc.createConf();
-      conf.put(MiniKdc.DEBUG, true);
-      conf.setProperty(MiniKdc.KDC_BIND_ADDRESS, LOCALHOST);
-      conf.setProperty(MiniKdc.KDC_PORT, Integer.toString(port));
-      File dir = new File(HTU.getDataTestDir("kdc-conflict").toUri().getPath());
-      MiniKdc conflictingKdc = new MiniKdc(conf, dir);
-
-      Exception thrown = assertThrows(Exception.class, conflictingKdc::start);
-
-      assertFalse(thrown instanceof BindException,
-        "Kerby wraps the bind failure in a KrbException, so it is not a BindException: " + thrown);
-      assertTrue(isBindException(thrown),
-        "expected a recognisable bind-conflict failure, got: " + thrown);
-    }
   }
 
   /**

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
@@ -159,10 +159,10 @@ public class TestLogLevel {
         // KrbException whose shape varies by version (see isBindException), so we recognise the
         // port conflict via that predicate rather than a type. We also avoid importing kerby types
         // here (see HBASE-29117).
+        FileUtils.deleteDirectory(dir); // clean directory regardless of failure type
         if (!isBindException(e)) {
           throw e; // not a port conflict, do not mask the real failure behind a retry
         }
-        FileUtils.deleteDirectory(dir); // clean directory
         numTries++;
         if (numTries == 3) {
           log.error("Failed setting up MiniKDC. Tried " + numTries + " times.");

--- a/hbase-http/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
+++ b/hbase-http/src/test/java/org/apache/hadoop/hbase/http/log/TestLogLevel.java
@@ -21,15 +21,20 @@ import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertNotEquals;
 import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 import static org.junit.jupiter.api.Assertions.fail;
 
 import java.io.File;
 import java.io.IOException;
 import java.net.BindException;
+import java.net.DatagramSocket;
+import java.net.InetAddress;
+import java.net.ServerSocket;
 import java.net.SocketException;
 import java.net.URI;
 import java.security.PrivilegedExceptionAction;
+import java.util.Locale;
 import java.util.Properties;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
@@ -153,18 +158,99 @@ public class TestLogLevel {
         dir = new File(HTU.getDataTestDir("kdc").toUri().getPath());
         kdc = new MiniKdc(conf, dir);
         kdc.start();
-      } catch (BindException e) {
+      } catch (Exception e) {
+        // Catch Exception, not BindException/KrbException: Kerby wraps the bind failure in a
+        // KrbException whose shape varies by version (see isBindException), so we recognise the
+        // port conflict via that predicate rather than a type. We also avoid importing kerby types
+        // here (see HBASE-29117).
+        if (!isBindException(e)) {
+          throw e; // not a port conflict, do not mask the real failure behind a retry
+        }
         FileUtils.deleteDirectory(dir); // clean directory
         numTries++;
         if (numTries == 3) {
           log.error("Failed setting up MiniKDC. Tried " + numTries + " times.");
           throw e;
         }
-        log.error("BindException encountered when setting up MiniKdc. Trying again.");
+        log.error("Bind conflict encountered when setting up MiniKdc, retrying (attempt " + numTries
+          + ").");
         bindException = true;
       }
     } while (bindException);
     return kdc;
+  }
+
+  /**
+   * The Kerby-backed {@link MiniKdc} wraps a failure to bind the KDC port in a
+   * {@code org.apache.kerby...KrbException} rather than surfacing a {@link BindException} directly,
+   * so we inspect the whole cause chain plus the message to recognise a port conflict. Both checks
+   * are load-bearing across Kerby versions: kerby 1.x preserves the original {@link BindException}
+   * as the cause (caught by the cause-chain check) while kerby 2.x drops the cause and only appends
+   * the bind message (caught by the message check). The message match is lower-cased since the
+   * wording is JDK/OS specific.
+   */
+  static boolean isBindException(Throwable t) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      if (cause instanceof BindException) {
+        return true;
+      }
+      String msg = cause.getMessage();
+      if (msg != null && msg.toLowerCase(Locale.ROOT).contains("address already in use")) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  /**
+   * Reproduces the port-conflict flake deterministically: occupy the KDC port on both TCP and UDP,
+   * pin MiniKdc to it, and show the resulting failure is a Kerby {@code KrbException}, not a
+   * {@link BindException}. This is why the {@code catch (BindException)} retry in
+   * {@link #setupMiniKdc()} never fired for the reported failure.
+   */
+  @Test
+  public void testKdcBindConflictSurfacesAsKrbException() throws Exception {
+    int port;
+    try (ServerSocket probe = new ServerSocket(0, 1, InetAddress.getByName(LOCALHOST))) {
+      port = probe.getLocalPort();
+    }
+    try (ServerSocket tcp = new ServerSocket(port, 1, InetAddress.getByName(LOCALHOST));
+      DatagramSocket udp = new DatagramSocket(port, InetAddress.getByName(LOCALHOST))) {
+      Properties conf = MiniKdc.createConf();
+      conf.put(MiniKdc.DEBUG, true);
+      conf.setProperty(MiniKdc.KDC_BIND_ADDRESS, LOCALHOST);
+      conf.setProperty(MiniKdc.KDC_PORT, Integer.toString(port));
+      File dir = new File(HTU.getDataTestDir("kdc-conflict").toUri().getPath());
+      MiniKdc conflictingKdc = new MiniKdc(conf, dir);
+
+      Exception thrown = assertThrows(Exception.class, conflictingKdc::start);
+
+      assertFalse(thrown instanceof BindException,
+        "Kerby wraps the bind failure in a KrbException, so it is not a BindException: " + thrown);
+      assertTrue(isBindException(thrown),
+        "expected a recognisable bind-conflict failure, got: " + thrown);
+    }
+  }
+
+  /**
+   * Deterministic regression test for the retry predicate. A port conflict raised by the
+   * Kerby-backed {@link MiniKdc} must be recognised as a bind failure whether the
+   * {@link BindException} is preserved in the cause chain or only reflected in the message;
+   * unrelated failures must not be. We model the Kerby wrapper with a plain {@link Exception}
+   * rather than constructing a real Kerby exception, so the test does not import kerby types (see
+   * HBASE-29117).
+   */
+  @Test
+  public void testIsBindExceptionRecognizesKerbyWrappedBindFailure() {
+    assertTrue(
+      isBindException(new Exception("Failed to start DefaultKrbServer",
+        new BindException("Address already in use"))),
+      "a bind failure preserved in the cause chain should be recognised");
+    assertTrue(
+      isBindException(new Exception("Failed to start DefaultKrbServer. Address already in use")),
+      "a wrapper whose message reports the bind conflict should be recognised");
+    assertFalse(isBindException(new RuntimeException("boom")),
+      "an unrelated failure must not be treated as a retryable bind conflict");
   }
 
   static private void setupSSL(File base) throws Exception {

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtil.java
@@ -3737,10 +3737,10 @@ public class HBaseTestingUtil extends HBaseZKTestingUtil {
         // KrbException whose shape varies by version (see isBindException), so we recognise the
         // port conflict via that predicate rather than a type. We also avoid importing kerby types
         // here (see HBASE-29117).
+        FileUtils.deleteDirectory(dir); // clean directory regardless of failure type
         if (!isBindException(e)) {
           throw e; // not a port conflict, do not mask the real failure behind a retry
         }
-        FileUtils.deleteDirectory(dir); // clean directory
         numTries++;
         if (numTries == 3) {
           LOG.error("Failed setting up MiniKDC. Tried " + numTries + " times.");

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/HBaseTestingUtil.java
@@ -43,6 +43,7 @@ import java.util.Collections;
 import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.Locale;
 import java.util.Map;
 import java.util.NavigableSet;
 import java.util.Properties;
@@ -3731,19 +3732,49 @@ public class HBaseTestingUtil extends HBaseZKTestingUtil {
         dir = new File(getDataTestDir("kdc").toUri().getPath());
         kdc = new MiniKdc(conf, dir);
         kdc.start();
-      } catch (BindException e) {
+      } catch (Exception e) {
+        // Catch Exception, not BindException/KrbException: Kerby wraps the bind failure in a
+        // KrbException whose shape varies by version (see isBindException), so we recognise the
+        // port conflict via that predicate rather than a type. We also avoid importing kerby types
+        // here (see HBASE-29117).
+        if (!isBindException(e)) {
+          throw e; // not a port conflict, do not mask the real failure behind a retry
+        }
         FileUtils.deleteDirectory(dir); // clean directory
         numTries++;
         if (numTries == 3) {
           LOG.error("Failed setting up MiniKDC. Tried " + numTries + " times.");
           throw e;
         }
-        LOG.error("BindException encountered when setting up MiniKdc. Trying again.");
+        LOG.error("Bind conflict encountered when setting up MiniKdc, retrying (attempt " + numTries
+          + ").");
         bindException = true;
       }
     } while (bindException);
     HBaseKerberosUtils.setKeytabFileForTesting(keytabFile.getAbsolutePath());
     return kdc;
+  }
+
+  /**
+   * The Kerby-backed {@link MiniKdc} wraps a failure to bind the KDC port in a
+   * {@code org.apache.kerby...KrbException} rather than surfacing a {@link BindException} directly,
+   * so we inspect the whole cause chain plus the message to recognise a port conflict. Both checks
+   * are load-bearing across Kerby versions: kerby 1.x preserves the original {@link BindException}
+   * as the cause (caught by the cause-chain check) while kerby 2.x drops the cause and only appends
+   * the bind message (caught by the message check). The message match is lower-cased since the
+   * wording is JDK/OS specific.
+   */
+  static boolean isBindException(Throwable t) {
+    for (Throwable cause = t; cause != null; cause = cause.getCause()) {
+      if (cause instanceof BindException) {
+        return true;
+      }
+      String msg = cause.getMessage();
+      if (msg != null && msg.toLowerCase(Locale.ROOT).contains("address already in use")) {
+        return true;
+      }
+    }
+    return false;
   }
 
   public int getNumHFiles(final TableName tableName, final byte[] family) {


### PR DESCRIPTION
### Problem

`TestLogLevel` fails intermittently in `setUp` when the MiniKDC port is already in use:

```
org.apache.kerby.kerberos.kerb.KrbException: Failed to start DefaultKrbServer. Address already in use (Bind failed)
    at ...AbstractInternalKdcServer.start
    at ...SimpleKdcServer.start
    at org.apache.hadoop.minikdc.MiniKdc.start(MiniKdc.java:284)
    at org.apache.hadoop.hbase.http.log.TestLogLevel.setupMiniKdc(TestLogLevel.java:155)
```

### Root cause

`setupMiniKdc` already retries on port conflicts, but only `catch (BindException e)`. The Kerby-backed `MiniKdc` does **not** throw `java.net.BindException` — it wraps the bind failure in a Kerby `KrbException`, and the cause chain carries **no** `BindException`; the conflict is only visible via the `"Address already in use"` message. So the retry is dead code and the first collision fails the test.

Same block exists in two places:
- `TestLogLevel.setupMiniKdc` (hbase-http)
- `HBaseTestingUtil.setupMiniKdc` (hbase-server) — also affects e.g. `TestSecureRESTServer`, `TestSecureExport`.

### Fix

Recognise a bind conflict regardless of wrapper type: `catch (Exception e)`, then a predicate that walks the whole cause chain and matches the `"Address already in use"` message; rethrow anything else so a genuine KDC misconfig is never masked.

Deliberately **not** `catch (BindException | KrbException)`:
- the message (not the type) is the discriminator — the cause chain has no `BindException`, and a future MiniKdc/Kerby could use a different wrapper;
- a bare `KrbException` catch would still need the message check (a real misconfig is also a `KrbException`);
- it avoids a compile-time import of a kerby type, which HBASE-29117 warns against (kerby version is unpinned; 1.x/2.x incompatible across Hadoop versions).

### Tests

- `testKdcBindConflictSurfacesAsKrbException` — deterministic reproduction: occupies the KDC port on TCP+UDP, pins MiniKdc to it, asserts the failure is a Kerby `KrbException` (not a `BindException`) recognised by the predicate.
- `testIsBindExceptionRecognizesKerbyWrappedBindFailure` — unit test for the predicate (wrapped `BindException`, message-only, and negative case).