### PR TITLE
HBASE-30357 OpenRegionProcedure#restoreSucceedState ignores persisted transitionCode, forcing OPEN even after a real FAILED_OPEN

### DIFF
--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/AssignmentManager.java
@@ -2232,8 +2232,13 @@ public class AssignmentManager {
   }
 
   // should be called under the RegionStateNode lock
-  // The parameter 'giveUp' means whether we will try to open the region again, if it is true, then
-  // we will persist the FAILED_OPEN state into hbase:meta.
+  // Called when a region open attempt has failed. The 'giveUp' parameter says whether we will try
+  // to open the region again. If true, this is a terminal failure with no more retries: we set
+  // RegionState.State to FAILED_OPEN and persist it to hbase:meta, and only remove the region from
+  // its old target server's bookkeeping once that persist succeeds. If false, we are about to
+  // retry the open with a new plan, so RegionState.State is intentionally left untouched (e.g.
+  // still OPENING), meta is not touched, and we remove the region from its old target server's
+  // bookkeeping immediately. In both cases the removal only happens if there was an old location.
   CompletableFuture<Void> regionFailedOpen(RegionStateNode regionNode, boolean giveUp) {
     RegionState.State state = regionNode.getState();
     ServerName regionLocation = regionNode.getRegionLocation();

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/CloseRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/CloseRegionProcedure.java
@@ -113,8 +113,9 @@ public class CloseRegionProcedure extends RegionRemoteProcedureBase {
   }
 
   @Override
-  protected void restoreSucceedState(AssignmentManager am, RegionStateNode regionNode, long seqId)
-    throws IOException {
+  protected void restoreSucceedState(AssignmentManager am, RegionStateNode regionNode,
+    TransitionCode transitionCode, long seqId) throws IOException {
+    // CLOSE has no failure variant, so transitionCode is always CLOSED here
     if (regionNode.getState() == State.CLOSED) {
       // should have already been persisted, ignore
       return;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/OpenRegionProcedure.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/OpenRegionProcedure.java
@@ -127,7 +127,12 @@ public class OpenRegionProcedure extends RegionRemoteProcedureBase {
 
   @Override
   protected void restoreSucceedState(AssignmentManager am, RegionStateNode regionNode,
-    long openSeqNum) throws IOException {
+    TransitionCode transitionCode, long openSeqNum) throws IOException {
+    if (transitionCode == TransitionCode.FAILED_OPEN) {
+      // will not persist to meta if giveUp is false, matches the live reportTransition path
+      am.regionFailedOpen(regionNode, false);
+      return;
+    }
     if (regionNode.getState() == State.OPEN) {
       // should have already been persisted, ignore
       return;

--- a/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionRemoteProcedureBase.java
+++ b/hbase-server/src/main/java/org/apache/hadoop/hbase/master/assignment/RegionRemoteProcedureBase.java
@@ -268,12 +268,12 @@ public abstract class RegionRemoteProcedureBase extends Procedure<MasterProcedur
   }
 
   protected abstract void restoreSucceedState(AssignmentManager am, RegionStateNode regionNode,
-    long seqId) throws IOException;
+    TransitionCode transitionCode, long seqId) throws IOException;
 
   void stateLoaded(AssignmentManager am, RegionStateNode regionNode) {
     if (state == RegionRemoteProcedureBaseState.REGION_REMOTE_PROCEDURE_REPORT_SUCCEED) {
       try {
-        restoreSucceedState(am, regionNode, seqId);
+        restoreSucceedState(am, regionNode, transitionCode, seqId);
       } catch (IOException e) {
         // should not happen as we are just restoring the state
         throw new AssertionError(e);

--- a/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestOpenRegionProcedureRestoreFailedOpen.java
+++ b/hbase-server/src/test/java/org/apache/hadoop/hbase/master/assignment/TestOpenRegionProcedureRestoreFailedOpen.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hadoop.hbase.master.assignment;
+
+import static org.junit.jupiter.api.Assertions.assertNotEquals;
+
+import java.io.IOException;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.hadoop.hbase.HConstants;
+import org.apache.hadoop.hbase.ServerName;
+import org.apache.hadoop.hbase.TableName;
+import org.apache.hadoop.hbase.client.RegionInfo;
+import org.apache.hadoop.hbase.master.RegionState;
+import org.apache.hadoop.hbase.testclassification.LargeTests;
+import org.apache.hadoop.hbase.testclassification.MasterTests;
+import org.junit.jupiter.api.Tag;
+import org.junit.jupiter.api.Test;
+
+import org.apache.hadoop.hbase.shaded.protobuf.ProtobufUtil;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.OpenRegionRequest.RegionOpenInfo;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.AdminProtos.OpenRegionResponse.RegionOpeningState;
+import org.apache.hadoop.hbase.shaded.protobuf.generated.RegionServerStatusProtos.RegionStateTransition.TransitionCode;
+
+/**
+ * HBASE-30357: OpenRegionProcedure#restoreSucceedState() must not force the region state to OPEN on
+ * master-failover restore when the persisted transition code is actually FAILED_OPEN.
+ */
+@Tag(MasterTests.TAG)
+@Tag(LargeTests.TAG)
+public class TestOpenRegionProcedureRestoreFailedOpen extends TestAssignmentManagerBase {
+
+  /**
+   * On the first open attempt, reports FAILED_OPEN and then immediately simulates a master restart
+   * happening before the child OpenRegionProcedure gets to run its own execute() (i.e. before it
+   * can persist anything to meta), by directly invoking the package-private stateLoaded() hook that
+   * a real restart would trigger. Records the region state right after that simulated restore.
+   * Subsequent attempts behave like a normal healthy RS so the assign procedure can converge and
+   * the test does not hang.
+   */
+  private class FailedOpenThenRestoreRsExecutor extends GoodRsExecutor {
+
+    private final AtomicBoolean firstAttempt = new AtomicBoolean(true);
+
+    final AtomicReference<RegionState.State> stateAfterRestore = new AtomicReference<>();
+
+    @Override
+    protected RegionOpeningState execOpenRegion(ServerName server, RegionOpenInfo openReq)
+      throws IOException {
+      if (!firstAttempt.compareAndSet(true, false)) {
+        return super.execOpenRegion(server, openReq);
+      }
+      RegionInfo hri = ProtobufUtil.toRegionInfo(openReq.getRegion());
+      RegionStateNode regionNode = am.getRegionStates().getRegionStateNode(hri);
+      TransitRegionStateProcedure trsp = (TransitRegionStateProcedure) regionNode.getProcedure();
+      regionNode.lock();
+      try {
+        sendTransitionReport(server, openReq.getRegion(), TransitionCode.FAILED_OPEN,
+          HConstants.NO_SEQNUM);
+        trsp.stateLoaded(am, regionNode);
+        stateAfterRestore.set(regionNode.getState());
+      } finally {
+        regionNode.unlock();
+      }
+      return RegionOpeningState.FAILED_OPENING;
+    }
+  }
+
+  @Test
+  public void testRestoreDoesNotForceOpenAfterFailedOpen() throws Exception {
+    TableName tableName = TableName.valueOf(testMethodName);
+    RegionInfo hri = createRegionInfo(tableName, 1);
+    FailedOpenThenRestoreRsExecutor executor = new FailedOpenThenRestoreRsExecutor();
+    rsDispatcher.setMockRsExecutor(executor);
+    TransitRegionStateProcedure proc = createAssignProcedure(hri);
+    waitOnFuture(submitProcedure(proc));
+
+    assertNotEquals(RegionState.State.OPEN, executor.stateAfterRestore.get());
+  }
+}


### PR DESCRIPTION
## What changes were proposed in this pull request?

`OpenRegionProcedure#restoreSucceedState()` is called on master-failover restore, once
per region, via `RegionRemoteProcedureBase#stateLoaded()`. It unconditionally forced the
region into `OPEN`, regardless of the actual persisted `transitionCode`, which can be
`FAILED_OPEN`. The method's signature only received `seqId`, not `transitionCode`, so it
was structurally unable to branch on the real outcome.

Concretely: an RS reports `FAILED_OPEN`; the master persists
`state=REPORT_SUCCEED, transitionCode=FAILED_OPEN` on the `OpenRegionProcedure`, but the
in-memory `RegionState.State` is left untouched (still `OPENING`, since
`AssignmentManager#regionFailedOpen(regionNode, false)` on the live path does not update
`RegionState.State`). If the master crashes/restarts before this reaches `confirmOpened()`
and before `hbase:meta` is updated, `restoreSucceedState()` sees the region isn't `OPEN`
yet and force-transitions it to `OPEN` anyway, then persists that (false) `OPEN` state to
`hbase:meta`. There is no rollback anywhere in this procedure chain (by design -
forward-only), so nothing downstream can detect or correct it; the region silently looks
healthy in meta while no RegionServer is actually serving it.

By contrast, `CloseRegionProcedure#restoreSucceedState()` is safe doing the equivalent
unconditional force, because CLOSE has no failure-variant transition code at the master
side (`checkTransition`/`updateTransitionWithoutPersistingToMeta` both assert
`transitionCode == CLOSED`).

This is not a regression - the logic is unchanged (modulo spotless formatting) since it
was introduced in HBASE-22365 (2019-05-10).

### The fix

- Widen `RegionRemoteProcedureBase#restoreSucceedState()` to also receive the persisted
  `transitionCode`, passed through from `stateLoaded()`.
- `OpenRegionProcedure#restoreSucceedState()` now branches: `FAILED_OPEN` calls
  `AssignmentManager#regionFailedOpen(regionNode, false)`, mirroring exactly what the live
  `reportTransition`/`updateTransitionWithoutPersistingToMeta` path already does for the
  same transition code; the existing `OPENED` handling is unchanged.
- `CloseRegionProcedure#restoreSucceedState()` accepts the new parameter and ignores it,
  since CLOSE has no failure variant.

After the fix, a restore-time `FAILED_OPEN` puts the region back into the same
retryable path (`OPENING`, cleared location) that `TransitRegionStateProcedure#confirmOpened()`
already drives on the live path - the region gets reassigned/retried through the normal
flow instead of being falsely marked `OPEN`.

## Why are the changes needed?

To prevent a region from being silently, durably marked `OPEN` in `hbase:meta` after a
master restart, when in reality no RegionServer opened it. Since HBase has no rollback
mechanism for these forward-only assignment procedures, this bug is otherwise
unrecoverable except by manual detection and intervention.

## Does this PR introduce any user-facing change?

No.

## Is there a corresponding Apache JIRA?

Yes: [HBASE-30357](https://issues.apache.org/jira/browse/HBASE-30357)

## How was this patch tested?

Added `TestOpenRegionProcedureRestoreFailedOpen`, extending `TestAssignmentManagerBase`. A
custom mock RS executor reports `FAILED_OPEN` on the first open attempt, then - while
holding the `RegionStateNode` lock, simulating the point right after a crash where the
child procedure has not yet resumed its own `execute()` - directly invokes the
`TransitRegionStateProcedure#stateLoaded()` hook that a real master restart would trigger,
and records the region's state immediately after. Confirmed the test fails against
unmodified code with the exact predicted `OPEN` state, and passes after the fix. Also ran
`TestAssignmentManager`, `TestTransitRegionStateProcedure`, `TestOpenRegionProcedureHang`,
`TestOpenRegionProcedureBackoff`, `TestRollbackSCP`, and `TestSCPGetRegionsRace` with no
regressions.