### PR TITLE
HBASE-30149 Fix PrefixFilter and range scans on hbase:meta

### DIFF
--- a/hbase-common/src/main/java/org/apache/hadoop/hbase/MetaCellComparator.java
+++ b/hbase-common/src/main/java/org/apache/hadoop/hbase/MetaCellComparator.java
@@ -148,11 +148,11 @@ public class MetaCellComparator extends CellComparatorImpl {
     if (result != 0) {
       return result;
     } else {
-      if (leftDelimiter < 0 && rightDelimiter >= 0) {
+      if (leftFarDelimiter < 0 && rightFarDelimiter >= 0) {
         return -1;
-      } else if (rightDelimiter < 0 && leftDelimiter >= 0) {
+      } else if (rightFarDelimiter < 0 && leftFarDelimiter >= 0) {
         return 1;
-      } else if (leftDelimiter < 0) {
+      } else if (leftFarDelimiter < 0) {
         return 0;
       }
     }

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/TestMetaTableAccessor.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/TestMetaTableAccessor.java
@@ -41,7 +41,9 @@ import org.apache.hadoop.hbase.client.RegionInfo;
 import org.apache.hadoop.hbase.client.RegionInfoBuilder;
 import org.apache.hadoop.hbase.client.RegionLocator;
 import org.apache.hadoop.hbase.client.Result;
+import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Table;
+import org.apache.hadoop.hbase.filter.PrefixFilter;
 import org.apache.hadoop.hbase.ipc.CallRunner;
 import org.apache.hadoop.hbase.ipc.DelegatingRpcScheduler;
 import org.apache.hadoop.hbase.ipc.PriorityFunction;
@@ -428,6 +430,17 @@ public class TestMetaTableAccessor {
     doReturn(true).when(visitor).visit(any());
     MetaTableAccessor.scanMeta(connection, visitor, tableName, Bytes.toBytes("region_ac"), 1);
     verify(visitor, times(1)).visit(any());
+
+    byte[] prefix = Bytes.add(tableName.getName(), new byte[] { HConstants.DELIMITER });
+    try (Table metaTable = connection.getTable(TableName.META_TABLE_NAME)) {
+      Scan rangeScan = new Scan().withStartRow(prefix)
+        .withStopRow(Bytes.add(tableName.getName(), new byte[] { HConstants.DELIMITER + 1 }));
+      assertEquals(3, HBaseTestingUtil.countRows(metaTable, rangeScan));
+
+      Scan prefixScan = new Scan();
+      prefixScan.setFilter(new PrefixFilter(prefix));
+      assertEquals(3, HBaseTestingUtil.countRows(metaTable, prefixScan));
+    }
     table.close();
   }
 


### PR DESCRIPTION
JIRA: https://issues.apache.org/jira/browse/HBASE-30149

## What changes were proposed in this pull request?

Fix MetaCellComparator to use the second row-key delimiters when determining whether a meta row contains the region-id section. Add regression coverage for range scans and PrefixFilter scans on hbase:meta.

## Why are the changes needed?
After comparing the middle section, MetaCellComparator.compareRows rechecked the first delimiters instead of the second delimiters. This incorrectly ordered a partial key such as test, after test,,<regionId>, causing scans to skip the first region of a table.

## How was this patch tested?

```bash
mvn -pl hbase-server -am -Dtest=TestMetaTableAccessor \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dsurefire.rerunFailingTestsCount=0 test

mvn -pl hbase-common -am -Dtest=TestKeyValue \
  -Dsurefire.failIfNoSpecifiedTests=false \
  -Dsurefire.rerunFailingTestsCount=0 test
```