### PR TITLE
HBASE-30348 Throttles should work for system tables (excluding quotas, meta, namespace)

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaCache.java
@@ -23,7 +23,12 @@ import java.util.EnumSet;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.hadoop.conf.Configuration;
 import org.apache.hadoop.hbase.ClusterMetrics;
 import org.apache.hadoop.hbase.ClusterMetrics.Option;
@@ -35,6 +40,7 @@ import org.apache.hadoop.hbase.ipc.RpcCall;
 import org.apache.hadoop.hbase.ipc.RpcServer;
 import org.apache.hadoop.hbase.regionserver.RegionServerServices;
 import org.apache.hadoop.hbase.util.Bytes;
+import org.apache.hadoop.hbase.util.Threads;
 import org.apache.hadoop.security.UserGroupInformation;
 import org.apache.yetus.audience.InterfaceAudience;
 import org.apache.yetus.audience.InterfaceStability;
@@ -44,6 +50,7 @@ import org.slf4j.LoggerFactory;
 import org.apache.hbase.thirdparty.com.google.common.cache.CacheBuilder;
 import org.apache.hbase.thirdparty.com.google.common.cache.CacheLoader;
 import org.apache.hbase.thirdparty.com.google.common.cache.LoadingCache;
+import org.apache.hbase.thirdparty.com.google.common.util.concurrent.ThreadFactoryBuilder;
 
 /**
  * Cache that keeps track of the quota settings for the users and tables that are interacting with
@@ -66,6 +73,9 @@ public class QuotaCache implements Stoppable {
     "hbase.quota.user.override.key";
   private static final int REFRESH_DEFAULT_PERIOD = 43_200_000; // 12 hours
 
+  public static final String INITIAL_LOAD_TIMEOUT_MS = "hbase.quota.cache.initial.load.timeout.ms";
+  private static final long INITIAL_LOAD_TIMEOUT_MS_DEFAULT = 10_000;
+
   private final Object initializerLock = new Object();
   private volatile boolean initialized = false;
 
@@ -85,6 +95,15 @@ public class QuotaCache implements Stoppable {
   private QuotaRefresherChore refreshChore;
   private boolean stopped = true;
 
+  // The initial load runs here rather than on the requesting thread, so that a request can put a
+  // bound on how long it waits for it. The load reads hbase:quota and asks the master for cluster
+  // metrics, neither of which is necessarily available yet when the first request arrives.
+  private final ExecutorService initialLoadExecutor = Executors
+    .newSingleThreadExecutor(new ThreadFactoryBuilder().setNameFormat("quota-cache-initial-load-%d")
+      .setDaemon(true).setUncaughtExceptionHandler(Threads.LOGGING_EXCEPTION_HANDLER).build());
+  private Future<?> initialLoad;
+  private long initialLoadTimeoutMs;
+
   public QuotaCache(final RegionServerServices rsServices) {
     this.rsServices = rsServices;
     this.userOverrideRequestAttributeKey =
@@ -99,6 +118,7 @@ public class QuotaCache implements Stoppable {
     // configuration reload is triggered. Periodic reloads are kept to a minimum to avoid
     // flooding the RegionServer holding the hbase:quota table with requests.
     int period = conf.getInt(REFRESH_CONF_KEY, REFRESH_DEFAULT_PERIOD);
+    initialLoadTimeoutMs = conf.getLong(INITIAL_LOAD_TIMEOUT_MS, INITIAL_LOAD_TIMEOUT_MS_DEFAULT);
     refreshChore = new QuotaRefresherChore(conf, period, this);
     rsServices.getChoreService().scheduleChore(refreshChore);
   }
@@ -109,6 +129,7 @@ public class QuotaCache implements Stoppable {
       LOG.debug("Stopping QuotaRefresherChore chore.");
       refreshChore.shutdown(true);
     }
+    initialLoadExecutor.shutdownNow();
     stopped = true;
   }
 
@@ -118,12 +139,31 @@ public class QuotaCache implements Stoppable {
   }
 
   private void ensureInitialized() {
-    if (!initialized) {
-      synchronized (initializerLock) {
-        if (!initialized) {
-          refreshChore.chore();
-          initialized = true;
-        }
+    if (initialized) {
+      return;
+    }
+    synchronized (initializerLock) {
+      if (initialized) {
+        return;
+      }
+      if (initialLoad == null) {
+        initialLoad = initialLoadExecutor.submit(() -> refreshChore.chore());
+      }
+      try {
+        initialLoad.get(initialLoadTimeoutMs, TimeUnit.MILLISECONDS);
+        initialized = true;
+      } catch (TimeoutException e) {
+        // The load is still running, and will mark the cache initialized once a later request
+        // observes that it finished. Until then requests get default quota state, which does not
+        // throttle. Waiting any longer would risk stalling the RPC handler behind a master that
+        // may not have finished initializing.
+        LOG.warn("Quota cache not loaded within {}ms, serving default quotas for now",
+          initialLoadTimeoutMs);
+      } catch (InterruptedException e) {
+        Thread.currentThread().interrupt();
+      } catch (ExecutionException e) {
+        LOG.warn("Failed to load quota cache", e.getCause());
+        initialLoad = null;
       }
     }
   }
@@ -155,7 +195,7 @@ public class QuotaCache implements Stoppable {
    * @return the limiter associated to the specified user/table
    */
   public QuotaLimiter getUserLimiter(final UserGroupInformation ugi, final TableName table) {
-    if (table.isSystemTable()) {
+    if (QuotaUtil.isThrottleExempt(table)) {
       return NoopQuotaLimiter.get();
     }
     return getUserQuotaState(ugi).getTableLimiter(table);

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/QuotaUtil.java
@@ -122,6 +122,17 @@ public class QuotaUtil extends QuotaTableUtil {
     return conf.getBoolean(QUOTA_CONF_KEY, QUOTA_ENABLED_DEFAULT);
   }
 
+  /**
+   * Returns true if the given table can never be throttled. These tables are read while a master is
+   * still initializing, before quotas can be served, so throttling them could prevent a throttle
+   * from ever being lifted.
+   */
+  @SuppressWarnings("deprecation") // hbase:namespace still exists on pre-3.x clusters
+  public static boolean isThrottleExempt(final TableName tableName) {
+    return TableName.META_TABLE_NAME.equals(tableName) || QUOTA_TABLE_NAME.equals(tableName)
+      || TableName.NAMESPACE_TABLE_NAME.equals(tableName);
+  }
+
   /*
    * ========================================================================= Quota "settings"
    * helpers

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/quotas/RegionServerRpcQuotaManager.java
@@ -137,7 +137,7 @@ public class RegionServerRpcQuotaManager implements RpcQuotaManager, Configurati
    */
   public OperationQuota getQuota(final UserGroupInformation ugi, final TableName table,
     final int blockSizeBytes) {
-    if (isQuotaEnabled() && !table.isSystemTable() && isRpcThrottleEnabled()) {
+    if (isQuotaEnabled() && !QuotaUtil.isThrottleExempt(table) && isRpcThrottleEnabled()) {
       UserQuotaState userQuotaState = quotaCache.getUserQuotaState(ugi);
       QuotaLimiter userLimiter = userQuotaState.getTableLimiter(table);
 

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaUtil.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/quotas/TestQuotaUtil.java
@@ -1,0 +1,74 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.quotas;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.testclassification.RegionServerTests;
+import org.apache.hadoop.hbase.testclassification.SmallTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+@Tag(RegionServerTests.TAG)
+@Tag(SmallTests.TAG)
+public class TestQuotaUtil {
+
+  @Test
+  public void testMetaTableIsThrottleExempt() {
+    assertTrue(QuotaUtil.isThrottleExempt(TableName.META_TABLE_NAME));
+  }
+
+  @Test
+  public void testQuotaTableIsThrottleExempt() {
+    assertTrue(QuotaUtil.isThrottleExempt(QuotaTableUtil.QUOTA_TABLE_NAME));
+  }
+
+  @Test
+  public void testNamespaceTableIsThrottleExempt() {
+    // TableNamespaceManager reads hbase:namespace during initClusterSchemaService, which runs
+    // before initQuotaManager creates hbase:quota. Throttling it deadlocks master startup.
+    assertTrue(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:namespace")));
+  }
+
+  @Test
+  public void testBackupTablesAreNotThrottleExempt() {
+    // Backup tables live in a system namespace, so they were previously exempt. They can
+    // accumulate very large cells, which makes them a meaningful source of IO pressure, so
+    // operators need to be able to throttle them.
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("backup:system")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("backup:system_bulk")));
+  }
+
+  @Test
+  public void testOtherSystemTablesAreNotThrottleExempt() {
+    // These are only read after the master is initialized, so a throttle on them cannot prevent
+    // itself from being lifted.
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:acl")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:labels")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:rsgroup")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("hbase:replication")));
+  }
+
+  @Test
+  public void testUserTablesAreNotThrottleExempt() {
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("my_table")));
+    assertFalse(QuotaUtil.isThrottleExempt(TableName.valueOf("my_ns:my_table")));
+  }
+}


### PR DESCRIPTION
https://issues.apache.org/jira/browse/HBASE-30348

Second attempt at HBASE-30348. The first was reverted because it deadlocked master startup on branch-2.x. Opening as a draft to get CI results on master and branch-2 before asking for review.

### What changed since the reverted version

**`hbase:namespace` is now exempt as well as `hbase:meta` and `hbase:quota`.** This is the actual fix for the deadlock. `TableNamespaceManager` reads `hbase:namespace` during `initClusterSchemaService()`, which runs before `initQuotaManager()` creates `hbase:quota` — so throttling that table meant the read could wait on a quota system that could not yet answer. Every other table becomes throttleable, including the backup tables, which is what motivated the issue: `backup:system` reads could not be bounded by any quota.

**The initial quota cache load no longer runs inline on the RPC handler.** `QuotaCache#ensureInitialized` submits it to a single background thread and waits with a timeout, configurable via `hbase.quota.cache.initial.load.timeout.ms` and defaulting to ten seconds. A request that waits out the timeout proceeds with default quota state, which does not throttle, and the load is picked up once it completes.

This second part is defence in depth rather than the fix. The load reads `hbase:quota` *and* asks the master for cluster metrics via `getRegionServers()`/`getClusterMetrics()`, so any read of a non-exempt table arriving during master initialization could previously wait on the master indefinitely. It also means requests no longer queue on the monitor that `QuotaRefresherChore#chore` holds across those RPCs.

The load remains synchronous in effect, which preserves two existing behaviours that a fully asynchronous version broke: a quota that was just set is still visible to the next lookup (`TestQuotaCache`), and cluster scope factors are still computed before the first cluster scope check (`TestClusterScopeQuotaThrottle`).

### On the 3.x review

The hazard window is any read of a non-exempt table before `setInitialized(true)` in `finishActiveMasterInitialization`. On master the only such read I found is `TableNamespaceManager#loadNamespaceIntoCache`, which takes `loadFromNamespace()` — a scan of `hbase:namespace` — when `shouldLoadFromMeta()` returns false. That is reachable on a cluster upgraded from 2.x whose namespace migration has not completed; clusters created by 3.x have `NAMESPACE_FAMILY` in meta and take the safe `loadFromMeta()` path, which is why CI was green on branch-3 and branch-3.0 while branch-2 failed.

`hbase:acl` and `hbase:labels` are read from `postStartMaster()`, after initialization. `hbase:rsgroup` is read by `RSGroupInfoManagerImpl.RSGroupStartupWorker`, a daemon thread that loops on `isMasterRunning()` and retries, so it is off the initialization path. `hbase:canary`, `hbase:slowlog` and `hbase:replication` are not read in that window.

I have not reproduced the upgrade case, so that finding is reasoned from the code rather than observed.

### Testing

`TestQuotaUtil` is added, covering that `hbase:meta`, `hbase:quota` and `hbase:namespace` are exempt while the backup tables, the other `hbase` namespace tables, and user tables are not.

Locally, the `org.apache.hadoop.hbase.quotas` and `org.apache.hadoop.hbase.master` packages pass on both branches:

- master: 440 tests, 0 failures, 0 errors, 25 skipped (127 classes)
- branch-2.6: 439 tests, 0 failures, 0 errors, 26 skipped (129 classes)

Not yet covered: nothing exercises the timeout branch, since no test makes the load exceed the bound. A test that injects a hanging refresh and asserts the lookup returns within the timeout would cover it, and would also serve as a regression test for the deadlock itself. Happy to add that if it seems worthwhile.
