### PR TITLE
HBASE-30373 Expose GITHUB_REPO to external environment

### DIFF
--- a/dev-support/hbase-personality.sh
+++ b/dev-support/hbase-personality.sh
@@ -75,7 +75,7 @@ function personality_globals
   #shellcheck disable=SC2034
   JIRA_ISSUE_RE='^HBASE-[0-9]+$'
   #shellcheck disable=SC2034
-  GITHUB_REPO="apache/hbase"
+  GITHUB_REPO="${GITHUB_REPO:-${GITHUB_REPOSITORY:-apache/hbase}}"
 
   # TODO use PATCH_BRANCH to select jdk versions to use.
 


### PR DESCRIPTION
Permit GITHUB_REPO variable override from execution environment. Support Github Action runner environment variable by default. Fallback to original hard-coded value.