### PR TITLE
HBASE-30365 Skip the MOB pseudo-region when building snapshot input splits

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/TableSnapshotInputFormatImpl.java
@@ -43,6 +43,7 @@ import org.apache.hadoop.hbase.client.Scan;
 import org.apache.hadoop.hbase.client.Scan.ReadType;
 import org.apache.hadoop.hbase.client.TableDescriptor;
 import org.apache.hadoop.hbase.io.ImmutableBytesWritable;
+import org.apache.hadoop.hbase.mob.MobUtils;
 import org.apache.hadoop.hbase.regionserver.HRegion;
 import org.apache.hadoop.hbase.snapshot.RestoreSnapshotHelper;
 import org.apache.hadoop.hbase.snapshot.SnapshotDescriptionUtils;
@@ -359,6 +360,11 @@ public class TableSnapshotInputFormatImpl {
     for (SnapshotRegionManifest regionManifest : regionManifests) {
       RegionInfo hri = ProtobufUtil.toRegionInfo(regionManifest.getRegionInfo());
       if (hri.isOffline() && (hri.isSplit() || hri.isSplitParent())) {
+        continue;
+      }
+      // The mob region is a dummy region used only to organise mob files under mobdir. It has no
+      // region directory under the table dir to open, and holds no rows. See HBASE-30365.
+      if (MobUtils.isMobRegionInfo(hri)) {
         continue;
       }
       regionInfos.add(hri);


### PR DESCRIPTION
Jira: HBASE-30365

`TableSnapshotInputFormatImpl.getRegionInfosFromManifest` creates a split for every region in the snapshot manifest, and a MOB snapshot manifest includes the MOB pseudo-region from `MobUtils.getMobRegionInfo`. Each split is then opened as a real region under the restore dir.

HBASE-30336 correctly stopped writing a `.regioninfo` for that pseudo-region under the table dir, so opening it now fails with "Region directory does not exist".

Skip it, next to the existing offline-split filter. Behaviour preserving: the pseudo-region's family files live under mobdir, so the split opened a region with no store files and returned zero rows. MOB values are read through references in the data regions, not by scanning the pseudo-region.

Covered by the existing `TestCopyTable` MOB snapshot tests, which fail without this change.

```sh
mvn -pl hbase-mapreduce test -Dtest='TestCopyTable#testLoadingSnapshotAndBulkLoadToMobTable+tsetLoadingSnapshotToMobTable'
```