### PR TITLE
HBASE-30377 WALInputFormat drops WAL files that span the requested time range

### DIFF
--- a/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALInputFormat.java
+++ b/hbase-mapreduce/src/main/java/org/apache/hadoop/hbase/mapreduce/WALInputFormat.java
@@ -32,6 +32,7 @@ import org.apache.hadoop.fs.FileSystem;
 import org.apache.hadoop.fs.LocatedFileStatus;
 import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.fs.RemoteIterator;
+import org.apache.hadoop.hbase.fs.HFileSystem;
 import org.apache.hadoop.hbase.regionserver.wal.WALHeaderEOFException;
 import org.apache.hadoop.hbase.util.LeaseNotRecoveredException;
 import org.apache.hadoop.hbase.wal.AbstractFSWALProvider;
@@ -41,6 +42,7 @@ import org.apache.hadoop.hbase.wal.WALEdit;
 import org.apache.hadoop.hbase.wal.WALFactory;
 import org.apache.hadoop.hbase.wal.WALKey;
 import org.apache.hadoop.hbase.wal.WALStreamReader;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.io.Writable;
 import org.apache.hadoop.mapreduce.InputFormat;
 import org.apache.hadoop.mapreduce.InputSplit;
@@ -382,7 +384,7 @@ public class WALInputFormat extends InputFormat<WALKey, WALEdit> {
         // Recurse into sub directories
         result.addAll(getFiles(fs, file.getPath(), startTime, endTime, conf));
       } else {
-        addFile(result, file, startTime, endTime);
+        addFile(result, fs, file, startTime, endTime);
       }
     }
     // TODO: These results should be sorted? Results could be content of recovered.edits directory
@@ -391,18 +393,44 @@ public class WALInputFormat extends InputFormat<WALKey, WALEdit> {
     return result;
   }
 
-  static void addFile(List<FileStatus> result, LocatedFileStatus lfs, long startTime,
+  /**
+   * Whether the file is known to be closed. Only a closed file has a final modification time, so
+   * only then can it be used as an upper bound on the entries inside. Anything we cannot answer
+   * for, including non-HDFS filesystems, is reported as open so that the file is kept.
+   */
+  private static boolean isClosed(FileSystem fs, Path path) {
+    try {
+      FileSystem backing = fs instanceof HFileSystem ? ((HFileSystem) fs).getBackingFs() : fs;
+      return backing instanceof DistributedFileSystem
+        && ((DistributedFileSystem) backing).isFileClosed(path);
+    } catch (IOException e) {
+      LOG.debug("Could not tell whether {} is closed, keeping it", path, e);
+      return false;
+    }
+  }
+
+  static void addFile(List<FileStatus> result, FileSystem fs, LocatedFileStatus lfs, long startTime,
     long endTime) {
     long timestamp = AbstractFSWALProvider.getTimestamp(lfs.getPath().getName());
     if (timestamp > 0) {
-      // Looks like a valid timestamp.
-      if (timestamp <= endTime && timestamp >= startTime) {
-        LOG.info("Found {}", lfs.getPath());
-        result.add(lfs);
-      } else {
-        LOG.info("Skipped {}, outside range [{}/{} - {}/{}]", lfs.getPath(), startTime,
-          Instant.ofEpochMilli(startTime), endTime, Instant.ofEpochMilli(endTime));
+      // The name carries the WAL's creation time, which only bounds its entries from below. A WAL
+      // stays open until it rolls, so one created before startTime can still hold entries in
+      // range and must not be dropped on the strength of its name alone.
+      if (timestamp > endTime) {
+        LOG.info("Skipped {}, created after endTime [{}/{}]", lfs.getPath(), endTime,
+          Instant.ofEpochMilli(endTime));
+        return;
       }
+      // The modification time is the upper bound, but HDFS leaves it at the creation time until
+      // the file is closed, so it is only meaningful once the file is. Order the checks so the
+      // extra RPC is only paid for files that the modification time alone would prune.
+      if (lfs.getModificationTime() < startTime && isClosed(fs, lfs.getPath())) {
+        LOG.info("Skipped {}, closed before startTime [{}/{}]", lfs.getPath(), startTime,
+          Instant.ofEpochMilli(startTime));
+        return;
+      }
+      LOG.info("Found {}", lfs.getPath());
+      result.add(lfs);
     } else {
       // If no timestamp, add it regardless.
       LOG.info("Found (no-timestamp!) {}", lfs);

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALInputFormat.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALInputFormat.java
@@ -38,6 +38,7 @@ import org.apache.hadoop.hbase.testclassification.MapReduceTests;
 import org.apache.hadoop.hbase.testclassification.MediumTests;
 import org.apache.hadoop.hbase.util.CommonFSUtils;
 import org.apache.hadoop.hbase.util.EnvironmentEdgeManager;
+import org.apache.hadoop.hdfs.DistributedFileSystem;
 import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.Job;
 import org.apache.hadoop.mapreduce.JobContext;
@@ -65,34 +66,74 @@ public class TestWALInputFormat {
   @Test
   public void testAddFile() {
     List<FileStatus> lfss = new ArrayList<>();
+    // a plain FileSystem is never reported closed, so nothing is skipped on the startTime side
+    FileSystem fs = Mockito.mock(FileSystem.class);
     LocatedFileStatus lfs = Mockito.mock(LocatedFileStatus.class);
     long now = EnvironmentEdgeManager.currentTime();
     Mockito.when(lfs.getPath()).thenReturn(new Path("/name." + now));
-    WALInputFormat.addFile(lfss, lfs, now, now);
+    WALInputFormat.addFile(lfss, fs, lfs, now, now);
     assertEquals(1, lfss.size());
-    WALInputFormat.addFile(lfss, lfs, now - 1, now - 1);
+    WALInputFormat.addFile(lfss, fs, lfs, now - 1, now - 1);
     assertEquals(1, lfss.size());
-    WALInputFormat.addFile(lfss, lfs, now - 2, now - 1);
+    WALInputFormat.addFile(lfss, fs, lfs, now - 2, now - 1);
     assertEquals(1, lfss.size());
-    WALInputFormat.addFile(lfss, lfs, now - 2, now);
+    WALInputFormat.addFile(lfss, fs, lfs, now - 2, now);
     assertEquals(2, lfss.size());
-    WALInputFormat.addFile(lfss, lfs, Long.MIN_VALUE, now);
+    WALInputFormat.addFile(lfss, fs, lfs, Long.MIN_VALUE, now);
     assertEquals(3, lfss.size());
-    WALInputFormat.addFile(lfss, lfs, Long.MIN_VALUE, Long.MAX_VALUE);
+    WALInputFormat.addFile(lfss, fs, lfs, Long.MIN_VALUE, Long.MAX_VALUE);
     assertEquals(4, lfss.size());
-    WALInputFormat.addFile(lfss, lfs, now, now + 2);
+    WALInputFormat.addFile(lfss, fs, lfs, now, now + 2);
     assertEquals(5, lfss.size());
-    WALInputFormat.addFile(lfss, lfs, now + 1, now + 2);
-    assertEquals(5, lfss.size());
-    Mockito.when(lfs.getPath()).thenReturn(new Path("/name"));
-    WALInputFormat.addFile(lfss, lfs, Long.MIN_VALUE, Long.MAX_VALUE);
+    // created before startTime, but it may have stayed open and collected in-range entries
+    WALInputFormat.addFile(lfss, fs, lfs, now + 1, now + 2);
     assertEquals(6, lfss.size());
-    Mockito.when(lfs.getPath()).thenReturn(new Path("/name.123"));
-    WALInputFormat.addFile(lfss, lfs, Long.MIN_VALUE, Long.MAX_VALUE);
+    Mockito.when(lfs.getPath()).thenReturn(new Path("/name"));
+    WALInputFormat.addFile(lfss, fs, lfs, Long.MIN_VALUE, Long.MAX_VALUE);
     assertEquals(7, lfss.size());
-    Mockito.when(lfs.getPath()).thenReturn(new Path("/name." + now + ".meta"));
-    WALInputFormat.addFile(lfss, lfs, now, now);
+    Mockito.when(lfs.getPath()).thenReturn(new Path("/name.123"));
+    WALInputFormat.addFile(lfss, fs, lfs, Long.MIN_VALUE, Long.MAX_VALUE);
     assertEquals(8, lfss.size());
+    Mockito.when(lfs.getPath()).thenReturn(new Path("/name." + now + ".meta"));
+    WALInputFormat.addFile(lfss, fs, lfs, now, now);
+    assertEquals(9, lfss.size());
+  }
+
+  private static boolean isKept(FileSystem fs, long created, long mtime, long start, long end) {
+    List<FileStatus> result = new ArrayList<>();
+    LocatedFileStatus lfs = Mockito.mock(LocatedFileStatus.class);
+    Mockito.when(lfs.getPath()).thenReturn(new Path("/name." + created));
+    Mockito.when(lfs.getModificationTime()).thenReturn(mtime);
+    WALInputFormat.addFile(result, fs, lfs, start, end);
+    return !result.isEmpty();
+  }
+
+  /**
+   * The name of a WAL carries its creation time, which only bounds its entries from below. A WAL
+   * stays open until it rolls, so one created before startTime can still hold entries in range.
+   * Only a closed file has a final modification time that can rule it out.
+   */
+  @Test
+  public void testAddFileUsesModificationTimeOfClosedFilesOnly() throws Exception {
+    long now = EnvironmentEdgeManager.currentTime();
+
+    DistributedFileSystem closed = Mockito.mock(DistributedFileSystem.class);
+    Mockito.when(closed.isFileClosed(Mockito.any())).thenReturn(true);
+    DistributedFileSystem open = Mockito.mock(DistributedFileSystem.class);
+    Mockito.when(open.isFileClosed(Mockito.any())).thenReturn(false);
+
+    // Closed, and its last write predates the window: nothing in it can be in range.
+    assertFalse(isKept(closed, now - 100, now - 50, now, now + 100));
+
+    // Same file, but the window opens before it was closed, so it spans the boundary.
+    assertTrue(isKept(closed, now - 100, now - 50, now - 60, now + 100));
+
+    // Still open. Its mtime is stuck near the creation time and says nothing about the entries
+    // it may yet receive, so it has to be kept even though mtime is before the window.
+    assertTrue(isKept(open, now - 100, now - 100, now, now + 100));
+
+    // Created after the window closed: every entry in it is later still.
+    assertFalse(isKept(closed, now + 200, now + 200, now, now + 100));
   }
 
   @Test

--- a/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALRecordReader.java
+++ b/hbase-mapreduce/src/test/java/org/apache/hadoop/hbase/mapreduce/TestWALRecordReader.java
@@ -190,9 +190,12 @@ public class TestWALRecordReader {
     jobConf.setLong(WALInputFormat.START_TIME_KEY, ts + 1);
     jobConf.setLong(WALInputFormat.END_TIME_KEY, ts1 + 1);
     splits = input.getSplits(MapreduceTestingShim.createJobContext(jobConf));
-    assertEquals(1, splits.size());
+    assertEquals(2, splits.size());
+    // The 1st file was created before startTime but stayed open until it rolled, so its 2nd
+    // entry, written at exactly startTime, is in-range.
+    testSplit(splits.get(0), Bytes.toBytes("2"));
     // Only the 1st entry from the 2nd file is in-range.
-    testSplit(splits.get(0), Bytes.toBytes("3"));
+    testSplit(splits.get(1), Bytes.toBytes("3"));
   }
 
   /**


### PR DESCRIPTION
Jira: HBASE-30377

The timestamp in a WAL's name is its creation time, which only bounds its entries from below. A WAL stays open until it rolls, so one created before `startTime` can still hold entries in range, and comparing the name against `startTime` threw the whole file away.

```
startTime = 100, endTime = 200
WAL created at t=50, rolled at t=150  ->  holds entries 50..150
  50 <= 200 passes, but 50 >= 100 fails  ->  file skipped
  lost: every entry in 100..150
```

### Fix

Compare against the modification time instead, which bounds the entries from above. That is only meaningful once the file is closed, since HDFS leaves mtime at the creation time through `hflush` and `hsync`, so it is gated on `DistributedFileSystem.isFileClosed`. Anything we cannot answer for, including non-HDFS filesystems, is treated as open and kept.

### End-to-end test

I verified the fix on a 6-node test cluster running on a local Kubernetes cluster. Without the 1-hour `logroll.period` workaround, WALPlayer correctly processes all WAL files.

### This is safe and conservative

With @mosmeh's suggestion applied, this patch never excludes files that the previous code included.